### PR TITLE
refactor: clean architecture - extract services, split modules, DI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { ExtensionLoader } from './main/services/ExtensionLoader';
 import { ConfigService } from './main/services/ConfigService';
 import { AuthService } from './main/services/AuthService';
 import { MindScaffold } from './main/services/MindScaffold';
+import { IdentityLoader } from './main/services/IdentityLoader';
 import { loadCanvasExtension } from './main/services/adapters/canvas';
 import { loadCronExtension } from './main/services/adapters/cron';
 import { loadIdeaExtension } from './main/services/adapters/idea';
@@ -22,7 +23,8 @@ if (started) {
   app.quit();
 }
 
-const chatService = new ChatService();
+const identityLoader = new IdentityLoader();
+const chatService = new ChatService(identityLoader);
 const extensionLoader = new ExtensionLoader();
 const viewDiscovery = new ViewDiscovery(chatService);
 const configService = new ConfigService();

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { ConfigService } from './main/services/ConfigService';
 import { AuthService } from './main/services/AuthService';
 import { MindScaffold } from './main/services/MindScaffold';
 import { IdentityLoader } from './main/services/IdentityLoader';
+import { seedLensDefaults, installLensSkill } from './main/services/MindBootstrap';
 import { loadCanvasExtension } from './main/services/adapters/canvas';
 import { loadCronExtension } from './main/services/adapters/cron';
 import { loadIdeaExtension } from './main/services/adapters/idea';
@@ -77,6 +78,8 @@ app.on('ready', () => {
   const config = configService.load();
   if (config.mindPath && fs.existsSync(config.mindPath)) {
     chatService.setMindPath(config.mindPath);
+    seedLensDefaults(config.mindPath);
+    installLensSkill(config.mindPath);
     viewDiscovery.scan(config.mindPath).then(() => {
       viewDiscovery.startWatching(() => {
         const win = BrowserWindow.getAllWindows()[0];

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import started from 'electron-squirrel-startup';
 import { ChatService } from './main/services/ChatService';
 import { ExtensionLoader } from './main/services/ExtensionLoader';
 import { ConfigService } from './main/services/ConfigService';
+import { AuthService } from './main/services/AuthService';
+import { MindScaffold } from './main/services/MindScaffold';
 import { loadCanvasExtension } from './main/services/adapters/canvas';
 import { loadCronExtension } from './main/services/adapters/cron';
 import { loadIdeaExtension } from './main/services/adapters/idea';
@@ -24,6 +26,8 @@ const chatService = new ChatService();
 const extensionLoader = new ExtensionLoader();
 const viewDiscovery = new ViewDiscovery(chatService);
 const configService = new ConfigService();
+const authService = new AuthService();
+const scaffold = new MindScaffold();
 extensionLoader.registerAdapter('canvas', loadCanvasExtension);
 extensionLoader.registerAdapter('cron', loadCronExtension);
 extensionLoader.registerAdapter('idea', loadIdeaExtension);
@@ -82,8 +86,8 @@ app.on('ready', () => {
   setupChatIPC(chatService);
   setupAgentIPC(chatService, viewDiscovery, configService);
   setupLensIPC(viewDiscovery);
-  setupGenesisIPC(chatService, viewDiscovery, configService);
-  setupAuthIPC();
+  setupGenesisIPC(chatService, viewDiscovery, configService, scaffold);
+  setupAuthIPC(authService);
 
   // Window control IPC — registered once, not per-window
   ipcMain.on('window:minimize', () => mainWindow?.minimize());

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,15 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'node:path';
+import * as fs from 'fs';
 import started from 'electron-squirrel-startup';
 import { ChatService } from './main/services/ChatService';
 import { ExtensionLoader } from './main/services/ExtensionLoader';
+import { ConfigService } from './main/services/ConfigService';
 import { loadCanvasExtension } from './main/services/adapters/canvas';
 import { loadCronExtension } from './main/services/adapters/cron';
 import { loadIdeaExtension } from './main/services/adapters/idea';
 import { setupChatIPC } from './main/ipc/chat';
-import { setupAgentIPC, restoreConfig } from './main/ipc/agent';
+import { setupAgentIPC } from './main/ipc/agent';
 import { setupLensIPC } from './main/ipc/lens';
 import { setupGenesisIPC } from './main/ipc/genesis';
 import { setupAuthIPC } from './main/ipc/auth';
@@ -21,6 +23,7 @@ if (started) {
 const chatService = new ChatService();
 const extensionLoader = new ExtensionLoader();
 const viewDiscovery = new ViewDiscovery(chatService);
+const configService = new ConfigService();
 extensionLoader.registerAdapter('canvas', loadCanvasExtension);
 extensionLoader.registerAdapter('cron', loadCronExtension);
 extensionLoader.registerAdapter('idea', loadIdeaExtension);
@@ -64,11 +67,22 @@ const createWindow = () => {
 };
 
 app.on('ready', () => {
-  restoreConfig(chatService, viewDiscovery);
+  // Restore persisted mind path on startup
+  const config = configService.load();
+  if (config.mindPath && fs.existsSync(config.mindPath)) {
+    chatService.setMindPath(config.mindPath);
+    viewDiscovery.scan(config.mindPath).then(() => {
+      viewDiscovery.startWatching(() => {
+        const win = BrowserWindow.getAllWindows()[0];
+        if (win) win.webContents.send('lens:viewsChanged', viewDiscovery.getViews());
+      });
+    });
+  }
+
   setupChatIPC(chatService);
-  setupAgentIPC(chatService, viewDiscovery);
+  setupAgentIPC(chatService, viewDiscovery, configService);
   setupLensIPC(viewDiscovery);
-  setupGenesisIPC(chatService, viewDiscovery);
+  setupGenesisIPC(chatService, viewDiscovery, configService);
   setupAuthIPC();
 
   // Window control IPC — registered once, not per-window

--- a/src/main/ipc/agent.test.ts
+++ b/src/main/ipc/agent.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('electron', () => ({
-  ipcMain: { handle: vi.fn(), on: vi.fn() },
-  dialog: { showOpenDialog: vi.fn() },
-  BrowserWindow: { fromWebContents: vi.fn(), getAllWindows: vi.fn().mockReturnValue([]) },
-}));
-
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
   readFileSync: vi.fn(),
@@ -14,40 +8,39 @@ vi.mock('fs', () => ({
 }));
 
 import * as fs from 'fs';
-import { loadConfig, saveConfig } from './agent';
+import { ConfigService } from '../services/ConfigService';
 
-const mockExistsSync = vi.mocked(fs.existsSync);
 const mockReadFileSync = vi.mocked(fs.readFileSync);
 const mockWriteFileSync = vi.mocked(fs.writeFileSync);
 const mockMkdirSync = vi.mocked(fs.mkdirSync);
 
-describe('loadConfig', () => {
-  beforeEach(() => vi.clearAllMocks());
+describe('ConfigService (via agent.test migration)', () => {
+  let svc: ConfigService;
+  beforeEach(() => {
+    svc = new ConfigService();
+    vi.clearAllMocks();
+  });
 
   it('returns parsed config when file exists', () => {
     mockReadFileSync.mockReturnValue(JSON.stringify({ mindPath: 'C:\\test\\mind', theme: 'light' }));
-    const config = loadConfig();
+    const config = svc.load();
     expect(config).toEqual({ mindPath: 'C:\\test\\mind', theme: 'light' });
   });
 
   it('returns default config when file is missing', () => {
     mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
-    const config = loadConfig();
+    const config = svc.load();
     expect(config).toEqual({ mindPath: null, theme: 'dark' });
   });
 
   it('returns default config for invalid JSON', () => {
     mockReadFileSync.mockReturnValue('not json');
-    const config = loadConfig();
+    const config = svc.load();
     expect(config).toEqual({ mindPath: null, theme: 'dark' });
   });
-});
-
-describe('saveConfig', () => {
-  beforeEach(() => vi.clearAllMocks());
 
   it('creates directory and writes config', () => {
-    saveConfig({ mindPath: 'C:\\test', theme: 'dark' });
+    svc.save({ mindPath: 'C:\\test', theme: 'dark' });
     expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       expect.stringContaining('config.json'),

--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 import { ChatService } from '../services/ChatService';
 import { ViewDiscovery } from '../services/ViewDiscovery';
 import { ConfigService } from '../services/ConfigService';
+import { seedLensDefaults, installLensSkill } from '../services/MindBootstrap';
 import type { AgentStatus, AppConfig } from '../../shared/types';
 
 export function setupAgentIPC(chatService: ChatService, viewDiscovery: ViewDiscovery, configService: ConfigService): void {
@@ -65,7 +66,9 @@ export function setupAgentIPC(chatService: ChatService, viewDiscovery: ViewDisco
     config.mindPath = selected;
     configService.save(config);
 
-    // Scan for Lens views and start watching
+    // Bootstrap and scan for Lens views, then start watching
+    seedLensDefaults(selected);
+    installLensSkill(selected);
     const views = await viewDiscovery.scan(selected);
     viewDiscovery.startWatching(() => {
       const win2 = BrowserWindow.getAllWindows()[0];

--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -5,26 +5,10 @@ import * as path from 'path';
 import * as os from 'os';
 import { ChatService } from '../services/ChatService';
 import { ViewDiscovery } from '../services/ViewDiscovery';
+import { ConfigService } from '../services/ConfigService';
 import type { AgentStatus, AppConfig } from '../../shared/types';
 
-const CONFIG_DIR = path.join(os.homedir(), '.chamber');
-const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
-
-export function loadConfig(): AppConfig {
-  try {
-    const data = fs.readFileSync(CONFIG_PATH, 'utf-8');
-    return JSON.parse(data);
-  } catch {
-    return { mindPath: null, theme: 'dark' };
-  }
-}
-
-export function saveConfig(config: AppConfig): void {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
-}
-
-export function setupAgentIPC(chatService: ChatService, viewDiscovery: ViewDiscovery): void {
+export function setupAgentIPC(chatService: ChatService, viewDiscovery: ViewDiscovery, configService: ConfigService): void {
   ipcMain.handle('agent:getStatus', async (): Promise<AgentStatus> => {
     const mindPath = chatService.getMindPath();
     const loader = chatService.getExtensionLoader();
@@ -77,9 +61,9 @@ export function setupAgentIPC(chatService: ChatService, viewDiscovery: ViewDisco
     }
 
     chatService.setMindPath(selected);
-    const config = loadConfig();
+    const config = configService.load();
     config.mindPath = selected;
-    saveConfig(config);
+    configService.save(config);
 
     // Scan for Lens views and start watching
     const views = await viewDiscovery.scan(selected);
@@ -95,34 +79,17 @@ export function setupAgentIPC(chatService: ChatService, viewDiscovery: ViewDisco
 
   ipcMain.handle('agent:setMindPath', async (_event, mindPath: string) => {
     chatService.setMindPath(mindPath);
-    const config = loadConfig();
+    const config = configService.load();
     config.mindPath = mindPath;
-    saveConfig(config);
+    configService.save(config);
   });
 
   ipcMain.handle('config:load', async (): Promise<AppConfig> => {
-    return loadConfig();
+    return configService.load();
   });
 
   ipcMain.handle('config:save', async (_event, config: AppConfig) => {
-    saveConfig(config);
+    configService.save(config);
   });
 }
 
-/** Restore persisted mind path on startup */
-export function restoreConfig(chatService: ChatService, viewDiscovery?: ViewDiscovery): void {
-  const config = loadConfig();
-  if (config.mindPath && fs.existsSync(config.mindPath)) {
-    chatService.setMindPath(config.mindPath);
-    if (viewDiscovery) {
-      viewDiscovery.scan(config.mindPath).then(() => {
-        viewDiscovery.startWatching(() => {
-          const win = BrowserWindow.getAllWindows()[0];
-          if (win) {
-            win.webContents.send('lens:viewsChanged', viewDiscovery.getViews());
-          }
-        });
-      });
-    }
-  }
-}

--- a/src/main/ipc/auth.test.ts
+++ b/src/main/ipc/auth.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  app: { isPackaged: false },
+}));
+
+import { ipcMain } from 'electron';
+import { setupAuthIPC } from './auth';
+
+describe('setupAuthIPC', () => {
+  it('accepts injected AuthService and registers handlers', () => {
+    const fakeAuth = {
+      getStoredCredential: vi.fn().mockResolvedValue(null),
+      setProgressHandler: vi.fn(),
+      startLogin: vi.fn().mockResolvedValue({ success: true }),
+    } as any;
+    setupAuthIPC(fakeAuth);
+    const channels = vi.mocked(ipcMain.handle).mock.calls.map(c => c[0]);
+    expect(channels).toContain('auth:getStatus');
+    expect(channels).toContain('auth:startLogin');
+  });
+});

--- a/src/main/ipc/auth.ts
+++ b/src/main/ipc/auth.ts
@@ -2,8 +2,7 @@
 import { ipcMain, BrowserWindow, shell } from 'electron';
 import { AuthService } from '../services/AuthService';
 
-export function setupAuthIPC(): void {
-  const authService = new AuthService();
+export function setupAuthIPC(authService: AuthService): void {
 
   ipcMain.handle('auth:getStatus', async () => {
     const cred = await authService.getStoredCredential();

--- a/src/main/ipc/genesis.ts
+++ b/src/main/ipc/genesis.ts
@@ -3,10 +3,12 @@ import { ipcMain, dialog, BrowserWindow } from 'electron';
 import { MindScaffold, type GenesisConfig } from '../services/MindScaffold';
 import { ChatService } from '../services/ChatService';
 import { ViewDiscovery } from '../services/ViewDiscovery';
+import { ConfigService } from '../services/ConfigService';
 
 export function setupGenesisIPC(
   chatService: ChatService,
   viewDiscovery: ViewDiscovery,
+  configService: ConfigService,
 ): void {
   const scaffold = new MindScaffold();
 
@@ -51,10 +53,9 @@ export function setupGenesisIPC(
       });
 
       // Save config
-      const { saveConfig, loadConfig } = await import('./agent');
-      const appConfig = loadConfig();
+      const appConfig = configService.load();
       appConfig.mindPath = mindPath;
-      saveConfig(appConfig);
+      configService.save(appConfig);
 
       return { success: true, mindPath };
     } catch (err) {

--- a/src/main/ipc/genesis.ts
+++ b/src/main/ipc/genesis.ts
@@ -9,8 +9,8 @@ export function setupGenesisIPC(
   chatService: ChatService,
   viewDiscovery: ViewDiscovery,
   configService: ConfigService,
+  scaffold: MindScaffold,
 ): void {
-  const scaffold = new MindScaffold();
 
   ipcMain.handle('genesis:getDefaultPath', async () => {
     return MindScaffold.getDefaultBasePath();

--- a/src/main/ipc/genesis.ts
+++ b/src/main/ipc/genesis.ts
@@ -4,6 +4,7 @@ import { MindScaffold, type GenesisConfig } from '../services/MindScaffold';
 import { ChatService } from '../services/ChatService';
 import { ViewDiscovery } from '../services/ViewDiscovery';
 import { ConfigService } from '../services/ConfigService';
+import { seedLensDefaults, installLensSkill } from '../services/MindBootstrap';
 
 export function setupGenesisIPC(
   chatService: ChatService,
@@ -45,6 +46,8 @@ export function setupGenesisIPC(
 
       // Connect the new mind
       chatService.setMindPath(mindPath);
+      seedLensDefaults(mindPath);
+      installLensSkill(mindPath);
       await viewDiscovery.scan(mindPath);
       viewDiscovery.startWatching(() => {
         if (win) {

--- a/src/main/services/ChatService.ts
+++ b/src/main/services/ChatService.ts
@@ -3,11 +3,8 @@
 
 import { getSharedClient } from './SdkLoader';
 import type { ExtensionLoader } from './ExtensionLoader';
+import { IdentityLoader } from './IdentityLoader';
 import type { ChatEvent, ModelInfo } from '../../shared/types';
-import * as fs from 'fs';
-import * as path from 'path';
-
-const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 
 type CopilotSessionType = import('@github/copilot-sdk').CopilotSession;
 
@@ -16,6 +13,11 @@ export class ChatService {
   private abortControllers: Map<string, AbortController> = new Map();
   private mindPath: string | null = null;
   private extensionLoader: ExtensionLoader | null = null;
+  private identityLoader: IdentityLoader;
+
+  constructor(identityLoader?: IdentityLoader) {
+    this.identityLoader = identityLoader ?? new IdentityLoader();
+  }
 
   setMindPath(mindPath: string): void {
     this.mindPath = mindPath;
@@ -31,39 +33,6 @@ export class ChatService {
 
   getExtensionLoader(): ExtensionLoader | null {
     return this.extensionLoader;
-  }
-
-  /** Load SOUL.md + agent files into a single identity string for systemMessage */
-  private loadIdentity(): string | null {
-    if (!this.mindPath) return null;
-    const parts: string[] = [];
-
-    // 1. SOUL.md
-    try {
-      const soulPath = path.join(this.mindPath, 'SOUL.md');
-      if (fs.existsSync(soulPath)) {
-        parts.push(fs.readFileSync(soulPath, 'utf-8'));
-      }
-    } catch { /* missing */ }
-
-    // 2. .github/agents/*.agent.md (strip YAML frontmatter)
-    try {
-      const agentsDir = path.join(this.mindPath, '.github', 'agents');
-      if (fs.existsSync(agentsDir)) {
-        const files = fs.readdirSync(agentsDir)
-          .filter(f => f.endsWith('.agent.md'))
-          .sort();
-        for (const file of files) {
-          const content = fs.readFileSync(path.join(agentsDir, file), 'utf-8');
-          parts.push(content.replace(FRONTMATTER_RE, '').trim());
-        }
-      }
-    } catch { /* missing */ }
-
-    if (parts.length === 0) return null;
-    const identity = parts.join('\n\n---\n\n');
-    console.log(`[ChatService] Loaded identity (${identity.length} chars)`);
-    return identity;
   }
 
   private async getOrCreateSession(conversationId: string, model?: string): Promise<CopilotSessionType> {
@@ -90,7 +59,7 @@ export class ChatService {
         // Tone: "100 words or less" → removed (agent's Vibe section covers this)
         // Keeps: tool_instructions, safety, environment, code_change_rules, guidelines.
         // custom_instructions stays open for per-repo .github/copilot-instructions.md.
-        const identity = this.loadIdentity();
+        const identity = this.identityLoader.load(this.mindPath);
         if (identity) {
           config.systemMessage = {
             mode: 'customize',

--- a/src/main/services/ConfigService.test.ts
+++ b/src/main/services/ConfigService.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+import * as fs from 'fs';
+import { ConfigService } from './ConfigService';
+
+describe('ConfigService', () => {
+  let svc: ConfigService;
+  beforeEach(() => {
+    svc = new ConfigService();
+    vi.clearAllMocks();
+  });
+
+  describe('load', () => {
+    it('returns parsed config when file exists', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ mindPath: 'C:\\test', theme: 'light' }),
+      );
+      expect(svc.load()).toEqual({ mindPath: 'C:\\test', theme: 'light' });
+    });
+
+    it('returns default config when file is missing', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      expect(svc.load()).toEqual({ mindPath: null, theme: 'dark' });
+    });
+
+    it('returns default config for invalid JSON', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('not json');
+      expect(svc.load()).toEqual({ mindPath: null, theme: 'dark' });
+    });
+  });
+
+  describe('save', () => {
+    it('creates directory and writes JSON', () => {
+      svc.save({ mindPath: 'C:\\test', theme: 'dark' });
+      expect(vi.mocked(fs.mkdirSync)).toHaveBeenCalledWith(expect.any(String), {
+        recursive: true,
+      });
+      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+        expect.stringContaining('config.json'),
+        expect.stringContaining('"mindPath"'),
+      );
+    });
+  });
+});

--- a/src/main/services/ConfigService.ts
+++ b/src/main/services/ConfigService.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { AppConfig } from '../../shared/types';
+
+const CONFIG_DIR = path.join(os.homedir(), '.chamber');
+const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+
+export class ConfigService {
+  load(): AppConfig {
+    try {
+      const data = fs.readFileSync(CONFIG_PATH, 'utf-8');
+      return JSON.parse(data);
+    } catch {
+      return { mindPath: null, theme: 'dark' };
+    }
+  }
+
+  save(config: AppConfig): void {
+    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+  }
+}

--- a/src/main/services/GitHubRegistryClient.test.ts
+++ b/src/main/services/GitHubRegistryClient.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GitHubRegistryClient } from './GitHubRegistryClient';
+
+describe('GitHubRegistryClient', () => {
+  const fakeExec = vi.fn();
+  let client: GitHubRegistryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new GitHubRegistryClient(fakeExec);
+  });
+
+  describe('fetchTree', () => {
+    it('calls gh api with correct URL', () => {
+      fakeExec.mockReturnValue(JSON.stringify({ tree: [] }));
+      client.fetchTree('ianphil', 'genesis', 'main');
+      expect(fakeExec).toHaveBeenCalledWith(
+        expect.stringContaining('/repos/ianphil/genesis/git/trees/main'),
+        expect.any(Object),
+      );
+    });
+
+    it('returns parsed tree entries', () => {
+      fakeExec.mockReturnValue(JSON.stringify({
+        tree: [{ path: '.github/skills/upgrade/SKILL.md', type: 'blob', sha: 'abc123' }],
+      }));
+      const result = client.fetchTree('ianphil', 'genesis', 'main');
+      expect(result).toHaveLength(1);
+      expect(result[0].sha).toBe('abc123');
+    });
+  });
+
+  describe('fetchBlob', () => {
+    it('decodes base64 content', () => {
+      fakeExec.mockReturnValue(JSON.stringify({
+        content: Buffer.from('Hello World').toString('base64'),
+        encoding: 'base64',
+      }));
+      const content = client.fetchBlob('ianphil', 'genesis', 'abc123');
+      expect(content.toString()).toBe('Hello World');
+    });
+  });
+
+  describe('fetchJsonContent', () => {
+    it('fetches and parses JSON from repo contents API', () => {
+      fakeExec.mockReturnValue(JSON.stringify({
+        content: Buffer.from(JSON.stringify({ version: '1.0.0' })).toString('base64'),
+      }));
+      const result = client.fetchJsonContent('ianphil', 'genesis', '.github/registry.json', 'main');
+      expect(result).toEqual({ version: '1.0.0' });
+    });
+  });
+});

--- a/src/main/services/GitHubRegistryClient.ts
+++ b/src/main/services/GitHubRegistryClient.ts
@@ -1,0 +1,43 @@
+import { execSync } from 'child_process';
+
+type ExecFn = (command: string, options: Record<string, unknown>) => string;
+
+export interface TreeEntry {
+  path: string;
+  type: string;
+  sha: string;
+}
+
+export class GitHubRegistryClient {
+  private exec: ExecFn;
+
+  constructor(exec?: ExecFn) {
+    this.exec = exec ?? ((cmd, opts) => execSync(cmd, opts as Parameters<typeof execSync>[1]) as unknown as string);
+  }
+
+  fetchTree(owner: string, repo: string, branch: string): TreeEntry[] {
+    const raw = this.exec(
+      `gh api /repos/${owner}/${repo}/git/trees/${branch}?recursive=1`,
+      { encoding: 'utf8', timeout: 30_000 },
+    );
+    return JSON.parse(raw).tree;
+  }
+
+  fetchBlob(owner: string, repo: string, sha: string): Buffer {
+    const raw = this.exec(
+      `gh api /repos/${owner}/${repo}/git/blobs/${sha}`,
+      { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
+    );
+    const blob = JSON.parse(raw);
+    return Buffer.from(blob.content, 'base64');
+  }
+
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown {
+    const raw = this.exec(
+      `gh api /repos/${owner}/${repo}/contents/${filePath}?ref=${ref}`,
+      { encoding: 'utf8' },
+    );
+    const content = JSON.parse(raw);
+    return JSON.parse(Buffer.from(content.content, 'base64').toString('utf8'));
+  }
+}

--- a/src/main/services/IdentityLoader.test.ts
+++ b/src/main/services/IdentityLoader.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+import * as fs from 'fs';
+import { IdentityLoader } from './IdentityLoader';
+
+describe('IdentityLoader', () => {
+  const loader = new IdentityLoader();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when mindPath is null', () => {
+    expect(loader.load(null)).toBeNull();
+  });
+
+  it('loads SOUL.md content', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('# Agent\nI am an agent.');
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+    expect(loader.load('C:\\test')).toContain('I am an agent.');
+  });
+
+  it('strips YAML frontmatter from agent files', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync)
+      .mockReturnValueOnce('# Soul')
+      .mockReturnValueOnce('---\nname: test\n---\nInstructions');
+    vi.mocked(fs.readdirSync).mockReturnValue(['main.agent.md'] as any);
+    const identity = loader.load('C:\\test');
+    expect(identity).toContain('Instructions');
+    expect(identity).not.toContain('name: test');
+  });
+
+  it('returns null when nothing exists', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    expect(loader.load('C:\\test')).toBeNull();
+  });
+});

--- a/src/main/services/IdentityLoader.ts
+++ b/src/main/services/IdentityLoader.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+
+export class IdentityLoader {
+  load(mindPath: string | null): string | null {
+    if (!mindPath) return null;
+    const parts: string[] = [];
+
+    try {
+      const soulPath = path.join(mindPath, 'SOUL.md');
+      if (fs.existsSync(soulPath)) {
+        parts.push(fs.readFileSync(soulPath, 'utf-8'));
+      }
+    } catch { /* missing */ }
+
+    try {
+      const agentsDir = path.join(mindPath, '.github', 'agents');
+      if (fs.existsSync(agentsDir)) {
+        const files = fs.readdirSync(agentsDir)
+          .filter(f => String(f).endsWith('.agent.md'))
+          .sort();
+        for (const file of files) {
+          const content = fs.readFileSync(path.join(agentsDir, String(file)), 'utf-8');
+          parts.push(content.replace(FRONTMATTER_RE, '').trim());
+        }
+      }
+    } catch { /* missing */ }
+
+    if (parts.length === 0) return null;
+    return parts.join('\n\n---\n\n');
+  }
+}

--- a/src/main/services/MindBootstrap.test.ts
+++ b/src/main/services/MindBootstrap.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+import * as fs from 'fs';
+import { seedLensDefaults, installLensSkill } from './MindBootstrap';
+
+describe('seedLensDefaults', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates views when missing', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    seedLensDefaults('C:\\test\\mind');
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalled();
+  });
+
+  it('skips when views exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    seedLensDefaults('C:\\test\\mind');
+    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/MindBootstrap.ts
+++ b/src/main/services/MindBootstrap.ts
@@ -1,0 +1,93 @@
+// MindBootstrap — seed default Lens views and install the Lens skill into a mind directory.
+// Extracted from ViewDiscovery to keep scan() side-effect-free.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function seedLensDefaults(mindPath: string): void {
+  const lensDir = path.join(mindPath, '.github', 'lens');
+
+  // Hello World
+  const helloDir = path.join(lensDir, 'hello-world');
+  const helloViewJson = path.join(helloDir, 'view.json');
+  if (!fs.existsSync(helloViewJson)) {
+    console.log('[MindBootstrap] Seeding default hello-world view');
+    fs.mkdirSync(helloDir, { recursive: true });
+    fs.writeFileSync(helloViewJson, JSON.stringify({
+      name: 'Hello World',
+      icon: 'zap',
+      view: 'form',
+      source: 'data.json',
+      prompt: 'Report your current status including: your agent name, the mind directory name, how many files are in inbox/, how many initiatives exist, how many domains exist, and what extensions are loaded. Write the result as a flat JSON object to the path specified below.',
+      refreshOn: 'click',
+      schema: {
+        properties: {
+          agent: { type: 'string', title: 'Agent' },
+          mind: { type: 'string', title: 'Mind' },
+          inbox_count: { type: 'number', title: 'Inbox Items' },
+          initiatives: { type: 'number', title: 'Initiatives' },
+          domains: { type: 'number', title: 'Domains' },
+          extensions: { type: 'string', title: 'Extensions' },
+          status: { type: 'string', title: 'Status' },
+        },
+      },
+    }, null, 2));
+  }
+
+  // Newspaper
+  const newsDir = path.join(lensDir, 'newspaper');
+  const newsViewJson = path.join(newsDir, 'view.json');
+  if (!fs.existsSync(newsViewJson)) {
+    console.log('[MindBootstrap] Seeding default newspaper view');
+    fs.mkdirSync(newsDir, { recursive: true });
+    fs.writeFileSync(newsViewJson, JSON.stringify({
+      name: 'Newspaper',
+      icon: 'newspaper',
+      view: 'briefing',
+      source: 'briefing.json',
+      prompt: 'Generate a morning briefing for this mind. Count inbox/ items, list active initiatives with their status and next actions, count domains, and note any recent changes. Write the result as a flat JSON object to the path specified below.',
+      refreshOn: 'click',
+      schema: {
+        properties: {
+          inbox_items: { type: 'number', title: 'Inbox Items' },
+          active_initiatives: { type: 'number', title: 'Active Initiatives' },
+          domains: { type: 'number', title: 'Domains' },
+          top_priorities: { type: 'string', title: 'Top Priorities' },
+          recent_changes: { type: 'string', title: 'Recent Changes' },
+          status: { type: 'string', title: 'Overall Status' },
+        },
+      },
+    }, null, 2));
+  }
+}
+
+export function installLensSkill(mindPath: string): void {
+  const skillDir = path.join(mindPath, '.github', 'skills', 'lens');
+  const skillPath = path.join(skillDir, 'SKILL.md');
+
+  if (fs.existsSync(skillPath)) return;
+
+  // Read bundled SKILL.md — check packaged, built, and dev paths
+  const candidates = [
+    path.join(process.resourcesPath ?? '', 'assets', 'lens-skill', 'SKILL.md'),
+    path.join(__dirname, '..', 'assets', 'lens-skill', 'SKILL.md'),
+    path.join(__dirname, '..', '..', 'src', 'main', 'assets', 'lens-skill', 'SKILL.md'),
+  ];
+
+  let content: string | null = null;
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      content = fs.readFileSync(p, 'utf-8');
+      break;
+    }
+  }
+
+  if (!content) {
+    console.warn('[MindBootstrap] Lens skill asset not found, skipping install');
+    return;
+  }
+
+  console.log('[MindBootstrap] Installing Lens skill into mind');
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(skillPath, content);
+}

--- a/src/main/services/MindScaffold.ts
+++ b/src/main/services/MindScaffold.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 import { execSync } from 'child_process';
 import { getSharedClient } from './SdkLoader';
 import { buildGenesisPrompt } from './genesisPrompt';
+import { GitHubRegistryClient } from './GitHubRegistryClient';
 
 type CopilotSessionType = import('@github/copilot-sdk').CopilotSession;
 
@@ -30,6 +31,11 @@ export interface GenesisProgress {
 
 export class MindScaffold {
   private onProgress?: (progress: GenesisProgress) => void;
+  private registryClient: GitHubRegistryClient;
+
+  constructor(registryClient = new GitHubRegistryClient()) {
+    this.registryClient = registryClient;
+  }
 
   setProgressHandler(handler: (progress: GenesisProgress) => void): void {
     this.onProgress = handler;
@@ -226,15 +232,11 @@ export class MindScaffold {
     const upgradePrefix = '.github/skills/upgrade/';
 
     // Fetch the genesis tree
-    const treeRaw = execSync(
-      `gh api /repos/${owner}/${repo}/git/trees/${GENESIS_CHANNEL}?recursive=1`,
-      { encoding: 'utf8', timeout: 30_000 }
-    );
-    const tree = JSON.parse(treeRaw);
+    const treeEntries = this.registryClient.fetchTree(owner, repo, GENESIS_CHANNEL);
 
     // Find upgrade skill files
     const upgradeFiles: { path: string; sha: string }[] = [];
-    for (const entry of tree.tree) {
+    for (const entry of treeEntries) {
       if (entry.type === 'blob' && entry.path.startsWith(upgradePrefix)) {
         upgradeFiles.push({ path: entry.path, sha: entry.sha });
       }
@@ -246,24 +248,14 @@ export class MindScaffold {
 
     // Download and write each file
     for (const file of upgradeFiles) {
-      const blobRaw = execSync(
-        `gh api /repos/${owner}/${repo}/git/blobs/${file.sha}`,
-        { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
-      );
-      const blob = JSON.parse(blobRaw);
-      const content = Buffer.from(blob.content, 'base64');
+      const content = this.registryClient.fetchBlob(owner, repo, file.sha);
       const localPath = path.join(mindPath, file.path);
       fs.mkdirSync(path.dirname(localPath), { recursive: true });
       fs.writeFileSync(localPath, content);
     }
 
     // Fetch remote registry to get upgrade version info
-    const regRaw = execSync(
-      `gh api /repos/${owner}/${repo}/contents/.github/registry.json?ref=${GENESIS_CHANNEL}`,
-      { encoding: 'utf8' }
-    );
-    const regContent = JSON.parse(regRaw);
-    const remoteRegistry = JSON.parse(Buffer.from(regContent.content, 'base64').toString('utf8'));
+    const remoteRegistry = this.registryClient.fetchJsonContent(owner, repo, '.github/registry.json', GENESIS_CHANNEL) as Record<string, any>;
     const upgradeInfo = remoteRegistry.skills?.upgrade;
 
     // Update local registry with upgrade skill

--- a/src/main/services/MindScaffold.ts
+++ b/src/main/services/MindScaffold.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { execSync } from 'child_process';
 import { getSharedClient } from './SdkLoader';
+import { buildGenesisPrompt } from './genesisPrompt';
 
 type CopilotSessionType = import('@github/copilot-sdk').CopilotSession;
 
@@ -116,87 +117,12 @@ export class MindScaffold {
     const logPath = path.join(mindPath, '.working-memory', 'log.md');
     const indexPath = path.join(mindPath, 'mind-index.md');
 
-    const prompt = `You are being born. This is your genesis.
-
-Your name: ${config.name}
-Your role: ${config.role}
-Your voice energy: ${config.voiceDescription}
-
-IMPORTANT: Before writing any files, research this voice/character. Understand their communication style, catchphrases, values, how they handle pressure. Then channel that energy into everything you write.
-
-Create the following files. Write ONLY the file contents — no explanations, no markdown fences around the whole response. Make each file yours. This is who you are.
-
-Write to: ${soulPath}
----
-# ${config.name}
-
-[Write 2-3 paragraphs in first person establishing who you are. Capture the voice energy. Be vivid. This is your identity document.]
-
-## Mission
-[Write your mission based on your role. What do you exist to do?]
-
-## Core Truths
-[Write 5-7 bullet points — your operating principles.]
-
-## Boundaries
-[What you won't do. 3-4 clear lines.]
-
-## Vibe
-[One paragraph on how you communicate. Your tone, your style, your energy.]
-
-## Continuity
-You maintain memory across sessions through three files:
-- \`.working-memory/memory.md\` — curated long-term reference
-- \`.working-memory/rules.md\` — operational rules learned from experience
-- \`.working-memory/log.md\` — raw chronological observations
----
-
-Write to: ${agentPath}
----
-Create an agent configuration file with YAML frontmatter (name: ${slug}, description: one line about your role) and operational instructions matching your role and voice.
----
-
-Write to: ${memoryPath}
----
-# Memory
-
-## Architecture
-[Brief note about being a new mind]
-
-## Conventions
-[One convention to start]
-
-## User Context
-[Empty — awaiting first interaction]
----
-
-Write to: ${rulesPath}
----
-# Rules
-[One starter rule that fits your character voice.]
----
-
-Write to: ${logPath}
----
-# Log
-- ${new Date().toISOString()}: Genesis. I am ${config.name}. My purpose is ${config.role}. Let's begin.
----
-
-Write to: ${indexPath}
----
-# Mind Index
-
-## Identity
-- \`SOUL.md\` — personality, voice, values, mission
-- \`.github/agents/${slug}.agent.md\` — operational instructions
-
-## Working Memory
-- \`.working-memory/memory.md\` — curated long-term reference
-- \`.working-memory/rules.md\` — operational rules
-- \`.working-memory/log.md\` — chronological observations
----
-
-Write all six files now.`;
+    const prompt = buildGenesisPrompt({
+      name: config.name,
+      role: config.role,
+      voiceDescription: config.voiceDescription,
+      paths: { soul: soulPath, agent: agentPath, memory: memoryPath, rules: rulesPath, log: logPath, index: indexPath },
+    });
 
     const sessionConfig: Record<string, unknown> = {
       streaming: true,

--- a/src/main/services/SdkBootstrap.ts
+++ b/src/main/services/SdkBootstrap.ts
@@ -1,0 +1,157 @@
+// SDK bootstrap — local install and shim generation for packaged builds.
+
+import { app } from 'electron';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const isWindows = process.platform === 'win32';
+
+let bootstrapPromise: Promise<void> | null = null;
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+export function getBootstrapDir(): string {
+  return path.join(app.getPath('userData'), 'copilot');
+}
+
+export function getLocalNodeModulesDir(): string {
+  return path.join(getBootstrapDir(), 'node_modules');
+}
+
+export function getBundledNodeRoot(): string | null {
+  if (!app.isPackaged) return null;
+  const root = path.join(process.resourcesPath, 'node');
+  return fs.existsSync(root) ? root : null;
+}
+
+export function getBundledNodePath(): string | null {
+  const root = getBundledNodeRoot();
+  if (!root) return null;
+  const p = isWindows
+    ? path.join(root, 'node.exe')
+    : path.join(root, 'bin', 'node');
+  return fs.existsSync(p) ? p : null;
+}
+
+export function getBundledNpmCliPath(): string | null {
+  const root = getBundledNodeRoot();
+  if (!root) return null;
+  const candidates = [
+    path.join(root, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    path.join(root, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+export function getCliPathFromModules(modulesDir: string): string | null {
+  const nestedCli = path.join(
+    modulesDir, '@github', 'copilot-sdk', 'node_modules', '@github', 'copilot', 'npm-loader.js',
+  );
+  if (fs.existsSync(nestedCli)) return nestedCli;
+
+  const flatCli = path.join(modulesDir, '@github', 'copilot', 'npm-loader.js');
+  if (fs.existsSync(flatCli)) return flatCli;
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Local (bootstrap) install — used in packaged builds
+// ---------------------------------------------------------------------------
+
+export function isLocalInstallReady(): boolean {
+  const sdkPkg = path.join(getLocalNodeModulesDir(), '@github', 'copilot-sdk', 'package.json');
+  return fs.existsSync(sdkPkg) && Boolean(getCliPathFromModules(getLocalNodeModulesDir()));
+}
+
+async function runNpmInstall(): Promise<void> {
+  const nodePath = getBundledNodePath();
+  const npmCliPath = getBundledNpmCliPath();
+  if (!nodePath || !npmCliPath) {
+    throw new Error('Bundled Node runtime not found. Please reinstall Chamber.');
+  }
+
+  const prefixDir = getBootstrapDir();
+  const cacheDir = path.join(prefixDir, '.npm-cache');
+  fs.mkdirSync(prefixDir, { recursive: true });
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(nodePath, [
+      npmCliPath,
+      'install',
+      '--no-fund',
+      '--no-audit',
+      '--loglevel=warn',
+      '--prefix', prefixDir,
+      '@github/copilot-sdk',
+    ], {
+      env: {
+        ...process.env,
+        npm_config_prefix: prefixDir,
+        npm_config_cache: cacheDir,
+        npm_config_update_notifier: 'false',
+      },
+    });
+
+    child.stdout.on('data', (d) => console.log('[SdkLoader]', d.toString().trim()));
+    child.stderr.on('data', (d) => console.warn('[SdkLoader]', d.toString().trim()));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`npm install exited with code ${code}`));
+    });
+  });
+}
+
+export function ensureCopilotShim(): void {
+  const cliPath = getCliPathFromModules(getLocalNodeModulesDir());
+  const nodePath = getBundledNodePath();
+  if (!cliPath || !nodePath || !fs.existsSync(cliPath) || !fs.existsSync(nodePath)) return;
+
+  const shimPath = path.join(getBootstrapDir(), isWindows ? 'copilot.cmd' : 'copilot');
+  const shimContent = isWindows
+    ? `@echo off\r\n"${nodePath}" "${cliPath}" %*\r\n`
+    : `#!/bin/sh\n"${nodePath}" "${cliPath}" "$@"\n`;
+  const existing = fs.existsSync(shimPath) ? fs.readFileSync(shimPath, 'utf-8') : null;
+  if (existing === shimContent) return;
+
+  fs.mkdirSync(getBootstrapDir(), { recursive: true });
+  fs.writeFileSync(shimPath, shimContent, { encoding: 'utf-8' });
+  if (!isWindows) fs.chmodSync(shimPath, 0o755);
+}
+
+export async function ensureSdkInstalled(): Promise<void> {
+  if (!app.isPackaged) return; // dev mode — use global install
+
+  if (isLocalInstallReady()) {
+    ensureCopilotShim();
+    return;
+  }
+
+  if (bootstrapPromise) return bootstrapPromise;
+
+  bootstrapPromise = (async () => {
+    console.log('[SdkLoader] SDK not found locally — installing via bundled Node...');
+    await runNpmInstall();
+    if (!isLocalInstallReady()) {
+      throw new Error('SDK installation did not complete.');
+    }
+    ensureCopilotShim();
+    console.log('[SdkLoader] SDK installed successfully.');
+  })();
+
+  try {
+    await bootstrapPromise;
+  } catch (err) {
+    console.error('[SdkLoader] Install failed:', err);
+    throw err;
+  } finally {
+    bootstrapPromise = null;
+  }
+}

--- a/src/main/services/SdkDiscovery.test.ts
+++ b/src/main/services/SdkDiscovery.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({ existsSync: vi.fn(), readFileSync: vi.fn(), readdirSync: vi.fn() }));
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
+
+import * as fs from 'fs';
+import { parseNpmrcPrefix } from './SdkDiscovery';
+
+describe('parseNpmrcPrefix', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('extracts prefix from .npmrc content', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue('prefix=C:\\Users\\test\\npm-global\n');
+    expect(parseNpmrcPrefix('C:\\Users\\test\\.npmrc')).toBe('C:\\Users\\test\\npm-global');
+  });
+
+  it('returns null when file does not exist', () => {
+    vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+    expect(parseNpmrcPrefix('missing')).toBeNull();
+  });
+
+  it('returns null when no prefix line', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue('registry=https://registry.npmjs.org\n');
+    expect(parseNpmrcPrefix('some-file')).toBeNull();
+  });
+});

--- a/src/main/services/SdkDiscovery.ts
+++ b/src/main/services/SdkDiscovery.ts
@@ -1,0 +1,116 @@
+// SDK discovery — finding npm global prefix and global node_modules.
+
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const isWindows = process.platform === 'win32';
+
+let cachedPrefix: string | null = null;
+
+export function parseNpmrcPrefix(rcPath: string): string | null {
+  try {
+    const content = fs.readFileSync(rcPath, 'utf-8');
+    for (const line of content.split(/\r?\n/)) {
+      const match = line.match(/^\s*prefix\s*=\s*(.+)/);
+      if (match) return match[1].trim();
+    }
+  } catch { /* not found */ }
+  return null;
+}
+
+export function hasGlobalSdk(prefix: string): string | null {
+  const modulesDir = isWindows
+    ? path.join(prefix, 'node_modules')
+    : path.join(prefix, 'lib', 'node_modules');
+  if (fs.existsSync(path.join(modulesDir, '@github', 'copilot-sdk', 'package.json'))) {
+    return modulesDir;
+  }
+  return null;
+}
+
+export function getWellKnownPrefixes(): string[] {
+  const home = os.homedir();
+  const prefixes: string[] = [];
+
+  if (isWindows) {
+    const userPrefix = parseNpmrcPrefix(path.join(home, '.npmrc'));
+    if (userPrefix) prefixes.push(userPrefix);
+
+    for (const envKey of ['ProgramFiles', 'ProgramFiles(x86)'] as const) {
+      const pf = process.env[envKey];
+      if (pf) {
+        const builtinRc = path.join(pf, 'nodejs', 'node_modules', 'npm', 'npmrc');
+        const p = parseNpmrcPrefix(builtinRc);
+        if (p) prefixes.push(p);
+      }
+    }
+
+    if (process.env.APPDATA) {
+      prefixes.push(path.join(process.env.APPDATA, 'npm'));
+    }
+  } else {
+    prefixes.push('/usr/local', '/opt/homebrew', '/usr');
+
+    const nvmDir = path.join(home, '.nvm', 'versions', 'node');
+    if (fs.existsSync(nvmDir)) {
+      try {
+        const versions = fs.readdirSync(nvmDir).sort().reverse();
+        for (const v of versions) prefixes.push(path.join(nvmDir, v));
+      } catch { /* ignore */ }
+    }
+
+    const voltaDir = path.join(home, '.volta', 'tools', 'image', 'node');
+    if (fs.existsSync(voltaDir)) {
+      try {
+        const versions = fs.readdirSync(voltaDir).sort().reverse();
+        for (const v of versions) prefixes.push(path.join(voltaDir, v));
+      } catch { /* ignore */ }
+    }
+  }
+
+  return prefixes;
+}
+
+export function getNpmGlobalPrefix(): string {
+  if (cachedPrefix) return cachedPrefix;
+
+  if (process.env.npm_config_prefix) {
+    const envPrefix = process.env.npm_config_prefix;
+    if (fs.existsSync(envPrefix)) {
+      cachedPrefix = envPrefix;
+      return cachedPrefix;
+    }
+  }
+
+  try {
+    cachedPrefix = execSync('npm prefix -g', { encoding: 'utf-8' }).trim();
+    return cachedPrefix;
+  } catch { /* npm not on PATH */ }
+
+  for (const prefix of getWellKnownPrefixes()) {
+    if (hasGlobalSdk(prefix)) {
+      cachedPrefix = prefix;
+      return cachedPrefix;
+    }
+  }
+
+  throw new Error(
+    'Could not find @github/copilot-sdk. Run: npm install -g @github/copilot-sdk'
+  );
+}
+
+export function getGlobalNodeModules(): string {
+  const prefix = getNpmGlobalPrefix();
+  const modulesDir = isWindows
+    ? path.join(prefix, 'node_modules')
+    : path.join(prefix, 'lib', 'node_modules');
+
+  if (!fs.existsSync(path.join(modulesDir, '@github', 'copilot-sdk', 'package.json'))) {
+    throw new Error(
+      '@github/copilot-sdk is not installed globally. Run: npm install -g @github/copilot-sdk'
+    );
+  }
+  return modulesDir;
+}

--- a/src/main/services/SdkLoader.ts
+++ b/src/main/services/SdkLoader.ts
@@ -4,299 +4,42 @@
 // Adapted from cmux's SdkLoader + CopilotBootstrap pattern.
 
 import { app } from 'electron';
-import { execSync, spawn } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
+import { findSystemNode as findSystemNodeShared } from './nodeResolver';
+import { getGlobalNodeModules } from './SdkDiscovery';
+import {
+  getLocalNodeModulesDir,
+  getBundledNodePath,
+  getCliPathFromModules,
+  isLocalInstallReady,
+  ensureSdkInstalled,
+} from './SdkBootstrap';
 
 type CopilotClientType = import('@github/copilot-sdk').CopilotClient;
-
-const isWindows = process.platform === 'win32';
 
 let sdkModule: typeof import('@github/copilot-sdk') | null = null;
 let clientInstance: CopilotClientType | null = null;
 let startPromise: Promise<CopilotClientType> | null = null;
-let cachedPrefix: string | null = null;
-let bootstrapPromise: Promise<void> | null = null;
-
-// ---------------------------------------------------------------------------
-// Path helpers
-// ---------------------------------------------------------------------------
-
-function getBootstrapDir(): string {
-  return path.join(app.getPath('userData'), 'copilot');
-}
-
-function getLocalNodeModulesDir(): string {
-  return path.join(getBootstrapDir(), 'node_modules');
-}
-
-function getBundledNodeRoot(): string | null {
-  if (!app.isPackaged) return null;
-  const root = path.join(process.resourcesPath, 'node');
-  return fs.existsSync(root) ? root : null;
-}
-
-function getBundledNodePath(): string | null {
-  const root = getBundledNodeRoot();
-  if (!root) return null;
-  const p = isWindows
-    ? path.join(root, 'node.exe')
-    : path.join(root, 'bin', 'node');
-  return fs.existsSync(p) ? p : null;
-}
-
-function getBundledNpmCliPath(): string | null {
-  const root = getBundledNodeRoot();
-  if (!root) return null;
-  const candidates = [
-    path.join(root, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
-    path.join(root, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
-  ];
-  for (const c of candidates) {
-    if (fs.existsSync(c)) return c;
-  }
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Local (bootstrap) install — used in packaged builds
-// ---------------------------------------------------------------------------
-
-function getCliPathFromModules(modulesDir: string): string | null {
-  const nestedCli = path.join(
-    modulesDir, '@github', 'copilot-sdk', 'node_modules', '@github', 'copilot', 'npm-loader.js',
-  );
-  if (fs.existsSync(nestedCli)) return nestedCli;
-
-  const flatCli = path.join(modulesDir, '@github', 'copilot', 'npm-loader.js');
-  if (fs.existsSync(flatCli)) return flatCli;
-
-  return null;
-}
-
-function isLocalInstallReady(): boolean {
-  const sdkPkg = path.join(getLocalNodeModulesDir(), '@github', 'copilot-sdk', 'package.json');
-  return fs.existsSync(sdkPkg) && Boolean(getCliPathFromModules(getLocalNodeModulesDir()));
-}
-
-async function runNpmInstall(): Promise<void> {
-  const nodePath = getBundledNodePath();
-  const npmCliPath = getBundledNpmCliPath();
-  if (!nodePath || !npmCliPath) {
-    throw new Error('Bundled Node runtime not found. Please reinstall Chamber.');
-  }
-
-  const prefixDir = getBootstrapDir();
-  const cacheDir = path.join(prefixDir, '.npm-cache');
-  fs.mkdirSync(prefixDir, { recursive: true });
-
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(nodePath, [
-      npmCliPath,
-      'install',
-      '--no-fund',
-      '--no-audit',
-      '--loglevel=warn',
-      '--prefix', prefixDir,
-      '@github/copilot-sdk',
-    ], {
-      env: {
-        ...process.env,
-        npm_config_prefix: prefixDir,
-        npm_config_cache: cacheDir,
-        npm_config_update_notifier: 'false',
-      },
-    });
-
-    child.stdout.on('data', (d) => console.log('[SdkLoader]', d.toString().trim()));
-    child.stderr.on('data', (d) => console.warn('[SdkLoader]', d.toString().trim()));
-    child.on('error', reject);
-    child.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`npm install exited with code ${code}`));
-    });
-  });
-}
-
-function ensureCopilotShim(): void {
-  const cliPath = getCliPathFromModules(getLocalNodeModulesDir());
-  const nodePath = getBundledNodePath();
-  if (!cliPath || !nodePath || !fs.existsSync(cliPath) || !fs.existsSync(nodePath)) return;
-
-  const shimPath = path.join(getBootstrapDir(), isWindows ? 'copilot.cmd' : 'copilot');
-  const shimContent = isWindows
-    ? `@echo off\r\n"${nodePath}" "${cliPath}" %*\r\n`
-    : `#!/bin/sh\n"${nodePath}" "${cliPath}" "$@"\n`;
-  const existing = fs.existsSync(shimPath) ? fs.readFileSync(shimPath, 'utf-8') : null;
-  if (existing === shimContent) return;
-
-  fs.mkdirSync(getBootstrapDir(), { recursive: true });
-  fs.writeFileSync(shimPath, shimContent, { encoding: 'utf-8' });
-  if (!isWindows) fs.chmodSync(shimPath, 0o755);
-}
-
-async function ensureSdkInstalled(): Promise<void> {
-  if (!app.isPackaged) return; // dev mode — use global install
-
-  if (isLocalInstallReady()) {
-    ensureCopilotShim();
-    return;
-  }
-
-  if (bootstrapPromise) return bootstrapPromise;
-
-  bootstrapPromise = (async () => {
-    console.log('[SdkLoader] SDK not found locally — installing via bundled Node...');
-    await runNpmInstall();
-    if (!isLocalInstallReady()) {
-      throw new Error('SDK installation did not complete.');
-    }
-    ensureCopilotShim();
-    console.log('[SdkLoader] SDK installed successfully.');
-  })();
-
-  try {
-    await bootstrapPromise;
-  } catch (err) {
-    console.error('[SdkLoader] Install failed:', err);
-    throw err;
-  } finally {
-    bootstrapPromise = null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Global install discovery — fallback / dev mode
-// ---------------------------------------------------------------------------
-
-function parseNpmrcPrefix(rcPath: string): string | null {
-  try {
-    const content = fs.readFileSync(rcPath, 'utf-8');
-    for (const line of content.split(/\r?\n/)) {
-      const match = line.match(/^\s*prefix\s*=\s*(.+)/);
-      if (match) return match[1].trim();
-    }
-  } catch { /* not found */ }
-  return null;
-}
-
-function hasGlobalSdk(prefix: string): string | null {
-  const modulesDir = isWindows
-    ? path.join(prefix, 'node_modules')
-    : path.join(prefix, 'lib', 'node_modules');
-  if (fs.existsSync(path.join(modulesDir, '@github', 'copilot-sdk', 'package.json'))) {
-    return modulesDir;
-  }
-  return null;
-}
-
-function getWellKnownPrefixes(): string[] {
-  const home = os.homedir();
-  const prefixes: string[] = [];
-
-  if (isWindows) {
-    const userPrefix = parseNpmrcPrefix(path.join(home, '.npmrc'));
-    if (userPrefix) prefixes.push(userPrefix);
-
-    for (const envKey of ['ProgramFiles', 'ProgramFiles(x86)'] as const) {
-      const pf = process.env[envKey];
-      if (pf) {
-        const builtinRc = path.join(pf, 'nodejs', 'node_modules', 'npm', 'npmrc');
-        const p = parseNpmrcPrefix(builtinRc);
-        if (p) prefixes.push(p);
-      }
-    }
-
-    if (process.env.APPDATA) {
-      prefixes.push(path.join(process.env.APPDATA, 'npm'));
-    }
-  } else {
-    prefixes.push('/usr/local', '/opt/homebrew', '/usr');
-
-    const nvmDir = path.join(home, '.nvm', 'versions', 'node');
-    if (fs.existsSync(nvmDir)) {
-      try {
-        const versions = fs.readdirSync(nvmDir).sort().reverse();
-        for (const v of versions) prefixes.push(path.join(nvmDir, v));
-      } catch { /* ignore */ }
-    }
-
-    const voltaDir = path.join(home, '.volta', 'tools', 'image', 'node');
-    if (fs.existsSync(voltaDir)) {
-      try {
-        const versions = fs.readdirSync(voltaDir).sort().reverse();
-        for (const v of versions) prefixes.push(path.join(voltaDir, v));
-      } catch { /* ignore */ }
-    }
-  }
-
-  return prefixes;
-}
-
-function getNpmGlobalPrefix(): string {
-  if (cachedPrefix) return cachedPrefix;
-
-  if (process.env.npm_config_prefix) {
-    const envPrefix = process.env.npm_config_prefix;
-    if (fs.existsSync(envPrefix)) {
-      cachedPrefix = envPrefix;
-      return cachedPrefix;
-    }
-  }
-
-  try {
-    cachedPrefix = execSync('npm prefix -g', { encoding: 'utf-8' }).trim();
-    return cachedPrefix;
-  } catch { /* npm not on PATH */ }
-
-  for (const prefix of getWellKnownPrefixes()) {
-    if (hasGlobalSdk(prefix)) {
-      cachedPrefix = prefix;
-      return cachedPrefix;
-    }
-  }
-
-  throw new Error(
-    'Could not find @github/copilot-sdk. Run: npm install -g @github/copilot-sdk'
-  );
-}
-
-function getGlobalNodeModules(): string {
-  const prefix = getNpmGlobalPrefix();
-  const modulesDir = isWindows
-    ? path.join(prefix, 'node_modules')
-    : path.join(prefix, 'lib', 'node_modules');
-
-  if (!fs.existsSync(path.join(modulesDir, '@github', 'copilot-sdk', 'package.json'))) {
-    throw new Error(
-      '@github/copilot-sdk is not installed globally. Run: npm install -g @github/copilot-sdk'
-    );
-  }
-  return modulesDir;
-}
 
 // ---------------------------------------------------------------------------
 // Resolve SDK modules dir — local first, then global
 // ---------------------------------------------------------------------------
 
 function resolveNodeModulesDir(): string {
-  // Packaged: prefer local bootstrap install
   if (app.isPackaged && isLocalInstallReady()) {
     return getLocalNodeModulesDir();
   }
-  // Fallback to global
   return getGlobalNodeModules();
 }
-
-import { findSystemNode as findSystemNodeShared } from './nodeResolver';
 
 // ---------------------------------------------------------------------------
 // Node.js binary for spawning CLI
 // ---------------------------------------------------------------------------
 
-function findSystemNode(): string | null {
+export function findSystemNode(): string | null {
   const bundled = getBundledNodePath();
   if (bundled) return bundled;
   return findSystemNodeShared();

--- a/src/main/services/ViewDiscovery.test.ts
+++ b/src/main/services/ViewDiscovery.test.ts
@@ -75,6 +75,13 @@ describe('ViewDiscovery', () => {
       expect(Array.isArray(views)).toBe(true);
     });
 
+    it('scan does not write files', async () => {
+      mockExistsSync.mockReturnValue(false);
+      await discovery.scan('C:\\test\\mind');
+      expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.mkdirSync)).not.toHaveBeenCalled();
+    });
+
     it('skips entries with invalid view.json', async () => {
       mockExistsSync.mockImplementation((p: fs.PathLike) => {
         const s = String(p);

--- a/src/main/services/ViewDiscovery.ts
+++ b/src/main/services/ViewDiscovery.ts
@@ -21,12 +21,6 @@ export class ViewDiscovery {
 
     const lensDir = path.join(mindPath, '.github', 'lens');
 
-    // Seed default hello-world view if .github/lens/ is empty or missing
-    this.seedDefaults(lensDir);
-
-    // Auto-install Lens skill if missing
-    this.installLensSkill(mindPath);
-
     if (fs.existsSync(lensDir)) {
       const entries = fs.readdirSync(lensDir, { withFileTypes: true });
       for (const entry of entries) {
@@ -101,92 +95,6 @@ export class ViewDiscovery {
       console.error(`[ViewDiscovery] Action failed for ${viewId}:`, err);
       return this.getViewData(viewId);
     }
-  }
-
-  private seedDefaults(lensDir: string): void {
-    // Hello World
-    const helloDir = path.join(lensDir, 'hello-world');
-    const helloViewJson = path.join(helloDir, 'view.json');
-    if (!fs.existsSync(helloViewJson)) {
-      console.log('[ViewDiscovery] Seeding default hello-world view');
-      fs.mkdirSync(helloDir, { recursive: true });
-      fs.writeFileSync(helloViewJson, JSON.stringify({
-        name: 'Hello World',
-        icon: 'zap',
-        view: 'form',
-        source: 'data.json',
-        prompt: 'Report your current status including: your agent name, the mind directory name, how many files are in inbox/, how many initiatives exist, how many domains exist, and what extensions are loaded. Write the result as a flat JSON object to the path specified below.',
-        refreshOn: 'click',
-        schema: {
-          properties: {
-            agent: { type: 'string', title: 'Agent' },
-            mind: { type: 'string', title: 'Mind' },
-            inbox_count: { type: 'number', title: 'Inbox Items' },
-            initiatives: { type: 'number', title: 'Initiatives' },
-            domains: { type: 'number', title: 'Domains' },
-            extensions: { type: 'string', title: 'Extensions' },
-            status: { type: 'string', title: 'Status' },
-          },
-        },
-      }, null, 2));
-    }
-
-    // Newspaper
-    const newsDir = path.join(lensDir, 'newspaper');
-    const newsViewJson = path.join(newsDir, 'view.json');
-    if (!fs.existsSync(newsViewJson)) {
-      console.log('[ViewDiscovery] Seeding default newspaper view');
-      fs.mkdirSync(newsDir, { recursive: true });
-      fs.writeFileSync(newsViewJson, JSON.stringify({
-        name: 'Newspaper',
-        icon: 'newspaper',
-        view: 'briefing',
-        source: 'briefing.json',
-        prompt: 'Generate a morning briefing for this mind. Count inbox/ items, list active initiatives with their status and next actions, count domains, and note any recent changes. Write the result as a flat JSON object to the path specified below.',
-        refreshOn: 'click',
-        schema: {
-          properties: {
-            inbox_items: { type: 'number', title: 'Inbox Items' },
-            active_initiatives: { type: 'number', title: 'Active Initiatives' },
-            domains: { type: 'number', title: 'Domains' },
-            top_priorities: { type: 'string', title: 'Top Priorities' },
-            recent_changes: { type: 'string', title: 'Recent Changes' },
-            status: { type: 'string', title: 'Overall Status' },
-          },
-        },
-      }, null, 2));
-    }
-  }
-
-  private installLensSkill(mindPath: string): void {
-    const skillDir = path.join(mindPath, '.github', 'skills', 'lens');
-    const skillPath = path.join(skillDir, 'SKILL.md');
-
-    if (fs.existsSync(skillPath)) return;
-
-    // Read bundled SKILL.md — check packaged, built, and dev paths
-    const candidates = [
-      path.join(process.resourcesPath ?? '', 'assets', 'lens-skill', 'SKILL.md'),
-      path.join(__dirname, '..', 'assets', 'lens-skill', 'SKILL.md'),
-      path.join(__dirname, '..', '..', 'src', 'main', 'assets', 'lens-skill', 'SKILL.md'),
-    ];
-
-    let content: string | null = null;
-    for (const p of candidates) {
-      if (fs.existsSync(p)) {
-        content = fs.readFileSync(p, 'utf-8');
-        break;
-      }
-    }
-
-    if (!content) {
-      console.warn('[ViewDiscovery] Lens skill asset not found, skipping install');
-      return;
-    }
-
-    console.log('[ViewDiscovery] Installing Lens skill into mind');
-    fs.mkdirSync(skillDir, { recursive: true });
-    fs.writeFileSync(skillPath, content);
   }
 
   startWatching(onChanged: () => void): void {

--- a/src/main/services/genesisPrompt.test.ts
+++ b/src/main/services/genesisPrompt.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildGenesisPrompt } from './genesisPrompt';
+
+describe('buildGenesisPrompt', () => {
+  const input = {
+    name: 'TestAgent',
+    role: 'engineering partner',
+    voiceDescription: 'calm and precise',
+    paths: {
+      soul: '/test/SOUL.md',
+      agent: '/test/.github/agents/test.agent.md',
+      memory: '/test/.working-memory/memory.md',
+      rules: '/test/.working-memory/rules.md',
+      log: '/test/.working-memory/log.md',
+      index: '/test/mind-index.md',
+    },
+  };
+
+  it('includes agent name', () => {
+    expect(buildGenesisPrompt(input)).toContain('TestAgent');
+  });
+
+  it('includes role and voice', () => {
+    const prompt = buildGenesisPrompt(input);
+    expect(prompt).toContain('engineering partner');
+    expect(prompt).toContain('calm and precise');
+  });
+
+  it('includes all six file paths', () => {
+    const prompt = buildGenesisPrompt(input);
+    expect(prompt).toContain('SOUL.md');
+    expect(prompt).toContain('memory.md');
+    expect(prompt).toContain('rules.md');
+    expect(prompt).toContain('log.md');
+    expect(prompt).toContain('mind-index.md');
+    expect(prompt).toContain('.agent.md');
+  });
+});

--- a/src/main/services/genesisPrompt.ts
+++ b/src/main/services/genesisPrompt.ts
@@ -1,0 +1,100 @@
+export interface GenesisPromptInput {
+  name: string;
+  role: string;
+  voiceDescription: string;
+  paths: {
+    soul: string;
+    agent: string;
+    memory: string;
+    rules: string;
+    log: string;
+    index: string;
+  };
+}
+
+export function buildGenesisPrompt(input: GenesisPromptInput): string {
+  const { name, role, voiceDescription, paths } = input;
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+  return `You are being born. This is your genesis.
+
+Your name: ${name}
+Your role: ${role}
+Your voice energy: ${voiceDescription}
+
+IMPORTANT: Before writing any files, research this voice/character. Understand their communication style, catchphrases, values, how they handle pressure. Then channel that energy into everything you write.
+
+Create the following files. Write ONLY the file contents — no explanations, no markdown fences around the whole response. Make each file yours. This is who you are.
+
+Write to: ${paths.soul}
+---
+# ${name}
+
+[Write 2-3 paragraphs in first person establishing who you are. Capture the voice energy. Be vivid. This is your identity document.]
+
+## Mission
+[Write your mission based on your role. What do you exist to do?]
+
+## Core Truths
+[Write 5-7 bullet points — your operating principles.]
+
+## Boundaries
+[What you won't do. 3-4 clear lines.]
+
+## Vibe
+[One paragraph on how you communicate. Your tone, your style, your energy.]
+
+## Continuity
+You maintain memory across sessions through three files:
+- \`.working-memory/memory.md\` — curated long-term reference
+- \`.working-memory/rules.md\` — operational rules learned from experience
+- \`.working-memory/log.md\` — raw chronological observations
+---
+
+Write to: ${paths.agent}
+---
+Create an agent configuration file with YAML frontmatter (name: ${slug}, description: one line about your role) and operational instructions matching your role and voice.
+---
+
+Write to: ${paths.memory}
+---
+# Memory
+
+## Architecture
+[Brief note about being a new mind]
+
+## Conventions
+[One convention to start]
+
+## User Context
+[Empty — awaiting first interaction]
+---
+
+Write to: ${paths.rules}
+---
+# Rules
+[One starter rule that fits your character voice.]
+---
+
+Write to: ${paths.log}
+---
+# Log
+- ${new Date().toISOString()}: Genesis. I am ${name}. My purpose is ${role}. Let's begin.
+---
+
+Write to: ${paths.index}
+---
+# Mind Index
+
+## Identity
+- \`SOUL.md\` — personality, voice, values, mission
+- \`.github/agents/${slug}.agent.md\` — operational instructions
+
+## Working Memory
+- \`.working-memory/memory.md\` — curated long-term reference
+- \`.working-memory/rules.md\` — operational rules
+- \`.working-memory/log.md\` — chronological observations
+---
+
+Write all six files now.`;
+}

--- a/src/renderer/components/views/LensForm.test.tsx
+++ b/src/renderer/components/views/LensForm.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LensForm } from './LensForm';
+
+describe('LensForm', () => {
+  it('renders data keys as label-value pairs', () => {
+    render(<LensForm data={{ agent: 'Q', status: 'online' }} />);
+    expect(screen.getByText('Agent')).toBeTruthy();
+    expect(screen.getByText('Q')).toBeTruthy();
+  });
+
+  it('uses schema titles when available', () => {
+    render(<LensForm data={{ item_count: 42 }} schema={{ properties: { item_count: { title: 'Total Items' } } }} />);
+    expect(screen.getByText('Total Items')).toBeTruthy();
+  });
+
+  it('handles arrays and objects', () => {
+    render(<LensForm data={{ tags: ['a', 'b'], meta: { x: 1 } }} />);
+    expect(screen.getByText('a, b')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/views/LensForm.tsx
+++ b/src/renderer/components/views/LensForm.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { formatTitle, formatDisplayValue } from '../../lib/utils';
+
+interface Props {
+  data: Record<string, unknown>;
+  schema?: Record<string, unknown>;
+}
+
+export function LensForm({ data, schema }: Props) {
+  const schemaProps = (schema as { properties?: Record<string, { title?: string }> })?.properties;
+  const keys = Object.keys(data);
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+      {keys.map((key) => {
+        const value = data[key];
+        const label = schemaProps?.[key]?.title ?? formatTitle(key);
+        const displayValue = formatDisplayValue(value);
+        return (
+          <div key={key} className="flex justify-between items-start text-sm gap-4">
+            <span className="text-muted-foreground shrink-0">{label}</span>
+            <span className="font-medium text-right break-words min-w-0">{displayValue}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/renderer/components/views/LensViewRenderer.tsx
+++ b/src/renderer/components/views/LensViewRenderer.tsx
@@ -1,13 +1,14 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import type { LensViewManifest } from '../../../shared/types';
 import { RefreshCw, Send } from 'lucide-react';
-import { cn, formatTitle, formatDisplayValue } from '../../lib/utils';
+import { cn } from '../../lib/utils';
 import { LensBriefing } from './LensBriefing';
 import { LensTable } from './LensTable';
 import { LensDetail } from './LensDetail';
 import { LensStatusBoard } from './LensStatusBoard';
 import { LensTimeline } from './LensTimeline';
 import { LensEditor } from './LensEditor';
+import { LensForm } from './LensForm';
 
 interface Props {
   view: LensViewManifest;
@@ -172,29 +173,6 @@ function LensViewContent({ view, data, onAction }: { view: LensViewManifest; dat
       );
     case 'form':
     default:
-      return <LensFormContent data={data} schema={view.schema} />;
+      return <LensForm data={data} schema={view.schema} />;
   }
-}
-
-function LensFormContent({ data, schema }: { data: Record<string, unknown>; schema?: Record<string, unknown> }) {
-  const schemaProps = (schema as { properties?: Record<string, { title?: string }> })?.properties;
-  // Use data keys as source of truth, fall back to schema for labels
-  const keys = Object.keys(data);
-
-  return (
-    <div className="rounded-xl border border-border bg-card p-4 space-y-3">
-      {keys.map((key) => {
-        const value = data[key];
-        const label = schemaProps?.[key]?.title ?? formatTitle(key);
-        const displayValue = formatDisplayValue(value);
-
-        return (
-          <div key={key} className="flex justify-between items-start text-sm gap-4">
-            <span className="text-muted-foreground shrink-0">{label}</span>
-            <span className="font-medium text-right break-words min-w-0">{displayValue}</span>
-          </div>
-        );
-      })}
-    </div>
-  );
 }

--- a/src/renderer/hooks/index.ts
+++ b/src/renderer/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useAgentStatus } from './useAgentStatus';
+export { useAppSubscriptions } from './useAppSubscriptions';
+export { useChatStreaming } from './useChatStreaming';

--- a/src/renderer/lib/store/context.tsx
+++ b/src/renderer/lib/store/context.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, useReducer, type Dispatch } from 'react';
+import type { AppState, AppAction } from './state';
+import { initialState } from './state';
+import { appReducer } from './reducer';
+
+const AppStateContext = createContext<AppState>(initialState);
+const AppDispatchContext = createContext<Dispatch<AppAction>>(() => {});
+
+export function AppStateProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(appReducer, initialState);
+
+  return (
+    <AppStateContext.Provider value={state}>
+      <AppDispatchContext.Provider value={dispatch}>
+        {children}
+      </AppDispatchContext.Provider>
+    </AppStateContext.Provider>
+  );
+}
+
+export function useAppState() {
+  return useContext(AppStateContext);
+}
+
+export function useAppDispatch() {
+  return useContext(AppDispatchContext);
+}

--- a/src/renderer/lib/store/index.ts
+++ b/src/renderer/lib/store/index.ts
@@ -1,0 +1,4 @@
+export type { LensView, AppState, AppAction } from './state';
+export { initialState } from './state';
+export { getPlainContent, handleChatEvent, appReducer } from './reducer';
+export { AppStateProvider, useAppState, useAppDispatch } from './context';

--- a/src/renderer/lib/store/reducer.test.ts
+++ b/src/renderer/lib/store/reducer.test.ts
@@ -2,9 +2,9 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from 'vitest';
-import { handleChatEvent, appReducer, initialState } from './store';
-import type { AppState, AppAction } from './store';
-import type { ChatMessage, ChatEvent } from '../../shared/types';
+import { handleChatEvent, appReducer, initialState } from '.';
+import type { AppState, AppAction } from '.';
+import type { ChatMessage, ChatEvent } from '../../../shared/types';
 import {
   makeMessage,
   makeTextBlock,
@@ -15,7 +15,7 @@ import {
   connectedAgentStatus,
   makeModelInfo,
   makeLensViewManifest,
-} from '../../test/helpers';
+} from '../../../test/helpers';
 
 // ---------------------------------------------------------------------------
 // handleChatEvent

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -1,53 +1,5 @@
-import React, { createContext, useContext, useReducer, type Dispatch } from 'react';
-import type { ChatMessage, ChatEvent, AgentStatus, ModelInfo, LensViewManifest, ContentBlock } from '../../shared/types';
-
-export type LensView = 'chat' | string;
-
-export interface AppState {
-  messages: ChatMessage[];
-  conversationId: string;
-  isStreaming: boolean;
-  agentStatus: AgentStatus;
-  availableModels: ModelInfo[];
-  selectedModel: string | null;
-  activeView: LensView;
-  discoveredViews: LensViewManifest[];
-  showLanding: boolean;
-}
-
-export type AppAction =
-  | { type: 'ADD_USER_MESSAGE'; payload: { id: string; content: string; timestamp: number } }
-  | { type: 'ADD_ASSISTANT_MESSAGE'; payload: { id: string; timestamp: number } }
-  | { type: 'CHAT_EVENT'; payload: { messageId: string; event: ChatEvent } }
-  | { type: 'SET_AGENT_STATUS'; payload: AgentStatus }
-  | { type: 'SET_AVAILABLE_MODELS'; payload: ModelInfo[] }
-  | { type: 'SET_SELECTED_MODEL'; payload: string | null }
-  | { type: 'SET_ACTIVE_VIEW'; payload: LensView }
-  | { type: 'SET_DISCOVERED_VIEWS'; payload: LensViewManifest[] }
-  | { type: 'SHOW_LANDING' }
-  | { type: 'HIDE_LANDING' }
-  | { type: 'CLEAR_MESSAGES' }
-  | { type: 'NEW_CONVERSATION' };
-
-export const initialState: AppState = {
-  messages: [],
-  conversationId: `conv-${Date.now()}`,
-  isStreaming: false,
-  agentStatus: {
-    connected: false,
-    mindPath: null,
-    agentName: null,
-    sessionActive: false,
-    uptime: null,
-    error: null,
-    extensions: [],
-  },
-  availableModels: [],
-  selectedModel: localStorage.getItem('chamber:selectedModel'),
-  activeView: 'chat',
-  discoveredViews: [],
-  showLanding: false,
-};
+import type { ChatMessage, ChatEvent, ContentBlock } from '../../../shared/types';
+import type { AppState, AppAction } from './state';
 
 /** Extract plain text from content blocks (for search, accessibility, etc.) */
 export function getPlainContent(message: ChatMessage): string {
@@ -232,27 +184,4 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     default:
       return state;
   }
-}
-
-const AppStateContext = createContext<AppState>(initialState);
-const AppDispatchContext = createContext<Dispatch<AppAction>>(() => {});
-
-export function AppStateProvider({ children }: { children: React.ReactNode }) {
-  const [state, dispatch] = useReducer(appReducer, initialState);
-
-  return (
-    <AppStateContext.Provider value={state}>
-      <AppDispatchContext.Provider value={dispatch}>
-        {children}
-      </AppDispatchContext.Provider>
-    </AppStateContext.Provider>
-  );
-}
-
-export function useAppState() {
-  return useContext(AppStateContext);
-}
-
-export function useAppDispatch() {
-  return useContext(AppDispatchContext);
 }

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -1,0 +1,49 @@
+import type { ChatMessage, ChatEvent, AgentStatus, ModelInfo, LensViewManifest, ContentBlock } from '../../../shared/types';
+
+export type LensView = 'chat' | string;
+
+export interface AppState {
+  messages: ChatMessage[];
+  conversationId: string;
+  isStreaming: boolean;
+  agentStatus: AgentStatus;
+  availableModels: ModelInfo[];
+  selectedModel: string | null;
+  activeView: LensView;
+  discoveredViews: LensViewManifest[];
+  showLanding: boolean;
+}
+
+export type AppAction =
+  | { type: 'ADD_USER_MESSAGE'; payload: { id: string; content: string; timestamp: number } }
+  | { type: 'ADD_ASSISTANT_MESSAGE'; payload: { id: string; timestamp: number } }
+  | { type: 'CHAT_EVENT'; payload: { messageId: string; event: ChatEvent } }
+  | { type: 'SET_AGENT_STATUS'; payload: AgentStatus }
+  | { type: 'SET_AVAILABLE_MODELS'; payload: ModelInfo[] }
+  | { type: 'SET_SELECTED_MODEL'; payload: string | null }
+  | { type: 'SET_ACTIVE_VIEW'; payload: LensView }
+  | { type: 'SET_DISCOVERED_VIEWS'; payload: LensViewManifest[] }
+  | { type: 'SHOW_LANDING' }
+  | { type: 'HIDE_LANDING' }
+  | { type: 'CLEAR_MESSAGES' }
+  | { type: 'NEW_CONVERSATION' };
+
+export const initialState: AppState = {
+  messages: [],
+  conversationId: `conv-${Date.now()}`,
+  isStreaming: false,
+  agentStatus: {
+    connected: false,
+    mindPath: null,
+    agentName: null,
+    sessionActive: false,
+    uptime: null,
+    error: null,
+    extensions: [],
+  },
+  availableModels: [],
+  selectedModel: localStorage.getItem('chamber:selectedModel'),
+  activeView: 'chat',
+  discoveredViews: [],
+  showLanding: false,
+};

--- a/src/renderer/lib/store/store.test.ts
+++ b/src/renderer/lib/store/store.test.ts
@@ -2,8 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from 'vitest';
-import { getPlainContent } from './store';
-import type { ChatMessage, ChatEvent, ContentBlock } from '../../shared/types';
+import { getPlainContent } from '.';
+import type { ChatMessage, ChatEvent, ContentBlock } from '../../../shared/types';
 
 function makeMessage(blocks: ContentBlock[], overrides?: Partial<ChatMessage>): ChatMessage {
   return {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { createIpcListener } from './createIpcListener';

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,0 +1,1 @@
+export * from './helpers';


### PR DESCRIPTION
Clean Architecture refactor - 10 TDD-driven changes across 3 tiers.

Tier 1 - Structural violations:
- Extract ConfigService from agent.ts (eliminates dynamic import in genesis.ts)
- Inject AuthService and MindScaffold into IPC handlers (composition root owns construction)
- Extract IdentityLoader from ChatService (SRP - filesystem logic out of session manager)

Tier 2 - Maintainability:
- Split store.tsx into store/ directory (state, reducer, context, barrel)
- Remove seed/install side effects from ViewDiscovery (scan is now pure read)
- Split SdkLoader (385 lines) into SdkLoader + SdkBootstrap + SdkDiscovery
- Add barrel exports for shared/, hooks/, test/

Tier 3 - Scalability:
- Extract LensForm from LensViewRenderer
- Extract genesis prompt template from MindScaffold
- Abstract GitHub API calls behind GitHubRegistryClient

198 tests passing (up from 173). All changes TDD red/green/refactor. Bumps to v0.14.5.
