### PR TITLE
feat: add Vitest test infrastructure and 173 tests

### DIFF
--- a/.testagent/plan.md
+++ b/.testagent/plan.md
@@ -1,0 +1,578 @@
+# Chamber Test Implementation Plan
+
+> **Baseline:** 17 tests passing (utils 9, getPlainContent 4, createIpcListener 4)
+> **Target:** ~160–190 tests across ~22 new test files
+> **Conventions:** Vitest 4 + jsdom opt-in, @testing-library/react, vi.fn() mocks, factory helpers
+
+---
+
+## Phase 1 — Test Infrastructure + Core State Machine
+
+### Why first
+Everything downstream depends on two things: (1) shared mock factories and helpers, and (2) confidence in the reducer that drives all app state. The store reducer (`handleChatEvent` + `appReducer`) is the single most complex and most important untested code in the app. Test it before anything that consumes it.
+
+### 1A. Shared test helpers — `src/test/helpers.ts`
+
+**Purpose:** Central factory for `mockElectronAPI`, state factories, and type builders reused by every renderer test.
+
+**Contents:**
+
+```ts
+// No vitest-environment comment — importable from any environment
+
+export function mockElectronAPI() {
+  // Return a fully-typed mock matching window.electronAPI shape.
+  // Every method is vi.fn() with sensible defaults:
+  //   chat.send → resolvedValue(undefined)
+  //   chat.stop → resolvedValue(undefined)
+  //   chat.newConversation → resolvedValue(undefined)
+  //   chat.listModels → resolvedValue([])
+  //   chat.onEvent → returnValue(() => {})   // unsubscribe stub
+  //   agent.getStatus → resolvedValue(defaultAgentStatus())
+  //   agent.selectMindDirectory → resolvedValue(null)
+  //   agent.setMindPath → resolvedValue(undefined)
+  //   agent.onStatusChanged → returnValue(() => {})
+  //   lens.getViews → resolvedValue([])
+  //   lens.getViewData → resolvedValue(null)
+  //   lens.refreshView → resolvedValue(null)
+  //   lens.sendAction → resolvedValue(null)
+  //   lens.onViewsChanged → returnValue(() => {})
+  //   auth.getStatus → resolvedValue({ authenticated: true })
+  //   auth.startLogin → resolvedValue({ success: true })
+  //   auth.onProgress → returnValue(() => {})
+  //   genesis.getDefaultPath → resolvedValue('C:\\Users\\test\\agents')
+  //   genesis.pickPath → resolvedValue(null)
+  //   genesis.create → resolvedValue({ success: true })
+  //   genesis.onProgress → returnValue(() => {})
+  //   config.load → resolvedValue({ mindPath: null, theme: 'dark' })
+  //   config.save → resolvedValue(undefined)
+  //   window.minimize → vi.fn()
+  //   window.maximize → vi.fn()
+  //   window.close → vi.fn()
+}
+
+export function installElectronAPI(api = mockElectronAPI()) {
+  Object.defineProperty(window, 'electronAPI', { value: api, writable: true, configurable: true });
+  return api;
+}
+
+export function defaultAgentStatus(): AgentStatus {
+  return { connected: false, mindPath: null, agentName: null, sessionActive: false, uptime: null, error: null, extensions: [] };
+}
+
+export function connectedAgentStatus(overrides?: Partial<AgentStatus>): AgentStatus {
+  return { connected: true, mindPath: 'C:\\test\\mind', agentName: 'test-agent', sessionActive: true, uptime: 100, error: null, extensions: [], ...overrides };
+}
+
+export function makeTextBlock(content: string, sdkMessageId?: string): TextBlock { ... }
+export function makeToolCallBlock(overrides?: Partial<ToolCallBlock>): ToolCallBlock { ... }
+export function makeReasoningBlock(content: string, reasoningId?: string): ReasoningBlock { ... }
+export function makeMessage(blocks: ContentBlock[], overrides?: Partial<ChatMessage>): ChatMessage { ... }
+export function makeChatEvent(type: string, overrides?: Record<string, unknown>): ChatEvent { ... }
+export function makeLensViewManifest(overrides?: Partial<LensViewManifest>): LensViewManifest { ... }
+```
+
+**Test file:** `src/test/helpers.test.ts` — 3–4 smoke tests confirming factories return valid shapes.
+
+---
+
+### 1B. Export `handleChatEvent` and `appReducer` from store.tsx
+
+**Source change required:** `src/renderer/lib/store.tsx`
+
+Currently `handleChatEvent` and `appReducer` are module-scoped and not exported. They are pure functions (`(state, event) → state` and `(state, action) → state`) and deserve direct unit testing.
+
+**Action:** Add named exports:
+
+```ts
+// Add to existing exports in store.tsx:
+export { handleChatEvent, appReducer, initialState };
+// Also export the AppState type and AppAction type for test type-safety.
+export type { AppState, AppAction };
+```
+
+This is a non-breaking change — nothing in the app imports these names today.
+
+---
+
+### 1C. Store reducer tests — `src/renderer/lib/store.reducer.test.ts`
+
+> **Environment:** `/** @vitest-environment jsdom */` (matches existing store.test.ts)
+
+**Import:** `handleChatEvent`, `appReducer`, `initialState` from `@/renderer/lib/store`
+
+#### `handleChatEvent` tests (~20 tests)
+
+Starting state for each test: a messages array containing one assistant message with `isStreaming: true` and an empty `blocks` array.
+
+| # | Scenario | Input event | Assertion |
+|---|----------|-------------|-----------|
+| 1 | `chunk` — first text creates a TextBlock | `{ type:'chunk', content:'Hello' }` | `blocks[0]` is `{ type:'text', content:'Hello' }` |
+| 2 | `chunk` — subsequent text appends to existing TextBlock | Two `chunk` events | `blocks[0].content === 'HelloWorld'` |
+| 3 | `chunk` — after a tool block, creates NEW text block | tool_start then chunk | `blocks.length === 2`, `blocks[1].type === 'text'` |
+| 4 | `chunk` — with sdkMessageId, sets it on block | `{ type:'chunk', content:'x', sdkMessageId:'sdk-1' }` | `blocks[0].sdkMessageId === 'sdk-1'` |
+| 5 | `tool_start` — creates tool_call block | `{ type:'tool_start', toolCallId:'tc1', toolName:'readFile' }` | `blocks[0]` is ToolCallBlock with status `'running'` |
+| 6 | `tool_start` — with arguments | include `arguments: '{"path":"x"}'` | block has `.arguments` |
+| 7 | `tool_start` — with parentToolCallId | include `parentToolCallId: 'tc0'` | block has `.parentToolCallId` |
+| 8 | `tool_progress` — appends output | tool_start then `{ type:'tool_progress', toolCallId:'tc1', output:'line1' }` | `blocks[0].output === 'line1'` |
+| 9 | `tool_progress` — accumulates output | Two progress events | output concatenated |
+| 10 | `tool_output` — appends output | tool_start then `{ type:'tool_output', toolCallId:'tc1', output:'result' }` | output contains 'result' |
+| 11 | `tool_done` — success sets status='done' | tool_start then `{ type:'tool_done', toolCallId:'tc1' }` | `status === 'done'` |
+| 12 | `tool_done` — with result | include `result: 'ok'` | block has `.result` |
+| 13 | `tool_done` — with error | include `error: 'fail'` | `status === 'error'`, block has `.error` |
+| 14 | `tool_done` — unknown toolCallId is no-op | `{ type:'tool_done', toolCallId:'unknown' }` | blocks unchanged |
+| 15 | `reasoning` — creates ReasoningBlock | `{ type:'reasoning', reasoningId:'r1', content:'thinking' }` | `blocks[0].type === 'reasoning'` |
+| 16 | `reasoning` — appends to existing block | Two reasoning events same id | content concatenated |
+| 17 | `reasoning` — new id creates new block | Two reasoning events different ids | `blocks.length === 2` |
+| 18 | `message_final` — reconciles with final text | `{ type:'message_final', content:'Final answer' }` | text block content matches |
+| 19 | `done` — sets isStreaming=false | `{ type:'done' }` | message `isStreaming === false` |
+| 20 | `error` — adds error text block, sets isStreaming=false | `{ type:'error', error:'timeout' }` | last block is TextBlock with error content, `isStreaming === false` |
+
+#### `appReducer` tests (~18 tests)
+
+| # | Action type | Setup | Assertion |
+|---|-------------|-------|-----------|
+| 1 | `ADD_USER_MESSAGE` | dispatch with id, content, timestamp | messages array has new user message with TextBlock |
+| 2 | `ADD_USER_MESSAGE` | sets `isStreaming: false` on message | message has `role: 'user'` |
+| 3 | `ADD_ASSISTANT_MESSAGE` | dispatch with id, timestamp | messages has new assistant msg, `isStreaming: true`, empty blocks |
+| 4 | `CHAT_EVENT` | prev: has assistant msg; dispatch event | delegates to `handleChatEvent`, message updated |
+| 5 | `CHAT_EVENT` — message not found | wrong messageId | state unchanged |
+| 6 | `SET_AGENT_STATUS` | dispatch with AgentStatus | `state.agentStatus` updated |
+| 7 | `SET_AVAILABLE_MODELS` | dispatch with ModelInfo[] | `state.availableModels` updated |
+| 8 | `SET_SELECTED_MODEL` | dispatch with model id | `state.selectedModel` updated |
+| 9 | `SET_SELECTED_MODEL` — null clears selection | dispatch null | `state.selectedModel === null` |
+| 10 | `SET_ACTIVE_VIEW` | dispatch 'chat' | `state.activeView === 'chat'` |
+| 11 | `SET_ACTIVE_VIEW` — custom lens view | dispatch 'briefing-1' | `state.activeView === 'briefing-1'` |
+| 12 | `SET_DISCOVERED_VIEWS` | dispatch LensViewManifest[] | `state.discoveredViews` updated |
+| 13 | `SHOW_LANDING` | dispatch | `state.showLanding === true` |
+| 14 | `HIDE_LANDING` | dispatch | `state.showLanding === false` |
+| 15 | `CLEAR_MESSAGES` | prev: 3 messages; dispatch | `state.messages` is empty array |
+| 16 | `NEW_CONVERSATION` | prev: messages + streaming; dispatch | messages cleared, isStreaming false, new conversationId |
+| 17 | `NEW_CONVERSATION` — generates new conversationId | compare before/after | IDs differ |
+| 18 | Unknown action type | dispatch `{ type: 'BOGUS' }` | state returned unchanged |
+
+### Phase 1 success criteria
+- `src/test/helpers.ts` exists and exports all factories listed above
+- `handleChatEvent`, `appReducer`, `initialState`, `AppState`, `AppAction` are exported from `store.tsx`
+- `store.reducer.test.ts` has ~38 passing tests covering every event type and every action type
+- Existing 17 tests still pass
+- `npm run test` green
+
+---
+
+## Phase 2 — Main Process Pure Functions & Services
+
+### Why second
+These are pure functions and classes in the main process with zero React/DOM deps. They establish patterns for `vi.mock('fs')` and class-level testing. Each file is independently testable and independently committable.
+
+### 2A. MindScaffold pure methods — `src/main/services/MindScaffold.test.ts`
+
+**Environment:** node (default — no jsdom comment)
+
+| # | Function | Scenario | Assertion |
+|---|----------|----------|-----------|
+| 1 | `slugify` | simple name → `'my-agent'` | lowercase, spaces → hyphens |
+| 2 | `slugify` | special chars → stripped | `'Hello World!'` → `'hello-world'` |
+| 3 | `slugify` | leading/trailing hyphens trimmed | `'--test--'` → `'test'` |
+| 4 | `slugify` | consecutive hyphens collapsed | `'a---b'` → `'a-b'` |
+| 5 | `slugify` | unicode/emoji stripped | `'café ☕'` → `'caf'` or `'caf-'` (verify actual) |
+| 6 | `slugify` | empty string | returns `''` |
+| 7 | `getDefaultBasePath` | returns `os.homedir()/agents` | `path.join(os.homedir(), 'agents')` |
+| 8 | `validate` — valid mind | create temp dir with IDEA folders + .github | `{ ok: true, missing: [] }` |
+| 9 | `validate` — missing folders | partial structure | `ok: false`, `missing` lists the gaps |
+| 10 | `validate` — nonexistent path | random path | `ok: false` |
+
+~10 tests. Mock `fs` for validate tests OR use real temp directories.
+
+### 2B. AuthService helpers — `src/main/services/AuthService.test.ts`
+
+**Source change required:** Export the three module-level helpers from `AuthService.ts`:
+```ts
+export { getCredentialAccount, getLoginFromAccount, resolveStoredCredential };
+```
+
+**Tests:**
+
+| # | Function | Scenario | Assertion |
+|---|----------|----------|-----------|
+| 1 | `getCredentialAccount` | `'alice'` | `'https://github.com:alice'` (or whatever the prefix is — verify actual `GITHUB_ACCOUNT_PREFIX`) |
+| 2 | `getCredentialAccount` | empty string | returns prefix only |
+| 3 | `getLoginFromAccount` | valid account string | extracts login |
+| 4 | `getLoginFromAccount` | wrong prefix | returns `null` |
+| 5 | `getLoginFromAccount` | empty string | returns `null` |
+| 6 | `resolveStoredCredential` | one valid cred | returns `{ login, account, password }` |
+| 7 | `resolveStoredCredential` | multiple valid creds | returns first, warns via console |
+| 8 | `resolveStoredCredential` | no valid creds | returns `null` |
+| 9 | `resolveStoredCredential` | empty array | returns `null` |
+
+~9 tests.
+
+### 2C. ExtensionLoader — `src/main/services/ExtensionLoader.test.ts`
+
+**Mocks:** `vi.mock('fs')` for `existsSync`, `readdirSync`.
+
+| # | Method | Scenario | Assertion |
+|---|--------|----------|-----------|
+| 1 | `registerAdapter` | register one adapter | `getLoadedExtensions()` empty until `loadTools` |
+| 2 | `registerAdapter` | register multiple adapters | all tracked |
+| 3 | `discoverExtensions` | mindPath has `.github/extensions/` with subdirs | returns extension names |
+| 4 | `discoverExtensions` | no extensions dir | returns `[]` |
+| 5 | `discoverExtensions` | extensions dir is empty | returns `[]` |
+| 6 | `loadTools` | adapter returns tools | tools aggregated, `getLoadedExtensions` updated |
+| 7 | `loadTools` | adapter throws | error handled gracefully, other adapters still run |
+| 8 | `loadTools` | no registered adapters | returns `[]` |
+| 9 | `getLoadedExtensions` | after loadTools | returns loaded extension names |
+| 10 | `cleanup` | calls cleanup on adapters | adapters' cleanup invoked |
+
+~10 tests.
+
+### 2D. loadConfig / saveConfig — `src/main/ipc/agent.test.ts`
+
+**Mocks:** `vi.mock('fs')` for `existsSync`, `readFileSync`, `writeFileSync`, `mkdirSync`.
+
+| # | Function | Scenario | Assertion |
+|---|----------|----------|-----------|
+| 1 | `loadConfig` | config file exists | returns parsed JSON |
+| 2 | `loadConfig` | config file missing | returns default `{ mindPath: null, theme: 'dark' }` |
+| 3 | `loadConfig` | config file has invalid JSON | returns default (graceful) |
+| 4 | `saveConfig` | writes JSON to path | `writeFileSync` called with stringified config |
+| 5 | `saveConfig` | creates directory if missing | `mkdirSync` called with `{ recursive: true }` |
+
+~5 tests.
+
+### Phase 2 success criteria
+- 4 new test files, ~34 passing tests
+- `AuthService.ts` exports the three helper functions
+- All 51+ total tests pass (17 existing + 34 new)
+- `npm run test` green
+
+---
+
+## Phase 3 — Presentational Components
+
+### Why third
+These components are pure data→UI with minimal dependencies. They establish `@testing-library/react` patterns and the `installElectronAPI()` helper usage for all subsequent component tests. Start simple, build confidence.
+
+### 3A. WelcomeScreen — `src/renderer/components/chat/WelcomeScreen.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | renders when connected | shows starter prompt buttons |
+| 2 | renders when disconnected | shows "not connected" message, no prompt buttons |
+| 3 | clicking a starter prompt | calls `onSendMessage` with the prompt text |
+| 4 | renders Chamber title/branding | title text present |
+
+~4 tests.
+
+### 3B. LandingScreen — `src/renderer/components/genesis/LandingScreen.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | renders two action buttons | "New Agent" and "Open Existing" visible |
+| 2 | clicking New Agent | calls `onNewAgent` |
+| 3 | clicking Open Existing | calls `onOpenExisting` |
+| 4 | renders title/branding | Chamber title present |
+
+~4 tests.
+
+### 3C. TypeWriter — `src/renderer/components/genesis/TypeWriter.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+> Uses `vi.useFakeTimers()`.
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | progressively reveals text | after N intervals, shows first N characters |
+| 2 | calls onComplete when done | after `text.length * speed` ms, callback fired |
+| 3 | shows cursor during animation | cursor character (▊) visible while animating |
+| 4 | hides cursor after completion | cursor gone (or `cursor={false}` hides it always) |
+| 5 | respects speed prop | faster speed = fewer ticks to complete |
+| 6 | text change restarts animation | update `text` prop, animation resets |
+
+~6 tests. Remember `vi.advanceTimersByTime(ms)` and `cleanup` with `vi.useRealTimers()`.
+
+### 3D. ToolBlock — `src/renderer/components/chat/ToolBlock.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | shows tool name | `screen.getByText('readFile')` |
+| 2 | running status shows spinner/badge | status badge text = 'running' |
+| 3 | done status shows check icon/badge | status badge text = 'done' |
+| 4 | error status shows X icon/badge | status badge text = 'error' |
+| 5 | output displayed when present | pre text contains output |
+| 6 | error text displayed when present | error content visible |
+
+~6 tests. Use `makeToolCallBlock()` from helpers.
+
+### 3E. ReasoningBlock — `src/renderer/components/chat/ReasoningBlock.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | streaming shows "Thinking…" label | text present |
+| 2 | non-streaming shows "Thought" label | text present |
+| 3 | renders reasoning content | content text visible |
+| 4 | collapsible toggle works | click expands/collapses |
+
+~4 tests.
+
+### 3F. StreamingMessage — `src/renderer/components/chat/StreamingMessage.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+> **Mock `react-markdown`** as a passthrough: `vi.mock('react-markdown', () => ({ default: ({ children }: any) => <div>{children}</div> }))` to avoid jsdom rendering issues.
+> Also mock `remark-gfm`: `vi.mock('remark-gfm', () => ({ default: () => {} }))`.
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | empty blocks + streaming | shows thinking dots animation |
+| 2 | text block renders content | text visible in DOM |
+| 3 | tool_call block renders ToolBlock | ToolBlock component renders |
+| 4 | reasoning block renders ReasoningBlock | ReasoningBlock component renders |
+| 5 | multiple block types render in order | all blocks present |
+| 6 | not streaming, no blocks | renders empty (no thinking dots) |
+| 7 | streaming after non-text block | shows trailing indicator |
+
+~7 tests.
+
+### 3G. Lens view components
+
+All follow the same pattern: `/** @vitest-environment jsdom */`, receive `data` and optional `schema` props.
+
+#### `LensBriefing.test.tsx` (~5 tests)
+| # | Scenario |
+|---|----------|
+| 1 | renders cards for each data key |
+| 2 | numbers display large/bold |
+| 3 | schema titles override key names |
+| 4 | arrays joined with commas |
+| 5 | empty data renders gracefully |
+
+#### `LensTable.test.tsx` (~5 tests)
+| # | Scenario |
+|---|----------|
+| 1 | single-row object renders as table |
+| 2 | array data renders multiple rows |
+| 3 | columns derived from schema when present |
+| 4 | columns derived from first row data keys |
+| 5 | empty data shows "No data" message |
+
+#### `LensStatusBoard.test.tsx` (~6 tests)
+
+**Source change recommended:** Export `getStatusVariant` and `getStatusDot` as named exports for direct testing. If not exported, test via rendered output.
+
+| # | Scenario |
+|---|----------|
+| 1 | 'running' / 'ok' / 'active' → green variant |
+| 2 | 'error' / 'fail' / 'down' → red variant |
+| 3 | 'warn' / 'pending' → yellow variant |
+| 4 | unknown status → default variant |
+| 5 | renders status dot emoji matching variant |
+| 6 | shows up to 3 metadata fields, truncates |
+
+#### `LensDetail.test.tsx` (~4 tests)
+| # | Scenario |
+|---|----------|
+| 1 | extracts title/description/status |
+| 2 | renders metadata key-value pairs |
+| 3 | status badge variant logic |
+| 4 | schema title overrides data key names |
+
+#### `LensTimeline.test.tsx` (~4 tests)
+| # | Scenario |
+|---|----------|
+| 1 | renders timeline items with dots |
+| 2 | field fallback: title→name→event |
+| 3 | field fallback: time→timestamp→date→created_at |
+| 4 | handles items without optional fields |
+
+#### `LensEditor.test.tsx` (~6 tests)
+| # | Scenario |
+|---|----------|
+| 1 | renders form fields from data |
+| 2 | changing input enables Save button |
+| 3 | Save button disabled when not dirty |
+| 4 | clicking Save calls onSave with updates |
+| 5 | enum schema renders select dropdown |
+| 6 | boolean schema renders checkbox |
+
+### Phase 3 success criteria
+- ~12 new test files, ~61 passing tests
+- All lens view components tested
+- All chat display components tested
+- `react-markdown` mock pattern established
+- `vi.useFakeTimers()` pattern established for TypeWriter
+- Total: ~112 tests passing
+- `npm run test` green
+
+---
+
+## Phase 4 — Interactive Components, Gates & Hooks
+
+### Why fourth
+These require the `mockElectronAPI` factory, context providers, and `renderHook` — patterns established in prior phases. They also test async flows (useEffect → API call → state update) which are more complex to get right.
+
+### 4A. ChatInput — `src/renderer/components/chat/ChatInput.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | typing updates textarea value | `fireEvent.change` → value updated |
+| 2 | Enter key submits non-empty text | `onSend` called with text, textarea cleared |
+| 3 | Enter on empty text does not submit | `onSend` not called |
+| 4 | Shift+Enter inserts newline | `onSend` not called, newline in value |
+| 5 | disabled prop disables textarea | textarea has `disabled` attribute |
+| 6 | streaming shows stop button | stop icon visible, send icon hidden |
+| 7 | clicking stop calls onStop | `onStop` called |
+| 8 | model selector renders models | options match `availableModels` prop |
+
+~8 tests.
+
+### 4B. AuthGate — `src/renderer/components/auth/AuthGate.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+> Requires `installElectronAPI()`.
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | loading state shows blank screen | no children visible initially |
+| 2 | authenticated → renders children | `await waitFor(() => screen.getByText('child'))` |
+| 3 | not authenticated → renders AuthScreen | `await waitFor(() => screen.getByText(/* auth screen text */))` |
+| 4 | API error → handles gracefully | no crash |
+
+~4 tests. Mock `auth.getStatus` to resolve `{ authenticated: true/false }`.
+
+### 4C. GenesisGate — `src/renderer/components/genesis/GenesisGate.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+> Requires `installElectronAPI()` and `AppStateProvider` wrapper.
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | connected agent → renders children | children visible |
+| 2 | not connected + showLanding → renders LandingScreen | landing buttons visible |
+| 3 | "New Agent" click → shows GenesisFlow | genesis flow UI appears |
+| 4 | "Open Existing" click → triggers file dialog | `selectMindDirectory` called |
+
+~4 tests.
+
+### 4D. ViewRouter — `src/renderer/components/layout/ViewRouter.test.tsx`
+
+> `/** @vitest-environment jsdom */`
+> Requires `AppStateProvider` wrapper with controlled state.
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | activeView='chat' → renders ChatPanel | ChatPanel content visible |
+| 2 | activeView=discovered view id → renders LensViewRenderer | LensViewRenderer rendered |
+| 3 | activeView=unknown id → falls back to ChatPanel | ChatPanel as fallback |
+
+~3 tests. May need to mock ChatPanel and LensViewRenderer as simple stubs.
+
+### 4E. useChatStreaming hook — `src/renderer/hooks/useChatStreaming.test.ts`
+
+> `/** @vitest-environment jsdom */`
+> Uses `renderHook` from `@testing-library/react` with `AppStateProvider` wrapper.
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | sendMessage dispatches ADD_USER_MESSAGE + ADD_ASSISTANT_MESSAGE | check state after call |
+| 2 | sendMessage calls electronAPI.chat.send | `chat.send` called with conversationId, content, model |
+| 3 | sendMessage no-ops when already streaming | `chat.send` not called |
+| 4 | stopStreaming calls electronAPI.chat.stop | `chat.stop` called |
+| 5 | isStreaming reflects app state | matches `state.isStreaming` |
+
+~5 tests.
+
+### 4F. useAgentStatus hook — `src/renderer/hooks/useAgentStatus.test.ts`
+
+> `/** @vitest-environment jsdom */`
+> Uses `renderHook` with `AppStateProvider` wrapper.
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | fetches initial status on mount | `agent.getStatus` called |
+| 2 | dispatches SET_AGENT_STATUS with result | state updated |
+| 3 | subscribes to onStatusChanged | `agent.onStatusChanged` called |
+| 4 | unsubscribes on unmount | cleanup function called |
+| 5 | selectMindDirectory triggers dialog + status refresh | `agent.selectMindDirectory` called |
+
+~5 tests.
+
+### Phase 4 success criteria
+- 6 new test files, ~29 passing tests
+- `renderHook` pattern established for hooks
+- `installElectronAPI()` + `AppStateProvider` wrapper pattern validated
+- Gate components tested with async auth/status flows
+- Total: ~141 tests passing
+- `npm run test` green
+
+---
+
+## Phase 5 — ViewDiscovery Service & Polish
+
+### Why last
+`ViewDiscovery` has deeper fs dependencies and requires a ChatService mock. It's medium priority and depends on patterns from Phase 2. This phase also covers any remaining gaps and ensures coverage parity.
+
+### 5A. ViewDiscovery — `src/main/services/ViewDiscovery.test.ts`
+
+**Mocks:** `vi.mock('fs')` for `existsSync`, `readdirSync`, `readFileSync`, `writeFileSync`, `mkdirSync`, `watch`.
+**ChatService mock:** `{ sendPrompt: vi.fn() }` or whatever the interface requires.
+
+| # | Method | Scenario | Assertion |
+|---|--------|----------|-----------|
+| 1 | `scan` | `.github/lens/` has view dirs with `view.json` | returns parsed manifests with ids |
+| 2 | `scan` | no lens dir | returns `[]` |
+| 3 | `scan` | empty lens dir | seeds defaults, returns seeded manifests |
+| 4 | `scan` | invalid `view.json` | skips bad entries |
+| 5 | `getViews` | after scan | returns cached manifests |
+| 6 | `getViews` | before scan | returns `[]` |
+| 7 | `getViewData` | valid viewId | reads + parses data file |
+| 8 | `getViewData` | unknown viewId | returns `null` |
+| 9 | `getViewData` | data file missing | returns `null` |
+| 10 | `stopWatching` | after startWatching | closes watcher |
+
+~10 tests.
+
+### 5B. Gap sweep
+
+Review coverage report (`npm run test:coverage`) and add tests for any critical gaps discovered. Likely candidates:
+
+- **`getPlainContent` edge cases** — add to existing `store.test.ts` if any new edge cases surfaced
+- **`AppStateProvider` integration** — verify context provides state and dispatch correctly (1-2 tests in `store.reducer.test.ts`)
+
+### Phase 5 success criteria
+- 1-2 new test files, ~12 passing tests
+- ViewDiscovery core logic covered
+- Total: ~153+ tests passing
+- `npm run test` and `npm run test:coverage` green
+- Coverage report shows meaningful improvement over baseline
+
+---
+
+## Summary
+
+| Phase | Focus | New Tests | New Files | Source Changes |
+|-------|-------|-----------|-----------|----------------|
+| 1 | Test infra + store reducer | ~41 | 3 | Export `handleChatEvent`, `appReducer`, `initialState`, types from `store.tsx` |
+| 2 | Main process pure functions | ~34 | 4 | Export 3 helpers from `AuthService.ts` |
+| 3 | Presentational components | ~61 | 12 | Optionally export `getStatusVariant`/`getStatusDot` from `LensStatusBoard.tsx` |
+| 4 | Interactive + gates + hooks | ~29 | 6 | None |
+| 5 | ViewDiscovery + polish | ~12 | 1-2 | None |
+| **Total** | | **~177** | **~27** | **3 files touched** |
+
+### Execution notes
+
+- Each phase is independently committable and independently valuable.
+- Run `npm run test` after each phase to confirm no regressions.
+- The implementer should read the specific source file before writing each test to catch any discrepancies with this plan (functions may have been renamed or refactored since the research was done).
+- Mock `react-markdown` and `remark-gfm` in any test that renders markdown content — jsdom doesn't handle them cleanly.
+- All renderer test files need `/** @vitest-environment jsdom */` as the first line.
+- Use `@/` path alias in imports (configured in vitest config).

--- a/.testagent/research.md
+++ b/.testagent/research.md
@@ -1,0 +1,407 @@
+# Test Generation Research
+
+## Project Overview
+
+- **Path**: `C:\src\chamber`
+- **Language**: TypeScript (strict)
+- **Framework**: Electron 41 (main process: Node.js, renderer: React 19)
+- **Build**: Electron Forge + Vite (separate configs for main, preload, renderer)
+- **Test Framework**: Vitest 4.1.4 + jsdom 29 + @testing-library/react 16 + @testing-library/jest-dom 6
+- **UI**: Tailwind CSS 4, Radix UI primitives, Lucide icons, class-variance-authority
+- **State**: React Context + `useReducer` (no external state lib)
+- **Markdown**: react-markdown + remark-gfm
+- **Description**: "Chamber" — desktop chat UI for Genesis agents, powered by @github/copilot-sdk
+
+## Build & Test Commands
+
+| Command | Purpose |
+|---------|---------|
+| `npm run test` | `vitest run` — run all tests once |
+| `npm run test:watch` | `vitest` — watch mode |
+| `npm run test:coverage` | `vitest run --coverage` (v8 provider) |
+| `npm run test:ui` | `vitest --ui` |
+| `npm run lint` | `eslint --ext .ts,.tsx .` |
+| `npm run start` | `electron-forge start` (dev mode) |
+
+## Vitest Configuration
+
+- **Default environment**: `node` (main process / shared code)
+- **Renderer tests**: opt-in `jsdom` via `/** @vitest-environment jsdom */` file-level comment
+- **Path alias**: `@/` → `./src`
+- **Test glob**: `src/**/*.{test,spec}.{ts,tsx}` and `test/**/*.{test,spec}.{ts,tsx}`
+- **Timeouts**: 10s for both test and hook
+
+## Project Structure
+
+```
+src/
+├── main.ts                          # Electron main entry — creates BrowserWindow, wires IPC
+├── preload.ts                       # contextBridge — exposes electronAPI to renderer
+├── renderer.tsx                     # React entry — createRoot + <App />
+├── index.css                        # Tailwind theme + scrollbar styles
+├── main/
+│   ├── ipc/
+│   │   ├── agent.ts                 # agent:* + config:* IPC handlers, loadConfig/saveConfig
+│   │   ├── auth.ts                  # auth:* IPC handlers
+│   │   ├── chat.ts                  # chat:* IPC handlers
+│   │   ├── genesis.ts               # genesis:* IPC handlers
+│   │   └── lens.ts                  # lens:* IPC handlers
+│   ├── services/
+│   │   ├── AuthService.ts           # GitHub device flow OAuth + keytar credential storage
+│   │   ├── ChatService.ts           # SDK session management, message streaming
+│   │   ├── ExtensionLoader.ts       # Discovers & loads mind extensions via adapters
+│   │   ├── MindScaffold.ts          # Genesis flow — creates mind directory structure
+│   │   ├── SdkLoader.ts             # Singleton CopilotClient — SDK bootstrap, path resolution
+│   │   ├── ViewDiscovery.ts         # Lens view scanning, data loading, prompt refresh
+│   │   └── adapters/
+│   │       ├── canvas.ts            # Canvas extension adapter
+│   │       ├── cron.ts              # Cron extension adapter
+│   │       └── idea.ts              # IDEA extension adapter (child-process Node)
+│   └── assets/
+│       └── lens-skill/              # Bundled SKILL.md for auto-install
+├── renderer/
+│   ├── App.tsx                      # Root: AppStateProvider → AuthGate → GenesisGate → AppShell
+│   ├── lib/
+│   │   ├── utils.ts                 # cn(), generateId(), formatTime()
+│   │   ├── utils.test.ts            # ✅ 9 tests
+│   │   ├── store.tsx                # AppState context, reducer, getPlainContent()
+│   │   └── store.test.ts            # ✅ 4 tests
+│   ├── hooks/
+│   │   ├── useAgentStatus.ts        # Fetches + subscribes to agent status
+│   │   ├── useAppSubscriptions.ts   # Chat events, lens views, model loading
+│   │   └── useChatStreaming.ts      # sendMessage + stopStreaming via electronAPI
+│   └── components/
+│       ├── auth/
+│       │   ├── AuthGate.tsx          # Checks auth status, shows AuthScreen if needed
+│       │   └── AuthScreen.tsx        # Device flow login UI
+│       ├── chat/
+│       │   ├── ChatPanel.tsx         # Composes MessageList + ChatInput + WelcomeScreen
+│       │   ├── ChatInput.tsx         # Textarea + model selector + send/stop button
+│       │   ├── MessageList.tsx       # Auto-scrolling message list
+│       │   ├── StreamingMessage.tsx  # Renders ContentBlock[] (text/tool/reasoning)
+│       │   ├── ToolBlock.tsx         # Collapsible tool call display
+│       │   ├── ReasoningBlock.tsx    # Collapsible reasoning display
+│       │   └── WelcomeScreen.tsx     # Starter prompts grid
+│       ├── genesis/
+│       │   ├── GenesisGate.tsx       # Shows landing or genesis flow if no mind connected
+│       │   ├── GenesisFlow.tsx       # Multi-stage: void → voice → role → boot → done
+│       │   ├── VoidScreen.tsx        # Boot text animation
+│       │   ├── VoiceScreen.tsx       # Voice/persona picker
+│       │   ├── RoleScreen.tsx        # Role picker (Chief of Staff, etc.)
+│       │   ├── BootScreen.tsx        # Genesis progress display
+│       │   ├── LandingScreen.tsx     # New Agent / Open Existing
+│       │   ├── NameScreen.tsx        # Name input (unused in current flow)
+│       │   └── TypeWriter.tsx        # Character-by-character text animation
+│       ├── layout/
+│       │   ├── AppShell.tsx          # Main layout: ActivityBar + SidePanel + ViewRouter
+│       │   ├── ActivityBar.tsx       # Icon sidebar for view switching
+│       │   ├── SidePanel.tsx         # Contextual sidebar (chat actions / lens info)
+│       │   ├── Sidebar.tsx           # Legacy sidebar (appears unused)
+│       │   └── ViewRouter.tsx        # Routes activeView to ChatPanel or LensViewRenderer
+│       ├── views/
+│       │   ├── LensViewRenderer.tsx  # Loads view data, handles refresh/action, routes to view type
+│       │   ├── HelloWorldView.tsx    # Debug/placeholder view
+│       │   ├── LensBriefing.tsx      # Card grid briefing view
+│       │   ├── LensTable.tsx         # Table view
+│       │   ├── LensStatusBoard.tsx   # Status card grid
+│       │   ├── LensDetail.tsx        # Single-item detail card
+│       │   ├── LensTimeline.tsx      # Timeline/feed view
+│       │   └── LensEditor.tsx        # Editable form view with save
+│       └── ui/                       # shadcn/Radix UI primitives
+│           ├── badge.tsx
+│           ├── card.tsx
+│           ├── collapsible.tsx
+│           ├── scroll-area.tsx
+│           ├── select.tsx
+│           ├── separator.tsx
+│           ├── table.tsx
+│           └── tooltip.tsx
+└── shared/
+    ├── types.ts                      # All shared types (ChatMessage, ChatEvent, ContentBlock, etc.)
+    ├── createIpcListener.ts          # IPC listener factory with cleanup
+    └── createIpcListener.test.ts     # ✅ 4 tests
+```
+
+## Existing Tests (17 passing)
+
+### 1. `src/shared/createIpcListener.test.ts` — 4 tests
+- Registers listener on channel ✅
+- Forwards events without IpcRendererEvent object ✅
+- Returns unsubscribe function ✅
+- Stops receiving after unsubscribe ✅
+- **Pattern**: Mock `IpcRenderer` with `on`/`removeListener` + helper `_emit`, uses `vi.fn()`
+
+### 2. `src/renderer/lib/utils.test.ts` — 9 tests (no jsdom comment — runs in node)
+- `cn()`: merges classes, handles conditionals, deduplicates Tailwind conflicts, empty input
+- `generateId()`: non-empty string, unique IDs, timestamp-random format
+- `formatTime()`: formatted output, fixed timestamp
+- **Pattern**: Pure function testing, no mocks needed
+
+### 3. `src/renderer/lib/store.test.ts` — 4 tests (`@vitest-environment jsdom`)
+- `getPlainContent()`: extracts text blocks, ignores non-text, empty blocks
+- **Pattern**: Helper `makeMessage()` factory, tests exported pure function only (not reducer/context)
+
+### What's NOT Covered
+
+| Area | Gap |
+|------|-----|
+| **store.tsx reducer** | `handleChatEvent()` (complex switch over 8 event types), `appReducer()` (12 action types) — the core state machine is untested |
+| **All React components** | Zero component render tests |
+| **All custom hooks** | `useAgentStatus`, `useAppSubscriptions`, `useChatStreaming` — untested |
+| **Main process services** | `ExtensionLoader`, `MindScaffold` (pure logic portions), `AuthService` (pure helpers), `ViewDiscovery` |
+| **IPC handlers** | `loadConfig`/`saveConfig` in agent.ts — pure fs functions |
+| **Preload bridge** | `preload.ts` — structural, low value |
+| **Shared types** | `types.ts` — type-only, no runtime logic |
+
+## Files to Test
+
+### High Priority
+
+| File | Exports to Test | Testability | Notes |
+|------|-----------------|-------------|-------|
+| `src/renderer/lib/store.tsx` | `handleChatEvent()`, `appReducer()` | **High** | Pure reducer functions. `handleChatEvent` is the most complex logic in the app — 8 event types mutating message blocks. `appReducer` handles 12 action types. Both are pure `(state, action) → state`. The existing test only covers `getPlainContent`. |
+| `src/main/services/ExtensionLoader.ts` | `ExtensionLoader.registerAdapter()`, `discoverExtensions()`, `loadTools()`, `getLoadedExtensions()`, `cleanup()` | **High** | Class with injectable adapter functions. `discoverExtensions()` reads fs but is easily mockable. Core logic is adapter registration + orchestration. No Electron deps. |
+| `src/main/services/MindScaffold.ts` | `MindScaffold.slugify()`, `MindScaffold.getDefaultBasePath()`, `validate()` | **High** | `slugify()` and `getDefaultBasePath()` are pure static methods. `validate()` reads fs but structure is simple. `createStructure()` is fs.mkdir calls — mockable. Skip `generateSoul()` and `bootstrapCapabilities()` (SDK + network deps). |
+| `src/renderer/components/chat/WelcomeScreen.tsx` | Render, starter prompts, callback | **High** | Simple presentational component. Tests: renders prompts when connected, shows directory message when not, calls `onSendMessage` on click. No external deps beyond props. |
+| `src/renderer/components/genesis/TypeWriter.tsx` | Character animation, onComplete | **High** | Self-contained component with timer logic. Tests: progressive reveal, completion callback, cursor display. Uses `setInterval` — use `vi.useFakeTimers()`. |
+| `src/renderer/components/genesis/LandingScreen.tsx` | Render, button callbacks | **High** | Pure presentational. Two buttons, two callbacks. Trivial to test. |
+
+### Medium Priority
+
+| File | Exports to Test | Testability | Notes |
+|------|-----------------|-------------|-------|
+| `src/renderer/components/chat/StreamingMessage.tsx` | Block rendering, thinking indicator | **Medium** | Renders `ContentBlock[]` — text (Markdown), tool calls, reasoning. Tests: empty+streaming shows dots, text blocks render, tool blocks render `ToolBlock`, reasoning renders. Needs `react-markdown` + `remark-gfm` in jsdom (may need mocking). |
+| `src/renderer/components/chat/ChatInput.tsx` | Submit, keyboard, disabled states | **Medium** | Controlled textarea + submit logic. Tests: Enter sends, Shift+Enter doesn't, disabled state, stop button when streaming. Needs mock for model `Select` (Radix). |
+| `src/renderer/components/chat/ToolBlock.tsx` | Collapsible tool display, status icons | **Medium** | Takes a `ToolCallBlock` prop. Tests: shows tool name, status badge, expandable output/error. Uses Radix Collapsible. |
+| `src/renderer/components/chat/ReasoningBlock.tsx` | Collapsible reasoning display | **Medium** | Similar to ToolBlock. Simple prop → render. |
+| `src/renderer/components/auth/AuthGate.tsx` | Auth check flow | **Medium** | Calls `window.electronAPI.auth.getStatus()` in useEffect. Tests: shows children when authenticated, shows AuthScreen when not. Needs `window.electronAPI` mock. |
+| `src/renderer/components/genesis/GenesisGate.tsx` | Gate logic | **Medium** | Shows landing or genesis flow based on state. Needs `AppStateProvider` + `window.electronAPI` mock. |
+| `src/renderer/components/layout/ViewRouter.tsx` | View routing | **Medium** | Routes `activeView` to ChatPanel or LensViewRenderer. Simple switch logic. Needs AppState context. |
+| `src/renderer/components/views/LensBriefing.tsx` | Card rendering from data+schema | **Medium** | Pure presentational. Maps data keys → Card components. Tests: renders all keys, uses schema titles, handles numbers vs strings. |
+| `src/renderer/components/views/LensTable.tsx` | Table rendering | **Medium** | Renders data as table. Tests: derives columns from schema or data, formats cells. |
+| `src/renderer/components/views/LensStatusBoard.tsx` | Status cards + status detection | **Medium** | `getStatusVariant()` and `getStatusDot()` are testable pure functions (currently not exported). Card rendering from data. |
+| `src/renderer/components/views/LensDetail.tsx` | Detail card rendering | **Medium** | Pure presentational from props. |
+| `src/renderer/components/views/LensTimeline.tsx` | Timeline rendering | **Medium** | Pure presentational from props. |
+| `src/renderer/components/views/LensEditor.tsx` | Form editing + dirty tracking | **Medium** | Stateful form. Tests: renders fields, tracks dirty state, calls onSave with updates. |
+| `src/renderer/hooks/useChatStreaming.ts` | sendMessage, stopStreaming | **Medium** | Calls `electronAPI.chat.send/stop`. Needs AppState context + electronAPI mock. Consider `renderHook` from @testing-library/react. |
+| `src/renderer/hooks/useAgentStatus.ts` | Status fetch + subscribe | **Medium** | Calls `electronAPI.agent.getStatus()` + `onStatusChanged`. Needs context + mock. |
+| `src/main/ipc/agent.ts` | `loadConfig()`, `saveConfig()` | **Medium** | Pure fs read/write to `~/.chamber/config.json`. Mockable with `vi.mock('fs')` or temp dir. |
+| `src/main/services/AuthService.ts` | `getLoginFromAccount()`, `getCredentialAccount()`, `resolveStoredCredential()` | **Medium** | Three pure helper functions (currently not exported). If exported, they're trivially testable. The class methods depend on keytar + https — harder. |
+| `src/main/services/ViewDiscovery.ts` | `scan()`, `getViews()`, `getViewData()` | **Medium** | Reads fs for view.json manifests. Mockable. `seedDefaults()` and `installLensSkill()` write files. Core scan logic is testable with mock fs. Depends on `BrowserWindow` only in `startWatching`. |
+
+### Low Priority / Skip
+
+| File | Reason |
+|------|--------|
+| `src/main.ts` | Electron app lifecycle — tightly coupled to `app`, `BrowserWindow`, `ipcMain`. Integration-only. |
+| `src/preload.ts` | Thin bridge — every method is a one-liner delegating to `ipcRenderer.invoke/send/on`. No logic. |
+| `src/renderer.tsx` | `createRoot` + `<App />` — entry point, no logic. |
+| `src/index.css` | CSS — not testable. |
+| `src/shared/types.ts` | Type-only file, no runtime code. |
+| `src/main/services/SdkLoader.ts` | Deep Electron + npm + fs + child_process integration. Singleton with module-level state. Too tightly coupled for unit tests. |
+| `src/main/services/ChatService.ts` | Depends on CopilotClient SDK sessions. Would need full SDK mock. Core streaming logic is complex but integration-heavy. |
+| `src/main/services/adapters/canvas.ts` | Dynamic ESM import from mind directory. Requires actual extension files. |
+| `src/main/services/adapters/cron.ts` | Same — dynamic import of extension modules. |
+| `src/main/services/adapters/idea.ts` | Spawns child process with system Node. Integration-only. |
+| `src/main/ipc/auth.ts` | Thin wiring — delegates to AuthService. 15 lines of Electron glue. |
+| `src/main/ipc/chat.ts` | Thin wiring — delegates to ChatService. |
+| `src/main/ipc/genesis.ts` | Thin wiring — delegates to MindScaffold. |
+| `src/main/ipc/lens.ts` | Thin wiring — 4 one-liner handlers delegating to ViewDiscovery. |
+| `src/renderer/components/ui/*.tsx` | Third-party shadcn/Radix primitives. Not project code. |
+| `src/renderer/components/layout/Sidebar.tsx` | Appears unused (replaced by SidePanel + ActivityBar). |
+| `src/renderer/components/genesis/NameScreen.tsx` | Not used in current GenesisFlow (voice screen replaced it). |
+| `src/renderer/components/layout/AppShell.tsx` | Thin composition — renders ActivityBar + SidePanel + ViewRouter. |
+| `src/renderer/components/layout/ActivityBar.tsx` | UI-heavy, Tooltip-heavy. Low logic density. |
+| `src/renderer/components/layout/SidePanel.tsx` | UI-heavy. Low logic beyond display. |
+| `src/renderer/components/genesis/VoidScreen.tsx` | Animation-heavy. Timer-dependent. Low logic. |
+| `src/renderer/components/genesis/VoiceScreen.tsx` | UI-heavy card picker. Calls electronAPI. Low isolated logic. |
+| `src/renderer/components/genesis/RoleScreen.tsx` | Card picker with selection animation. Low isolated logic. |
+| `src/renderer/components/genesis/BootScreen.tsx` | Progress display. Subscribes to genesis:onProgress. Timer-heavy. |
+| `src/renderer/components/chat/ChatPanel.tsx` | Thin composition of MessageList + ChatInput + WelcomeScreen. |
+| `src/renderer/components/chat/MessageList.tsx` | Scroll handling + message iteration. Most logic is auto-scroll. |
+| `src/renderer/components/views/HelloWorldView.tsx` | Debug view. Reads state and displays. |
+| `src/renderer/components/views/LensViewRenderer.tsx` | Orchestrator with `electronAPI` calls. Medium logic but heavy integration. |
+| `src/renderer/hooks/useAppSubscriptions.ts` | Subscribes to 3 IPC channels + fetches models/views. Side-effect heavy. |
+
+## Testing Patterns (from existing tests)
+
+### 1. Environment Selection
+```typescript
+// Renderer tests requiring DOM:
+/** @vitest-environment jsdom */
+
+// Shared/main tests: no comment needed (default is 'node')
+```
+
+### 2. Imports
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+// No global setup file — vitest globals are enabled in config
+```
+
+### 3. Mock Factories
+```typescript
+// IPC mock pattern (from createIpcListener.test.ts):
+function makeMockIpcRenderer() {
+  const listeners = new Map<string, Function[]>();
+  return {
+    on: vi.fn((channel, handler) => { /* ... */ }),
+    removeListener: vi.fn((channel, handler) => { /* ... */ }),
+    _emit(channel, ...args) { /* simulate event */ },
+  } as unknown as IpcRenderer & { _emit: (...) => void };
+}
+```
+
+### 4. Test Data Factories
+```typescript
+// Message factory pattern (from store.test.ts):
+function makeMessage(blocks: ContentBlock[], overrides?: Partial<ChatMessage>): ChatMessage {
+  return { id: 'msg-1', role: 'assistant', blocks, timestamp: Date.now(), ...overrides };
+}
+```
+
+### 5. Assertions
+- Direct value comparison: `expect(result).toBe('expected')`
+- Pattern matching: `expect(result).toMatch(/\d{1,2}:\d{2}/)`
+- Spy verification: `expect(spy).toHaveBeenCalledWith('arg', expect.any(Function))`
+- Call count: `expect(callback).toHaveBeenCalledTimes(1)`
+
+## Recommendations
+
+### Priority Order for Test Generation
+
+1. **`store.tsx` reducer** — `handleChatEvent()` + `appReducer()` — the untested heart of the app. Pure functions, high complexity, high value. ~30-40 tests covering all event types and action types.
+
+2. **`ExtensionLoader.ts`** — Clean class design with injectable adapters. Mock `fs` for `discoverExtensions`, provide fake adapters for `loadTools`. ~10-15 tests.
+
+3. **`MindScaffold.ts` pure methods** — `slugify()`, `getDefaultBasePath()`, `validate()`. ~8-10 tests.
+
+4. **Presentational components** (WelcomeScreen, LandingScreen, TypeWriter) — Quick wins, high confidence. ~5-8 tests each.
+
+5. **Lens view components** (LensBriefing, LensTable, LensDetail, LensStatusBoard, LensTimeline, LensEditor) — Pure data→UI. ~5-8 tests each.
+
+6. **Chat display components** (StreamingMessage, ToolBlock, ReasoningBlock) — Medium complexity. ~5-8 tests each.
+
+7. **ChatInput** — Form behavior testing. ~6-8 tests.
+
+8. **Gate components** (AuthGate, GenesisGate) — Need electronAPI mock. ~4-6 tests each.
+
+9. **Hooks** (useChatStreaming, useAgentStatus) — Need renderHook + context + mocks. ~4-6 tests each.
+
+10. **`loadConfig`/`saveConfig`** — fs mocking. ~4 tests.
+
+### Mocking Strategy
+
+#### `window.electronAPI` (for renderer tests)
+```typescript
+// Global mock for all renderer component/hook tests:
+const mockElectronAPI = {
+  chat: {
+    send: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    newConversation: vi.fn().mockResolvedValue(undefined),
+    listModels: vi.fn().mockResolvedValue([]),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+  },
+  agent: {
+    getStatus: vi.fn().mockResolvedValue({ connected: false, mindPath: null, agentName: null, sessionActive: false, uptime: null, error: null, extensions: [] }),
+    selectMindDirectory: vi.fn().mockResolvedValue(null),
+    setMindPath: vi.fn().mockResolvedValue(undefined),
+    onStatusChanged: vi.fn().mockReturnValue(() => {}),
+  },
+  lens: {
+    getViews: vi.fn().mockResolvedValue([]),
+    getViewData: vi.fn().mockResolvedValue(null),
+    refreshView: vi.fn().mockResolvedValue(null),
+    sendAction: vi.fn().mockResolvedValue(null),
+    onViewsChanged: vi.fn().mockReturnValue(() => {}),
+  },
+  auth: {
+    getStatus: vi.fn().mockResolvedValue({ authenticated: true }),
+    startLogin: vi.fn().mockResolvedValue({ success: true }),
+    onProgress: vi.fn().mockReturnValue(() => {}),
+  },
+  genesis: {
+    getDefaultPath: vi.fn().mockResolvedValue('C:\\Users\\test\\agents'),
+    pickPath: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({ success: true }),
+    onProgress: vi.fn().mockReturnValue(() => {}),
+  },
+  config: {
+    load: vi.fn().mockResolvedValue({ mindPath: null, theme: 'dark' }),
+    save: vi.fn().mockResolvedValue(undefined),
+  },
+  window: {
+    minimize: vi.fn(),
+    maximize: vi.fn(),
+    close: vi.fn(),
+  },
+};
+
+// In beforeEach:
+Object.defineProperty(window, 'electronAPI', { value: mockElectronAPI, writable: true });
+```
+
+#### `localStorage` (for store.tsx tests in jsdom)
+jsdom provides `localStorage` automatically. No mock needed.
+
+#### `fs` module (for main process tests)
+```typescript
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+```
+
+#### `electron` module (for main process tests)
+```typescript
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(), getVersion: vi.fn().mockReturnValue('0.14.0'), isPackaged: false },
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn(), getAllWindows: vi.fn().mockReturnValue([]) },
+  dialog: { showOpenDialog: vi.fn() },
+  shell: { openExternal: vi.fn() },
+}));
+```
+
+### Framework Choices
+
+- **Renderer component tests**: `@testing-library/react` (`render`, `screen`, `fireEvent`, `waitFor`)
+- **Hook tests**: `@testing-library/react` `renderHook` with wrapper providing `AppStateProvider`
+- **Pure function tests**: Direct import + assertions
+- **Main process service tests**: `vi.mock()` for `fs`, `electron`, `child_process`
+- **Timers**: `vi.useFakeTimers()` for TypeWriter and any setTimeout-dependent code
+- **Async**: `await waitFor(() => ...)` for React state updates, direct `await` for promises
+
+### Key Architectural Notes
+
+1. **`handleChatEvent()` is not exported** — it's a module-level function in `store.tsx`. To test it, either:
+   - Export it (recommended — it's pure, deserves direct testing)
+   - Test indirectly by dispatching `CHAT_EVENT` actions through the reducer
+
+2. **`appReducer()` is not exported** — same situation. Either export or test through context. Exporting the reducer is the recommended approach for maximum test coverage.
+
+3. **AuthService pure helpers** (`getLoginFromAccount`, `getCredentialAccount`, `resolveStoredCredential`) are module-level functions, not exported. Consider exporting for testability.
+
+4. **LensStatusBoard helpers** (`getStatusVariant`, `getStatusDot`) are module-level functions, not exported. Could be extracted and tested directly.
+
+5. **`react-markdown`** in StreamingMessage may need mocking in jsdom if it doesn't render cleanly. Alternative: mock it as a passthrough `({children}) => <div>{children}</div>`.
+
+### Estimated Test Count
+
+| Category | Files | Est. Tests |
+|----------|-------|------------|
+| store.tsx reducer (handleChatEvent + appReducer) | 1 | 35-45 |
+| ExtensionLoader | 1 | 10-15 |
+| MindScaffold pure methods | 1 | 8-10 |
+| Presentational components | 3 | 15-20 |
+| Lens view components | 6 | 30-40 |
+| Chat display components | 3 | 15-20 |
+| ChatInput | 1 | 6-8 |
+| Gate components | 2 | 8-12 |
+| Hooks | 2-3 | 8-12 |
+| Config helpers | 1 | 4-6 |
+| **Total** | **~22** | **~140-190** |

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,20 +34,32 @@
         "@electron/fuses": "^1.8.0",
         "@github/copilot-sdk": "^0.2.1",
         "@tailwindcss/postcss": "^4.2.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/electron-squirrel-startup": "^1.0.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
+        "@vitest/coverage-v8": "^4.1.4",
         "autoprefixer": "^10.4.27",
         "electron": "41.2.0",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.32.0",
+        "jsdom": "^29.0.2",
         "postcss": "^8.5.9",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.7.0",
-        "vite": "^5.4.21"
+        "vite": "^5.4.21",
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -60,6 +72,284 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.9.tgz",
+      "integrity": "sha512-zd9c/Wdso6v1U7v6w3i/hbAr4K7NaSHImdpvmLt+Y9ea5BhilnIGNkfhOJ7FEIuPipAnE9tZeDOll05WDT0kgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@electron-forge/cli": {
@@ -896,6 +1186,64 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1348,6 +1696,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2095,6 +2461,25 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2481,6 +2866,16 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3981,6 +4376,270 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -4351,6 +5010,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -4699,6 +5365,82 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -4708,6 +5450,33 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
@@ -4722,6 +5491,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -4730,6 +5510,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/electron-squirrel-startup": {
       "version": "1.0.2",
@@ -5122,6 +5909,123 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@vscode/sudo-prompt": {
       "version": "9.3.2",
@@ -5537,6 +6441,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -5668,6 +6582,35 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -5808,6 +6751,16 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -6136,6 +7089,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6459,6 +7422,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
@@ -6505,11 +7475,84 @@
         "node": ">=12.10"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6581,6 +7624,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -6785,6 +7835,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7277,6 +8335,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -7868,6 +8939,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8007,6 +9088,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -8898,6 +9989,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -9475,6 +10586,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9670,6 +10788,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -9711,6 +10868,14 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -9722,6 +10887,95 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -10283,6 +11537,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -10291,6 +11556,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -10649,6 +11942,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mem": {
       "version": "4.3.0",
@@ -11302,6 +12602,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -11792,6 +13102,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12076,6 +13397,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12122,6 +13456,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pe-library": {
       "version": "1.0.1",
@@ -12313,6 +13654,36 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proc-log": {
@@ -12547,6 +13918,14 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -12805,6 +14184,20 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -13087,6 +14480,40 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -13237,6 +14664,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -13500,6 +14940,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -13731,6 +15178,20 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -13907,6 +15368,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -13999,6 +15473,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -14213,6 +15694,101 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14259,6 +15835,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -14503,6 +16092,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -14866,6 +16465,214 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
@@ -14874,6 +16681,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/watchpack": {
@@ -14964,6 +16784,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
@@ -15082,6 +16912,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -15158,6 +17005,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -15167,6 +17024,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "package": "node scripts/prepare-node-runtime.js && electron-forge package",
     "make": "node scripts/prepare-node-runtime.js && electron-forge make",
     "publish": "node scripts/prepare-node-runtime.js && electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx ."
+    "lint": "eslint --ext .ts,.tsx .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:ui": "vitest --ui"
   },
   "keywords": [],
   "author": {
@@ -30,19 +34,24 @@
     "@electron/fuses": "^1.8.0",
     "@github/copilot-sdk": "^0.2.1",
     "@tailwindcss/postcss": "^4.2.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/electron-squirrel-startup": "^1.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "autoprefixer": "^10.4.27",
     "electron": "41.2.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.32.0",
+    "jsdom": "^29.0.2",
     "postcss": "^8.5.9",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.7.0",
-    "vite": "^5.4.21"
+    "vite": "^5.4.21",
+    "vitest": "^4.1.4"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/src/main/ipc/agent.test.ts
+++ b/src/main/ipc/agent.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  dialog: { showOpenDialog: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn(), getAllWindows: vi.fn().mockReturnValue([]) },
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+import * as fs from 'fs';
+import { loadConfig, saveConfig } from './agent';
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+const mockMkdirSync = vi.mocked(fs.mkdirSync);
+
+describe('loadConfig', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns parsed config when file exists', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ mindPath: 'C:\\test\\mind', theme: 'light' }));
+    const config = loadConfig();
+    expect(config).toEqual({ mindPath: 'C:\\test\\mind', theme: 'light' });
+  });
+
+  it('returns default config when file is missing', () => {
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    const config = loadConfig();
+    expect(config).toEqual({ mindPath: null, theme: 'dark' });
+  });
+
+  it('returns default config for invalid JSON', () => {
+    mockReadFileSync.mockReturnValue('not json');
+    const config = loadConfig();
+    expect(config).toEqual({ mindPath: null, theme: 'dark' });
+  });
+});
+
+describe('saveConfig', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates directory and writes config', () => {
+    saveConfig({ mindPath: 'C:\\test', theme: 'dark' });
+    expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('config.json'),
+      expect.stringContaining('"mindPath": "C:\\\\test"'),
+    );
+  });
+});

--- a/src/main/services/AuthService.test.ts
+++ b/src/main/services/AuthService.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock electron's app module before importing AuthService helpers
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn().mockReturnValue('0.14.0'), isPackaged: false },
+}));
+
+// Mock keytar to avoid native module loading
+vi.mock('keytar', () => ({
+  findCredentials: vi.fn().mockResolvedValue([]),
+  setPassword: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getCredentialAccount, getLoginFromAccount, resolveStoredCredential } from './AuthService';
+
+describe('getCredentialAccount', () => {
+  it('prefixes login with GitHub account prefix', () => {
+    expect(getCredentialAccount('alice')).toBe('https://github.com:alice');
+  });
+
+  it('returns prefix only for empty string', () => {
+    expect(getCredentialAccount('')).toBe('https://github.com:');
+  });
+});
+
+describe('getLoginFromAccount', () => {
+  it('extracts login from valid account string', () => {
+    expect(getLoginFromAccount('https://github.com:alice')).toBe('alice');
+  });
+
+  it('returns null for wrong prefix', () => {
+    expect(getLoginFromAccount('https://gitlab.com:alice')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(getLoginFromAccount('')).toBeNull();
+  });
+
+  it('returns null for prefix only (no login)', () => {
+    expect(getLoginFromAccount('https://github.com:')).toBeNull();
+  });
+});
+
+describe('resolveStoredCredential', () => {
+  it('returns credential for valid entry', () => {
+    const result = resolveStoredCredential([
+      { account: 'https://github.com:alice', password: 'gho_token123' },
+    ]);
+    expect(result).toEqual({ login: 'alice', account: 'https://github.com:alice', password: 'gho_token123' });
+  });
+
+  it('returns first credential when multiple exist', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = resolveStoredCredential([
+      { account: 'https://github.com:alice', password: 'token1' },
+      { account: 'https://github.com:bob', password: 'token2' },
+    ]);
+    expect(result?.login).toBe('alice');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('returns null for no valid credentials', () => {
+    expect(resolveStoredCredential([
+      { account: 'https://gitlab.com:alice', password: 'token' },
+    ])).toBeNull();
+  });
+
+  it('returns null for empty array', () => {
+    expect(resolveStoredCredential([])).toBeNull();
+  });
+
+  it('skips entries with empty password', () => {
+    expect(resolveStoredCredential([
+      { account: 'https://github.com:alice', password: '' },
+    ])).toBeNull();
+  });
+});

--- a/src/main/services/AuthService.ts
+++ b/src/main/services/AuthService.ts
@@ -37,17 +37,17 @@ function getUserAgent(): string {
   return `Chamber/${app.getVersion()}`;
 }
 
-function getCredentialAccount(login: string): string {
+export function getCredentialAccount(login: string): string {
   return `${GITHUB_ACCOUNT_PREFIX}${login}`;
 }
 
-function getLoginFromAccount(account: string): string | null {
+export function getLoginFromAccount(account: string): string | null {
   if (!account.startsWith(GITHUB_ACCOUNT_PREFIX)) return null;
   const login = account.slice(GITHUB_ACCOUNT_PREFIX.length).trim();
   return login || null;
 }
 
-function resolveStoredCredential(credentials: Array<{ account: string; password: string }>): StoredCredential | null {
+export function resolveStoredCredential(credentials: Array<{ account: string; password: string }>): StoredCredential | null {
   const matchingCredentials = credentials
     .map((credential) => {
       const login = getLoginFromAccount(credential.account);

--- a/src/main/services/ExtensionLoader.test.ts
+++ b/src/main/services/ExtensionLoader.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExtensionLoader } from './ExtensionLoader';
+import type { ExtensionAdapter, LoadedExtension, ExtensionTool } from './ExtensionLoader';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+import * as fs from 'fs';
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockReaddirSync = vi.mocked(fs.readdirSync);
+
+function fakeTool(name: string): ExtensionTool {
+  return { name, description: `Tool ${name}`, handler: vi.fn().mockResolvedValue(null) };
+}
+
+function fakeAdapter(tools: ExtensionTool[], cleanup = vi.fn()): ExtensionAdapter {
+  return vi.fn().mockResolvedValue({
+    name: 'test-ext',
+    tools,
+    cleanup,
+  } satisfies LoadedExtension);
+}
+
+describe('ExtensionLoader', () => {
+  let loader: ExtensionLoader;
+
+  beforeEach(() => {
+    loader = new ExtensionLoader();
+    vi.clearAllMocks();
+  });
+
+  describe('registerAdapter', () => {
+    it('registers an adapter by name', () => {
+      loader.registerAdapter('canvas', fakeAdapter([]));
+      // No direct getter — verified via loadTools
+      expect(loader.getLoadedExtensions()).toEqual([]);
+    });
+  });
+
+  describe('discoverExtensions', () => {
+    it('returns extension directory names', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'canvas', isDirectory: () => true },
+        { name: 'cron', isDirectory: () => true },
+        { name: 'README.md', isDirectory: () => false },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      const result = loader.discoverExtensions('C:\\test\\mind');
+      expect(result).toEqual(['canvas', 'cron']);
+    });
+
+    it('returns empty array when extensions dir missing', () => {
+      mockExistsSync.mockReturnValue(false);
+      expect(loader.discoverExtensions('C:\\test\\mind')).toEqual([]);
+    });
+
+    it('returns empty array when extensions dir is empty', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([]);
+      expect(loader.discoverExtensions('C:\\test\\mind')).toEqual([]);
+    });
+  });
+
+  describe('loadTools', () => {
+    it('loads tools from adapters matching discovered extensions', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'canvas', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      const tool = fakeTool('canvas_show');
+      loader.registerAdapter('canvas', fakeAdapter([tool]));
+
+      const tools = await loader.loadTools('C:\\test\\mind');
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('canvas_show');
+      expect(loader.getLoadedExtensions()).toEqual(['canvas']);
+    });
+
+    it('skips extensions without matching adapter', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'unknown-ext', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      const tools = await loader.loadTools('C:\\test\\mind');
+      expect(tools).toHaveLength(0);
+    });
+
+    it('handles adapter errors gracefully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'bad', isDirectory: () => true },
+        { name: 'good', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      loader.registerAdapter('bad', vi.fn().mockRejectedValue(new Error('boom')));
+      loader.registerAdapter('good', fakeAdapter([fakeTool('good_tool')]));
+
+      const tools = await loader.loadTools('C:\\test\\mind');
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('good_tool');
+    });
+
+    it('returns empty array with no registered adapters', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'canvas', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      const tools = await loader.loadTools('C:\\test\\mind');
+      expect(tools).toHaveLength(0);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('calls cleanup on loaded extensions', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'canvas', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      const cleanupFn = vi.fn().mockResolvedValue(undefined);
+      loader.registerAdapter('canvas', fakeAdapter([fakeTool('t')], cleanupFn));
+
+      await loader.loadTools('C:\\test\\mind');
+      await loader.cleanup();
+
+      expect(cleanupFn).toHaveBeenCalled();
+      expect(loader.getLoadedExtensions()).toEqual([]);
+    });
+  });
+});

--- a/src/main/services/MindScaffold.test.ts
+++ b/src/main/services/MindScaffold.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { MindScaffold } from './MindScaffold';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('MindScaffold.slugify', () => {
+  it('lowercases and replaces spaces with hyphens', () => {
+    expect(MindScaffold.slugify('My Agent')).toBe('my-agent');
+  });
+
+  it('strips special characters', () => {
+    expect(MindScaffold.slugify('Hello World!')).toBe('hello-world');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(MindScaffold.slugify('--test--')).toBe('test');
+  });
+
+  it('collapses consecutive hyphens', () => {
+    expect(MindScaffold.slugify('a---b')).toBe('a-b');
+  });
+
+  it('strips non-ascii characters', () => {
+    expect(MindScaffold.slugify('café ☕')).toBe('caf');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(MindScaffold.slugify('')).toBe('');
+  });
+
+  it('handles all-special-char input', () => {
+    expect(MindScaffold.slugify('!@#$%')).toBe('');
+  });
+});
+
+describe('MindScaffold.getDefaultBasePath', () => {
+  it('returns homedir/agents', () => {
+    expect(MindScaffold.getDefaultBasePath()).toBe(path.join(os.homedir(), 'agents'));
+  });
+});

--- a/src/main/services/ViewDiscovery.test.ts
+++ b/src/main/services/ViewDiscovery.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn().mockReturnValue([]) },
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  watch: vi.fn().mockReturnValue({ close: vi.fn() }),
+}));
+
+import * as fs from 'fs';
+import { ViewDiscovery } from './ViewDiscovery';
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockReaddirSync = vi.mocked(fs.readdirSync);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+
+const fakeChatService = {
+  sendBackgroundPrompt: vi.fn().mockResolvedValue(undefined),
+} as any;
+
+describe('ViewDiscovery', () => {
+  let discovery: ViewDiscovery;
+
+  beforeEach(() => {
+    discovery = new ViewDiscovery(fakeChatService);
+    vi.clearAllMocks();
+    // By default, existsSync returns false (no dirs exist)
+    mockExistsSync.mockReturnValue(false);
+  });
+
+  describe('scan', () => {
+    it('returns parsed view manifests from .github/lens/', async () => {
+      // seedDefaults: hello-world and newspaper view.json don't exist → seed them
+      // installLensSkill: skill doesn't exist, no candidates found
+      // Then scan the lens dir
+      let callCount = 0;
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        // On scan, lens dir exists
+        if (s.endsWith('.github\\lens')) return true;
+        // view.json for my-view exists
+        if (s.endsWith('my-view\\view.json')) return true;
+        return false;
+      });
+
+      mockReaddirSync.mockReturnValue([
+        { name: 'my-view', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        name: 'My View',
+        icon: 'eye',
+        view: 'briefing',
+        source: 'data.json',
+      }));
+
+      const views = await discovery.scan('C:\\test\\mind');
+      expect(views.length).toBeGreaterThanOrEqual(1);
+      const myView = views.find(v => v.id === 'my-view');
+      expect(myView).toBeDefined();
+      expect(myView!.name).toBe('My View');
+    });
+
+    it('returns empty when no lens dir exists', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const views = await discovery.scan('C:\\test\\mind');
+      // May include seeded defaults
+      expect(Array.isArray(views)).toBe(true);
+    });
+
+    it('skips entries with invalid view.json', async () => {
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        if (s.endsWith('.github\\lens')) return true;
+        if (s.endsWith('bad-view\\view.json')) return true;
+        return false;
+      });
+
+      mockReaddirSync.mockReturnValue([
+        { name: 'bad-view', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      mockReadFileSync.mockReturnValue('not json');
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const views = await discovery.scan('C:\\test\\mind');
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('getViews', () => {
+    it('returns empty before scan', () => {
+      expect(discovery.getViews()).toEqual([]);
+    });
+  });
+
+  describe('getViewData', () => {
+    it('returns parsed data for valid view', async () => {
+      // Set up a scanned view
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'test', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValueOnce(JSON.stringify({
+        name: 'Test', icon: 'eye', view: 'briefing', source: 'data.json',
+      }));
+
+      await discovery.scan('C:\\test\\mind');
+
+      // Now getViewData reads the source file
+      mockReadFileSync.mockReturnValueOnce(JSON.stringify({ count: 42 }));
+      const data = discovery.getViewData('test');
+      expect(data).toEqual({ count: 42 });
+    });
+
+    it('returns null for unknown viewId', () => {
+      expect(discovery.getViewData('nonexistent')).toBeNull();
+    });
+  });
+
+  describe('stopWatching', () => {
+    it('closes watchers', async () => {
+      const mockClose = vi.fn();
+      vi.mocked(fs.watch).mockReturnValue({ close: mockClose } as any);
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([]);
+      mockReadFileSync.mockReturnValue('{}');
+
+      await discovery.scan('C:\\test\\mind');
+      discovery.startWatching(vi.fn());
+      discovery.stopWatching();
+
+      expect(mockClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/renderer/components/auth/AuthGate.test.tsx
+++ b/src/renderer/components/auth/AuthGate.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthGate } from './AuthGate';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+
+describe('AuthGate', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = installElectronAPI();
+  });
+
+  it('renders children when authenticated', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true });
+    render(<AuthGate><div>Protected Content</div></AuthGate>);
+    await waitFor(() => {
+      expect(screen.getByText('Protected Content')).toBeTruthy();
+    });
+  });
+
+  it('does not render children when not authenticated', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: false });
+    render(<AuthGate><div>Protected Content</div></AuthGate>);
+    await waitFor(() => {
+      expect(screen.queryByText('Protected Content')).toBeNull();
+    });
+  });
+
+  it('shows loading state initially', () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {})); // never resolves
+    render(<AuthGate><div>Protected Content</div></AuthGate>);
+    expect(screen.queryByText('Protected Content')).toBeNull();
+  });
+});

--- a/src/renderer/components/chat/ChatInput.test.tsx
+++ b/src/renderer/components/chat/ChatInput.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChatInput } from './ChatInput';
+import type { ModelInfo } from '../../../shared/types';
+
+const defaultProps = {
+  onSend: vi.fn(),
+  onStop: vi.fn(),
+  isStreaming: false,
+  disabled: false,
+  availableModels: [] as ModelInfo[],
+  selectedModel: null,
+  onModelChange: vi.fn(),
+};
+
+describe('ChatInput', () => {
+  it('typing updates textarea value', () => {
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByPlaceholderText('Message your agent…');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    expect((textarea as HTMLTextAreaElement).value).toBe('Hello');
+  });
+
+  it('Enter key submits non-empty text', () => {
+    const onSend = vi.fn();
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByPlaceholderText('Message your agent…');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+    expect(onSend).toHaveBeenCalledWith('Hello');
+  });
+
+  it('Enter on empty text does not submit', () => {
+    const onSend = vi.fn();
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByPlaceholderText('Message your agent…');
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('Shift+Enter does not submit', () => {
+    const onSend = vi.fn();
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByPlaceholderText('Message your agent…');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('disabled prop disables textarea', () => {
+    render(<ChatInput {...defaultProps} disabled={true} />);
+    const textarea = screen.getByPlaceholderText('Select a mind directory to start…');
+    expect(textarea).toHaveProperty('disabled', true);
+  });
+
+  it('streaming shows stop button, clicking calls onStop', () => {
+    const onStop = vi.fn();
+    render(<ChatInput {...defaultProps} isStreaming={true} onStop={onStop} />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(onStop).toHaveBeenCalled();
+  });
+
+  it('shows Loading models when no models available and not disabled', () => {
+    render(<ChatInput {...defaultProps} />);
+    expect(screen.getByText('Loading models…')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/chat/ReasoningBlock.test.tsx
+++ b/src/renderer/components/chat/ReasoningBlock.test.tsx
@@ -1,0 +1,24 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReasoningBlock } from './ReasoningBlock';
+import { makeReasoningBlock } from '@/test/helpers';
+
+describe('ReasoningBlock', () => {
+  it('shows "Thinking…" when streaming', () => {
+    render(<ReasoningBlock block={makeReasoningBlock('analyzing')} isStreaming={true} />);
+    expect(screen.getByText('Thinking…')).toBeTruthy();
+  });
+
+  it('shows "Thought" when not streaming', () => {
+    render(<ReasoningBlock block={makeReasoningBlock('analyzed')} isStreaming={false} />);
+    expect(screen.getByText('Thought')).toBeTruthy();
+  });
+
+  it('renders reasoning content in collapsible', () => {
+    render(<ReasoningBlock block={makeReasoningBlock('deep reasoning here')} />);
+    // Content is inside a collapsible — click trigger to open
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('deep reasoning here')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/chat/StreamingMessage.test.tsx
+++ b/src/renderer/components/chat/StreamingMessage.test.tsx
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StreamingMessage } from './StreamingMessage';
+import { makeTextBlock, makeToolCallBlock, makeReasoningBlock } from '@/test/helpers';
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+vi.mock('remark-gfm', () => ({ default: () => {} }));
+
+describe('StreamingMessage', () => {
+  it('shows thinking dots when empty blocks and streaming', () => {
+    render(<StreamingMessage blocks={[]} isStreaming={true} />);
+    expect(screen.getByText('Thinking…')).toBeTruthy();
+  });
+
+  it('renders text content', () => {
+    render(<StreamingMessage blocks={[makeTextBlock('Hello world')]} />);
+    expect(screen.getByText('Hello world')).toBeTruthy();
+  });
+
+  it('renders ToolBlock for tool_call blocks', () => {
+    const block = makeToolCallBlock({ toolName: 'read_file', status: 'running' });
+    render(<StreamingMessage blocks={[block]} />);
+    expect(screen.getByText('read_file')).toBeTruthy();
+  });
+
+  it('renders ReasoningBlock for reasoning blocks', () => {
+    const block = makeReasoningBlock('considering options');
+    render(<StreamingMessage blocks={[block]} />);
+    // ReasoningBlock renders inside a collapsible — click to open
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('considering options')).toBeTruthy();
+  });
+
+  it('shows trailing indicator when streaming after non-text block', () => {
+    const block = makeToolCallBlock({ toolName: 'grep', status: 'done' });
+    const { container } = render(<StreamingMessage blocks={[block]} isStreaming={true} />);
+    // Trailing indicator has bouncing dots
+    const dots = container.querySelectorAll('.animate-bounce');
+    expect(dots.length).toBeGreaterThan(0);
+  });
+
+  it('renders nothing special when not streaming with no blocks', () => {
+    const { container } = render(<StreamingMessage blocks={[]} isStreaming={false} />);
+    expect(container.querySelector('.animate-bounce')).toBeNull();
+    expect(screen.queryByText('Thinking…')).toBeNull();
+  });
+});

--- a/src/renderer/components/chat/ToolBlock.test.tsx
+++ b/src/renderer/components/chat/ToolBlock.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToolBlock } from './ToolBlock';
+import { makeToolCallBlock } from '@/test/helpers';
+
+describe('ToolBlock', () => {
+  it('shows tool name', () => {
+    render(<ToolBlock block={makeToolCallBlock({ toolName: 'grep' })} />);
+    expect(screen.getByText('grep')).toBeTruthy();
+  });
+
+  it('shows running status badge', () => {
+    render(<ToolBlock block={makeToolCallBlock({ status: 'running' })} />);
+    expect(screen.getByText('running')).toBeTruthy();
+  });
+
+  it('shows done status badge', () => {
+    render(<ToolBlock block={makeToolCallBlock({ status: 'done' })} />);
+    expect(screen.getByText('done')).toBeTruthy();
+  });
+
+  it('shows error status badge', () => {
+    render(<ToolBlock block={makeToolCallBlock({ status: 'error' })} />);
+    expect(screen.getByText('error')).toBeTruthy();
+  });
+
+  it('renders output text when present', () => {
+    render(<ToolBlock block={makeToolCallBlock({ output: 'search results here' })} />);
+    // Content is inside a collapsible — click trigger to open
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('search results here')).toBeTruthy();
+  });
+
+  it('renders error text when present', () => {
+    render(<ToolBlock block={makeToolCallBlock({ error: 'command failed' })} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('command failed')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/chat/WelcomeScreen.test.tsx
+++ b/src/renderer/components/chat/WelcomeScreen.test.tsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WelcomeScreen } from './WelcomeScreen';
+
+describe('WelcomeScreen', () => {
+  it('renders "How can I help you today?" when connected', () => {
+    render(<WelcomeScreen onSendMessage={vi.fn()} connected={true} />);
+    expect(screen.getByText('How can I help you today?')).toBeTruthy();
+  });
+
+  it('renders prompt buttons when connected (6 buttons)', () => {
+    render(<WelcomeScreen onSendMessage={vi.fn()} connected={true} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(6);
+  });
+
+  it('clicking a starter prompt calls onSendMessage with the prompt text', () => {
+    const onSendMessage = vi.fn();
+    render(<WelcomeScreen onSendMessage={onSendMessage} connected={true} />);
+    fireEvent.click(screen.getByText('Daily briefing'));
+    expect(onSendMessage).toHaveBeenCalledWith('Give me my daily report');
+  });
+
+  it('renders "Select a mind directory" when not connected', () => {
+    render(<WelcomeScreen onSendMessage={vi.fn()} connected={false} />);
+    expect(screen.getByText(/Select a mind directory/)).toBeTruthy();
+  });
+
+  it('does not render prompt buttons when not connected', () => {
+    render(<WelcomeScreen onSendMessage={vi.fn()} connected={false} />);
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+});

--- a/src/renderer/components/genesis/GenesisGate.test.tsx
+++ b/src/renderer/components/genesis/GenesisGate.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { GenesisGate } from './GenesisGate';
+import { AppStateProvider } from '../../lib/store';
+import { installElectronAPI, mockElectronAPI, connectedAgentStatus } from '../../../test/helpers';
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<AppStateProvider>{ui}</AppStateProvider>);
+}
+
+describe('GenesisGate', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = installElectronAPI();
+  });
+
+  it('shows LandingScreen when agent is not connected', () => {
+    renderWithProvider(<GenesisGate><div>App</div></GenesisGate>);
+    expect(screen.getByText('New Agent', { exact: false })).toBeTruthy();
+    expect(screen.getByText('Open Existing', { exact: false })).toBeTruthy();
+    expect(screen.queryByText('App')).toBeNull();
+  });
+
+  it('clicking Open Existing triggers file dialog', async () => {
+    (api.agent.selectMindDirectory as ReturnType<typeof vi.fn>).mockResolvedValue('C:\\test\\mind');
+    (api.agent.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue(connectedAgentStatus());
+
+    renderWithProvider(<GenesisGate><div>App</div></GenesisGate>);
+    fireEvent.click(screen.getByText('Open Existing', { exact: false }));
+
+    await waitFor(() => {
+      expect(api.agent.selectMindDirectory).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/renderer/components/genesis/LandingScreen.test.tsx
+++ b/src/renderer/components/genesis/LandingScreen.test.tsx
@@ -1,0 +1,31 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LandingScreen } from './LandingScreen';
+
+describe('LandingScreen', () => {
+  it('renders Chamber title', () => {
+    render(<LandingScreen onNewAgent={vi.fn()} onOpenExisting={vi.fn()} />);
+    expect(screen.getByText('Chamber')).toBeTruthy();
+  });
+
+  it('renders New Agent and Open Existing buttons', () => {
+    render(<LandingScreen onNewAgent={vi.fn()} onOpenExisting={vi.fn()} />);
+    expect(screen.getByText('New Agent')).toBeTruthy();
+    expect(screen.getByText('Open Existing')).toBeTruthy();
+  });
+
+  it('clicking New Agent calls onNewAgent', () => {
+    const onNewAgent = vi.fn();
+    render(<LandingScreen onNewAgent={onNewAgent} onOpenExisting={vi.fn()} />);
+    fireEvent.click(screen.getByText('New Agent'));
+    expect(onNewAgent).toHaveBeenCalledOnce();
+  });
+
+  it('clicking Open Existing calls onOpenExisting', () => {
+    const onOpenExisting = vi.fn();
+    render(<LandingScreen onNewAgent={vi.fn()} onOpenExisting={onOpenExisting} />);
+    fireEvent.click(screen.getByText('Open Existing'));
+    expect(onOpenExisting).toHaveBeenCalledOnce();
+  });
+});

--- a/src/renderer/components/genesis/TypeWriter.test.tsx
+++ b/src/renderer/components/genesis/TypeWriter.test.tsx
@@ -1,0 +1,50 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { TypeWriter } from './TypeWriter';
+
+describe('TypeWriter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('progressively reveals text character by character', () => {
+    render(<TypeWriter text="Hello" speed={50} />);
+
+    // After one tick, first char should appear
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(screen.getByText(/^H/)).toBeTruthy();
+
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(screen.getByText(/^He/)).toBeTruthy();
+  });
+
+  it('calls onComplete when done', () => {
+    const onComplete = vi.fn();
+    render(<TypeWriter text="Hi" speed={50} onComplete={onComplete} />);
+
+    // Two ticks for two characters
+    act(() => { vi.advanceTimersByTime(100); });
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it('shows cursor while animating', () => {
+    const { container } = render(<TypeWriter text="Hello" speed={50} cursor={true} />);
+
+    // Before completion, cursor should be visible
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(container.textContent).toContain('▊');
+  });
+
+  it('hides cursor after completion', () => {
+    const { container } = render(<TypeWriter text="Hi" speed={50} cursor={true} />);
+
+    // Complete all characters
+    act(() => { vi.advanceTimersByTime(100); });
+    expect(container.textContent).not.toContain('▊');
+  });
+});

--- a/src/renderer/components/views/LensBriefing.test.tsx
+++ b/src/renderer/components/views/LensBriefing.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LensBriefing } from './LensBriefing';
+
+describe('LensBriefing', () => {
+  it('renders cards for each data key', () => {
+    const data = { inbox: 'empty', initiatives: '3 active' };
+    render(<LensBriefing data={data} />);
+    expect(screen.getByText('Inbox')).toBeTruthy();
+    expect(screen.getByText('Initiatives')).toBeTruthy();
+  });
+
+  it('numbers display in large text', () => {
+    const data = { count: 42 };
+    render(<LensBriefing data={data} />);
+    const el = screen.getByText('42');
+    expect(el.className).toContain('text-2xl');
+    expect(el.className).toContain('font-bold');
+  });
+
+  it('schema titles override key names', () => {
+    const data = { foo: 'bar' };
+    const schema = { properties: { foo: { title: 'Custom Title' } } };
+    render(<LensBriefing data={data} schema={schema} />);
+    expect(screen.getByText('Custom Title')).toBeTruthy();
+  });
+
+  it('arrays are joined with commas', () => {
+    const data = { tags: ['a', 'b', 'c'] };
+    render(<LensBriefing data={data} />);
+    expect(screen.getByText('a, b, c')).toBeTruthy();
+  });
+
+  it('empty data renders no cards', () => {
+    const { container } = render(<LensBriefing data={{}} />);
+    expect(container.querySelectorAll('[class*="Card"]').length).toBe(0);
+    expect(screen.queryByRole('heading')).toBeNull();
+  });
+});

--- a/src/renderer/components/views/LensDetail.test.tsx
+++ b/src/renderer/components/views/LensDetail.test.tsx
@@ -1,0 +1,29 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LensDetail } from './LensDetail';
+
+describe('LensDetail', () => {
+  it('extracts title from data.name', () => {
+    render(<LensDetail data={{ name: 'My Service' }} />);
+    expect(screen.getByText('My Service')).toBeTruthy();
+  });
+
+  it('shows description', () => {
+    render(<LensDetail data={{ name: 'Svc', description: 'A great service' }} />);
+    expect(screen.getByText('A great service')).toBeTruthy();
+  });
+
+  it('shows status badge', () => {
+    render(<LensDetail data={{ name: 'Svc', status: 'active' }} />);
+    expect(screen.getByText('active')).toBeTruthy();
+  });
+
+  it('renders metadata key-value pairs', () => {
+    render(<LensDetail data={{ name: 'Svc', region: 'us-west', version: '1.0' }} />);
+    expect(screen.getByText('Region')).toBeTruthy();
+    expect(screen.getByText('us-west')).toBeTruthy();
+    expect(screen.getByText('Version')).toBeTruthy();
+    expect(screen.getByText('1.0')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/views/LensEditor.test.tsx
+++ b/src/renderer/components/views/LensEditor.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LensEditor } from './LensEditor';
+
+describe('LensEditor', () => {
+  it('renders form fields from data', () => {
+    render(<LensEditor data={{ name: 'Agent', region: 'us-east' }} onSave={vi.fn()} />);
+    expect(screen.getByDisplayValue('Agent')).toBeTruthy();
+    expect(screen.getByDisplayValue('us-east')).toBeTruthy();
+  });
+
+  it('Save button disabled when not dirty', () => {
+    render(<LensEditor data={{ name: 'Agent' }} onSave={vi.fn()} />);
+    const btn = screen.getByText('Save Changes');
+    expect(btn.closest('button')!.disabled).toBe(true);
+  });
+
+  it('changing input enables Save button', () => {
+    render(<LensEditor data={{ name: 'Agent' }} onSave={vi.fn()} />);
+    fireEvent.change(screen.getByDisplayValue('Agent'), { target: { value: 'NewName' } });
+    const btn = screen.getByText('Save Changes');
+    expect(btn.closest('button')!.disabled).toBe(false);
+  });
+
+  it('clicking Save calls onSave with updated data', () => {
+    const onSave = vi.fn();
+    render(<LensEditor data={{ name: 'Agent' }} onSave={onSave} />);
+    fireEvent.change(screen.getByDisplayValue('Agent'), { target: { value: 'NewName' } });
+    fireEvent.click(screen.getByText('Save Changes'));
+    expect(onSave).toHaveBeenCalledWith({ name: 'NewName' });
+  });
+
+  it('enum schema renders select dropdown', () => {
+    const schema = { properties: { env: { title: 'Environment', type: 'string', enum: ['dev', 'staging', 'prod'] } } };
+    render(<LensEditor data={{ env: 'dev' }} schema={schema} onSave={vi.fn()} />);
+    const select = screen.getByDisplayValue('dev') as HTMLSelectElement;
+    expect(select.tagName).toBe('SELECT');
+    expect(select.options).toHaveLength(3);
+  });
+
+  it('boolean schema renders checkbox', () => {
+    const schema = { properties: { enabled: { title: 'Enabled', type: 'boolean' } } };
+    render(<LensEditor data={{ enabled: true }} schema={schema} onSave={vi.fn()} />);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+});

--- a/src/renderer/components/views/LensStatusBoard.test.tsx
+++ b/src/renderer/components/views/LensStatusBoard.test.tsx
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LensStatusBoard } from './LensStatusBoard';
+
+describe('LensStatusBoard', () => {
+  it('renders card with name', () => {
+    const data = [{ name: 'Web Server', status: 'running' }] as unknown as Record<string, unknown>;
+    render(<LensStatusBoard data={data} />);
+    expect(screen.getByText('Web Server')).toBeTruthy();
+  });
+
+  it('running/active/ok shows green dot 🟢', () => {
+    const data = [{ name: 'Svc', status: 'running' }] as unknown as Record<string, unknown>;
+    render(<LensStatusBoard data={data} />);
+    expect(screen.getByText('🟢')).toBeTruthy();
+  });
+
+  it('error/fail shows red dot 🔴', () => {
+    const data = [{ name: 'Svc', status: 'error' }] as unknown as Record<string, unknown>;
+    render(<LensStatusBoard data={data} />);
+    expect(screen.getByText('🔴')).toBeTruthy();
+  });
+
+  it('warn/pending shows yellow dot 🟡', () => {
+    const data = [{ name: 'Svc', status: 'pending' }] as unknown as Record<string, unknown>;
+    render(<LensStatusBoard data={data} />);
+    expect(screen.getByText('🟡')).toBeTruthy();
+  });
+
+  it('shows status badge', () => {
+    const data = [{ name: 'DB', status: 'active' }] as unknown as Record<string, unknown>;
+    render(<LensStatusBoard data={data} />);
+    expect(screen.getByText('active')).toBeTruthy();
+  });
+
+  it('shows up to 3 metadata fields', () => {
+    const data = [{
+      name: 'API',
+      status: 'ok',
+      region: 'us-east',
+      version: '2.1',
+      uptime: '99.9%',
+      extra: 'hidden',
+    }] as unknown as Record<string, unknown>;
+    render(<LensStatusBoard data={data} />);
+    expect(screen.getByText(/Region/)).toBeTruthy();
+    expect(screen.getByText(/Version/)).toBeTruthy();
+    expect(screen.getByText(/Uptime/)).toBeTruthy();
+    // 4th field should not appear
+    expect(screen.queryByText(/Extra/)).toBeNull();
+  });
+});

--- a/src/renderer/components/views/LensTable.test.tsx
+++ b/src/renderer/components/views/LensTable.test.tsx
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LensTable } from './LensTable';
+
+describe('LensTable', () => {
+  it('renders single object as one-row table', () => {
+    const data = { name: 'Alice', role: 'admin' } as Record<string, unknown>;
+    render(<LensTable data={data} />);
+    expect(screen.getByText('Alice')).toBeTruthy();
+    expect(screen.getByText('admin')).toBeTruthy();
+    // Should have table headers
+    expect(screen.getByText('Name')).toBeTruthy();
+    expect(screen.getByText('Role')).toBeTruthy();
+  });
+
+  it('renders array data as multiple rows', () => {
+    const data = [
+      { name: 'Alice', role: 'admin' },
+      { name: 'Bob', role: 'user' },
+    ] as unknown as Record<string, unknown>;
+    render(<LensTable data={data} />);
+    expect(screen.getByText('Alice')).toBeTruthy();
+    expect(screen.getByText('Bob')).toBeTruthy();
+  });
+
+  it('derives columns from schema when present', () => {
+    const data = [{ name: 'Alice', role: 'admin', extra: 'ignored' }] as unknown as Record<string, unknown>;
+    const schema = { items: { properties: { name: { title: 'Full Name' }, role: { title: 'User Role' } } } };
+    render(<LensTable data={data} schema={schema} />);
+    expect(screen.getByText('Full Name')).toBeTruthy();
+    expect(screen.getByText('User Role')).toBeTruthy();
+  });
+
+  it('derives columns from first row data keys', () => {
+    const data = [{ alpha: 1, beta: 2 }] as unknown as Record<string, unknown>;
+    render(<LensTable data={data} />);
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.getByText('Beta')).toBeTruthy();
+  });
+
+  it('shows "No data." for empty array', () => {
+    const data = [] as unknown as Record<string, unknown>;
+    render(<LensTable data={data} />);
+    expect(screen.getByText('No data.')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/views/LensTimeline.test.tsx
+++ b/src/renderer/components/views/LensTimeline.test.tsx
@@ -1,0 +1,44 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LensTimeline } from './LensTimeline';
+
+describe('LensTimeline', () => {
+  it('renders timeline items', () => {
+    const data = [
+      { title: 'Deploy v1', time: '10:00' },
+      { title: 'Deploy v2', time: '11:00' },
+    ] as unknown as Record<string, unknown>;
+    render(<LensTimeline data={data} />);
+    expect(screen.getByText('Deploy v1')).toBeTruthy();
+    expect(screen.getByText('Deploy v2')).toBeTruthy();
+  });
+
+  it('uses title field for entry title', () => {
+    const data = [{ title: 'Release v3' }] as unknown as Record<string, unknown>;
+    render(<LensTimeline data={data} />);
+    expect(screen.getByText('Release v3')).toBeTruthy();
+  });
+
+  it('falls back to name, then event', () => {
+    const data = [
+      { name: 'Name Fallback' },
+      { event: 'Event Fallback' },
+    ] as unknown as Record<string, unknown>;
+    render(<LensTimeline data={data} />);
+    expect(screen.getByText('Name Fallback')).toBeTruthy();
+    expect(screen.getByText('Event Fallback')).toBeTruthy();
+  });
+
+  it('renders time when present', () => {
+    const data = [{ title: 'Item', time: '14:30 UTC' }] as unknown as Record<string, unknown>;
+    render(<LensTimeline data={data} />);
+    expect(screen.getByText('14:30 UTC')).toBeTruthy();
+  });
+
+  it('renders description when present', () => {
+    const data = [{ title: 'Item', description: 'Something happened' }] as unknown as Record<string, unknown>;
+    render(<LensTimeline data={data} />);
+    expect(screen.getByText('Something happened')).toBeTruthy();
+  });
+});

--- a/src/renderer/hooks/useAgentStatus.test.tsx
+++ b/src/renderer/hooks/useAgentStatus.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { AppStateProvider, useAppDispatch, useAppState } from '../lib/store';
+import { installElectronAPI, mockElectronAPI, connectedAgentStatus } from '../../test/helpers';
+import { useAgentStatus } from './useAgentStatus';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <AppStateProvider>{children}</AppStateProvider>;
+}
+
+describe('useAgentStatus', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = installElectronAPI();
+  });
+
+  it('fetches initial status on mount', async () => {
+    const status = connectedAgentStatus();
+    (api.agent.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue(status);
+
+    const { result } = renderHook(() => useAgentStatus(), { wrapper });
+
+    await waitFor(() => {
+      expect(api.agent.getStatus).toHaveBeenCalled();
+    });
+  });
+
+  it('subscribes to onStatusChanged', () => {
+    renderHook(() => useAgentStatus(), { wrapper });
+    expect(api.agent.onStatusChanged).toHaveBeenCalled();
+  });
+
+  it('unsubscribes on unmount', () => {
+    const unsub = vi.fn();
+    (api.agent.onStatusChanged as ReturnType<typeof vi.fn>).mockReturnValue(unsub);
+
+    const { unmount } = renderHook(() => useAgentStatus(), { wrapper });
+    unmount();
+    expect(unsub).toHaveBeenCalled();
+  });
+
+  it('selectMindDirectory triggers dialog and refreshes status', async () => {
+    (api.agent.selectMindDirectory as ReturnType<typeof vi.fn>).mockResolvedValue('C:\\test\\mind');
+    (api.agent.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue(connectedAgentStatus());
+
+    const { result } = renderHook(() => useAgentStatus(), { wrapper });
+
+    await act(async () => {
+      await result.current.selectMindDirectory();
+    });
+
+    expect(api.agent.selectMindDirectory).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/hooks/useChatStreaming.test.tsx
+++ b/src/renderer/hooks/useChatStreaming.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { act, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { AppStateProvider } from '../lib/store';
+import { installElectronAPI, mockElectronAPI } from '../../test/helpers';
+import { useChatStreaming } from './useChatStreaming';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <AppStateProvider>{children}</AppStateProvider>;
+}
+
+describe('useChatStreaming', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = installElectronAPI();
+  });
+
+  it('sendMessage calls electronAPI.chat.send', async () => {
+    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(api.chat.send).toHaveBeenCalled();
+    const args = (api.chat.send as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(args[1]).toBe('Hello');
+  });
+
+  it('sendMessage no-ops on empty string', async () => {
+    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage('   ');
+    });
+
+    expect(api.chat.send).not.toHaveBeenCalled();
+  });
+
+  it('stopStreaming calls electronAPI.chat.stop', async () => {
+    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+
+    // First send a message to set currentMessageId
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    await act(async () => {
+      await result.current.stopStreaming();
+    });
+
+    expect(api.chat.stop).toHaveBeenCalled();
+  });
+
+  it('isStreaming reflects state', () => {
+    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+    expect(result.current.isStreaming).toBe(false);
+  });
+});

--- a/src/renderer/lib/store.reducer.test.ts
+++ b/src/renderer/lib/store.reducer.test.ts
@@ -1,0 +1,280 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { handleChatEvent, appReducer, initialState } from './store';
+import type { AppState, AppAction } from './store';
+import type { ChatMessage, ChatEvent } from '../../shared/types';
+import {
+  makeMessage,
+  makeTextBlock,
+  makeToolCallBlock,
+  makeReasoningBlock,
+  makeChatEvent,
+  defaultAgentStatus,
+  connectedAgentStatus,
+  makeModelInfo,
+  makeLensViewManifest,
+} from '../../test/helpers';
+
+// ---------------------------------------------------------------------------
+// handleChatEvent
+// ---------------------------------------------------------------------------
+
+function assistantMsg(id = 'msg-1'): ChatMessage[] {
+  return [makeMessage([], { id, isStreaming: true })];
+}
+
+describe('handleChatEvent', () => {
+  describe('chunk', () => {
+    it('creates a TextBlock on the first chunk', () => {
+      const msgs = handleChatEvent(assistantMsg(), 'msg-1', makeChatEvent('chunk', { content: 'Hello' }));
+      expect(msgs[0].blocks).toHaveLength(1);
+      expect(msgs[0].blocks[0]).toEqual({ type: 'text', content: 'Hello', sdkMessageId: undefined });
+    });
+
+    it('appends to existing TextBlock', () => {
+      const initial = [makeMessage([makeTextBlock('Hello')], { id: 'msg-1', isStreaming: true })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('chunk', { content: ' World' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ type: 'text', content: 'Hello World' });
+    });
+
+    it('creates new TextBlock after a tool block', () => {
+      const initial = [makeMessage([makeToolCallBlock()], { id: 'msg-1', isStreaming: true })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('chunk', { content: 'After tool' }));
+      expect(msgs[0].blocks).toHaveLength(2);
+      expect(msgs[0].blocks[1]).toMatchObject({ type: 'text', content: 'After tool' });
+    });
+
+    it('sets sdkMessageId on the text block', () => {
+      const msgs = handleChatEvent(assistantMsg(), 'msg-1', makeChatEvent('chunk', { content: 'x', sdkMessageId: 'sdk-1' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ sdkMessageId: 'sdk-1' });
+    });
+  });
+
+  describe('tool_start', () => {
+    it('creates a tool_call block with running status', () => {
+      const msgs = handleChatEvent(assistantMsg(), 'msg-1', makeChatEvent('tool_start', { toolCallId: 'tc1', toolName: 'readFile' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ type: 'tool_call', toolCallId: 'tc1', toolName: 'readFile', status: 'running' });
+    });
+
+    it('includes arguments when provided', () => {
+      const msgs = handleChatEvent(assistantMsg(), 'msg-1', makeChatEvent('tool_start', { toolCallId: 'tc1', toolName: 'grep', args: { pattern: 'foo' } }));
+      expect(msgs[0].blocks[0]).toMatchObject({ arguments: { pattern: 'foo' } });
+    });
+
+    it('includes parentToolCallId when provided', () => {
+      const msgs = handleChatEvent(assistantMsg(), 'msg-1', makeChatEvent('tool_start', { toolCallId: 'tc1', toolName: 'grep', parentToolCallId: 'tc0' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ parentToolCallId: 'tc0' });
+    });
+  });
+
+  describe('tool_progress', () => {
+    it('appends progress message to tool block output', () => {
+      const initial = [makeMessage([makeToolCallBlock({ toolCallId: 'tc1' })], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('tool_progress', { toolCallId: 'tc1', message: 'line1' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ output: expect.stringContaining('line1') });
+    });
+
+    it('accumulates multiple progress messages', () => {
+      const initial = [makeMessage([makeToolCallBlock({ toolCallId: 'tc1' })], { id: 'msg-1' })];
+      let msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('tool_progress', { toolCallId: 'tc1', message: 'a' }));
+      msgs = handleChatEvent(msgs, 'msg-1', makeChatEvent('tool_progress', { toolCallId: 'tc1', message: 'b' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ output: expect.stringContaining('a') });
+      expect(msgs[0].blocks[0]).toMatchObject({ output: expect.stringContaining('b') });
+    });
+  });
+
+  describe('tool_output', () => {
+    it('appends output to tool block', () => {
+      const initial = [makeMessage([makeToolCallBlock({ toolCallId: 'tc1' })], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('tool_output', { toolCallId: 'tc1', output: 'result data' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ output: expect.stringContaining('result data') });
+    });
+  });
+
+  describe('tool_done', () => {
+    it('sets status to done on success', () => {
+      const initial = [makeMessage([makeToolCallBlock({ toolCallId: 'tc1' })], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('tool_done', { toolCallId: 'tc1', success: true }));
+      expect(msgs[0].blocks[0]).toMatchObject({ status: 'done' });
+    });
+
+    it('sets status to error on failure', () => {
+      const initial = [makeMessage([makeToolCallBlock({ toolCallId: 'tc1' })], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('tool_done', { toolCallId: 'tc1', success: false, error: 'fail' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ status: 'error', error: 'fail' });
+    });
+
+    it('appends result to output when provided', () => {
+      const initial = [makeMessage([makeToolCallBlock({ toolCallId: 'tc1' })], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('tool_done', { toolCallId: 'tc1', success: true, result: 'ok' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ output: expect.stringContaining('ok') });
+    });
+
+    it('is a no-op for unknown toolCallId', () => {
+      const initial = [makeMessage([makeToolCallBlock({ toolCallId: 'tc1' })], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('tool_done', { toolCallId: 'unknown', success: true }));
+      expect(msgs[0].blocks[0]).toMatchObject({ status: 'running' });
+    });
+  });
+
+  describe('reasoning', () => {
+    it('creates a ReasoningBlock', () => {
+      const msgs = handleChatEvent(assistantMsg(), 'msg-1', makeChatEvent('reasoning', { reasoningId: 'r1', content: 'thinking' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ type: 'reasoning', reasoningId: 'r1', content: 'thinking' });
+    });
+
+    it('appends to existing block with same id', () => {
+      const initial = [makeMessage([makeReasoningBlock('a', 'r1')], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('reasoning', { reasoningId: 'r1', content: 'b' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ content: 'ab' });
+    });
+
+    it('creates new block for different id', () => {
+      const initial = [makeMessage([makeReasoningBlock('a', 'r1')], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('reasoning', { reasoningId: 'r2', content: 'b' }));
+      expect(msgs[0].blocks).toHaveLength(2);
+    });
+  });
+
+  describe('message_final', () => {
+    it('creates text block when no text blocks exist', () => {
+      const msgs = handleChatEvent(assistantMsg(), 'msg-1', makeChatEvent('message_final', { sdkMessageId: 'sdk-1', content: 'Final' }));
+      expect(msgs[0].blocks[0]).toMatchObject({ type: 'text', content: 'Final' });
+    });
+
+    it('is a no-op when text blocks already exist', () => {
+      const initial = [makeMessage([makeTextBlock('existing')], { id: 'msg-1' })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('message_final', { sdkMessageId: 'sdk-1', content: 'Final' }));
+      expect(msgs[0].blocks).toHaveLength(1);
+      expect(msgs[0].blocks[0]).toMatchObject({ content: 'existing' });
+    });
+  });
+
+  describe('done', () => {
+    it('sets isStreaming to false', () => {
+      const initial = [makeMessage([], { id: 'msg-1', isStreaming: true })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('done'));
+      expect(msgs[0].isStreaming).toBe(false);
+    });
+  });
+
+  describe('error', () => {
+    it('adds error text block and sets isStreaming false', () => {
+      const initial = [makeMessage([], { id: 'msg-1', isStreaming: true })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('error', { message: 'timeout' }));
+      expect(msgs[0].isStreaming).toBe(false);
+      expect(msgs[0].blocks[msgs[0].blocks.length - 1]).toMatchObject({ type: 'text', content: 'Error: timeout' });
+    });
+  });
+
+  it('ignores events for unknown messageId', () => {
+    const initial = assistantMsg();
+    const msgs = handleChatEvent(initial, 'wrong-id', makeChatEvent('chunk', { content: 'x' }));
+    expect(msgs[0].blocks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appReducer
+// ---------------------------------------------------------------------------
+
+describe('appReducer', () => {
+  it('ADD_USER_MESSAGE adds a user message with text block', () => {
+    const state = appReducer(initialState, { type: 'ADD_USER_MESSAGE', payload: { id: 'u1', content: 'Hello', timestamp: 1000 } });
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]).toMatchObject({ id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'Hello' }] });
+  });
+
+  it('ADD_ASSISTANT_MESSAGE adds a streaming assistant message', () => {
+    const state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]).toMatchObject({ id: 'a1', role: 'assistant', blocks: [], isStreaming: true });
+    expect(state.isStreaming).toBe(true);
+  });
+
+  it('CHAT_EVENT delegates to handleChatEvent', () => {
+    let state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    state = appReducer(state, { type: 'CHAT_EVENT', payload: { messageId: 'a1', event: makeChatEvent('chunk', { content: 'Hi' }) } });
+    expect(state.messages[0].blocks[0]).toMatchObject({ type: 'text', content: 'Hi' });
+  });
+
+  it('CHAT_EVENT with done sets isStreaming false', () => {
+    let state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    state = appReducer(state, { type: 'CHAT_EVENT', payload: { messageId: 'a1', event: makeChatEvent('done') } });
+    expect(state.isStreaming).toBe(false);
+  });
+
+  it('CHAT_EVENT with error sets isStreaming false', () => {
+    let state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    state = appReducer(state, { type: 'CHAT_EVENT', payload: { messageId: 'a1', event: makeChatEvent('error', { message: 'fail' }) } });
+    expect(state.isStreaming).toBe(false);
+  });
+
+  it('SET_AGENT_STATUS updates agentStatus', () => {
+    const status = connectedAgentStatus();
+    const state = appReducer(initialState, { type: 'SET_AGENT_STATUS', payload: status });
+    expect(state.agentStatus).toEqual(status);
+  });
+
+  it('SET_AVAILABLE_MODELS updates model list', () => {
+    const models = [makeModelInfo('m1', 'Model 1'), makeModelInfo('m2', 'Model 2')];
+    const state = appReducer(initialState, { type: 'SET_AVAILABLE_MODELS', payload: models });
+    expect(state.availableModels).toEqual(models);
+  });
+
+  it('SET_SELECTED_MODEL updates selection and persists to localStorage', () => {
+    const state = appReducer(initialState, { type: 'SET_SELECTED_MODEL', payload: 'model-1' });
+    expect(state.selectedModel).toBe('model-1');
+    expect(localStorage.getItem('chamber:selectedModel')).toBe('model-1');
+  });
+
+  it('SET_SELECTED_MODEL with null clears selection', () => {
+    localStorage.setItem('chamber:selectedModel', 'old');
+    const state = appReducer(initialState, { type: 'SET_SELECTED_MODEL', payload: null });
+    expect(state.selectedModel).toBeNull();
+    expect(localStorage.getItem('chamber:selectedModel')).toBeNull();
+  });
+
+  it('SET_ACTIVE_VIEW updates activeView', () => {
+    const state = appReducer(initialState, { type: 'SET_ACTIVE_VIEW', payload: 'briefing-1' });
+    expect(state.activeView).toBe('briefing-1');
+  });
+
+  it('SET_DISCOVERED_VIEWS updates discoveredViews', () => {
+    const views = [makeLensViewManifest({ id: 'v1' })];
+    const state = appReducer(initialState, { type: 'SET_DISCOVERED_VIEWS', payload: views });
+    expect(state.discoveredViews).toEqual(views);
+  });
+
+  it('SHOW_LANDING sets showLanding true', () => {
+    const state = appReducer(initialState, { type: 'SHOW_LANDING' });
+    expect(state.showLanding).toBe(true);
+  });
+
+  it('HIDE_LANDING sets showLanding false', () => {
+    const state = appReducer({ ...initialState, showLanding: true }, { type: 'HIDE_LANDING' });
+    expect(state.showLanding).toBe(false);
+  });
+
+  it('CLEAR_MESSAGES empties messages', () => {
+    const withMsgs = { ...initialState, messages: [makeMessage([makeTextBlock('hi')])] };
+    const state = appReducer(withMsgs, { type: 'CLEAR_MESSAGES' });
+    expect(state.messages).toHaveLength(0);
+  });
+
+  it('NEW_CONVERSATION resets messages, streaming, and generates new conversationId', () => {
+    const prev = { ...initialState, messages: [makeMessage([])], isStreaming: true, conversationId: 'old' };
+    const state = appReducer(prev, { type: 'NEW_CONVERSATION' });
+    expect(state.messages).toHaveLength(0);
+    expect(state.isStreaming).toBe(false);
+    expect(state.conversationId).not.toBe('old');
+    expect(state.conversationId).toMatch(/^conv-/);
+  });
+
+  it('unknown action returns state unchanged', () => {
+    const state = appReducer(initialState, { type: 'BOGUS' } as unknown as AppAction);
+    expect(state).toBe(initialState);
+  });
+});

--- a/src/renderer/lib/store.test.ts
+++ b/src/renderer/lib/store.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { getPlainContent } from './store';
+import type { ChatMessage, ChatEvent, ContentBlock } from '../../shared/types';
+
+function makeMessage(blocks: ContentBlock[], overrides?: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    blocks,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('getPlainContent', () => {
+  it('extracts text from text blocks', () => {
+    const msg = makeMessage([
+      { type: 'text', content: 'Hello ' },
+      { type: 'text', content: 'world' },
+    ]);
+    expect(getPlainContent(msg)).toBe('Hello world');
+  });
+
+  it('ignores non-text blocks', () => {
+    const msg = makeMessage([
+      { type: 'text', content: 'visible' },
+      { type: 'tool_call', toolCallId: 'tc1', toolName: 'grep', status: 'done' },
+      { type: 'reasoning', reasoningId: 'r1', content: 'thinking...' },
+    ]);
+    expect(getPlainContent(msg)).toBe('visible');
+  });
+
+  it('returns empty string for message with no text blocks', () => {
+    const msg = makeMessage([
+      { type: 'tool_call', toolCallId: 'tc1', toolName: 'grep', status: 'running' },
+    ]);
+    expect(getPlainContent(msg)).toBe('');
+  });
+
+  it('returns empty string for message with empty blocks', () => {
+    const msg = makeMessage([]);
+    expect(getPlainContent(msg)).toBe('');
+  });
+});

--- a/src/renderer/lib/store.tsx
+++ b/src/renderer/lib/store.tsx
@@ -3,7 +3,7 @@ import type { ChatMessage, ChatEvent, AgentStatus, ModelInfo, LensViewManifest, 
 
 export type LensView = 'chat' | string;
 
-interface AppState {
+export interface AppState {
   messages: ChatMessage[];
   conversationId: string;
   isStreaming: boolean;
@@ -15,7 +15,7 @@ interface AppState {
   showLanding: boolean;
 }
 
-type AppAction =
+export type AppAction =
   | { type: 'ADD_USER_MESSAGE'; payload: { id: string; content: string; timestamp: number } }
   | { type: 'ADD_ASSISTANT_MESSAGE'; payload: { id: string; timestamp: number } }
   | { type: 'CHAT_EVENT'; payload: { messageId: string; event: ChatEvent } }
@@ -29,7 +29,7 @@ type AppAction =
   | { type: 'CLEAR_MESSAGES' }
   | { type: 'NEW_CONVERSATION' };
 
-const initialState: AppState = {
+export const initialState: AppState = {
   messages: [],
   conversationId: `conv-${Date.now()}`,
   isStreaming: false,
@@ -57,7 +57,7 @@ export function getPlainContent(message: ChatMessage): string {
     .join('');
 }
 
-function handleChatEvent(messages: ChatMessage[], messageId: string, event: ChatEvent): ChatMessage[] {
+export function handleChatEvent(messages: ChatMessage[], messageId: string, event: ChatEvent): ChatMessage[] {
   return messages.map((m) => {
     if (m.id !== messageId) return m;
 
@@ -155,7 +155,7 @@ function handleChatEvent(messages: ChatMessage[], messageId: string, event: Chat
   });
 }
 
-function appReducer(state: AppState, action: AppAction): AppState {
+export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case 'ADD_USER_MESSAGE':
       return {

--- a/src/renderer/lib/utils.test.ts
+++ b/src/renderer/lib/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { cn, generateId, formatTime } from './utils';
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn('base', false && 'hidden', 'visible')).toBe('base visible');
+  });
+
+  it('deduplicates tailwind conflicts', () => {
+    expect(cn('p-4', 'p-2')).toBe('p-2');
+  });
+
+  it('returns empty string for no inputs', () => {
+    expect(cn()).toBe('');
+  });
+});
+
+describe('generateId', () => {
+  it('returns a non-empty string', () => {
+    const id = generateId();
+    expect(id).toBeTruthy();
+    expect(typeof id).toBe('string');
+  });
+
+  it('produces unique IDs', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateId()));
+    expect(ids.size).toBe(100);
+  });
+
+  it('contains a timestamp prefix and random suffix', () => {
+    const id = generateId();
+    expect(id).toMatch(/^\d+-[a-z0-9]+$/);
+  });
+});
+
+describe('formatTime', () => {
+  it('returns a formatted time string', () => {
+    const result = formatTime(Date.now());
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it('formats a known timestamp consistently', () => {
+    // Use a fixed timestamp: 2026-01-15T14:30:00Z
+    const ts = new Date('2026-01-15T14:30:00Z').getTime();
+    const result = formatTime(ts);
+    // Should contain hour and minute separated by colon
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/src/shared/createIpcListener.test.ts
+++ b/src/shared/createIpcListener.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createIpcListener } from './createIpcListener';
+import type { IpcRenderer, IpcRendererEvent } from 'electron';
+
+function makeMockIpcRenderer() {
+  const listeners = new Map<string, Function[]>();
+  return {
+    on: vi.fn((channel: string, handler: Function) => {
+      if (!listeners.has(channel)) listeners.set(channel, []);
+      listeners.get(channel)!.push(handler);
+    }),
+    removeListener: vi.fn((channel: string, handler: Function) => {
+      const arr = listeners.get(channel);
+      if (arr) {
+        const idx = arr.indexOf(handler);
+        if (idx >= 0) arr.splice(idx, 1);
+      }
+    }),
+    // Helper to simulate an event
+    _emit(channel: string, ...args: unknown[]) {
+      const fakeEvent = {} as IpcRendererEvent;
+      for (const fn of listeners.get(channel) || []) {
+        fn(fakeEvent, ...args);
+      }
+    },
+  } as unknown as IpcRenderer & { _emit: (channel: string, ...args: unknown[]) => void };
+}
+
+describe('createIpcListener', () => {
+  it('registers a listener on the given channel', () => {
+    const ipc = makeMockIpcRenderer();
+    const callback = vi.fn();
+
+    createIpcListener(ipc, 'test-channel', callback);
+
+    expect(ipc.on).toHaveBeenCalledWith('test-channel', expect.any(Function));
+  });
+
+  it('forwards IPC events to the callback without the event object', () => {
+    const ipc = makeMockIpcRenderer();
+    const callback = vi.fn();
+
+    createIpcListener(ipc, 'chat:event', callback);
+    ipc._emit('chat:event', 'msg-1', { type: 'chunk', content: 'hi' });
+
+    expect(callback).toHaveBeenCalledWith('msg-1', { type: 'chunk', content: 'hi' });
+  });
+
+  it('returns an unsubscribe function that removes the listener', () => {
+    const ipc = makeMockIpcRenderer();
+    const callback = vi.fn();
+
+    const unsub = createIpcListener(ipc, 'my-channel', callback);
+    unsub();
+
+    expect(ipc.removeListener).toHaveBeenCalledWith('my-channel', expect.any(Function));
+  });
+
+  it('stops receiving events after unsubscribe', () => {
+    const ipc = makeMockIpcRenderer();
+    const callback = vi.fn();
+
+    const unsub = createIpcListener(ipc, 'data', callback);
+    ipc._emit('data', 'first');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unsub();
+    ipc._emit('data', 'second');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,0 +1,178 @@
+import { vi } from 'vitest';
+import type {
+  AgentStatus,
+  ChatMessage,
+  ChatEvent,
+  ContentBlock,
+  TextBlock,
+  ToolCallBlock,
+  ReasoningBlock,
+  ModelInfo,
+  LensViewManifest,
+  ElectronAPI,
+} from '../shared/types';
+
+// ---------------------------------------------------------------------------
+// AgentStatus factories
+// ---------------------------------------------------------------------------
+
+export function defaultAgentStatus(): AgentStatus {
+  return {
+    connected: false,
+    mindPath: null,
+    agentName: null,
+    sessionActive: false,
+    uptime: null,
+    error: null,
+    extensions: [],
+  };
+}
+
+export function connectedAgentStatus(overrides?: Partial<AgentStatus>): AgentStatus {
+  return {
+    connected: true,
+    mindPath: 'C:\\test\\mind',
+    agentName: 'test-agent',
+    sessionActive: true,
+    uptime: 100,
+    error: null,
+    extensions: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ContentBlock factories
+// ---------------------------------------------------------------------------
+
+export function makeTextBlock(content: string, sdkMessageId?: string): TextBlock {
+  return { type: 'text', content, ...(sdkMessageId && { sdkMessageId }) };
+}
+
+export function makeToolCallBlock(overrides?: Partial<ToolCallBlock>): ToolCallBlock {
+  return {
+    type: 'tool_call',
+    toolCallId: 'tc-1',
+    toolName: 'grep',
+    status: 'running',
+    ...overrides,
+  };
+}
+
+export function makeReasoningBlock(content: string, reasoningId?: string): ReasoningBlock {
+  return { type: 'reasoning', reasoningId: reasoningId ?? 'r-1', content };
+}
+
+// ---------------------------------------------------------------------------
+// ChatMessage factory
+// ---------------------------------------------------------------------------
+
+export function makeMessage(blocks: ContentBlock[], overrides?: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    blocks,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ChatEvent factory
+// ---------------------------------------------------------------------------
+
+export function makeChatEvent<T extends ChatEvent['type']>(
+  type: T,
+  overrides?: Omit<Extract<ChatEvent, { type: T }>, 'type'>,
+): Extract<ChatEvent, { type: T }> {
+  const defaults: Record<string, Record<string, unknown>> = {
+    chunk: { content: 'hello' },
+    tool_start: { toolCallId: 'tc-1', toolName: 'grep' },
+    tool_progress: { toolCallId: 'tc-1', message: 'progress' },
+    tool_output: { toolCallId: 'tc-1', output: 'result' },
+    tool_done: { toolCallId: 'tc-1', success: true },
+    reasoning: { reasoningId: 'r-1', content: 'thinking' },
+    message_final: { sdkMessageId: 'sdk-1', content: 'final' },
+    done: {},
+    error: { message: 'something went wrong' },
+  };
+  return { type, ...defaults[type], ...overrides } as Extract<ChatEvent, { type: T }>;
+}
+
+// ---------------------------------------------------------------------------
+// LensViewManifest factory
+// ---------------------------------------------------------------------------
+
+export function makeLensViewManifest(overrides?: Partial<LensViewManifest>): LensViewManifest {
+  return {
+    id: 'test-view',
+    name: 'Test View',
+    icon: 'layout',
+    view: 'briefing',
+    source: 'test.json',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ModelInfo factory
+// ---------------------------------------------------------------------------
+
+export function makeModelInfo(id = 'claude-sonnet', name = 'Claude Sonnet'): ModelInfo {
+  return { id, name };
+}
+
+// ---------------------------------------------------------------------------
+// ElectronAPI mock
+// ---------------------------------------------------------------------------
+
+export function mockElectronAPI(): ElectronAPI {
+  return {
+    chat: {
+      send: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      newConversation: vi.fn().mockResolvedValue(undefined),
+      listModels: vi.fn().mockResolvedValue([]),
+      onEvent: vi.fn().mockReturnValue(() => {}),
+    },
+    agent: {
+      getStatus: vi.fn().mockResolvedValue(defaultAgentStatus()),
+      selectMindDirectory: vi.fn().mockResolvedValue(null),
+      setMindPath: vi.fn().mockResolvedValue(undefined),
+      onStatusChanged: vi.fn().mockReturnValue(() => {}),
+    },
+    lens: {
+      getViews: vi.fn().mockResolvedValue([]),
+      getViewData: vi.fn().mockResolvedValue(null),
+      refreshView: vi.fn().mockResolvedValue(null),
+      sendAction: vi.fn().mockResolvedValue(null),
+      onViewsChanged: vi.fn().mockReturnValue(() => {}),
+    },
+    auth: {
+      getStatus: vi.fn().mockResolvedValue({ authenticated: true }),
+      startLogin: vi.fn().mockResolvedValue({ success: true }),
+      onProgress: vi.fn().mockReturnValue(() => {}),
+    },
+    genesis: {
+      getDefaultPath: vi.fn().mockResolvedValue('C:\\Users\\test\\agents'),
+      pickPath: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ success: true }),
+      onProgress: vi.fn().mockReturnValue(() => {}),
+    },
+    config: {
+      load: vi.fn().mockResolvedValue({ mindPath: null, theme: 'dark' }),
+      save: vi.fn().mockResolvedValue(undefined),
+    },
+    window: {
+      minimize: vi.fn(),
+      maximize: vi.fn(),
+      close: vi.fn(),
+    },
+  };
+}
+
+export function installElectronAPI(api?: ElectronAPI): ElectronAPI {
+  const mock = api ?? mockElectronAPI();
+  Object.defineProperty(window, 'electronAPI', { value: mock, writable: true, configurable: true });
+  return mock;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: [
+      'src/**/*.{test,spec}.{ts,tsx}',
+      'test/**/*.{test,spec}.{ts,tsx}',
+    ],
+    exclude: ['node_modules', 'dist', 'out', '.vite'],
+    testTimeout: 10_000,
+    hookTimeout: 10_000,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## What

Add comprehensive test coverage to Chamber using Vitest + jsdom + @testing-library/react.

## Details

- **173 tests** across **26 test files**
- **5 phases**: test infra → store reducer → main process services → presentational components → interactive components/hooks → ViewDiscovery
- Shared test helpers with factories for all types and a full \mockElectronAPI\ 
- Minimal source changes: exported pure functions from \store.tsx\ and \AuthService.ts\ for testability

## Coverage highlights

| Area | Lines |
|------|-------|
| renderer/lib (store + utils) | 98.6% |
| renderer/components/chat | 97.6% |
| renderer/components/views | 94.4% |
| renderer/hooks | 96.7% |
| shared | 100% |
| ExtensionLoader | 94.1% |

## New scripts

- \
pm test\ — run all tests
- \
pm run test:watch\ — watch mode
- \
pm run test:coverage\ — coverage report
- \
pm run test:ui\ — Vitest UI

Bumps version to 0.14.3.