### PR TITLE
fix: package Chamber keytar auth

### DIFF
--- a/.working-memory/log.md
+++ b/.working-memory/log.md
@@ -1,0 +1,6 @@
+# Working Memory — Log
+
+## 2026-04-10
+- [auth] Packaged Chamber cannot rely on Vite externalization alone for `keytar`; the installed app needs `node_modules/keytar` bundled under `resources/` and loaded from `process.resourcesPath`.
+- [packaging] `prepare-node-runtime.js` must stage and validate `resources/node` before swapping it into place; deleting the existing runtime first can strand Forge with a missing bundled Node folder.
+- [installer] Squirrel upgrades can fail if another process, including VS Code, holds the previous `app-<version>/resources/app.asar` open inside `LocalAppData`.

--- a/.working-memory/memory.md
+++ b/.working-memory/memory.md
@@ -1,0 +1,1 @@
+# Working Memory — Memory

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -2,6 +2,7 @@ import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
 import { MakerDeb } from '@electron-forge/maker-deb';
+import AutoUnpackNativesPlugin from '@electron-forge/plugin-auto-unpack-natives';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { FusesPlugin } from '@electron-forge/plugin-fuses';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
@@ -17,7 +18,7 @@ const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
     executableName: 'chamber',
-    extraResource: ['./resources/node', './src/main/assets'],
+    extraResource: ['./resources/node', './src/main/assets', './node_modules/keytar'],
     ...(enableMacOSSigning
       ? {
           osxSign: {},
@@ -56,6 +57,7 @@ const config: ForgeConfig = {
     new MakerDeb({}),
   ],
   plugins: [
+    new AutoUnpackNativesPlugin({}),
     new VitePlugin({
       // `build` can specify multiple entry builds, which can be Main process, Preload scripts, Worker process, etc.
       // If you are familiar with Vite configuration, it will look really familiar.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "chamber",
-  "version": "0.12.0",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.12.0",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "electron-squirrel-startup": "^1.0.1",
+        "keytar": "^7.9.0",
         "lucide-react": "^1.7.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.5",
@@ -5772,7 +5773,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5813,7 +5813,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -5906,7 +5905,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6601,7 +6599,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -6617,13 +6614,21 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -6712,7 +6717,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -7256,7 +7260,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -7997,6 +8000,15 @@
         "which": "bin/which"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -8284,6 +8296,12 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -8548,6 +8566,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -8962,7 +8986,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9049,7 +9072,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -9772,6 +9794,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
       }
     },
     "node_modules/keyv": {
@@ -11286,7 +11319,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11402,6 +11434,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11436,6 +11474,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -11479,7 +11523,6 @@
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -11487,6 +11530,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "license": "MIT"
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",
@@ -11747,7 +11796,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -12214,6 +12262,33 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12295,7 +12370,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -12421,6 +12495,36 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -12680,7 +12784,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -13077,7 +13180,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13203,7 +13305,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13406,6 +13507,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13603,7 +13749,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -13905,6 +14050,40 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -14166,6 +14345,18 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tw-animate-css": {
@@ -14574,7 +14765,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
@@ -14966,7 +15156,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.14.0",
+  "version": "0.14.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,
@@ -48,6 +48,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "electron-squirrel-startup": "^1.0.1",
+    "keytar": "^7.9.0",
     "lucide-react": "^1.7.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.5",

--- a/scripts/prepare-node-runtime.js
+++ b/scripts/prepare-node-runtime.js
@@ -10,6 +10,48 @@ const repoRoot = path.resolve(__dirname, '..');
 const targetDir = path.join(repoRoot, 'resources', 'node');
 const markerPath = path.join(targetDir, 'version.txt');
 
+function getNodeBinary(rootDir) {
+  return process.platform === 'win32'
+    ? path.join(rootDir, 'node.exe')
+    : path.join(rootDir, 'bin', 'node');
+}
+
+function getNpmCli(rootDir) {
+  const candidates = process.platform === 'win32'
+    ? [
+        path.join(rootDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+        path.join(rootDir, 'npm', 'bin', 'npm-cli.js'),
+      ]
+    : [
+        path.join(rootDir, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+        path.join(rootDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+      ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+function validateRuntimeDir(rootDir) {
+  const nodeBinary = getNodeBinary(rootDir);
+  if (!fs.existsSync(nodeBinary)) {
+    throw new Error(`Node binary not found in runtime: ${nodeBinary}`);
+  }
+
+  const npmCli = getNpmCli(rootDir);
+  if (!npmCli) {
+    throw new Error(`npm CLI not found in runtime: ${rootDir}`);
+  }
+
+  return { nodeBinary, npmCli };
+}
+
+function quotePowerShell(value) {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 function readNvmrcVersion() {
   try {
     const content = fs.readFileSync(path.join(repoRoot, '.nvmrc'), 'utf-8').trim();
@@ -46,6 +88,61 @@ function runCommand(command, args) {
   const result = spawnSync(command, args, { stdio: 'inherit' });
   if (result.status !== 0) {
     throw new Error(`Command failed: ${command} ${args.join(' ')}`);
+  }
+}
+
+function extractArchive(archivePath, extractDir, ext) {
+  if (ext === 'zip') {
+    const script = [
+      "$ErrorActionPreference = 'Stop'",
+      "$ProgressPreference = 'SilentlyContinue'",
+      `Expand-Archive -LiteralPath ${quotePowerShell(archivePath)} -DestinationPath ${quotePowerShell(extractDir)} -Force`,
+    ].join('; ');
+
+    runCommand('powershell', [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      script,
+    ]);
+    return;
+  }
+
+  runCommand('tar', ['-xzf', archivePath, '-C', extractDir]);
+}
+
+function promoteRuntime(extractedDir, version) {
+  const resourcesDir = path.dirname(targetDir);
+  const stagingDir = path.join(resourcesDir, 'node.new');
+  const backupDir = path.join(resourcesDir, 'node.old');
+
+  fs.mkdirSync(resourcesDir, { recursive: true });
+  fs.rmSync(stagingDir, { recursive: true, force: true });
+  fs.rmSync(backupDir, { recursive: true, force: true });
+
+  fs.cpSync(extractedDir, stagingDir, { recursive: true });
+  fs.writeFileSync(path.join(stagingDir, 'version.txt'), version, 'utf-8');
+  validateRuntimeDir(stagingDir);
+
+  let previousRuntimeMoved = false;
+  try {
+    if (fs.existsSync(targetDir)) {
+      fs.renameSync(targetDir, backupDir);
+      previousRuntimeMoved = true;
+    }
+
+    fs.renameSync(stagingDir, targetDir);
+    validateRuntimeDir(targetDir);
+    fs.rmSync(backupDir, { recursive: true, force: true });
+  } catch (error) {
+    fs.rmSync(targetDir, { recursive: true, force: true });
+    if (previousRuntimeMoved && fs.existsSync(backupDir)) {
+      fs.renameSync(backupDir, targetDir);
+    }
+    throw error;
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
   }
 }
 
@@ -105,9 +202,9 @@ async function verifyIntegrity(filePath, version, filename) {
 
   if (actualHash !== expectedHash) {
     throw new Error(
-      `Integrity check failed for ${filename}.\n` +
-      `  Expected: ${expectedHash}\n` +
-      `  Actual:   ${actualHash}`
+      `Integrity check failed for ${filename}.\n`
+      + `  Expected: ${expectedHash}\n`
+      + `  Actual:   ${actualHash}`
     );
   }
   console.log('Integrity check passed.');
@@ -116,9 +213,7 @@ async function verifyIntegrity(filePath, version, filename) {
 async function main() {
   const version = resolveVersion();
   const { dist, ext } = resolveDist(version);
-  const nodeBinary = process.platform === 'win32'
-    ? path.join(targetDir, 'node.exe')
-    : path.join(targetDir, 'bin', 'node');
+  const nodeBinary = getNodeBinary(targetDir);
 
   if (fs.existsSync(markerPath) && fs.existsSync(nodeBinary)) {
     const existing = fs.readFileSync(markerPath, 'utf-8').trim();
@@ -132,6 +227,7 @@ async function main() {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'genesis-node-'));
   try {
     const archivePath = path.join(tempDir, `${dist}.${ext}`);
+    const extractDir = path.join(tempDir, 'extract');
 
     console.log(`Downloading ${url}`);
     await downloadFile(url, archivePath);
@@ -140,34 +236,16 @@ async function main() {
     await verifyIntegrity(archivePath, version, archiveFilename);
 
     console.log('Extracting Node runtime...');
-    if (ext === 'zip') {
-      runCommand('powershell', [
-        '-NoProfile',
-        '-Command',
-        `Expand-Archive -Path "${archivePath}" -DestinationPath "${tempDir}" -Force`,
-      ]);
-    } else {
-      runCommand('tar', ['-xzf', archivePath, '-C', tempDir]);
-    }
+    fs.mkdirSync(extractDir, { recursive: true });
+    extractArchive(archivePath, extractDir, ext);
 
-    const extractedDir = path.join(tempDir, dist);
+    const extractedDir = path.join(extractDir, dist);
     if (!fs.existsSync(extractedDir)) {
       throw new Error(`Extracted Node directory not found: ${extractedDir}`);
     }
+    validateRuntimeDir(extractedDir);
 
-    fs.rmSync(targetDir, { recursive: true, force: true });
-    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
-    try {
-      fs.renameSync(extractedDir, targetDir);
-    } catch (error) {
-      if (error && error.code === 'EXDEV') {
-        fs.cpSync(extractedDir, targetDir, { recursive: true });
-        fs.rmSync(extractedDir, { recursive: true, force: true });
-      } else {
-        throw error;
-      }
-    }
-    fs.writeFileSync(markerPath, version, 'utf-8');
+    promoteRuntime(extractedDir, version);
 
     console.log(`Bundled Node runtime ready at ${targetDir}`);
   } finally {

--- a/src/main/ipc/auth.ts
+++ b/src/main/ipc/auth.ts
@@ -6,7 +6,7 @@ export function setupAuthIPC(): void {
   const authService = new AuthService();
 
   ipcMain.handle('auth:getStatus', async () => {
-    const cred = authService.getStoredCredential();
+    const cred = await authService.getStoredCredential();
     return {
       authenticated: cred !== null,
       login: cred?.login,

--- a/src/main/services/AuthService.ts
+++ b/src/main/services/AuthService.ts
@@ -1,124 +1,68 @@
-// AuthService — GitHub device flow + Windows Credential Manager storage.
-// Stores token where copilot CLI expects it — one login, everything works.
-// IMPORTANT: The CLI reads credentials via keytar, which interprets the
-// CredentialBlob as UTF-8. We must write UTF-8 bytes — NOT cmdkey, which
-// writes UTF-16LE and produces null-byte-riddled tokens when keytar reads them.
+// AuthService — GitHub device flow + Copilot CLI credential storage via keytar.
+// Stores the token in the exact Windows credential shape the CLI reads.
 
+import { app } from 'electron';
 import * as https from 'https';
-import { execFileSync } from 'child_process';
+import { createRequire } from 'module';
+import * as path from 'path';
 
 const CLIENT_ID = 'Ov23ctDVkRmgkPke0Mmm';
 const DEVICE_CODE_URL = 'https://github.com/login/device/code';
 const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 const AUTH_SCOPE = 'read:user,read:org,repo,gist';
-const CREDENTIAL_TARGET_PREFIX = 'copilot-cli/https://github.com';
+// The previous CredWrite-based implementation used the same service/account shape,
+// so existing Windows credentials remain readable after the switch to keytar.
+const KEYTAR_SERVICE = 'copilot-cli';
+const GITHUB_ACCOUNT_PREFIX = 'https://github.com:';
+const runtimeRequire = createRequire(__filename);
 
-// Win32 Credential Manager — write UTF-8 blobs compatible with keytar.
-// Uses a precompiled .NET script via PowerShell to call CredWriteW directly.
-// cmdkey stores UTF-16LE; keytar reads UTF-8. This bridges the gap.
+interface StoredCredential {
+  login: string;
+  account: string;
+  password: string;
+}
 
-function writeCredentialUtf8(target: string, user: string, token: string): boolean {
-  // Write a temp .cs file, compile, and run — too slow.
-  // Instead, use csc.exe directly via a temp C# source to avoid Add-Type latency.
-  // Actually simplest: write the token as raw UTF-8 bytes to a temp file,
-  // then use a minimal PowerShell script with P/Invoke preloaded from disk.
-  //
-  // Cleanest approach: Node.js can call advapi32 CredWriteW via a tiny native shim.
-  // But for now, write a .NET console app inline with csc.
-
-  // Actually — just write the raw bytes ourselves. Node has access to everything we need.
-  // Use a C# one-liner via dotnet-script or csc. But those may not be present.
-
-  // Final approach: Use node child_process to run a small C# program via csc.exe
-  // which is always present in the .NET Framework directory on Windows.
-  const fs = require('fs') as typeof import('fs');
-  const path = require('path') as typeof import('path');
-  const os = require('os') as typeof import('os');
-  const { execFileSync: efs } = require('child_process') as typeof import('child_process');
-
-  const tmpDir = path.join(os.tmpdir(), 'chamber-cred');
-  fs.mkdirSync(tmpDir, { recursive: true });
-
-  const csPath = path.join(tmpDir, 'CredWrite.cs');
-  const exePath = path.join(tmpDir, 'CredWrite.exe');
-
-  // Only compile once — reuse the exe if it exists
-  if (!fs.existsSync(exePath)) {
-    const csSource = `
-using System;
-using System.Runtime.InteropServices;
-using System.Text;
-
-class Program {
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    struct CREDENTIAL {
-        public int Flags;
-        public int Type;
-        public string TargetName;
-        public string Comment;
-        public long LastWritten;
-        public int CredentialBlobSize;
-        public IntPtr CredentialBlob;
-        public int Persist;
-        public int AttributeCount;
-        public IntPtr Attributes;
-        public string TargetAlias;
-        public string UserName;
-    }
-
-    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    static extern bool CredWrite(ref CREDENTIAL cred, int flags);
-
-    static int Main(string[] args) {
-        if (args.Length < 3) { Console.Error.WriteLine("Usage: CredWrite target user token"); return 1; }
-        byte[] blob = Encoding.UTF8.GetBytes(args[2]);
-        IntPtr blobPtr = Marshal.AllocHGlobal(blob.Length);
-        Marshal.Copy(blob, 0, blobPtr, blob.Length);
-        CREDENTIAL cred = new CREDENTIAL();
-        cred.Type = 1;
-        cred.TargetName = args[0];
-        cred.UserName = args[1];
-        cred.CredentialBlob = blobPtr;
-        cred.CredentialBlobSize = blob.Length;
-        cred.Persist = 2;
-        bool ok = CredWrite(ref cred, 0);
-        Marshal.FreeHGlobal(blobPtr);
-        if (!ok) { Console.Error.WriteLine("CredWrite failed: " + Marshal.GetLastWin32Error()); return 1; }
-        return 0;
-    }
-}`;
-    fs.writeFileSync(csPath, csSource);
-
-    // Find csc.exe from .NET Framework (always present on Windows)
-    const frameworkDir = path.join(
-      process.env.WINDIR || 'C:\\Windows',
-      'Microsoft.NET', 'Framework64', 'v4.0.30319'
-    );
-    const cscPath = path.join(frameworkDir, 'csc.exe');
-
-    if (!fs.existsSync(cscPath)) {
-      console.error('[Auth] csc.exe not found at', cscPath);
-      return false;
-    }
-
-    try {
-      efs(cscPath, ['/nologo', '/optimize', `/out:${exePath}`, csPath], {
-        stdio: 'pipe',
-        timeout: 15_000,
-      });
-    } catch (err) {
-      console.error('[Auth] Failed to compile CredWrite:', err);
-      return false;
-    }
+function loadKeytar(): typeof import('keytar') {
+  if (!app.isPackaged) {
+    return runtimeRequire('keytar') as typeof import('keytar');
   }
 
-  try {
-    efs(exePath, [target, user, token], { stdio: 'pipe', timeout: 5_000 });
-    return true;
-  } catch (err) {
-    console.error('[Auth] CredWrite.exe failed:', err);
-    return false;
+  const packagedKeytarPath = path.join(process.resourcesPath, 'keytar', 'lib', 'keytar.js');
+  return runtimeRequire(packagedKeytarPath) as typeof import('keytar');
+}
+
+const keytar = loadKeytar();
+
+function getUserAgent(): string {
+  return `Chamber/${app.getVersion()}`;
+}
+
+function getCredentialAccount(login: string): string {
+  return `${GITHUB_ACCOUNT_PREFIX}${login}`;
+}
+
+function getLoginFromAccount(account: string): string | null {
+  if (!account.startsWith(GITHUB_ACCOUNT_PREFIX)) return null;
+  const login = account.slice(GITHUB_ACCOUNT_PREFIX.length).trim();
+  return login || null;
+}
+
+function resolveStoredCredential(credentials: Array<{ account: string; password: string }>): StoredCredential | null {
+  const matchingCredentials = credentials
+    .map((credential) => {
+      const login = getLoginFromAccount(credential.account);
+      if (!login || !credential.password) return null;
+      return { login, account: credential.account, password: credential.password };
+    })
+    .filter((credential): credential is StoredCredential => credential !== null);
+
+  if (matchingCredentials.length === 0) return null;
+
+  if (matchingCredentials.length > 1) {
+    console.warn(`[Auth] Multiple Copilot credentials found; using ${matchingCredentials[0].account}`);
   }
+
+  return matchingCredentials[0];
 }
 
 export interface AuthProgress {
@@ -141,7 +85,7 @@ function postJson(url: string, body: Record<string, string>): Promise<Record<str
         'Accept': 'application/json',
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(data),
-        'User-Agent': 'Chamber/0.11.0',
+        'User-Agent': getUserAgent(),
       },
     };
 
@@ -169,7 +113,7 @@ function getJson(url: string, token: string): Promise<Record<string, unknown>> {
       headers: {
         'Accept': 'application/json',
         'Authorization': `Bearer ${token}`,
-        'User-Agent': 'Chamber/0.11.0',
+        'User-Agent': getUserAgent(),
       },
     };
 
@@ -198,36 +142,20 @@ export class AuthService {
     this.aborted = true;
   }
 
-  /** Check if a copilot credential exists in Windows Credential Manager */
-  getStoredCredential(): { login: string } | null {
+  async getStoredCredential(): Promise<{ login: string } | null> {
     try {
-      const output = execFileSync('cmdkey', [
-        `/list:${CREDENTIAL_TARGET_PREFIX}*`,
-      ], { encoding: 'utf-8' });
-      const match = output.match(/Target:\s+copilot-cli\/https:\/\/github\.com:(\S+)/);
-      if (match) {
-        return { login: match[1] };
-      }
-    } catch { /* no credentials */ }
+      const credential = resolveStoredCredential(await keytar.findCredentials(KEYTAR_SERVICE));
+      return credential ? { login: credential.login } : null;
+    } catch (err) {
+      console.error('[Auth] Failed to read stored credential:', err);
+    }
+
     return null;
   }
 
-  /** Store token in Windows Credential Manager as UTF-8 blob.
-   *  The CLI reads credentials via keytar which interprets blobs as UTF-8.
-   *  cmdkey writes UTF-16LE, causing null-byte corruption when keytar reads. */
-  private storeCredential(login: string, token: string): void {
-    const target = `${CREDENTIAL_TARGET_PREFIX}:${login}`;
-    const user = `https://github.com:${login}`;
-    try {
-      const ok = writeCredentialUtf8(target, user, token);
-      if (ok) {
-        console.log(`[Auth] Stored credential for ${login} (UTF-8 blob)`);
-      } else {
-        console.error('[Auth] CredWrite returned false');
-      }
-    } catch (err) {
-      console.error('[Auth] Failed to store credential:', err);
-    }
+  private async storeCredential(login: string, token: string): Promise<void> {
+    await keytar.setPassword(KEYTAR_SERVICE, getCredentialAccount(login), token);
+    console.log(`[Auth] Stored credential for ${login} via keytar`);
   }
 
   async startLogin(): Promise<{ success: boolean; login?: string }> {
@@ -270,10 +198,11 @@ export class AuthService {
           try {
             const user = await getJson('https://api.github.com/user', token);
             login = String(user.login);
-          } catch { /* use default */ }
+          } catch (err) {
+            console.warn('[Auth] Failed to fetch user login, using default account name:', err);
+          }
 
-          // Store in Windows Credential Manager
-          this.storeCredential(login, token);
+          await this.storeCredential(login, token);
 
           this.onProgress?.({ step: 'authenticated', login });
           return { success: true, login };

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,4 +1,10 @@
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config
-export default defineConfig({});
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      external: ['keytar'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- switch Windows Copilot credential storage to keytar and remove the inline C# writer
- bundle keytar for packaged installs and load it from resources in packaged builds
- make bundled Node runtime preparation transactional so packaging keeps resources/node intact

## Validation
- exercised fresh auth flow in dev and confirmed credential persistence on relaunch
- built and installed the fixed 0.14.2 Windows package successfully