### PR TITLE
v0.15.0 — Multi-Mind Runtime (Phase 1)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -8,9 +8,12 @@
 - [ ] **Inject local time/timezone into every prompt** `bug` — agent should know the time without shelling out. Inject `current_datetime` and timezone into each `session.send()`. SDK has a `current_datetime` section in the prompt template.
 - [ ] **Teams Agency MCP issue** `bug` — Kent reported problem with Teams MCP proxy; shared log in AET SWE Chat. Needs investigation. *(Kent, 2026-04-09)*
 - [ ] **No Start Menu icon** `bug` — installer doesn't create Start Menu shortcut. Likely Electron Forge / Squirrel config in packaging step.
+- [ ] **Upgrade genesis-created minds on open** `bug` — minds created via CLI genesis (not Chamber) may be missing lens defaults, lens skill, and other Chamber-specific bootstrapping. When a mind is opened in Chamber for the first time, detect and run `seedLensDefaults` + `installLensSkill` + any missing capabilities. *(Ian, 2026-04-12)*
+- [ ] **Landing screen needs a back button** `ux` — when "Add Agent" navigates to the landing screen, there's no way to go back if you change your mind. Add a back/cancel action that returns to the previous chat view. *(Ian, 2026-04-12)*
 
 ## Next
 
+- [ ] **Chat history** `ux` — conversations are lost on new conversation or restart. Show past conversations per-mind — either a list in the sidebar panel or a history view. SDK may support `resumeSession` for reloading context. *(Ian, 2026-04-12)*
 - [ ] **Boot screen activity log** `ux` — spinner too passive during genesis/startup; surface log output so user sees real-time progress. *(Kent feedback 2026-04-09)*
 - [ ] **"Open Existing" defaults to ~/agents/** `ux` — folder picker should open to `$HOME/agents/` by default (where `MindScaffold.getDefaultBasePath()` creates minds).
 - [ ] **Surface agent questions in chat** `ux` — #13, `onUserInputRequest` returns "Not available" — agent questions never reach the user.

--- a/backlog.md
+++ b/backlog.md
@@ -10,6 +10,7 @@
 - [ ] **No Start Menu icon** `bug` — installer doesn't create Start Menu shortcut. Likely Electron Forge / Squirrel config in packaging step.
 - [ ] **Upgrade genesis-created minds on open** `bug` — minds created via CLI genesis (not Chamber) may be missing lens defaults, lens skill, and other Chamber-specific bootstrapping. When a mind is opened in Chamber for the first time, detect and run `seedLensDefaults` + `installLensSkill` + any missing capabilities. *(Ian, 2026-04-12)*
 - [ ] **Landing screen needs a back button** `ux` — when "Add Agent" navigates to the landing screen, there's no way to go back if you change your mind. Add a back/cancel action that returns to the previous chat view. *(Ian, 2026-04-12)*
+- [ ] **Lens refresh survives view switching** `ux` — clicking away from a lens while it's refreshing drops the pending result. The agent still writes the file, but the UI never picks up the new data. Either show a toast when refresh completes, or re-read data when returning to the view. *(Ian, 2026-04-12)*
 
 ## Next
 

--- a/backlog.md
+++ b/backlog.md
@@ -13,7 +13,7 @@
 
 ## Next
 
-- [ ] **Chat history** `ux` — conversations are lost on new conversation or restart. Show past conversations per-mind — either a list in the sidebar panel or a history view. SDK may support `resumeSession` for reloading context. *(Ian, 2026-04-12)*
+- [ ] **Chat history** `ux` — conversations are lost on new conversation or restart. Show past conversations per-mind in MindSidebar, indented under each agent. Data already in `~/.copilot/session-state/`. See [[conversation-history]] for spec. *(Ian, 2026-04-12)*
 - [ ] **Boot screen activity log** `ux` — spinner too passive during genesis/startup; surface log output so user sees real-time progress. *(Kent feedback 2026-04-09)*
 - [ ] **"Open Existing" defaults to ~/agents/** `ux` — folder picker should open to `$HOME/agents/` by default (where `MindScaffold.getDefaultBasePath()` creates minds).
 - [ ] **Surface agent questions in chat** `ux` — #13, `onUserInputRequest` returns "Not available" — agent questions never reach the user.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.14.6",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.14.6",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.14.6",
+  "version": "0.15.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,12 +48,22 @@ const chatService = new ChatService(mindManager);
 // Wire Lens refresh to use the mind's session via ChatService
 viewDiscovery.setRefreshHandler({
   sendBackgroundPrompt: async (mindPath: string, prompt: string) => {
-    // Find the mind by path and send the prompt
     const mind = mindManager.listMinds().find(m => m.mindPath === mindPath);
     if (!mind) return;
     const context = mindManager.getMind(mind.mindId);
     if (!context?.session) return;
+
     await context.session.send({ prompt });
+
+    // Wait for the agent to finish processing
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 120_000);
+      const unsub = context.session!.on('session.idle', () => {
+        clearTimeout(timeout);
+        unsub();
+        resolve();
+      });
+    });
   },
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,7 +84,7 @@ const createWindow = () => {
 
 app.on('ready', async () => {
   // --- IPC adapters (thin, parameter-injected) ---
-  setupChatIPC(chatService);
+  setupChatIPC(chatService, mindManager);
   setupMindIPC(mindManager);
   setupLensIPC(viewDiscovery, mindManager);
   setupGenesisIPC(mindManager, scaffold);

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,10 +106,13 @@ app.on('ready', async () => {
   // Create window first (don't block on restore)
   createWindow();
 
-  // Restore minds async (each loads independently, errors don't block others)
-  mindManager.restoreFromConfig().catch((err) => {
+  // Restore minds async — store promise so IPC can await it
+  const restorePromise = mindManager.restoreFromConfig().catch((err) => {
     console.error('[main] Failed to restore minds:', err);
   });
+
+  // Expose restore promise for IPC handlers that need to wait
+  (mindManager as any)._restorePromise = restorePromise;
 });
 
 app.on('window-all-closed', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,40 +1,50 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'node:path';
-import * as fs from 'fs';
 import started from 'electron-squirrel-startup';
-import { ChatService } from './main/services/chat';
+
+// Services
+import { CopilotClientFactory } from './main/services/sdk/CopilotClientFactory';
+import { IdentityLoader } from './main/services/chat';
 import { ExtensionLoader } from './main/services/extensions';
 import { ConfigService } from './main/services/config';
 import { AuthService } from './main/services/auth';
 import { MindScaffold } from './main/services/genesis';
-import { IdentityLoader } from './main/services/chat';
-import { seedLensDefaults, installLensSkill } from './main/services/lens';
+import { ViewDiscovery } from './main/services/lens';
+import { MindManager } from './main/services/mind/MindManager';
+import { ChatService } from './main/services/chat/ChatService';
 import { loadCanvasExtension } from './main/services/extensions/adapters/canvas';
 import { loadCronExtension } from './main/services/extensions/adapters/cron';
 import { loadIdeaExtension } from './main/services/extensions/adapters/idea';
+
+// IPC adapters
 import { setupChatIPC } from './main/ipc/chat';
-import { setupAgentIPC } from './main/ipc/agent';
+import { setupMindIPC } from './main/ipc/mind';
 import { setupLensIPC } from './main/ipc/lens';
 import { setupGenesisIPC } from './main/ipc/genesis';
 import { setupAuthIPC } from './main/ipc/auth';
-import { stopSharedClient } from './main/services/sdk';
-import { ViewDiscovery } from './main/services/lens';
 
 if (started) {
   app.quit();
 }
 
+// --- Infrastructure (no business logic, creates capabilities) ---
+
+const clientFactory = new CopilotClientFactory();
 const identityLoader = new IdentityLoader();
-const chatService = new ChatService(identityLoader);
 const extensionLoader = new ExtensionLoader();
-const viewDiscovery = new ViewDiscovery(chatService);
-const configService = new ConfigService();
-const authService = new AuthService();
-const scaffold = new MindScaffold();
 extensionLoader.registerAdapter('canvas', loadCanvasExtension);
 extensionLoader.registerAdapter('cron', loadCronExtension);
 extensionLoader.registerAdapter('idea', loadIdeaExtension);
-chatService.setExtensionLoader(extensionLoader);
+const configService = new ConfigService();
+const authService = new AuthService();
+const scaffold = new MindScaffold();
+const viewDiscovery = new ViewDiscovery();
+
+// --- Services (business rules, all dependencies injected) ---
+
+const mindManager = new MindManager(clientFactory, identityLoader, extensionLoader, configService, viewDiscovery);
+const chatService = new ChatService(mindManager);
+
 let mainWindow: BrowserWindow | null = null;
 let isQuitting = false;
 
@@ -55,7 +65,7 @@ const createWindow = () => {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false, // Required for copilot-sdk IPC
+      sandbox: false,
     },
   });
 
@@ -67,34 +77,20 @@ const createWindow = () => {
     );
   }
 
-  // Open DevTools in dev mode
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.webContents.openDevTools({ mode: 'bottom' });
   }
 };
 
-app.on('ready', () => {
-  // Restore persisted mind path on startup
-  const config = configService.load();
-  if (config.mindPath && fs.existsSync(config.mindPath)) {
-    chatService.setMindPath(config.mindPath);
-    seedLensDefaults(config.mindPath);
-    installLensSkill(config.mindPath);
-    viewDiscovery.scan(config.mindPath).then(() => {
-      viewDiscovery.startWatching(() => {
-        const win = BrowserWindow.getAllWindows()[0];
-        if (win) win.webContents.send('lens:viewsChanged', viewDiscovery.getViews());
-      });
-    });
-  }
-
+app.on('ready', async () => {
+  // --- IPC adapters (thin, parameter-injected) ---
   setupChatIPC(chatService);
-  setupAgentIPC(chatService, viewDiscovery, configService);
-  setupLensIPC(viewDiscovery);
-  setupGenesisIPC(chatService, viewDiscovery, configService, scaffold);
+  setupMindIPC(mindManager);
+  setupLensIPC(viewDiscovery, mindManager);
+  setupGenesisIPC(mindManager, scaffold);
   setupAuthIPC(authService);
 
-  // Window control IPC — registered once, not per-window
+  // Window controls
   ipcMain.on('window:minimize', () => mainWindow?.minimize());
   ipcMain.on('window:maximize', () => {
     if (mainWindow?.isMaximized()) mainWindow.unmaximize();
@@ -102,7 +98,13 @@ app.on('ready', () => {
   });
   ipcMain.on('window:close', () => mainWindow?.close());
 
+  // Create window first (don't block on restore)
   createWindow();
+
+  // Restore minds async (each loads independently, errors don't block others)
+  mindManager.restoreFromConfig().catch((err) => {
+    console.error('[main] Failed to restore minds:', err);
+  });
 });
 
 app.on('window-all-closed', () => {
@@ -122,10 +124,7 @@ app.on('before-quit', (e) => {
   e.preventDefault();
   isQuitting = true;
 
-  Promise.all([
-    chatService.stop(),
-    stopSharedClient(),
-  ])
+  mindManager.shutdown()
     .catch(() => {})
     .finally(() => app.quit());
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,26 +45,9 @@ const viewDiscovery = new ViewDiscovery();
 const mindManager = new MindManager(clientFactory, identityLoader, extensionLoader, configService, viewDiscovery);
 const chatService = new ChatService(mindManager);
 
-// Wire Lens refresh to use the mind's session via ChatService
+// Wire Lens refresh to use the mind's session
 viewDiscovery.setRefreshHandler({
-  sendBackgroundPrompt: async (mindPath: string, prompt: string) => {
-    const mind = mindManager.listMinds().find(m => m.mindPath === mindPath);
-    if (!mind) return;
-    const context = mindManager.getMind(mind.mindId);
-    if (!context?.session) return;
-
-    await context.session.send({ prompt });
-
-    // Wait for the agent to finish processing
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(resolve, 120_000);
-      const unsub = context.session!.on('session.idle', () => {
-        clearTimeout(timeout);
-        unsub();
-        resolve();
-      });
-    });
-  },
+  sendBackgroundPrompt: (path, prompt) => mindManager.sendBackgroundPrompt(path, prompt),
 });
 
 let mainWindow: BrowserWindow | null = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,18 @@ const viewDiscovery = new ViewDiscovery();
 const mindManager = new MindManager(clientFactory, identityLoader, extensionLoader, configService, viewDiscovery);
 const chatService = new ChatService(mindManager);
 
+// Wire Lens refresh to use the mind's session via ChatService
+viewDiscovery.setRefreshHandler({
+  sendBackgroundPrompt: async (mindPath: string, prompt: string) => {
+    // Find the mind by path and send the prompt
+    const mind = mindManager.listMinds().find(m => m.mindPath === mindPath);
+    if (!mind) return;
+    const context = mindManager.getMind(mind.mindId);
+    if (!context?.session) return;
+    await context.session.send({ prompt });
+  },
+});
+
 let mainWindow: BrowserWindow | null = null;
 let isQuitting = false;
 

--- a/src/main/ipc/agent.test.ts
+++ b/src/main/ipc/agent.test.ts
@@ -21,30 +21,33 @@ describe('ConfigService (via agent.test migration)', () => {
     vi.clearAllMocks();
   });
 
-  it('returns parsed config when file exists', () => {
+  it('migrates v1 config to v2 when file exists', () => {
     mockReadFileSync.mockReturnValue(JSON.stringify({ mindPath: 'C:\\test\\mind', theme: 'light' }));
     const config = svc.load();
-    expect(config).toEqual({ mindPath: 'C:\\test\\mind', theme: 'light' });
+    expect(config.version).toBe(2);
+    expect(config.minds).toHaveLength(1);
+    expect(config.minds[0].path).toBe('C:\\test\\mind');
+    expect(config.theme).toBe('light');
   });
 
-  it('returns default config when file is missing', () => {
+  it('returns default v2 config when file is missing', () => {
     mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
     const config = svc.load();
-    expect(config).toEqual({ mindPath: null, theme: 'dark' });
+    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, theme: 'dark' });
   });
 
-  it('returns default config for invalid JSON', () => {
+  it('returns default v2 config for invalid JSON', () => {
     mockReadFileSync.mockReturnValue('not json');
     const config = svc.load();
-    expect(config).toEqual({ mindPath: null, theme: 'dark' });
+    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, theme: 'dark' });
   });
 
-  it('creates directory and writes config', () => {
-    svc.save({ mindPath: 'C:\\test', theme: 'dark' });
+  it('creates directory and writes v2 config', () => {
+    svc.save({ version: 2, minds: [{ id: 'test-a1b2', path: 'C:\\test' }], activeMindId: 'test-a1b2', theme: 'dark' });
     expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       expect.stringContaining('config.json'),
-      expect.stringContaining('"mindPath": "C:\\\\test"'),
+      expect.stringContaining('"version": 2'),
     );
   });
 });

--- a/src/main/ipc/chat.ts
+++ b/src/main/ipc/chat.ts
@@ -1,38 +1,26 @@
-// Chat IPC handlers — wire ChatService to renderer via ipcMain
+// Chat IPC handlers — thin adapters for ChatService
 import { ipcMain, BrowserWindow } from 'electron';
-import { ChatService } from '../services/chat';
+import type { ChatService } from '../services/chat/ChatService';
 import type { ChatEvent } from '../../shared/types';
 
 export function setupChatIPC(chatService: ChatService): void {
-  ipcMain.handle('chat:send', async (event, conversationId: string, message: string, messageId: string, model?: string) => {
+  ipcMain.handle('chat:send', async (event, mindId: string, message: string, messageId: string, model?: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return;
 
-    const emit = (evt: ChatEvent) => win.webContents.send('chat:event', messageId, evt);
-
-    await chatService.sendMessage(conversationId, message, messageId, emit, model);
+    const emit = (evt: ChatEvent) => win.webContents.send('chat:event', mindId, messageId, evt);
+    await chatService.sendMessage(mindId, message, messageId, emit, model);
   });
 
-  ipcMain.handle('chat:listModels', async () => {
-    return chatService.listModels();
+  ipcMain.handle('chat:listModels', async (_event, mindId: string) => {
+    return chatService.listModels(mindId);
   });
 
-  ipcMain.handle('chat:stop', async (event, conversationId: string, messageId: string) => {
-    const win = BrowserWindow.fromWebContents(event.sender);
-    if (!win) return;
-
-    await chatService.cancelMessage(
-      conversationId,
-      messageId,
-      (msgId) => win.webContents.send('chat:event', msgId, { type: 'done' } as ChatEvent),
-    );
+  ipcMain.handle('chat:stop', async (_event, mindId: string, messageId: string) => {
+    await chatService.cancelMessage(mindId, messageId);
   });
 
-  ipcMain.handle('chat:newConversation', async (_event, conversationId: string) => {
-    const controller = chatService.getAbortController(conversationId);
-    if (controller) {
-      controller.abort();
-    }
-    await chatService.destroySession(conversationId);
+  ipcMain.handle('chat:newConversation', async (_event, mindId: string) => {
+    await chatService.newConversation(mindId);
   });
 }

--- a/src/main/ipc/chat.ts
+++ b/src/main/ipc/chat.ts
@@ -1,9 +1,10 @@
 // Chat IPC handlers — thin adapters for ChatService
 import { ipcMain, BrowserWindow } from 'electron';
 import type { ChatService } from '../services/chat/ChatService';
+import type { MindManager } from '../services/mind/MindManager';
 import type { ChatEvent } from '../../shared/types';
 
-export function setupChatIPC(chatService: ChatService): void {
+export function setupChatIPC(chatService: ChatService, mindManager: MindManager): void {
   ipcMain.handle('chat:send', async (event, mindId: string, message: string, messageId: string, model?: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return;
@@ -12,8 +13,11 @@ export function setupChatIPC(chatService: ChatService): void {
     await chatService.sendMessage(mindId, message, messageId, emit, model);
   });
 
-  ipcMain.handle('chat:listModels', async (_event, mindId: string) => {
-    return chatService.listModels(mindId);
+  ipcMain.handle('chat:listModels', async (_event, mindId?: string) => {
+    // Fall back to any available mind if no mindId provided
+    const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
+    if (!id) return [];
+    return chatService.listModels(id);
   });
 
   ipcMain.handle('chat:stop', async (_event, mindId: string, messageId: string) => {

--- a/src/main/ipc/chat.ts
+++ b/src/main/ipc/chat.ts
@@ -20,8 +20,10 @@ export function setupChatIPC(chatService: ChatService, mindManager: MindManager)
     return chatService.listModels(id);
   });
 
-  ipcMain.handle('chat:stop', async (_event, mindId: string, messageId: string) => {
+  ipcMain.handle('chat:stop', async (event, mindId: string, messageId: string) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
     await chatService.cancelMessage(mindId, messageId);
+    if (win) win.webContents.send('chat:event', mindId, messageId, { type: 'done' });
   });
 
   ipcMain.handle('chat:newConversation', async (_event, mindId: string) => {

--- a/src/main/ipc/genesis.ts
+++ b/src/main/ipc/genesis.ts
@@ -1,15 +1,11 @@
 // Genesis IPC handlers — wire MindScaffold to renderer
 import { ipcMain, dialog, BrowserWindow } from 'electron';
 import { MindScaffold, type GenesisConfig } from '../services/genesis';
-import { ChatService } from '../services/chat';
-import { ViewDiscovery } from '../services/lens';
-import { ConfigService } from '../services/config';
+import type { MindManager } from '../services/mind/MindManager';
 import { seedLensDefaults, installLensSkill } from '../services/lens';
 
 export function setupGenesisIPC(
-  chatService: ChatService,
-  viewDiscovery: ViewDiscovery,
-  configService: ConfigService,
+  mindManager: MindManager,
   scaffold: MindScaffold,
 ): void {
 
@@ -34,38 +30,25 @@ export function setupGenesisIPC(
   ipcMain.handle('genesis:create', async (event, config: GenesisConfig) => {
     const win = BrowserWindow.fromWebContents(event.sender);
 
-    // Send progress updates to renderer
     scaffold.setProgressHandler((progress) => {
-      if (win) {
-        win.webContents.send('genesis:progress', progress);
-      }
+      if (win) win.webContents.send('genesis:progress', progress);
     });
 
     try {
       const mindPath = await scaffold.create(config);
 
-      // Connect the new mind
-      chatService.setMindPath(mindPath);
+      // Bootstrap Lens defaults
       seedLensDefaults(mindPath);
       installLensSkill(mindPath);
-      await viewDiscovery.scan(mindPath);
-      viewDiscovery.startWatching(() => {
-        if (win) {
-          win.webContents.send('lens:viewsChanged', viewDiscovery.getViews());
-        }
-      });
 
-      // Save config
-      const appConfig = configService.load();
-      appConfig.mindPath = mindPath;
-      configService.save(appConfig);
+      // Load into MindManager (creates client, session, scans views)
+      const mind = await mindManager.loadMind(mindPath);
+      mindManager.setActiveMind(mind.mindId);
 
       return { success: true, mindPath };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (win) {
-        win.webContents.send('genesis:progress', { step: 'error', detail: message });
-      }
+      if (win) win.webContents.send('genesis:progress', { step: 'error', detail: message });
       return { success: false, error: message };
     }
   });

--- a/src/main/ipc/lens.ts
+++ b/src/main/ipc/lens.ts
@@ -1,21 +1,28 @@
-// Lens IPC handlers — wire ViewDiscovery to renderer
+// Lens IPC handlers — thin adapters for ViewDiscovery
 import { ipcMain } from 'electron';
 import type { ViewDiscovery } from '../services/lens';
+import type { MindManager } from '../services/mind/MindManager';
 
-export function setupLensIPC(viewDiscovery: ViewDiscovery): void {
-  ipcMain.handle('lens:getViews', async () => {
-    return viewDiscovery.getViews();
+export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindManager): void {
+  ipcMain.handle('lens:getViews', async (_event, mindId?: string) => {
+    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
+    return viewDiscovery.getViews(mindPath);
   });
 
-  ipcMain.handle('lens:getViewData', async (_event, viewId: string) => {
-    return viewDiscovery.getViewData(viewId);
+  ipcMain.handle('lens:getViewData', async (_event, viewId: string, mindId?: string) => {
+    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
+    return viewDiscovery.getViewData(viewId, mindPath);
   });
 
-  ipcMain.handle('lens:refreshView', async (_event, viewId: string) => {
-    return viewDiscovery.refreshView(viewId);
+  ipcMain.handle('lens:refreshView', async (_event, viewId: string, mindId?: string) => {
+    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
+    if (!mindPath) return viewDiscovery.getViewData(viewId);
+    return viewDiscovery.refreshView(viewId, mindPath);
   });
 
-  ipcMain.handle('lens:sendAction', async (_event, viewId: string, action: string) => {
-    return viewDiscovery.sendAction(viewId, action);
+  ipcMain.handle('lens:sendAction', async (_event, viewId: string, action: string, mindId?: string) => {
+    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
+    if (!mindPath) return viewDiscovery.getViewData(viewId);
+    return viewDiscovery.sendAction(viewId, action, mindPath);
   });
 }

--- a/src/main/ipc/lens.ts
+++ b/src/main/ipc/lens.ts
@@ -4,25 +4,28 @@ import type { ViewDiscovery } from '../services/lens';
 import type { MindManager } from '../services/mind/MindManager';
 
 export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindManager): void {
+  const resolveMindPath = (mindId?: string): string | undefined => {
+    const id = mindId ?? mindManager.getActiveMindId() ?? undefined;
+    return id ? mindManager.getMind(id)?.mindPath : undefined;
+  };
+
   ipcMain.handle('lens:getViews', async (_event, mindId?: string) => {
-    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
-    return viewDiscovery.getViews(mindPath);
+    return viewDiscovery.getViews(resolveMindPath(mindId));
   });
 
   ipcMain.handle('lens:getViewData', async (_event, viewId: string, mindId?: string) => {
-    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
-    return viewDiscovery.getViewData(viewId, mindPath);
+    return viewDiscovery.getViewData(viewId, resolveMindPath(mindId));
   });
 
   ipcMain.handle('lens:refreshView', async (_event, viewId: string, mindId?: string) => {
-    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
-    if (!mindPath) return viewDiscovery.getViewData(viewId);
+    const mindPath = resolveMindPath(mindId);
+    if (!mindPath) return null;
     return viewDiscovery.refreshView(viewId, mindPath);
   });
 
   ipcMain.handle('lens:sendAction', async (_event, viewId: string, action: string, mindId?: string) => {
-    const mindPath = mindId ? mindManager.getMind(mindId)?.mindPath : undefined;
-    if (!mindPath) return viewDiscovery.getViewData(viewId);
+    const mindPath = resolveMindPath(mindId);
+    if (!mindPath) return null;
     return viewDiscovery.sendAction(viewId, action, mindPath);
   });
 }

--- a/src/main/ipc/mind.ts
+++ b/src/main/ipc/mind.ts
@@ -1,0 +1,50 @@
+// Mind IPC handlers — thin adapters for MindManager
+import { ipcMain, dialog, BrowserWindow } from 'electron';
+import * as path from 'path';
+import * as os from 'os';
+import type { MindManager } from '../services/mind/MindManager';
+
+export function setupMindIPC(mindManager: MindManager): void {
+  ipcMain.handle('mind:add', async (event, mindPath: string) => {
+    return mindManager.loadMind(mindPath);
+  });
+
+  ipcMain.handle('mind:remove', async (_event, mindId: string) => {
+    await mindManager.unloadMind(mindId);
+  });
+
+  ipcMain.handle('mind:list', async () => {
+    return mindManager.listMinds();
+  });
+
+  ipcMain.handle('mind:setActive', async (_event, mindId: string) => {
+    mindManager.setActiveMind(mindId);
+  });
+
+  ipcMain.handle('mind:selectDirectory', async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win) return null;
+
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openDirectory'],
+      title: 'Select Genesis Mind Directory',
+      defaultPath: path.join(os.homedir(), 'agents'),
+    });
+
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
+
+  // Emit mind changes to all windows
+  mindManager.on('mind:loaded', () => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('mind:changed', mindManager.listMinds());
+    }
+  });
+
+  mindManager.on('mind:unloaded', () => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('mind:changed', mindManager.listMinds());
+    }
+  });
+}

--- a/src/main/ipc/mind.ts
+++ b/src/main/ipc/mind.ts
@@ -35,6 +35,68 @@ export function setupMindIPC(mindManager: MindManager): void {
     return result.filePaths[0];
   });
 
+  // Backward compat: renderer still calls agent:getStatus during startup
+  ipcMain.handle('agent:getStatus', async () => {
+    const minds = mindManager.listMinds();
+    const active = minds.find(m => m.mindId === mindManager.getActiveMindId()) ?? minds[0];
+    return {
+      connected: minds.length > 0,
+      mindPath: active?.mindPath ?? null,
+      agentName: active?.identity.name ?? null,
+      sessionActive: minds.length > 0,
+      uptime: null,
+      error: null,
+      extensions: [],
+    };
+  });
+
+  // Backward compat: renderer calls agent:selectMindDirectory
+  ipcMain.handle('agent:selectMindDirectory', async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win) return null;
+
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openDirectory'],
+      title: 'Select Genesis Mind Directory',
+      defaultPath: path.join(os.homedir(), 'agents'),
+    });
+
+    if (result.canceled || result.filePaths.length === 0) return null;
+    const selected = result.filePaths[0];
+
+    try {
+      const mind = await mindManager.loadMind(selected);
+      mindManager.setActiveMind(mind.mindId);
+      return selected;
+    } catch {
+      return null;
+    }
+  });
+
+  // Backward compat: renderer calls agent:setMindPath
+  ipcMain.handle('agent:setMindPath', async (_event, mindPath: string) => {
+    try {
+      const mind = await mindManager.loadMind(mindPath);
+      mindManager.setActiveMind(mind.mindId);
+    } catch { /* ignore */ }
+  });
+
+  // Backward compat: config load/save
+  ipcMain.handle('config:load', async () => {
+    const minds = mindManager.listMinds();
+    const active = mindManager.getActiveMindId();
+    return {
+      version: 2,
+      minds: minds.map(m => ({ id: m.mindId, path: m.mindPath })),
+      activeMindId: active,
+      theme: 'dark',
+    };
+  });
+
+  ipcMain.handle('config:save', async () => {
+    // No-op — MindManager persists config internally
+  });
+
   // Emit mind changes to all windows
   mindManager.on('mind:loaded', () => {
     for (const win of BrowserWindow.getAllWindows()) {

--- a/src/main/ipc/mind.ts
+++ b/src/main/ipc/mind.ts
@@ -14,6 +14,10 @@ export function setupMindIPC(mindManager: MindManager): void {
   });
 
   ipcMain.handle('mind:list', async () => {
+    // Wait for restore to complete before returning the list
+    if ((mindManager as any)._restorePromise) {
+      await (mindManager as any)._restorePromise;
+    }
     return mindManager.listMinds();
   });
 

--- a/src/main/services/chat/ChatService.test.ts
+++ b/src/main/services/chat/ChatService.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChatService } from './ChatService';
+
+const mockSession = {
+  send: vi.fn(async () => {}),
+  abort: vi.fn(async () => {}),
+  destroy: vi.fn(async () => {}),
+  on: vi.fn((_eventOrCb: any, _cb?: any) => vi.fn()),
+};
+
+const mockMindManager = {
+  getMind: vi.fn((mindId: string) => {
+    if (mindId === 'valid-mind') {
+      return { session: mockSession, client: { listModels: vi.fn(async () => [{ id: 'm1', name: 'Model 1' }]) } };
+    }
+    return undefined;
+  }),
+  recreateSession: vi.fn(async () => {}),
+};
+
+describe('ChatService', () => {
+  let svc: ChatService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new ChatService(mockMindManager as any);
+  });
+
+  describe('sendMessage', () => {
+    it('gets session from MindManager and calls send', async () => {
+      // Mock session.on to fire session.idle immediately
+      mockSession.on.mockImplementation((eventOrCb: any, cb?: any) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          setTimeout(() => cb(), 0);
+        }
+        return vi.fn();
+      });
+
+      const emit = vi.fn();
+      await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+      expect(mockMindManager.getMind).toHaveBeenCalledWith('valid-mind');
+      expect(mockSession.send).toHaveBeenCalledWith({ prompt: 'hello' });
+      expect(emit).toHaveBeenCalledWith({ type: 'done' });
+    });
+
+    it('throws for invalid mindId', async () => {
+      const emit = vi.fn();
+      await svc.sendMessage('nonexistent', 'hello', 'msg-1', emit);
+      expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+  });
+
+  describe('cancelMessage', () => {
+    it('aborts the session for a mind', async () => {
+      mockSession.on.mockReturnValue(vi.fn());
+      await svc.cancelMessage('valid-mind', 'msg-1');
+      expect(mockSession.abort).toHaveBeenCalled();
+    });
+  });
+
+  describe('newConversation', () => {
+    it('delegates to mindManager.recreateSession', async () => {
+      await svc.newConversation('valid-mind');
+      expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
+    });
+  });
+
+  describe('listModels', () => {
+    it('returns models from the minds client', async () => {
+      const models = await svc.listModels('valid-mind');
+      expect(models).toEqual([{ id: 'm1', name: 'Model 1' }]);
+    });
+
+    it('returns empty array for invalid mind', async () => {
+      const models = await svc.listModels('nonexistent');
+      expect(models).toEqual([]);
+    });
+  });
+});

--- a/src/main/services/chat/ChatService.ts
+++ b/src/main/services/chat/ChatService.ts
@@ -1,126 +1,36 @@
-// Chat session management — creates SDK sessions, streams all events via single callback.
-// Adapted from cmux's CopilotService pattern.
+// ChatService — thin message streaming layer.
+// Gets sessions from MindManager, streams SDK events via callback.
 
-import { getSharedClient } from '../sdk/SdkLoader';
-import type { ExtensionLoader } from '../extensions/ExtensionLoader';
-import { IdentityLoader } from './IdentityLoader';
+import type { MindManager } from '../mind/MindManager';
 import type { ChatEvent, ModelInfo } from '../../../shared/types';
 
-type CopilotSessionType = import('@github/copilot-sdk').CopilotSession;
-
 export class ChatService {
-  private sessions: Map<string, CopilotSessionType> = new Map();
-  private abortControllers: Map<string, AbortController> = new Map();
-  private mindPath: string | null = null;
-  private extensionLoader: ExtensionLoader | null = null;
-  private identityLoader: IdentityLoader;
+  private abortControllers = new Map<string, AbortController>();
 
-  constructor(identityLoader?: IdentityLoader) {
-    this.identityLoader = identityLoader ?? new IdentityLoader();
-  }
-
-  setMindPath(mindPath: string): void {
-    this.mindPath = mindPath;
-  }
-
-  getMindPath(): string | null {
-    return this.mindPath;
-  }
-
-  setExtensionLoader(loader: ExtensionLoader): void {
-    this.extensionLoader = loader;
-  }
-
-  getExtensionLoader(): ExtensionLoader | null {
-    return this.extensionLoader;
-  }
-
-  private async getOrCreateSession(conversationId: string, model?: string): Promise<CopilotSessionType> {
-    let session = this.sessions.get(conversationId);
-    if (!session) {
-      console.log('[ChatService] No existing session, creating new one');
-      console.log('[ChatService] Mind path:', this.mindPath);
-      const client = await getSharedClient();
-      console.log('[ChatService] Got shared client');
-      const config: Record<string, unknown> = {
-        streaming: true,
-      };
-
-      if (model) {
-        config.model = model;
-        console.log('[ChatService] Using model:', model);
-      }
-
-      if (this.mindPath) {
-        config.workingDirectory = this.mindPath;
-
-        // Replace the SDK's identity and tone with the agent's SOUL + instructions.
-        // Identity: "You are GitHub Copilot CLI" → agent's SOUL.md + agent file
-        // Tone: "100 words or less" → removed (agent's Vibe section covers this)
-        // Keeps: tool_instructions, safety, environment, code_change_rules, guidelines.
-        // custom_instructions stays open for per-repo .github/copilot-instructions.md.
-        const identity = this.identityLoader.load(this.mindPath);
-        if (identity) {
-          config.systemMessage = {
-            mode: 'customize',
-            sections: {
-              identity: { action: 'replace', content: identity },
-              tone: { action: 'remove' },
-            },
-          };
-        }
-
-        if (this.extensionLoader) {
-          try {
-            const tools = await this.extensionLoader.loadTools(this.mindPath);
-            if (tools.length > 0) {
-              config.tools = tools;
-              console.log(`[ChatService] Loaded ${tools.length} extension tool(s)`);
-            }
-          } catch (err) {
-            console.error('[ChatService] Failed to load extension tools:', err);
-          }
-        }
-      }
-
-      config.onPermissionRequest = async (request: { kind: string }) => {
-        return { kind: 'approved' };
-      };
-
-      config.onUserInputRequest = async (request: { question: string }) => {
-        return { answer: 'Not available in this context', wasFreeform: true };
-      };
-
-      console.log('[ChatService] Creating session with config:', Object.keys(config));
-      session = await client.createSession(
-        config as unknown as Parameters<typeof client.createSession>[0]
-      );
-      console.log('[ChatService] Session created successfully');
-      this.sessions.set(conversationId, session);
-    }
-    return session;
-  }
+  constructor(private readonly mindManager: MindManager) {}
 
   async sendMessage(
-    conversationId: string,
+    mindId: string,
     prompt: string,
     messageId: string,
     emit: (event: ChatEvent) => void,
     model?: string,
   ): Promise<void> {
     const abortController = new AbortController();
-    this.abortControllers.set(conversationId, abortController);
+    this.abortControllers.set(mindId, abortController);
 
     const unsubs: (() => void)[] = [];
     const guard = (fn: () => void) => { if (!abortController.signal.aborted) fn(); };
 
     try {
-      console.log('[ChatService] Creating/getting session for', conversationId);
-      const session = await this.getOrCreateSession(conversationId, model);
-      console.log('[ChatService] Session ready, sending prompt');
+      const context = this.mindManager.getMind(mindId);
+      if (!context?.session) {
+        throw new Error(`Mind ${mindId} not found or has no session`);
+      }
+      const session = context.session;
 
       // Text streaming
-      unsubs.push(session.on('assistant.message_delta', (event) => {
+      unsubs.push(session.on('assistant.message_delta', (event: any) => {
         guard(() => emit({
           type: 'chunk',
           sdkMessageId: event.data.messageId,
@@ -128,8 +38,8 @@ export class ChatService {
         }));
       }));
 
-      // Final assistant message (reconciliation / no-delta fallback)
-      unsubs.push(session.on('assistant.message', (event) => {
+      // Final assistant message
+      unsubs.push(session.on('assistant.message', (event: any) => {
         guard(() => {
           if (event.data.content) {
             emit({
@@ -142,7 +52,7 @@ export class ChatService {
       }));
 
       // Reasoning
-      unsubs.push(session.on('assistant.reasoning_delta', (event) => {
+      unsubs.push(session.on('assistant.reasoning_delta', (event: any) => {
         guard(() => emit({
           type: 'reasoning',
           reasoningId: event.data.reasoningId,
@@ -151,7 +61,7 @@ export class ChatService {
       }));
 
       // Tool execution
-      unsubs.push(session.on('tool.execution_start', (event) => {
+      unsubs.push(session.on('tool.execution_start', (event: any) => {
         guard(() => emit({
           type: 'tool_start',
           toolCallId: event.data.toolCallId,
@@ -161,7 +71,7 @@ export class ChatService {
         }));
       }));
 
-      unsubs.push(session.on('tool.execution_progress', (event) => {
+      unsubs.push(session.on('tool.execution_progress', (event: any) => {
         guard(() => emit({
           type: 'tool_progress',
           toolCallId: event.data.toolCallId,
@@ -169,7 +79,7 @@ export class ChatService {
         }));
       }));
 
-      unsubs.push(session.on('tool.execution_partial_result', (event) => {
+      unsubs.push(session.on('tool.execution_partial_result', (event: any) => {
         guard(() => emit({
           type: 'tool_output',
           toolCallId: event.data.toolCallId,
@@ -177,7 +87,7 @@ export class ChatService {
         }));
       }));
 
-      unsubs.push(session.on('tool.execution_complete', (event) => {
+      unsubs.push(session.on('tool.execution_complete', (event: any) => {
         guard(() => emit({
           type: 'tool_done',
           toolCallId: event.data.toolCallId,
@@ -187,19 +97,11 @@ export class ChatService {
         }));
       }));
 
-      // Log all events for debugging
-      unsubs.push(session.on((event) => {
-        console.log('[ChatService] Event:', event.type, JSON.stringify(event.data ?? {}).slice(0, 200));
-      }));
-
-      console.log('[ChatService] Calling send...');
       await session.send({ prompt });
 
-      // Wait for session.idle to signal completion
+      // Wait for idle
       await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          resolve(); // 5 min safety timeout
-        }, 300_000);
+        const timeout = setTimeout(resolve, 300_000);
 
         const unsubIdle = session.on('session.idle', () => {
           clearTimeout(timeout);
@@ -208,14 +110,13 @@ export class ChatService {
         });
         unsubs.push(unsubIdle);
 
-        const unsubError = session.on('session.error', (event) => {
+        const unsubError = session.on('session.error', (event: any) => {
           clearTimeout(timeout);
           unsubError();
           reject(new Error(event.data.message));
         });
         unsubs.push(unsubError);
 
-        // If aborted externally, resolve immediately
         abortController.signal.addEventListener('abort', () => {
           clearTimeout(timeout);
           resolve();
@@ -230,85 +131,34 @@ export class ChatService {
       emit({ type: 'error', message });
     } finally {
       for (const unsub of unsubs) unsub();
-      this.abortControllers.delete(conversationId);
+      this.abortControllers.delete(mindId);
     }
   }
 
-  async cancelMessage(
-    conversationId: string,
-    messageId: string,
-    onDone: (messageId: string) => void,
-  ): Promise<void> {
-    const controller = this.abortControllers.get(conversationId);
+  async cancelMessage(mindId: string, messageId: string): Promise<void> {
+    const controller = this.abortControllers.get(mindId);
     if (controller) {
       controller.abort();
-      this.abortControllers.delete(conversationId);
+      this.abortControllers.delete(mindId);
     }
-    const session = this.sessions.get(conversationId);
-    if (session) {
-      await session.abort().catch(() => {});
-    }
-    onDone(messageId);
-  }
-
-  getAbortController(conversationId: string): AbortController | undefined {
-    return this.abortControllers.get(conversationId);
-  }
-
-  async destroySession(conversationId: string): Promise<void> {
-    const session = this.sessions.get(conversationId);
-    if (session) {
-      await session.destroy().catch(() => {});
-      this.sessions.delete(conversationId);
-    }
-    if (this.extensionLoader) {
-      await this.extensionLoader.cleanup();
+    const context = this.mindManager.getMind(mindId);
+    if (context?.session) {
+      await context.session.abort().catch(() => {});
     }
   }
 
-  async sendBackgroundPrompt(prompt: string): Promise<void> {
-    const bgConversationId = `bg-${Date.now()}`;
+  async newConversation(mindId: string): Promise<void> {
+    await this.mindManager.recreateSession(mindId);
+  }
+
+  async listModels(mindId: string): Promise<ModelInfo[]> {
     try {
-      const session = await this.getOrCreateSession(bgConversationId);
-      await session.send({ prompt });
-
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(resolve, 120_000);
-        const unsubIdle = session.on('session.idle', () => {
-          clearTimeout(timeout);
-          unsubIdle();
-          resolve();
-        });
-        const unsubError = session.on('session.error', (event) => {
-          clearTimeout(timeout);
-          unsubError();
-          reject(new Error(event.data.message));
-        });
-      });
-    } finally {
-      await this.destroySession(bgConversationId);
-    }
-  }
-
-  async listModels(): Promise<ModelInfo[]> {
-    try {
-      const client = await getSharedClient();
-      const models = await client.listModels();
+      const context = this.mindManager.getMind(mindId);
+      if (!context?.client) return [];
+      const models = await context.client.listModels();
       return models.map((m: { id: string; name: string }) => ({ id: m.id, name: m.name }));
-    } catch (err) {
-      console.error('[ChatService] Failed to list models:', err);
+    } catch {
       return [];
-    }
-  }
-
-  async stop(): Promise<void> {
-    for (const [, session] of this.sessions) {
-      await session.destroy().catch(() => {});
-    }
-    this.sessions.clear();
-    this.abortControllers.clear();
-    if (this.extensionLoader) {
-      await this.extensionLoader.cleanup();
     }
   }
 }

--- a/src/main/services/chat/IdentityLoader.test.ts
+++ b/src/main/services/chat/IdentityLoader.test.ts
@@ -43,6 +43,13 @@ describe('IdentityLoader', () => {
       expect(loader.load('C:\\agents\\fox')?.name).toBe('fox');
     });
 
+    it('strips "— Soul" suffix from name', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('# The Dude — Soul\nContent');
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      expect(loader.load('C:\\agents\\dude')?.name).toBe('The Dude');
+    });
+
     it('includes agent file content in systemMessage', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync)

--- a/src/main/services/chat/IdentityLoader.test.ts
+++ b/src/main/services/chat/IdentityLoader.test.ts
@@ -13,30 +13,50 @@ describe('IdentityLoader', () => {
   const loader = new IdentityLoader();
   beforeEach(() => vi.clearAllMocks());
 
-  it('returns null when mindPath is null', () => {
-    expect(loader.load(null)).toBeNull();
-  });
+  describe('load', () => {
+    it('returns null when mindPath is null', () => {
+      expect(loader.load(null)).toBeNull();
+    });
 
-  it('loads SOUL.md content', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValue('# Agent\nI am an agent.');
-    vi.mocked(fs.readdirSync).mockReturnValue([]);
-    expect(loader.load('C:\\test')).toContain('I am an agent.');
-  });
+    it('returns MindIdentity with name and systemMessage', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('# Q\nI am an agent.');
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      const result = loader.load('C:\\test');
+      expect(result).toEqual({
+        name: 'Q',
+        systemMessage: '# Q\nI am an agent.',
+      });
+    });
 
-  it('strips YAML frontmatter from agent files', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync)
-      .mockReturnValueOnce('# Soul')
-      .mockReturnValueOnce('---\nname: test\n---\nInstructions');
-    vi.mocked(fs.readdirSync).mockReturnValue(['main.agent.md'] as any);
-    const identity = loader.load('C:\\test');
-    expect(identity).toContain('Instructions');
-    expect(identity).not.toContain('name: test');
-  });
+    it('extracts name from first H1 heading', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('# My Agent Name\nSome content\n# Another heading');
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      expect(loader.load('C:\\test')?.name).toBe('My Agent Name');
+    });
 
-  it('returns null when nothing exists', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-    expect(loader.load('C:\\test')).toBeNull();
+    it('falls back to folder name when no H1 exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('No heading here, just content.');
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      expect(loader.load('C:\\agents\\fox')?.name).toBe('fox');
+    });
+
+    it('includes agent file content in systemMessage', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync)
+        .mockReturnValueOnce('# Soul')
+        .mockReturnValueOnce('---\nname: test\n---\nInstructions');
+      vi.mocked(fs.readdirSync).mockReturnValue(['main.agent.md'] as any);
+      const result = loader.load('C:\\test');
+      expect(result?.systemMessage).toContain('Instructions');
+      expect(result?.systemMessage).not.toContain('name: test');
+    });
+
+    it('returns null when nothing exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(loader.load('C:\\test')).toBeNull();
+    });
   });
 });

--- a/src/main/services/chat/IdentityLoader.ts
+++ b/src/main/services/chat/IdentityLoader.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { MindIdentity } from '../../../shared/types';
 
 const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+const H1_RE = /^#\s+(.+)$/m;
 
 export class IdentityLoader {
-  load(mindPath: string | null): string | null {
+  load(mindPath: string | null): MindIdentity | null {
     if (!mindPath) return null;
     const parts: string[] = [];
 
@@ -29,6 +31,16 @@ export class IdentityLoader {
     } catch { /* missing */ }
 
     if (parts.length === 0) return null;
-    return parts.join('\n\n---\n\n');
+
+    const systemMessage = parts.join('\n\n---\n\n');
+    const name = this.extractName(systemMessage, mindPath);
+
+    return { name, systemMessage };
+  }
+
+  private extractName(content: string, mindPath: string): string {
+    const match = content.match(H1_RE);
+    if (match) return match[1].trim();
+    return path.basename(mindPath);
   }
 }

--- a/src/main/services/chat/IdentityLoader.ts
+++ b/src/main/services/chat/IdentityLoader.ts
@@ -40,7 +40,10 @@ export class IdentityLoader {
 
   private extractName(content: string, mindPath: string): string {
     const match = content.match(H1_RE);
-    if (match) return match[1].trim();
+    if (match) {
+      // Strip common suffixes like "— Soul", "- Soul"
+      return match[1].trim().replace(/\s*[—–-]\s*Soul$/i, '').trim();
+    }
     return path.basename(mindPath);
   }
 }

--- a/src/main/services/config/ConfigService.test.ts
+++ b/src/main/services/config/ConfigService.test.ts
@@ -9,6 +9,9 @@ vi.mock('fs', () => ({
 
 import * as fs from 'fs';
 import { ConfigService } from './ConfigService';
+import type { AppConfig } from '../../../shared/types';
+
+const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, theme: 'dark' };
 
 describe('ConfigService', () => {
   let svc: ConfigService;
@@ -18,36 +21,92 @@ describe('ConfigService', () => {
   });
 
   describe('load', () => {
-    it('returns parsed config when file exists', () => {
+    it('returns v2 config as-is', () => {
+      const v2: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: 'C:\\agents\\q' }], activeMindId: 'q-a1b2', theme: 'light' };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(v2));
+      expect(svc.load()).toEqual(v2);
+    });
+
+    it('migrates v1 config with mindPath to v2', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
-        JSON.stringify({ mindPath: 'C:\\test', theme: 'light' }),
+        JSON.stringify({ mindPath: 'C:\\agents\\q', theme: 'light' }),
       );
-      expect(svc.load()).toEqual({ mindPath: 'C:\\test', theme: 'light' });
+      const result = svc.load();
+      expect(result.version).toBe(2);
+      expect(result.minds).toHaveLength(1);
+      expect(result.minds[0].path).toBe('C:\\agents\\q');
+      expect(result.minds[0].id).toMatch(/^q-[a-f0-9]{4}$/);
+      expect(result.activeMindId).toBe(result.minds[0].id);
+      expect(result.theme).toBe('light');
+    });
+
+    it('migrates v1 config with null mindPath to empty v2', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ mindPath: null, theme: 'dark' }),
+      );
+      expect(svc.load()).toEqual(DEFAULT_CONFIG);
     });
 
     it('returns default config when file is missing', () => {
       vi.mocked(fs.readFileSync).mockImplementation(() => {
         throw new Error('ENOENT');
       });
-      expect(svc.load()).toEqual({ mindPath: null, theme: 'dark' });
+      expect(svc.load()).toEqual(DEFAULT_CONFIG);
     });
 
     it('returns default config for invalid JSON', () => {
       vi.mocked(fs.readFileSync).mockReturnValue('not json');
-      expect(svc.load()).toEqual({ mindPath: null, theme: 'dark' });
+      expect(svc.load()).toEqual(DEFAULT_CONFIG);
+    });
+
+    it('deduplicates minds with the same path', () => {
+      const v2: AppConfig = {
+        version: 2,
+        minds: [
+          { id: 'q-a1b2', path: 'C:\\agents\\q' },
+          { id: 'q-c3d4', path: 'C:\\agents\\q' },
+        ],
+        activeMindId: 'q-a1b2',
+        theme: 'dark',
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(v2));
+      const result = svc.load();
+      expect(result.minds).toHaveLength(1);
+      expect(result.minds[0].id).toBe('q-a1b2');
     });
   });
 
   describe('save', () => {
-    it('creates directory and writes JSON', () => {
-      svc.save({ mindPath: 'C:\\test', theme: 'dark' });
+    it('creates directory and writes v2 JSON', () => {
+      const config: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: 'C:\\agents\\q' }], activeMindId: 'q-a1b2', theme: 'dark' };
+      svc.save(config);
       expect(vi.mocked(fs.mkdirSync)).toHaveBeenCalledWith(expect.any(String), {
         recursive: true,
       });
-      expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
-        expect.stringContaining('config.json'),
-        expect.stringContaining('"mindPath"'),
-      );
+      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      const parsed = JSON.parse(written);
+      expect(parsed.version).toBe(2);
+      expect(parsed.minds).toHaveLength(1);
+    });
+  });
+
+  describe('generateMindId', () => {
+    it('generates id from folder basename + 4 hex chars', () => {
+      const id = ConfigService.generateMindId('C:\\agents\\my-agent');
+      expect(id).toMatch(/^my-agent-[a-f0-9]{4}$/);
+    });
+
+    it('generates id from unix-style path', () => {
+      const id = ConfigService.generateMindId('/home/user/agents/fox');
+      expect(id).toMatch(/^fox-[a-f0-9]{4}$/);
+    });
+
+    it('generates unique ids for same path', () => {
+      const id1 = ConfigService.generateMindId('C:\\agents\\q');
+      const id2 = ConfigService.generateMindId('C:\\agents\\q');
+      // Statistically should differ, but both match the pattern
+      expect(id1).toMatch(/^q-[a-f0-9]{4}$/);
+      expect(id2).toMatch(/^q-[a-f0-9]{4}$/);
     });
   });
 });

--- a/src/main/services/config/ConfigService.ts
+++ b/src/main/services/config/ConfigService.ts
@@ -1,23 +1,65 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import type { AppConfig } from '../../../shared/types';
+import * as crypto from 'crypto';
+import type { AppConfig, AppConfigV1, MindRecord } from '../../../shared/types';
 
 const CONFIG_DIR = path.join(os.homedir(), '.chamber');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 
+const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, theme: 'dark' };
+
 export class ConfigService {
+  static generateMindId(mindPath: string): string {
+    const basename = path.basename(mindPath);
+    const suffix = crypto.randomBytes(2).toString('hex');
+    return `${basename}-${suffix}`;
+  }
+
   load(): AppConfig {
     try {
       const data = fs.readFileSync(CONFIG_PATH, 'utf-8');
-      return JSON.parse(data);
+      const raw = JSON.parse(data);
+      return this.normalize(raw);
     } catch {
-      return { mindPath: null, theme: 'dark' };
+      return { ...DEFAULT_CONFIG };
     }
   }
 
   save(config: AppConfig): void {
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+  }
+
+  private normalize(raw: Record<string, unknown>): AppConfig {
+    if (raw.version === 2) {
+      return this.deduplicateMinds(raw as AppConfig);
+    }
+    return this.migrateV1(raw as unknown as AppConfigV1);
+  }
+
+  private migrateV1(v1: AppConfigV1): AppConfig {
+    if (!v1.mindPath) {
+      return { ...DEFAULT_CONFIG, theme: v1.theme ?? 'dark' };
+    }
+    const id = ConfigService.generateMindId(v1.mindPath);
+    return {
+      version: 2,
+      minds: [{ id, path: v1.mindPath }],
+      activeMindId: id,
+      theme: v1.theme ?? 'dark',
+    };
+  }
+
+  private deduplicateMinds(config: AppConfig): AppConfig {
+    const seen = new Set<string>();
+    const deduped: MindRecord[] = [];
+    for (const mind of config.minds) {
+      if (!seen.has(mind.path)) {
+        seen.add(mind.path);
+        deduped.push(mind);
+      }
+    }
+    return { ...config, minds: deduped };
   }
 }

--- a/src/main/services/config/ConfigService.ts
+++ b/src/main/services/config/ConfigService.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import * as crypto from 'crypto';
+import { generateMindId } from '../mind/generateMindId';
 import type { AppConfig, AppConfigV1, MindRecord } from '../../../shared/types';
 
 const CONFIG_DIR = path.join(os.homedir(), '.chamber');
@@ -10,11 +10,8 @@ const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, theme: 'dark' };
 
 export class ConfigService {
-  static generateMindId(mindPath: string): string {
-    const basename = path.basename(mindPath);
-    const suffix = crypto.randomBytes(2).toString('hex');
-    return `${basename}-${suffix}`;
-  }
+  /** @deprecated Use generateMindId() from mind/generateMindId instead */
+  static generateMindId = generateMindId;
 
   load(): AppConfig {
     try {

--- a/src/main/services/extensions/ExtensionLoader.test.ts
+++ b/src/main/services/extensions/ExtensionLoader.test.ts
@@ -32,14 +32,6 @@ describe('ExtensionLoader', () => {
     vi.clearAllMocks();
   });
 
-  describe('registerAdapter', () => {
-    it('registers an adapter by name', () => {
-      loader.registerAdapter('canvas', fakeAdapter([]));
-      // No direct getter — verified via loadTools
-      expect(loader.getLoadedExtensions()).toEqual([]);
-    });
-  });
-
   describe('discoverExtensions', () => {
     it('returns extension directory names', () => {
       mockExistsSync.mockReturnValue(true);
@@ -57,16 +49,10 @@ describe('ExtensionLoader', () => {
       mockExistsSync.mockReturnValue(false);
       expect(loader.discoverExtensions('C:\\test\\mind')).toEqual([]);
     });
-
-    it('returns empty array when extensions dir is empty', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValue([]);
-      expect(loader.discoverExtensions('C:\\test\\mind')).toEqual([]);
-    });
   });
 
   describe('loadTools', () => {
-    it('loads tools from adapters matching discovered extensions', async () => {
+    it('returns tools and loaded extensions from adapters', async () => {
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue([
         { name: 'canvas', isDirectory: () => true },
@@ -75,10 +61,10 @@ describe('ExtensionLoader', () => {
       const tool = fakeTool('canvas_show');
       loader.registerAdapter('canvas', fakeAdapter([tool]));
 
-      const tools = await loader.loadTools('C:\\test\\mind');
+      const { tools, loaded } = await loader.loadTools('C:\\test\\mind');
       expect(tools).toHaveLength(1);
       expect(tools[0].name).toBe('canvas_show');
-      expect(loader.getLoadedExtensions()).toEqual(['canvas']);
+      expect(loaded).toHaveLength(1);
     });
 
     it('skips extensions without matching adapter', async () => {
@@ -87,7 +73,7 @@ describe('ExtensionLoader', () => {
         { name: 'unknown-ext', isDirectory: () => true },
       ] as unknown as ReturnType<typeof fs.readdirSync>);
 
-      const tools = await loader.loadTools('C:\\test\\mind');
+      const { tools } = await loader.loadTools('C:\\test\\mind');
       expect(tools).toHaveLength(0);
     });
 
@@ -101,24 +87,35 @@ describe('ExtensionLoader', () => {
       loader.registerAdapter('bad', vi.fn().mockRejectedValue(new Error('boom')));
       loader.registerAdapter('good', fakeAdapter([fakeTool('good_tool')]));
 
-      const tools = await loader.loadTools('C:\\test\\mind');
+      const { tools } = await loader.loadTools('C:\\test\\mind');
       expect(tools).toHaveLength(1);
       expect(tools[0].name).toBe('good_tool');
     });
 
-    it('returns empty array with no registered adapters', async () => {
+    it('returns empty when no extensions directory', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const { tools, loaded } = await loader.loadTools('C:\\test\\mind');
+      expect(tools).toHaveLength(0);
+      expect(loaded).toHaveLength(0);
+    });
+
+    it('does not store internal state between calls', async () => {
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue([
         { name: 'canvas', isDirectory: () => true },
       ] as unknown as ReturnType<typeof fs.readdirSync>);
 
-      const tools = await loader.loadTools('C:\\test\\mind');
-      expect(tools).toHaveLength(0);
+      loader.registerAdapter('canvas', fakeAdapter([fakeTool('t')]));
+      const result1 = await loader.loadTools('C:\\mind1');
+      const result2 = await loader.loadTools('C:\\mind2');
+
+      // Each call returns its own loaded array — no shared state
+      expect(result1.loaded).not.toBe(result2.loaded);
     });
   });
 
   describe('cleanup', () => {
-    it('calls cleanup on loaded extensions', async () => {
+    it('calls cleanup on provided extensions', async () => {
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue([
         { name: 'canvas', isDirectory: () => true },
@@ -127,11 +124,19 @@ describe('ExtensionLoader', () => {
       const cleanupFn = vi.fn().mockResolvedValue(undefined);
       loader.registerAdapter('canvas', fakeAdapter([fakeTool('t')], cleanupFn));
 
-      await loader.loadTools('C:\\test\\mind');
-      await loader.cleanup();
+      const { loaded } = await loader.loadTools('C:\\test\\mind');
+      await ExtensionLoader.cleanup(loaded);
 
       expect(cleanupFn).toHaveBeenCalled();
-      expect(loader.getLoadedExtensions()).toEqual([]);
+    });
+
+    it('handles cleanup errors gracefully', async () => {
+      const badExt: LoadedExtension = {
+        name: 'bad',
+        tools: [],
+        cleanup: vi.fn().mockRejectedValue(new Error('cleanup fail')),
+      };
+      await expect(ExtensionLoader.cleanup([badExt])).resolves.not.toThrow();
     });
   });
 });

--- a/src/main/services/extensions/ExtensionLoader.ts
+++ b/src/main/services/extensions/ExtensionLoader.ts
@@ -1,5 +1,5 @@
 // ExtensionLoader — discovers mind extensions and loads their tools into SDK sessions.
-// Each supported extension has an adapter that knows how to initialize it.
+// Stateless: returns loaded extensions, caller stores them per-mind.
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -19,9 +19,13 @@ export interface LoadedExtension {
 
 export type ExtensionAdapter = (extDir: string) => Promise<LoadedExtension>;
 
+export interface LoadResult {
+  tools: ExtensionTool[];
+  loaded: LoadedExtension[];
+}
+
 export class ExtensionLoader {
   private adapters = new Map<string, ExtensionAdapter>();
-  private loaded = new Map<string, LoadedExtension>();
 
   registerAdapter(name: string, adapter: ExtensionAdapter): void {
     this.adapters.set(name, adapter);
@@ -40,48 +44,35 @@ export class ExtensionLoader {
     }
   }
 
-  async loadTools(mindPath: string): Promise<ExtensionTool[]> {
-    // Clean up previously loaded extensions
-    await this.cleanup();
-
+  async loadTools(mindPath: string): Promise<LoadResult> {
     const discovered = this.discoverExtensions(mindPath);
     const allTools: ExtensionTool[] = [];
+    const loaded: LoadedExtension[] = [];
 
     for (const extName of discovered) {
       const adapter = this.adapters.get(extName);
-      if (!adapter) {
-        console.log(`[ExtensionLoader] No adapter for '${extName}', skipping`);
-        continue;
-      }
+      if (!adapter) continue;
 
       const extDir = path.join(mindPath, '.github', 'extensions', extName);
       try {
-        console.log(`[ExtensionLoader] Loading '${extName}' from ${extDir}`);
-        const loaded = await adapter(extDir);
-        this.loaded.set(extName, loaded);
-        allTools.push(...loaded.tools);
-        console.log(`[ExtensionLoader] Loaded '${extName}': ${loaded.tools.length} tool(s)`);
+        const ext = await adapter(extDir);
+        loaded.push(ext);
+        allTools.push(...ext.tools);
       } catch (err) {
         console.error(`[ExtensionLoader] Failed to load '${extName}':`, err);
       }
     }
 
-    return allTools;
+    return { tools: allTools, loaded };
   }
 
-  getLoadedExtensions(): string[] {
-    return Array.from(this.loaded.keys());
-  }
-
-  async cleanup(): Promise<void> {
-    for (const [name, ext] of this.loaded) {
+  static async cleanup(loaded: LoadedExtension[]): Promise<void> {
+    for (const ext of loaded) {
       try {
         await ext.cleanup();
-        console.log(`[ExtensionLoader] Cleaned up '${name}'`);
       } catch (err) {
-        console.error(`[ExtensionLoader] Cleanup error for '${name}':`, err);
+        console.error(`[ExtensionLoader] Cleanup error for '${ext.name}':`, err);
       }
     }
-    this.loaded.clear();
   }
 }

--- a/src/main/services/extensions/ExtensionLoader.ts
+++ b/src/main/services/extensions/ExtensionLoader.ts
@@ -19,7 +19,7 @@ export interface LoadedExtension {
 
 export type ExtensionAdapter = (extDir: string) => Promise<LoadedExtension>;
 
-export interface LoadResult {
+export interface ExtensionLoadResult {
   tools: ExtensionTool[];
   loaded: LoadedExtension[];
 }
@@ -44,7 +44,7 @@ export class ExtensionLoader {
     }
   }
 
-  async loadTools(mindPath: string): Promise<LoadResult> {
+  async loadTools(mindPath: string): Promise<ExtensionLoadResult> {
     const discovered = this.discoverExtensions(mindPath);
     const allTools: ExtensionTool[] = [];
     const loaded: LoadedExtension[] = [];
@@ -66,6 +66,17 @@ export class ExtensionLoader {
     return { tools: allTools, loaded };
   }
 
+  async cleanupExtensions(loaded: LoadedExtension[]): Promise<void> {
+    for (const ext of loaded) {
+      try {
+        await ext.cleanup();
+      } catch (err) {
+        console.error(`[ExtensionLoader] Cleanup error for '${ext.name}':`, err);
+      }
+    }
+  }
+
+  /** @deprecated Use cleanupExtensions() instance method */
   static async cleanup(loaded: LoadedExtension[]): Promise<void> {
     for (const ext of loaded) {
       try {

--- a/src/main/services/lens/ViewDiscovery.test.ts
+++ b/src/main/services/lens/ViewDiscovery.test.ts
@@ -19,33 +19,21 @@ import { ViewDiscovery } from './ViewDiscovery';
 const mockExistsSync = vi.mocked(fs.existsSync);
 const mockReaddirSync = vi.mocked(fs.readdirSync);
 const mockReadFileSync = vi.mocked(fs.readFileSync);
-const mockWriteFileSync = vi.mocked(fs.writeFileSync);
-
-const fakeChatService = {
-  sendBackgroundPrompt: vi.fn().mockResolvedValue(undefined),
-} as any;
 
 describe('ViewDiscovery', () => {
   let discovery: ViewDiscovery;
 
   beforeEach(() => {
-    discovery = new ViewDiscovery(fakeChatService);
+    discovery = new ViewDiscovery();
     vi.clearAllMocks();
-    // By default, existsSync returns false (no dirs exist)
     mockExistsSync.mockReturnValue(false);
   });
 
   describe('scan', () => {
     it('returns parsed view manifests from .github/lens/', async () => {
-      // seedDefaults: hello-world and newspaper view.json don't exist → seed them
-      // installLensSkill: skill doesn't exist, no candidates found
-      // Then scan the lens dir
-      let callCount = 0;
       mockExistsSync.mockImplementation((p: fs.PathLike) => {
         const s = String(p);
-        // On scan, lens dir exists
         if (s.endsWith('.github\\lens')) return true;
-        // view.json for my-view exists
         if (s.endsWith('my-view\\view.json')) return true;
         return false;
       });
@@ -55,31 +43,37 @@ describe('ViewDiscovery', () => {
       ] as unknown as ReturnType<typeof fs.readdirSync>);
 
       mockReadFileSync.mockReturnValue(JSON.stringify({
-        name: 'My View',
-        icon: 'eye',
-        view: 'briefing',
-        source: 'data.json',
+        name: 'My View', icon: 'eye', view: 'briefing', source: 'data.json',
       }));
 
       const views = await discovery.scan('C:\\test\\mind');
-      expect(views.length).toBeGreaterThanOrEqual(1);
-      const myView = views.find(v => v.id === 'my-view');
-      expect(myView).toBeDefined();
-      expect(myView!.name).toBe('My View');
+      expect(views).toHaveLength(1);
+      expect(views[0].name).toBe('My View');
+      expect(views[0].id).toBe('my-view');
+    });
+
+    it('stores views per-mind without clobbering others', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'v1', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'V1', icon: 'a', view: 'form', source: 'd.json' }));
+
+      await discovery.scan('C:\\mind-a');
+
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'V2', icon: 'b', view: 'form', source: 'd.json' }));
+      await discovery.scan('C:\\mind-b');
+
+      expect(discovery.getViews('C:\\mind-a')).toHaveLength(1);
+      expect(discovery.getViews('C:\\mind-b')).toHaveLength(1);
+      expect(discovery.getViews('C:\\mind-a')[0].name).toBe('V1');
+      expect(discovery.getViews('C:\\mind-b')[0].name).toBe('V2');
     });
 
     it('returns empty when no lens dir exists', async () => {
       mockExistsSync.mockReturnValue(false);
       const views = await discovery.scan('C:\\test\\mind');
-      // May include seeded defaults
-      expect(Array.isArray(views)).toBe(true);
-    });
-
-    it('scan does not write files', async () => {
-      mockExistsSync.mockReturnValue(false);
-      await discovery.scan('C:\\test\\mind');
-      expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
-      expect(vi.mocked(fs.mkdirSync)).not.toHaveBeenCalled();
+      expect(views).toEqual([]);
     });
 
     it('skips entries with invalid view.json', async () => {
@@ -98,6 +92,7 @@ describe('ViewDiscovery', () => {
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const views = await discovery.scan('C:\\test\\mind');
+      expect(views).toEqual([]);
       expect(consoleSpy).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
@@ -105,13 +100,25 @@ describe('ViewDiscovery', () => {
 
   describe('getViews', () => {
     it('returns empty before scan', () => {
-      expect(discovery.getViews()).toEqual([]);
+      expect(discovery.getViews('C:\\mind')).toEqual([]);
+    });
+
+    it('returns all views when no mindPath given', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'v', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'V', icon: 'x', view: 'form', source: 'd.json' }));
+
+      await discovery.scan('C:\\mind-a');
+      await discovery.scan('C:\\mind-b');
+
+      expect(discovery.getViews()).toHaveLength(2);
     });
   });
 
   describe('getViewData', () => {
     it('returns parsed data for valid view', async () => {
-      // Set up a scanned view
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue([
         { name: 'test', isDirectory: () => true },
@@ -122,30 +129,54 @@ describe('ViewDiscovery', () => {
 
       await discovery.scan('C:\\test\\mind');
 
-      // Now getViewData reads the source file
       mockReadFileSync.mockReturnValueOnce(JSON.stringify({ count: 42 }));
-      const data = discovery.getViewData('test');
+      const data = discovery.getViewData('test', 'C:\\test\\mind');
       expect(data).toEqual({ count: 42 });
     });
 
     it('returns null for unknown viewId', () => {
-      expect(discovery.getViewData('nonexistent')).toBeNull();
+      expect(discovery.getViewData('nonexistent', 'C:\\mind')).toBeNull();
     });
   });
 
-  describe('stopWatching', () => {
-    it('closes watchers', async () => {
+  describe('removeMind', () => {
+    it('clears views and stops watching for that mind', async () => {
       const mockClose = vi.fn();
       vi.mocked(fs.watch).mockReturnValue({ close: mockClose } as any);
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue([]);
-      mockReadFileSync.mockReturnValue('{}');
 
-      await discovery.scan('C:\\test\\mind');
-      discovery.startWatching(vi.fn());
-      discovery.stopWatching();
+      await discovery.scan('C:\\mind-a');
+      discovery.startWatching('C:\\mind-a', vi.fn());
+      discovery.removeMind('C:\\mind-a');
 
+      expect(discovery.getViews('C:\\mind-a')).toEqual([]);
       expect(mockClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('stopWatching', () => {
+    it('closes watchers for a specific mind', () => {
+      const mockClose = vi.fn();
+      vi.mocked(fs.watch).mockReturnValue({ close: mockClose } as any);
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([]);
+
+      discovery.startWatching('C:\\mind', vi.fn());
+      discovery.stopWatching('C:\\mind');
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('closes all watchers when no mindPath given', () => {
+      const mockClose = vi.fn();
+      vi.mocked(fs.watch).mockReturnValue({ close: mockClose } as any);
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([]);
+
+      discovery.startWatching('C:\\mind-a', vi.fn());
+      discovery.startWatching('C:\\mind-b', vi.fn());
+      discovery.stopWatching();
+      expect(mockClose).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/main/services/lens/ViewDiscovery.ts
+++ b/src/main/services/lens/ViewDiscovery.ts
@@ -1,24 +1,25 @@
-// Lens view discovery — scans mind for view.json manifests, reads view data, handles prompt refresh.
+// Lens view discovery — scans minds for view.json manifests, reads view data, handles prompt refresh.
+// Per-mind storage: views and watchers keyed by mindPath.
 
 import * as fs from 'fs';
 import * as path from 'path';
 import type { LensViewManifest } from '../../../shared/types';
-import type { ChatService } from '../chat/ChatService';
+
+export interface ViewRefreshHandler {
+  sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void>;
+}
 
 export class ViewDiscovery {
-  private views: LensViewManifest[] = [];
-  private watchers: fs.FSWatcher[] = [];
-  private mindPath: string | null = null;
-  private chatService: ChatService;
+  private viewsByMind = new Map<string, LensViewManifest[]>();
+  private watchersByMind = new Map<string, fs.FSWatcher[]>();
+  private refreshHandler: ViewRefreshHandler | null = null;
 
-  constructor(chatService: ChatService) {
-    this.chatService = chatService;
+  setRefreshHandler(handler: ViewRefreshHandler): void {
+    this.refreshHandler = handler;
   }
 
   async scan(mindPath: string): Promise<LensViewManifest[]> {
-    this.mindPath = mindPath;
-    this.views = [];
-
+    const views: LensViewManifest[] = [];
     const lensDir = path.join(mindPath, '.github', 'lens');
 
     if (fs.existsSync(lensDir)) {
@@ -33,100 +34,105 @@ export class ViewDiscovery {
           const manifest = JSON.parse(raw) as LensViewManifest;
           manifest.id = entry.name;
           manifest._basePath = path.join(lensDir, entry.name);
-          this.views.push(manifest);
-          console.log(`[ViewDiscovery] Found view: ${manifest.name} (${entry.name})`);
+          views.push(manifest);
         } catch (err) {
           console.error(`[ViewDiscovery] Failed to parse ${viewJsonPath}:`, err);
         }
       }
     }
 
-    return this.views;
+    this.viewsByMind.set(mindPath, views);
+    return views;
   }
 
-  getViews(): LensViewManifest[] {
-    return this.views;
+  getViews(mindPath?: string): LensViewManifest[] {
+    if (mindPath) return this.viewsByMind.get(mindPath) ?? [];
+    // Return all views across all minds
+    const all: LensViewManifest[] = [];
+    for (const views of this.viewsByMind.values()) all.push(...views);
+    return all;
   }
 
-  getViewData(viewId: string): Record<string, unknown> | null {
-    const view = this.views.find(v => v.id === viewId);
+  getViewData(viewId: string, mindPath?: string): Record<string, unknown> | null {
+    const views = mindPath ? this.getViews(mindPath) : this.getViews();
+    const view = views.find(v => v.id === viewId);
     if (!view || !view._basePath) return null;
 
     const dataPath = path.join(view._basePath, view.source);
     if (!fs.existsSync(dataPath)) return null;
 
     try {
-      const raw = fs.readFileSync(dataPath, 'utf-8');
-      return JSON.parse(raw);
-    } catch (err) {
-      console.error(`[ViewDiscovery] Failed to read data for ${viewId}:`, err);
+      return JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+    } catch {
       return null;
     }
   }
 
-  async refreshView(viewId: string): Promise<Record<string, unknown> | null> {
-    const view = this.views.find(v => v.id === viewId);
-    if (!view || !view.prompt || !view._basePath) return this.getViewData(viewId);
+  async refreshView(viewId: string, mindPath: string): Promise<Record<string, unknown> | null> {
+    const views = this.getViews(mindPath);
+    const view = views.find(v => v.id === viewId);
+    if (!view || !view.prompt || !view._basePath) return this.getViewData(viewId, mindPath);
 
-    // Build the full prompt with output path context
     const dataPath = path.join(view._basePath, view.source);
     const fullPrompt = `${view.prompt}\n\nWrite the JSON output to: ${dataPath}`;
 
     try {
-      await this.chatService.sendBackgroundPrompt(fullPrompt);
-      return this.getViewData(viewId);
-    } catch (err) {
-      console.error(`[ViewDiscovery] Refresh failed for ${viewId}:`, err);
-      return this.getViewData(viewId);
+      await this.refreshHandler?.sendBackgroundPrompt(mindPath, fullPrompt);
+      return this.getViewData(viewId, mindPath);
+    } catch {
+      return this.getViewData(viewId, mindPath);
     }
   }
 
-  async sendAction(viewId: string, action: string): Promise<Record<string, unknown> | null> {
-    const view = this.views.find(v => v.id === viewId);
-    if (!view || !view._basePath) return this.getViewData(viewId);
+  async sendAction(viewId: string, action: string, mindPath: string): Promise<Record<string, unknown> | null> {
+    const views = this.getViews(mindPath);
+    const view = views.find(v => v.id === viewId);
+    if (!view || !view._basePath) return this.getViewData(viewId, mindPath);
 
     const dataPath = path.join(view._basePath, view.source);
     const fullPrompt = `The user is viewing "${view.name}" (source: ${dataPath}).\n\nAction requested: ${action}\n\nMake the requested change and write the updated JSON to: ${dataPath}`;
 
     try {
-      await this.chatService.sendBackgroundPrompt(fullPrompt);
-      return this.getViewData(viewId);
-    } catch (err) {
-      console.error(`[ViewDiscovery] Action failed for ${viewId}:`, err);
-      return this.getViewData(viewId);
+      await this.refreshHandler?.sendBackgroundPrompt(mindPath, fullPrompt);
+      return this.getViewData(viewId, mindPath);
+    } catch {
+      return this.getViewData(viewId, mindPath);
     }
   }
 
-  startWatching(onChanged: () => void): void {
-    this.stopWatching();
-    if (!this.mindPath) return;
+  startWatching(mindPath: string, onChanged: () => void): void {
+    this.stopWatching(mindPath);
+    const lensDir = path.join(mindPath, '.github', 'lens');
+    if (!fs.existsSync(lensDir)) return;
 
-    const lensDir = path.join(this.mindPath, '.github', 'lens');
+    const watchers: fs.FSWatcher[] = [];
+    try {
+      const watcher = fs.watch(lensDir, { recursive: true }, (_eventType, filename) => {
+        if (filename && (filename.endsWith('view.json') || filename.endsWith('.json'))) {
+          setTimeout(() => this.scan(mindPath).then(onChanged), 300);
+        }
+      });
+      watchers.push(watcher);
+    } catch { /* watch not supported */ }
 
-    for (const dir of [lensDir]) {
-      if (!fs.existsSync(dir)) continue;
-      try {
-        const watcher = fs.watch(dir, { recursive: true }, (eventType, filename) => {
-          if (filename && (filename.endsWith('view.json') || filename.endsWith('.json'))) {
-            // Debounce: re-scan after a short delay
-            setTimeout(() => {
-              if (this.mindPath) {
-                this.scan(this.mindPath).then(onChanged);
-              }
-            }, 300);
-          }
-        });
-        this.watchers.push(watcher);
-      } catch (err) {
-        console.error(`[ViewDiscovery] Failed to watch ${dir}:`, err);
+    this.watchersByMind.set(mindPath, watchers);
+  }
+
+  stopWatching(mindPath?: string): void {
+    if (mindPath) {
+      const watchers = this.watchersByMind.get(mindPath) ?? [];
+      for (const w of watchers) w.close();
+      this.watchersByMind.delete(mindPath);
+    } else {
+      for (const watchers of this.watchersByMind.values()) {
+        for (const w of watchers) w.close();
       }
+      this.watchersByMind.clear();
     }
   }
 
-  stopWatching(): void {
-    for (const watcher of this.watchers) {
-      watcher.close();
-    }
-    this.watchers = [];
+  removeMind(mindPath: string): void {
+    this.stopWatching(mindPath);
+    this.viewsByMind.delete(mindPath);
   }
 }

--- a/src/main/services/lens/ViewDiscovery.ts
+++ b/src/main/services/lens/ViewDiscovery.ts
@@ -14,6 +14,10 @@ export class ViewDiscovery {
   private watchersByMind = new Map<string, fs.FSWatcher[]>();
   private refreshHandler: ViewRefreshHandler | null = null;
 
+  constructor(refreshHandler?: ViewRefreshHandler) {
+    this.refreshHandler = refreshHandler ?? null;
+  }
+
   setRefreshHandler(handler: ViewRefreshHandler): void {
     this.refreshHandler = handler;
   }

--- a/src/main/services/mind/MindManager.test.ts
+++ b/src/main/services/mind/MindManager.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MindManager } from './MindManager';
+import type { MindContext } from '../../../shared/types';
+
+// --- Mocks ---
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  readFileSync: vi.fn(),
+}));
+
+import * as fs from 'fs';
+
+const mockStart = vi.fn(async () => {});
+const mockStop = vi.fn(async () => {});
+const mockCreateSession = vi.fn(() => ({
+  send: vi.fn(),
+  sendAndWait: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+}));
+
+function makeMockClient() {
+  return {
+    start: mockStart,
+    stop: mockStop,
+    createSession: mockCreateSession,
+  };
+}
+
+const mockClientFactory = {
+  createClient: vi.fn(async () => makeMockClient()),
+  destroyClient: vi.fn(async () => {}),
+};
+
+const mockIdentityLoader = {
+  load: vi.fn((mindPath: string) => ({
+    name: mindPath.split('\\').pop() ?? 'unknown',
+    systemMessage: `Identity for ${mindPath}`,
+  })),
+};
+
+const mockExtensionLoader = {
+  registerAdapter: vi.fn(),
+  discoverExtensions: vi.fn(() => []),
+  loadTools: vi.fn(async () => ({ tools: [], loaded: [] })),
+};
+
+const mockConfigService = {
+  load: vi.fn(() => ({ version: 2 as const, minds: [], activeMindId: null, theme: 'dark' as const })),
+  save: vi.fn(),
+};
+
+const mockViewDiscovery = {
+  scan: vi.fn(async () => []),
+  getViews: vi.fn(() => []),
+  startWatching: vi.fn(),
+  stopWatching: vi.fn(),
+  removeMind: vi.fn(),
+  setRefreshHandler: vi.fn(),
+};
+
+describe('MindManager', () => {
+  let manager: MindManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
+    manager = new MindManager(
+      mockClientFactory as any,
+      mockIdentityLoader as any,
+      mockExtensionLoader as any,
+      mockConfigService as any,
+      mockViewDiscovery as any,
+    );
+  });
+
+  describe('loadMind', () => {
+    it('loads a mind from a valid directory', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      expect(mind.mindPath).toBe('C:\\agents\\q');
+      expect(mind.identity.name).toBe('q');
+      expect(mind.status).toBe('ready');
+      expect(mockClientFactory.createClient).toHaveBeenCalledWith('C:\\agents\\q');
+      expect(mockExtensionLoader.loadTools).toHaveBeenCalledWith('C:\\agents\\q');
+      expect(mockConfigService.save).toHaveBeenCalled();
+    });
+
+    it('generates a stable mind ID from folder name', async () => {
+      const mind = await manager.loadMind('C:\\agents\\fox');
+      expect(mind.mindId).toMatch(/^fox-[a-f0-9]{4}$/);
+    });
+
+    it('throws on invalid directory (no SOUL.md or .github)', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      await expect(manager.loadMind('C:\\invalid')).rejects.toThrow();
+    });
+
+    it('deduplicates — same path loaded twice returns existing mind', async () => {
+      const mind1 = await manager.loadMind('C:\\agents\\q');
+      const mind2 = await manager.loadMind('C:\\agents\\q');
+      expect(mind1.mindId).toBe(mind2.mindId);
+      expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits mind:loaded event', async () => {
+      const listener = vi.fn();
+      manager.on('mind:loaded', listener);
+      await manager.loadMind('C:\\agents\\q');
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ mindPath: 'C:\\agents\\q' }));
+    });
+  });
+
+  describe('unloadMind', () => {
+    it('destroys session, client, extensions and removes from map', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      await manager.unloadMind(mind.mindId);
+      expect(mockClientFactory.destroyClient).toHaveBeenCalled();
+      expect(manager.getMind(mind.mindId)).toBeUndefined();
+      expect(mockConfigService.save).toHaveBeenCalled();
+    });
+
+    it('emits mind:unloaded event', async () => {
+      const listener = vi.fn();
+      manager.on('mind:unloaded', listener);
+      const mind = await manager.loadMind('C:\\agents\\q');
+      await manager.unloadMind(mind.mindId);
+      expect(listener).toHaveBeenCalledWith(mind.mindId);
+    });
+
+    it('is a no-op for non-existent mindId', async () => {
+      await expect(manager.unloadMind('nonexistent')).resolves.not.toThrow();
+    });
+
+    it('falls back activeMindId when active mind is unloaded', async () => {
+      const mind1 = await manager.loadMind('C:\\agents\\a');
+      const mind2 = await manager.loadMind('C:\\agents\\b');
+      manager.setActiveMind(mind1.mindId);
+      await manager.unloadMind(mind1.mindId);
+      // Should fall back to remaining mind or null
+      const config = mockConfigService.save.mock.calls.at(-1)?.[0];
+      expect(config?.activeMindId).toBe(mind2.mindId);
+    });
+  });
+
+  describe('listMinds', () => {
+    it('returns MindContext array (no internal details)', async () => {
+      await manager.loadMind('C:\\agents\\q');
+      await manager.loadMind('C:\\agents\\fox');
+      const minds = manager.listMinds();
+      expect(minds).toHaveLength(2);
+      // Verify no internal properties leaked
+      for (const m of minds) {
+        expect(m).toHaveProperty('mindId');
+        expect(m).toHaveProperty('mindPath');
+        expect(m).toHaveProperty('identity');
+        expect(m).toHaveProperty('status');
+        expect(m).not.toHaveProperty('client');
+        expect(m).not.toHaveProperty('session');
+        expect(m).not.toHaveProperty('extensions');
+      }
+    });
+  });
+
+  describe('getMind', () => {
+    it('returns internal context for valid ID', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      const internal = manager.getMind(mind.mindId);
+      expect(internal).toBeDefined();
+      expect(internal!.client).toBeDefined();
+      expect(internal!.session).toBeDefined();
+    });
+
+    it('returns undefined for invalid ID', () => {
+      expect(manager.getMind('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('recreateSession', () => {
+    it('destroys old session and creates new one', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      const oldSession = manager.getMind(mind.mindId)!.session;
+
+      await manager.recreateSession(mind.mindId);
+
+      const newSession = manager.getMind(mind.mindId)!.session;
+      expect(newSession).toBeDefined();
+      expect(mockCreateSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws for non-existent mind', async () => {
+      await expect(manager.recreateSession('nonexistent')).rejects.toThrow();
+    });
+  });
+
+  describe('restoreFromConfig', () => {
+    it('loads all minds from config on startup', async () => {
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [
+          { id: 'q-a1b2', path: 'C:\\agents\\q' },
+          { id: 'fox-c3d4', path: 'C:\\agents\\fox' },
+        ],
+        activeMindId: 'q-a1b2',
+        theme: 'dark',
+      });
+
+      await manager.restoreFromConfig();
+      expect(manager.listMinds()).toHaveLength(2);
+    });
+
+    it('skips invalid paths without blocking others', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        return !String(p).includes('bad');
+      });
+
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [
+          { id: 'good-a1b2', path: 'C:\\agents\\good' },
+          { id: 'bad-c3d4', path: 'C:\\agents\\bad' },
+        ],
+        activeMindId: 'good-a1b2',
+        theme: 'dark',
+      });
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await manager.restoreFromConfig();
+      expect(manager.listMinds()).toHaveLength(1);
+      expect(manager.listMinds()[0].identity.name).toBe('good');
+      consoleSpy.mockRestore();
+    });
+
+    it('handles empty config gracefully', async () => {
+      mockConfigService.load.mockReturnValue({
+        version: 2, minds: [], activeMindId: null, theme: 'dark',
+      });
+
+      await manager.restoreFromConfig();
+      expect(manager.listMinds()).toHaveLength(0);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('unloads all minds', async () => {
+      await manager.loadMind('C:\\agents\\q');
+      await manager.loadMind('C:\\agents\\fox');
+      await manager.shutdown();
+      expect(manager.listMinds()).toHaveLength(0);
+      expect(mockClientFactory.destroyClient).toHaveBeenCalledTimes(2);
+    });
+
+    it('is idempotent', async () => {
+      await manager.loadMind('C:\\agents\\q');
+      await manager.shutdown();
+      await expect(manager.shutdown()).resolves.not.toThrow();
+    });
+  });
+
+  describe('event isolation', () => {
+    it('creates separate sessions for different minds', async () => {
+      await manager.loadMind('C:\\agents\\q');
+      await manager.loadMind('C:\\agents\\fox');
+      // Each mind gets its own createSession call
+      expect(mockCreateSession).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/main/services/mind/MindManager.test.ts
+++ b/src/main/services/mind/MindManager.test.ts
@@ -45,6 +45,7 @@ const mockExtensionLoader = {
   registerAdapter: vi.fn(),
   discoverExtensions: vi.fn(() => []),
   loadTools: vi.fn(async () => ({ tools: [], loaded: [] })),
+  cleanupExtensions: vi.fn(async () => {}),
 };
 
 const mockConfigService = {

--- a/src/main/services/mind/MindManager.test.ts
+++ b/src/main/services/mind/MindManager.test.ts
@@ -264,8 +264,34 @@ describe('MindManager', () => {
     it('creates separate sessions for different minds', async () => {
       await manager.loadMind('C:\\agents\\q');
       await manager.loadMind('C:\\agents\\fox');
-      // Each mind gets its own createSession call
       expect(mockCreateSession).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('restoreFromConfig ID preservation', () => {
+    it('uses persisted IDs instead of generating new ones', async () => {
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [{ id: 'my-stable-id', path: 'C:\\agents\\q' }],
+        activeMindId: 'my-stable-id',
+        theme: 'dark',
+      });
+
+      await manager.restoreFromConfig();
+      const minds = manager.listMinds();
+      expect(minds).toHaveLength(1);
+      expect(minds[0].mindId).toBe('my-stable-id');
+    });
+  });
+
+  describe('concurrent loadMind guard', () => {
+    it('returns same promise for concurrent calls with same path', async () => {
+      const promise1 = manager.loadMind('C:\\agents\\q');
+      const promise2 = manager.loadMind('C:\\agents\\q');
+      const [mind1, mind2] = await Promise.all([promise1, promise2]);
+      expect(mind1.mindId).toBe(mind2.mindId);
+      // Only one client created despite two concurrent calls
+      expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -1,0 +1,230 @@
+// MindManager — aggregate root for multi-mind runtime.
+// Owns Map<mindId, InternalMindContext>, lifecycle, persistence.
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { MindContext, AppConfig, MindRecord } from '../../../shared/types';
+import type { InternalMindContext } from './types';
+import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
+import type { IdentityLoader } from '../chat/IdentityLoader';
+import type { ExtensionLoader, LoadedExtension } from '../extensions/ExtensionLoader';
+import { ExtensionLoader as ExtensionLoaderClass } from '../extensions/ExtensionLoader';
+import { ConfigService } from '../config/ConfigService';
+import type { ViewDiscovery } from '../lens/ViewDiscovery';
+
+export class MindManager extends EventEmitter {
+  private minds = new Map<string, InternalMindContext>();
+  private pathToId = new Map<string, string>();
+  private activeMindId: string | null = null;
+
+  constructor(
+    private readonly clientFactory: CopilotClientFactory,
+    private readonly identityLoader: IdentityLoader,
+    private readonly extensionLoader: ExtensionLoader,
+    private readonly configService: ConfigService,
+    private readonly viewDiscovery: ViewDiscovery,
+  ) {
+    super();
+  }
+
+  async loadMind(mindPath: string): Promise<MindContext> {
+    // Deduplicate
+    const existingId = this.pathToId.get(mindPath);
+    if (existingId && this.minds.has(existingId)) {
+      return this.toPublic(this.minds.get(existingId)!);
+    }
+
+    // Validate
+    this.validateMindPath(mindPath);
+
+    // Generate ID
+    const mindId = ConfigService.generateMindId(mindPath);
+
+    // Load identity
+    const identity = this.identityLoader.load(mindPath);
+    if (!identity) {
+      throw new Error(`Failed to load identity from ${mindPath}`);
+    }
+
+    // Create client
+    const client = await this.clientFactory.createClient(mindPath);
+
+    // Load extensions
+    const { tools, loaded } = await this.extensionLoader.loadTools(mindPath);
+
+    // Create session
+    const session = client.createSession({
+      workingDirectory: mindPath,
+      tools: tools as any[],
+      systemMessage: {
+        mode: 'customize',
+        sectionOverrides: [
+          { section: 'identity', override: { type: 'replace', content: identity.systemMessage } },
+          { section: 'tone', override: { type: 'remove' } },
+        ],
+      },
+      permissions: { autoApprove: true },
+    });
+
+    const context: InternalMindContext = {
+      mindId,
+      mindPath,
+      identity,
+      status: 'ready',
+      client,
+      session,
+      extensions: loaded as any[],
+    };
+
+    this.minds.set(mindId, context);
+    this.pathToId.set(mindPath, mindId);
+
+    // Scan views
+    await this.viewDiscovery.scan(mindPath);
+
+    // Persist
+    this.persistConfig();
+
+    this.emit('mind:loaded', this.toPublic(context));
+    return this.toPublic(context);
+  }
+
+  async unloadMind(mindId: string): Promise<void> {
+    const context = this.minds.get(mindId);
+    if (!context) return;
+
+    // Cleanup extensions
+    await ExtensionLoaderClass.cleanup(context.extensions);
+
+    // Destroy client
+    await this.clientFactory.destroyClient(context.client);
+
+    // Remove views/watchers
+    this.viewDiscovery.removeMind(context.mindPath);
+
+    // Remove from maps
+    this.minds.delete(mindId);
+    this.pathToId.delete(context.mindPath);
+
+    // Update active mind if needed
+    if (this.activeMindId === mindId) {
+      const remaining = Array.from(this.minds.keys());
+      this.activeMindId = remaining.length > 0 ? remaining[0] : null;
+    }
+
+    // Persist
+    this.persistConfig();
+
+    this.emit('mind:unloaded', mindId);
+  }
+
+  listMinds(): MindContext[] {
+    return Array.from(this.minds.values()).map(m => this.toPublic(m));
+  }
+
+  getMind(mindId: string): InternalMindContext | undefined {
+    return this.minds.get(mindId);
+  }
+
+  setActiveMind(mindId: string): void {
+    if (this.minds.has(mindId)) {
+      this.activeMindId = mindId;
+    }
+  }
+
+  getActiveMindId(): string | null {
+    return this.activeMindId;
+  }
+
+  async recreateSession(mindId: string): Promise<void> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+
+    const session = context.client.createSession({
+      workingDirectory: context.mindPath,
+      tools: (context.extensions as any[]).flatMap((e: any) => e.tools ?? []),
+      systemMessage: {
+        mode: 'customize',
+        sectionOverrides: [
+          { section: 'identity', override: { type: 'replace', content: context.identity.systemMessage } },
+          { section: 'tone', override: { type: 'remove' } },
+        ],
+      },
+      permissions: { autoApprove: true },
+    });
+
+    context.session = session;
+  }
+
+  async restoreFromConfig(): Promise<void> {
+    const config = this.configService.load();
+    for (const record of config.minds) {
+      try {
+        const mind = await this.loadMind(record.path);
+        // Override the generated ID with the persisted one for stability
+        if (mind.mindId !== record.id) {
+          this.rekey(mind.mindId, record.id);
+        }
+      } catch (err) {
+        console.error(`[MindManager] Failed to restore mind at ${record.path}:`, err);
+      }
+    }
+
+    if (config.activeMindId && this.minds.has(config.activeMindId)) {
+      this.activeMindId = config.activeMindId;
+    } else if (this.minds.size > 0) {
+      this.activeMindId = Array.from(this.minds.keys())[0];
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    const ids = Array.from(this.minds.keys());
+    for (const id of ids) {
+      await this.unloadMind(id);
+    }
+  }
+
+  // --- Private helpers ---
+
+  private validateMindPath(mindPath: string): void {
+    const hasSoul = fs.existsSync(path.join(mindPath, 'SOUL.md'));
+    const hasGithub = fs.existsSync(path.join(mindPath, '.github'));
+    if (!hasSoul && !hasGithub) {
+      throw new Error(`Invalid mind directory: ${mindPath} — must contain SOUL.md or .github/`);
+    }
+  }
+
+  private toPublic(ctx: InternalMindContext): MindContext {
+    return {
+      mindId: ctx.mindId,
+      mindPath: ctx.mindPath,
+      identity: ctx.identity,
+      status: ctx.status,
+      error: ctx.error,
+    };
+  }
+
+  private rekey(oldId: string, newId: string): void {
+    const ctx = this.minds.get(oldId);
+    if (!ctx) return;
+    this.minds.delete(oldId);
+    (ctx as any).mindId = newId;
+    this.minds.set(newId, ctx);
+    this.pathToId.set(ctx.mindPath, newId);
+  }
+
+  private persistConfig(): void {
+    const minds: MindRecord[] = Array.from(this.minds.values()).map(m => ({
+      id: m.mindId,
+      path: m.mindPath,
+    }));
+    const config: AppConfig = {
+      version: 2,
+      minds,
+      activeMindId: this.activeMindId,
+      theme: this.configService.load().theme,
+    };
+    this.configService.save(config);
+  }
+}

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -54,7 +54,7 @@ export class MindManager extends EventEmitter {
     const { tools, loaded } = await this.extensionLoader.loadTools(mindPath);
 
     // Create session
-    const session = client.createSession({
+    const session = await client.createSession({
       workingDirectory: mindPath,
       tools: tools as any[],
       systemMessage: {
@@ -142,7 +142,7 @@ export class MindManager extends EventEmitter {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
 
-    const session = context.client.createSession({
+    const session = await context.client.createSession({
       workingDirectory: context.mindPath,
       tools: (context.extensions as any[]).flatMap((e: any) => e.tools ?? []),
       systemMessage: {

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -16,6 +16,7 @@ import type { ViewDiscovery } from '../lens/ViewDiscovery';
 export class MindManager extends EventEmitter {
   private minds = new Map<string, InternalMindContext>();
   private pathToId = new Map<string, string>();
+  private loading = new Map<string, Promise<MindContext>>();
   private activeMindId: string | null = null;
 
   constructor(
@@ -29,12 +30,26 @@ export class MindManager extends EventEmitter {
   }
 
   async loadMind(mindPath: string, mindId?: string): Promise<MindContext> {
-    // Deduplicate
+    // Deduplicate — return existing mind
     const existingId = this.pathToId.get(mindPath);
     if (existingId && this.minds.has(existingId)) {
       return this.toPublic(this.minds.get(existingId)!);
     }
 
+    // Concurrent guard — return in-flight promise
+    const inflight = this.loading.get(mindPath);
+    if (inflight) return inflight;
+
+    const promise = this.doLoadMind(mindPath, mindId);
+    this.loading.set(mindPath, promise);
+    try {
+      return await promise;
+    } finally {
+      this.loading.delete(mindPath);
+    }
+  }
+
+  private async doLoadMind(mindPath: string, mindId?: string): Promise<MindContext> {
     // Validate
     this.validateMindPath(mindPath);
 

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -64,8 +64,9 @@ export class MindManager extends EventEmitter {
           { section: 'tone', override: { type: 'remove' } },
         ],
       },
-      permissions: { autoApprove: true },
-    });
+      onPermissionRequest: async () => ({ kind: 'approved' }),
+      onUserInputRequest: async () => ({ answer: 'Not available in this context', wasFreeform: true }),
+    } as any);
 
     const context: InternalMindContext = {
       mindId,
@@ -151,8 +152,9 @@ export class MindManager extends EventEmitter {
           { section: 'tone', override: { type: 'remove' } },
         ],
       },
-      permissions: { autoApprove: true },
-    });
+      onPermissionRequest: async () => ({ kind: 'approved' }),
+      onUserInputRequest: async () => ({ answer: 'Not available in this context', wasFreeform: true }),
+    } as any);
 
     context.session = session;
   }

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -169,10 +169,17 @@ export class MindManager extends EventEmitter {
   }
 
   async shutdown(): Promise<void> {
-    const ids = Array.from(this.minds.keys());
-    for (const id of ids) {
-      await this.unloadMind(id);
+    // Save config BEFORE destroying anything — preserve mind list for next launch
+    this.persistConfig();
+
+    // Clean up resources without persisting (don't call unloadMind which clears config)
+    for (const [, context] of this.minds) {
+      await this.extensionLoader.cleanupExtensions(context.extensions);
+      await this.clientFactory.destroyClient(context.client);
+      this.viewDiscovery.removeMind(context.mindPath);
     }
+    this.minds.clear();
+    this.pathToId.clear();
   }
 
   // --- Private helpers ---

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -6,11 +6,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { MindContext, AppConfig, MindRecord } from '../../../shared/types';
 import type { InternalMindContext } from './types';
+import { generateMindId } from './generateMindId';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import type { IdentityLoader } from '../chat/IdentityLoader';
-import type { ExtensionLoader, LoadedExtension } from '../extensions/ExtensionLoader';
-import { ExtensionLoader as ExtensionLoaderClass } from '../extensions/ExtensionLoader';
-import { ConfigService } from '../config/ConfigService';
+import type { ExtensionLoader } from '../extensions/ExtensionLoader';
+import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
 
 export class MindManager extends EventEmitter {
@@ -33,7 +33,7 @@ export class MindManager extends EventEmitter {
     // Deduplicate — return existing mind
     const existingId = this.pathToId.get(mindPath);
     if (existingId && this.minds.has(existingId)) {
-      return this.toPublic(this.minds.get(existingId)!);
+      return this.toExternalContext(this.minds.get(existingId)!);
     }
 
     // Concurrent guard — return in-flight promise
@@ -54,7 +54,7 @@ export class MindManager extends EventEmitter {
     this.validateMindPath(mindPath);
 
     // Use provided ID or generate a new one
-    const id = mindId ?? ConfigService.generateMindId(mindPath);
+    const id = mindId ?? generateMindId(mindPath);
 
     // Load identity
     const identity = this.identityLoader.load(mindPath);
@@ -102,8 +102,8 @@ export class MindManager extends EventEmitter {
     // Persist
     this.persistConfig();
 
-    this.emit('mind:loaded', this.toPublic(context));
-    return this.toPublic(context);
+    this.emit('mind:loaded', this.toExternalContext(context));
+    return this.toExternalContext(context);
   }
 
   async unloadMind(mindId: string): Promise<void> {
@@ -111,7 +111,7 @@ export class MindManager extends EventEmitter {
     if (!context) return;
 
     // Cleanup extensions
-    await ExtensionLoaderClass.cleanup(context.extensions);
+    await this.extensionLoader.cleanupExtensions(context.extensions);
 
     // Destroy client
     await this.clientFactory.destroyClient(context.client);
@@ -136,7 +136,7 @@ export class MindManager extends EventEmitter {
   }
 
   listMinds(): MindContext[] {
-    return Array.from(this.minds.values()).map(m => this.toPublic(m));
+    return Array.from(this.minds.values()).map(m => this.toExternalContext(m));
   }
 
   getMind(mindId: string): InternalMindContext | undefined {
@@ -208,7 +208,7 @@ export class MindManager extends EventEmitter {
     }
   }
 
-  private toPublic(ctx: InternalMindContext): MindContext {
+  private toExternalContext(ctx: InternalMindContext): MindContext {
     return {
       mindId: ctx.mindId,
       mindPath: ctx.mindPath,

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -69,19 +69,7 @@ export class MindManager extends EventEmitter {
     const { tools, loaded } = await this.extensionLoader.loadTools(mindPath);
 
     // Create session
-    const session = await client.createSession({
-      workingDirectory: mindPath,
-      tools: tools as any[],
-      systemMessage: {
-        mode: 'customize',
-        sectionOverrides: [
-          { section: 'identity', override: { type: 'replace', content: identity.systemMessage } },
-          { section: 'tone', override: { type: 'remove' } },
-        ],
-      },
-      onPermissionRequest: async () => ({ kind: 'approved' }),
-      onUserInputRequest: async () => ({ answer: 'Not available in this context', wasFreeform: true }),
-    } as any);
+    const session = await this.createSessionForMind(client, mindPath, identity.systemMessage, tools);
 
     const context: InternalMindContext = {
       mindId: id,
@@ -90,7 +78,7 @@ export class MindManager extends EventEmitter {
       status: 'ready',
       client,
       session,
-      extensions: loaded as any[],
+      extensions: loaded,
     };
 
     this.minds.set(id, context);
@@ -139,7 +127,7 @@ export class MindManager extends EventEmitter {
     return Array.from(this.minds.values()).map(m => this.toExternalContext(m));
   }
 
-  getMind(mindId: string): InternalMindContext | undefined {
+  getMind(mindId: string): Readonly<InternalMindContext> | undefined {
     return this.minds.get(mindId);
   }
 
@@ -157,21 +145,10 @@ export class MindManager extends EventEmitter {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
 
-    const session = await context.client.createSession({
-      workingDirectory: context.mindPath,
-      tools: (context.extensions as any[]).flatMap((e: any) => e.tools ?? []),
-      systemMessage: {
-        mode: 'customize',
-        sectionOverrides: [
-          { section: 'identity', override: { type: 'replace', content: context.identity.systemMessage } },
-          { section: 'tone', override: { type: 'remove' } },
-        ],
-      },
-      onPermissionRequest: async () => ({ kind: 'approved' }),
-      onUserInputRequest: async () => ({ answer: 'Not available in this context', wasFreeform: true }),
-    } as any);
-
-    context.session = session;
+    const tools = context.extensions.flatMap((e: { tools?: unknown[] }) => e.tools ?? []);
+    context.session = await this.createSessionForMind(
+      context.client, context.mindPath, context.identity.systemMessage, tools,
+    );
   }
 
   async restoreFromConfig(): Promise<void> {
@@ -216,6 +193,40 @@ export class MindManager extends EventEmitter {
       status: ctx.status,
       error: ctx.error,
     };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async createSessionForMind(client: any, mindPath: string, systemMessage: string, tools: unknown[]): Promise<any> {
+    return client.createSession({
+      workingDirectory: mindPath,
+      tools,
+      systemMessage: {
+        mode: 'customize',
+        sectionOverrides: [
+          { section: 'identity', override: { type: 'replace', content: systemMessage } },
+          { section: 'tone', override: { type: 'remove' } },
+        ],
+      },
+      onPermissionRequest: async () => ({ kind: 'approved' }),
+      onUserInputRequest: async () => ({ answer: 'Not available in this context', wasFreeform: true }),
+    });
+  }
+
+  async sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void> {
+    const mind = this.listMinds().find(m => m.mindPath === mindPath);
+    if (!mind) return;
+    const context = this.minds.get(mind.mindId);
+    if (!context?.session) return;
+
+    await context.session.send({ prompt });
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 120_000);
+      const unsub = context.session!.on('session.idle', () => {
+        clearTimeout(timeout);
+        unsub();
+        resolve();
+      });
+    });
   }
 
   private persistConfig(): void {

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -28,7 +28,7 @@ export class MindManager extends EventEmitter {
     super();
   }
 
-  async loadMind(mindPath: string): Promise<MindContext> {
+  async loadMind(mindPath: string, mindId?: string): Promise<MindContext> {
     // Deduplicate
     const existingId = this.pathToId.get(mindPath);
     if (existingId && this.minds.has(existingId)) {
@@ -38,8 +38,8 @@ export class MindManager extends EventEmitter {
     // Validate
     this.validateMindPath(mindPath);
 
-    // Generate ID
-    const mindId = ConfigService.generateMindId(mindPath);
+    // Use provided ID or generate a new one
+    const id = mindId ?? ConfigService.generateMindId(mindPath);
 
     // Load identity
     const identity = this.identityLoader.load(mindPath);
@@ -69,7 +69,7 @@ export class MindManager extends EventEmitter {
     } as any);
 
     const context: InternalMindContext = {
-      mindId,
+      mindId: id,
       mindPath,
       identity,
       status: 'ready',
@@ -78,8 +78,8 @@ export class MindManager extends EventEmitter {
       extensions: loaded as any[],
     };
 
-    this.minds.set(mindId, context);
-    this.pathToId.set(mindPath, mindId);
+    this.minds.set(id, context);
+    this.pathToId.set(mindPath, id);
 
     // Scan views
     await this.viewDiscovery.scan(mindPath);
@@ -163,11 +163,7 @@ export class MindManager extends EventEmitter {
     const config = this.configService.load();
     for (const record of config.minds) {
       try {
-        const mind = await this.loadMind(record.path);
-        // Override the generated ID with the persisted one for stability
-        if (mind.mindId !== record.id) {
-          this.rekey(mind.mindId, record.id);
-        }
+        await this.loadMind(record.path, record.id);
       } catch (err) {
         console.error(`[MindManager] Failed to restore mind at ${record.path}:`, err);
       }
@@ -205,15 +201,6 @@ export class MindManager extends EventEmitter {
       status: ctx.status,
       error: ctx.error,
     };
-  }
-
-  private rekey(oldId: string, newId: string): void {
-    const ctx = this.minds.get(oldId);
-    if (!ctx) return;
-    this.minds.delete(oldId);
-    (ctx as any).mindId = newId;
-    this.minds.set(newId, ctx);
-    this.pathToId.set(ctx.mindPath, newId);
   }
 
   private persistConfig(): void {

--- a/src/main/services/mind/generateMindId.ts
+++ b/src/main/services/mind/generateMindId.ts
@@ -1,0 +1,9 @@
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+/** Generate a stable, human-readable mind ID from a directory path. */
+export function generateMindId(mindPath: string): string {
+  const basename = path.basename(mindPath);
+  const suffix = crypto.randomBytes(2).toString('hex');
+  return `${basename}-${suffix}`;
+}

--- a/src/main/services/mind/types.ts
+++ b/src/main/services/mind/types.ts
@@ -1,0 +1,15 @@
+// Internal mind context — main process only, not exposed to renderer
+// Extends the shared MindContext with infrastructure details
+
+import type { MindContext } from '../../../shared/types.js';
+import type { CopilotClient } from '@github/copilot-sdk';
+import type { CopilotSession, Tool } from '@github/copilot-sdk';
+
+export type { CopilotClient, CopilotSession };
+export type ExtensionTool = Tool;
+
+export interface InternalMindContext extends MindContext {
+  client: CopilotClient;
+  session: CopilotSession | null;
+  extensions: ExtensionTool[];
+}

--- a/src/main/services/sdk/CopilotClientFactory.test.ts
+++ b/src/main/services/sdk/CopilotClientFactory.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock electron app
+vi.mock('electron', () => ({ app: { isPackaged: false, getPath: vi.fn(() => '/tmp') } }));
+
+// Mock SDK bootstrap/discovery
+vi.mock('./SdkBootstrap', () => ({
+  getLocalNodeModulesDir: vi.fn(() => '/local/node_modules'),
+  getBundledNodePath: vi.fn(() => null),
+  getCliPathFromModules: vi.fn(() => '/global/node_modules/@github/copilot/bin/copilot'),
+  isLocalInstallReady: vi.fn(() => false),
+  ensureSdkInstalled: vi.fn(async () => {}),
+}));
+vi.mock('./SdkDiscovery', () => ({
+  getGlobalNodeModules: vi.fn(() => '/global/node_modules'),
+}));
+vi.mock('./nodeResolver', () => ({
+  findSystemNode: vi.fn(() => '/usr/bin/node'),
+}));
+vi.mock('fs', () => ({
+  mkdirSync: vi.fn(),
+}));
+
+// Mock the dynamic SDK import
+const mockStart = vi.fn(async () => {});
+const mockStop = vi.fn(async () => {});
+
+class FakeCopilotClient {
+  start = mockStart;
+  stop = mockStop;
+}
+
+vi.mock('./sdkImport', () => ({
+  loadSdkModule: vi.fn(async () => ({ CopilotClient: FakeCopilotClient })),
+}));
+
+import { CopilotClientFactory } from './CopilotClientFactory';
+
+describe('CopilotClientFactory', () => {
+  let factory: CopilotClientFactory;
+
+  beforeEach(() => {
+    factory = new CopilotClientFactory();
+    vi.clearAllMocks();
+  });
+
+  describe('createClient', () => {
+    it('creates and starts a CopilotClient', async () => {
+      const client = await factory.createClient('C:\\agents\\q');
+      expect(mockStart).toHaveBeenCalledTimes(1);
+      expect(client).toBeDefined();
+      expect(client.start).toBeDefined();
+    });
+
+    it('creates separate clients for different mind paths', async () => {
+      const client1 = await factory.createClient('C:\\agents\\q');
+      const client2 = await factory.createClient('C:\\agents\\fox');
+      expect(mockStart).toHaveBeenCalledTimes(2);
+      expect(client1).not.toBe(client2);
+    });
+
+    it('caches SDK module across multiple createClient calls', async () => {
+      const { loadSdkModule } = await import('./sdkImport');
+      await factory.createClient('C:\\agents\\q');
+      await factory.createClient('C:\\agents\\fox');
+      // SDK module loaded once, cached
+      expect(loadSdkModule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('destroyClient', () => {
+    it('stops the client without throwing', async () => {
+      const client = await factory.createClient('C:\\agents\\q');
+      await expect(factory.destroyClient(client)).resolves.not.toThrow();
+      expect(mockStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles stop() throwing gracefully', async () => {
+      mockStop.mockRejectedValueOnce(new Error('stop failed'));
+      const client = await factory.createClient('C:\\agents\\q');
+      await expect(factory.destroyClient(client)).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/main/services/sdk/CopilotClientFactory.ts
+++ b/src/main/services/sdk/CopilotClientFactory.ts
@@ -5,11 +5,9 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { loadSdkModule } from './sdkImport';
+import { resolveNodeModulesDir } from './sdkPaths';
 import { getCliPathFromModules, getBundledNodePath } from './SdkBootstrap';
-import { getGlobalNodeModules } from './SdkDiscovery';
 import { findSystemNode as findSystemNodeShared } from './nodeResolver';
-import { app } from 'electron';
-import { isLocalInstallReady, getLocalNodeModulesDir } from './SdkBootstrap';
 
 import type { CopilotClient } from '@github/copilot-sdk';
 
@@ -17,13 +15,6 @@ function findSystemNode(): string | null {
   const bundled = getBundledNodePath();
   if (bundled) return bundled;
   return findSystemNodeShared();
-}
-
-function resolveNodeModulesDir(): string {
-  if (app.isPackaged && isLocalInstallReady()) {
-    return getLocalNodeModulesDir();
-  }
-  return getGlobalNodeModules();
 }
 
 export class CopilotClientFactory {

--- a/src/main/services/sdk/CopilotClientFactory.ts
+++ b/src/main/services/sdk/CopilotClientFactory.ts
@@ -1,0 +1,79 @@
+// Instance-based CopilotClient factory — replaces SdkLoader singleton.
+// Each mind gets its own CopilotClient (separate CLI process).
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadSdkModule } from './sdkImport';
+import { getCliPathFromModules, getBundledNodePath } from './SdkBootstrap';
+import { getGlobalNodeModules } from './SdkDiscovery';
+import { findSystemNode as findSystemNodeShared } from './nodeResolver';
+import { app } from 'electron';
+import { isLocalInstallReady, getLocalNodeModulesDir } from './SdkBootstrap';
+
+import type { CopilotClient } from '@github/copilot-sdk';
+
+function findSystemNode(): string | null {
+  const bundled = getBundledNodePath();
+  if (bundled) return bundled;
+  return findSystemNodeShared();
+}
+
+function resolveNodeModulesDir(): string {
+  if (app.isPackaged && isLocalInstallReady()) {
+    return getLocalNodeModulesDir();
+  }
+  return getGlobalNodeModules();
+}
+
+export class CopilotClientFactory {
+  private sdkModule: typeof import('@github/copilot-sdk') | null = null;
+
+  async createClient(mindPath: string): Promise<CopilotClient> {
+    const sdk = await this.getSdk();
+    const modulesDir = resolveNodeModulesDir();
+    const cliPath = getCliPathFromModules(modulesDir);
+
+    if (!cliPath) {
+      throw new Error('@github/copilot CLI not found. Install @github/copilot-sdk globally.');
+    }
+
+    const logDir = path.join(os.homedir(), '.chamber', 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+
+    let resolvedCliPath = cliPath;
+    const cliArgs = ['--log-dir', logDir];
+
+    if (cliPath.endsWith('.js')) {
+      const systemNode = findSystemNode();
+      if (systemNode) {
+        resolvedCliPath = systemNode;
+        cliArgs.unshift(cliPath);
+      }
+    }
+
+    const client = new sdk.CopilotClient({
+      cliPath: resolvedCliPath,
+      logLevel: 'all',
+      cliArgs,
+    });
+
+    await client.start();
+    return client;
+  }
+
+  async destroyClient(client: CopilotClient): Promise<void> {
+    try {
+      await client.stop();
+    } catch {
+      // Swallow stop errors — cleanup is best-effort
+    }
+  }
+
+  private async getSdk(): Promise<typeof import('@github/copilot-sdk')> {
+    if (!this.sdkModule) {
+      this.sdkModule = await loadSdkModule();
+    }
+    return this.sdkModule;
+  }
+}

--- a/src/main/services/sdk/index.ts
+++ b/src/main/services/sdk/index.ts
@@ -1,2 +1,3 @@
+export { CopilotClientFactory } from './CopilotClientFactory';
 export { getSharedClient, stopSharedClient } from './SdkLoader';
 export { findSystemNode, requireSystemNode } from './nodeResolver';

--- a/src/main/services/sdk/sdkImport.ts
+++ b/src/main/services/sdk/sdkImport.ts
@@ -1,0 +1,34 @@
+// Extracted SDK dynamic import — isolates the ESM import() hack for testability
+
+import { app } from 'electron';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { getGlobalNodeModules } from './SdkDiscovery';
+import {
+  getLocalNodeModulesDir,
+  isLocalInstallReady,
+  ensureSdkInstalled,
+} from './SdkBootstrap';
+
+type SdkModule = typeof import('@github/copilot-sdk');
+
+let cached: SdkModule | null = null;
+
+function resolveNodeModulesDir(): string {
+  if (app.isPackaged && isLocalInstallReady()) {
+    return getLocalNodeModulesDir();
+  }
+  return getGlobalNodeModules();
+}
+
+export async function loadSdkModule(): Promise<SdkModule> {
+  if (cached) return cached;
+  await ensureSdkInstalled();
+  const modulesDir = resolveNodeModulesDir();
+  const sdkEntry = path.join(modulesDir, '@github', 'copilot-sdk', 'dist', 'index.js');
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  cached = await (new Function('url', 'return import(url)')(
+    pathToFileURL(sdkEntry).href
+  ) as Promise<SdkModule>);
+  return cached;
+}

--- a/src/main/services/sdk/sdkImport.ts
+++ b/src/main/services/sdk/sdkImport.ts
@@ -1,25 +1,13 @@
 // Extracted SDK dynamic import — isolates the ESM import() hack for testability
 
-import { app } from 'electron';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
-import { getGlobalNodeModules } from './SdkDiscovery';
-import {
-  getLocalNodeModulesDir,
-  isLocalInstallReady,
-  ensureSdkInstalled,
-} from './SdkBootstrap';
+import { resolveNodeModulesDir } from './sdkPaths';
+import { ensureSdkInstalled } from './SdkBootstrap';
 
 type SdkModule = typeof import('@github/copilot-sdk');
 
 let cached: SdkModule | null = null;
-
-function resolveNodeModulesDir(): string {
-  if (app.isPackaged && isLocalInstallReady()) {
-    return getLocalNodeModulesDir();
-  }
-  return getGlobalNodeModules();
-}
 
 export async function loadSdkModule(): Promise<SdkModule> {
   if (cached) return cached;

--- a/src/main/services/sdk/sdkPaths.ts
+++ b/src/main/services/sdk/sdkPaths.ts
@@ -1,0 +1,12 @@
+// Shared SDK path resolution — used by both sdkImport and CopilotClientFactory
+
+import { app } from 'electron';
+import { getGlobalNodeModules } from './SdkDiscovery';
+import { getLocalNodeModulesDir, isLocalInstallReady } from './SdkBootstrap';
+
+export function resolveNodeModulesDir(): string {
+  if (app.isPackaged && isLocalInstallReady()) {
+    return getLocalNodeModulesDir();
+  }
+  return getGlobalNodeModules();
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,14 +4,22 @@ import type { ElectronAPI } from './shared/types';
 
 const electronAPI: ElectronAPI = {
   chat: {
-    send: (conversationId, message, messageId, model) =>
-      ipcRenderer.invoke('chat:send', conversationId, message, messageId, model),
-    stop: (conversationId, messageId) =>
-      ipcRenderer.invoke('chat:stop', conversationId, messageId),
-    newConversation: (conversationId) =>
-      ipcRenderer.invoke('chat:newConversation', conversationId),
+    send: (mindId, message, messageId, model) =>
+      ipcRenderer.invoke('chat:send', mindId, message, messageId, model),
+    stop: (mindId, messageId) =>
+      ipcRenderer.invoke('chat:stop', mindId, messageId),
+    newConversation: (mindId) =>
+      ipcRenderer.invoke('chat:newConversation', mindId),
     listModels: () => ipcRenderer.invoke('chat:listModels'),
     onEvent: (callback) => createIpcListener(ipcRenderer, 'chat:event', callback),
+  },
+  mind: {
+    add: (mindPath) => ipcRenderer.invoke('mind:add', mindPath),
+    remove: (mindId) => ipcRenderer.invoke('mind:remove', mindId),
+    list: () => ipcRenderer.invoke('mind:list'),
+    setActive: (mindId) => ipcRenderer.invoke('mind:setActive', mindId),
+    selectDirectory: () => ipcRenderer.invoke('mind:selectDirectory'),
+    onMindChanged: (callback) => createIpcListener(ipcRenderer, 'mind:changed', callback),
   },
   agent: {
     getStatus: () => ipcRenderer.invoke('agent:getStatus'),
@@ -20,25 +28,24 @@ const electronAPI: ElectronAPI = {
     onStatusChanged: (callback) => createIpcListener(ipcRenderer, 'agent:statusChanged', callback),
   },
   lens: {
-    getViews: () => ipcRenderer.invoke('lens:getViews'),
-    getViewData: (viewId: string) => ipcRenderer.invoke('lens:getViewData', viewId),
-    refreshView: (viewId: string) => ipcRenderer.invoke('lens:refreshView', viewId),
-    sendAction: (viewId: string, action: string) => ipcRenderer.invoke('lens:sendAction', viewId, action),
-    onViewsChanged: (callback: (views: import('./shared/types').LensViewManifest[]) => void) =>
+    getViews: (mindId?) => ipcRenderer.invoke('lens:getViews', mindId),
+    getViewData: (viewId, mindId?) => ipcRenderer.invoke('lens:getViewData', viewId, mindId),
+    refreshView: (viewId, mindId?) => ipcRenderer.invoke('lens:refreshView', viewId, mindId),
+    sendAction: (viewId, action, mindId?) => ipcRenderer.invoke('lens:sendAction', viewId, action, mindId),
+    onViewsChanged: (callback) =>
       createIpcListener(ipcRenderer, 'lens:viewsChanged', callback),
   },
   auth: {
     getStatus: () => ipcRenderer.invoke('auth:getStatus'),
     startLogin: () => ipcRenderer.invoke('auth:startLogin'),
-    onProgress: (callback: (progress: { step: string; userCode?: string; verificationUri?: string; login?: string; error?: string }) => void) =>
+    onProgress: (callback) =>
       createIpcListener(ipcRenderer, 'auth:progress', callback),
   },
   genesis: {
     getDefaultPath: () => ipcRenderer.invoke('genesis:getDefaultPath'),
     pickPath: () => ipcRenderer.invoke('genesis:pickPath'),
-    create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) =>
-      ipcRenderer.invoke('genesis:create', config),
-    onProgress: (callback: (progress: { step: string; detail: string }) => void) =>
+    create: (config) => ipcRenderer.invoke('genesis:create', config),
+    onProgress: (callback) =>
       createIpcListener(ipcRenderer, 'genesis:progress', callback),
   },
   config: {
@@ -53,4 +60,3 @@ const electronAPI: ElectronAPI = {
 };
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI);
-

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -6,7 +6,9 @@ import { ChatInput } from './ChatInput';
 import { WelcomeScreen } from './WelcomeScreen';
 
 export function ChatPanel() {
-  const { messages, agentStatus, availableModels, selectedModel } = useAppState();
+  const { messagesByMind, activeMindId, minds, agentStatus, availableModels, selectedModel } = useAppState();
+  const messages = activeMindId ? (messagesByMind[activeMindId] ?? []) : [];
+  const connected = minds.length > 0 || agentStatus.connected;
   const dispatch = useAppDispatch();
   const { sendMessage, stopStreaming, isStreaming } = useChatStreaming();
 
@@ -15,7 +17,7 @@ export function ChatPanel() {
       {messages.length === 0 ? (
         <WelcomeScreen
           onSendMessage={sendMessage}
-          connected={agentStatus.connected}
+          connected={connected}
         />
       ) : (
         <MessageList />
@@ -25,7 +27,7 @@ export function ChatPanel() {
         onSend={sendMessage}
         onStop={stopStreaming}
         isStreaming={isStreaming}
-        disabled={!agentStatus.connected}
+        disabled={!connected}
         availableModels={availableModels}
         selectedModel={selectedModel}
         onModelChange={(model) => dispatch({ type: 'SET_SELECTED_MODEL', payload: model })}

--- a/src/renderer/components/chat/MessageList.tsx
+++ b/src/renderer/components/chat/MessageList.tsx
@@ -4,8 +4,10 @@ import { StreamingMessage } from './StreamingMessage';
 import { cn, formatTime } from '../../lib/utils';
 
 export function MessageList() {
-  const { messages, agentStatus } = useAppState();
-  const agentName = agentStatus.agentName ?? 'Agent';
+  const { messagesByMind, activeMindId, minds, agentStatus } = useAppState();
+  const messages = activeMindId ? (messagesByMind[activeMindId] ?? []) : [];
+  const activeMind = minds.find(m => m.mindId === activeMindId);
+  const agentName = activeMind?.identity.name ?? agentStatus.agentName ?? 'Agent';
   const scrollRef = useRef<HTMLDivElement>(null);
   const isAutoScrolling = useRef(true);
 

--- a/src/renderer/components/genesis/ChamberLoadingScreen.tsx
+++ b/src/renderer/components/genesis/ChamberLoadingScreen.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react';
+
+const BOOT_LINES = [
+  '> chamber v0.15.0',
+  '> initializing runtime...',
+  '> scanning mind registry...',
+];
+
+export function ChamberLoadingScreen() {
+  const [lines, setLines] = useState<string[]>([]);
+
+  useEffect(() => {
+    let i = 0;
+    const interval = setInterval(() => {
+      if (i < BOOT_LINES.length) {
+        setLines(prev => [...prev, BOOT_LINES[i]]);
+        i++;
+      } else {
+        clearInterval(interval);
+      }
+    }, 200);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="fixed inset-0 bg-black flex flex-col items-center justify-center z-50">
+      <div className="font-mono text-sm text-green-500 space-y-1 max-w-md w-full px-8">
+        {lines.map((line, i) => (
+          <div key={i}>{line}</div>
+        ))}
+        <span className="animate-pulse">▊</span>
+      </div>
+
+      <div className="absolute bottom-12 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3">
+        <div className="w-6 h-6 border-2 border-green-500/30 border-t-green-500 rounded-full animate-spin" />
+        <p className="text-xs text-green-500/50 font-mono">waking agents...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/genesis/GenesisGate.test.tsx
+++ b/src/renderer/components/genesis/GenesisGate.test.tsx
@@ -6,10 +6,16 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { GenesisGate } from './GenesisGate';
 import { AppStateProvider } from '../../lib/store';
+import { useAgentStatus } from '../../hooks/useAgentStatus';
 import { installElectronAPI, mockElectronAPI, connectedAgentStatus } from '../../../test/helpers';
 
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  useAgentStatus();
+  return <>{children}</>;
+}
+
 function renderWithProvider(ui: React.ReactElement) {
-  return render(<AppStateProvider>{ui}</AppStateProvider>);
+  return render(<AppStateProvider><TestWrapper>{ui}</TestWrapper></AppStateProvider>);
 }
 
 describe('GenesisGate', () => {
@@ -19,18 +25,33 @@ describe('GenesisGate', () => {
     api = installElectronAPI();
   });
 
-  it('shows LandingScreen when agent is not connected', () => {
+  it('shows LandingScreen when no minds exist after check', async () => {
     renderWithProvider(<GenesisGate><div>App</div></GenesisGate>);
-    expect(screen.getByText('New Agent', { exact: false })).toBeTruthy();
+
+    // Wait for async mind.list() to resolve and MINDS_CHECKED to dispatch
+    await waitFor(() => {
+      expect(screen.getByText('New Agent', { exact: false })).toBeTruthy();
+    });
     expect(screen.getByText('Open Existing', { exact: false })).toBeTruthy();
     expect(screen.queryByText('App')).toBeNull();
   });
 
   it('clicking Open Existing triggers file dialog', async () => {
     (api.agent.selectMindDirectory as ReturnType<typeof vi.fn>).mockResolvedValue('C:\\test\\mind');
-    (api.agent.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue(connectedAgentStatus());
+    // After dialog, mind.list returns the newly added mind
+    let callCount = 0;
+    (api.mind.list as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 1) return []; // Initial check: empty
+      return [{ mindId: 'test-1234', mindPath: 'C:\\test\\mind', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }];
+    });
 
     renderWithProvider(<GenesisGate><div>App</div></GenesisGate>);
+
+    await waitFor(() => {
+      expect(screen.getByText('Open Existing', { exact: false })).toBeTruthy();
+    });
+
     fireEvent.click(screen.getByText('Open Existing', { exact: false }));
 
     await waitFor(() => {

--- a/src/renderer/components/genesis/GenesisGate.tsx
+++ b/src/renderer/components/genesis/GenesisGate.tsx
@@ -8,11 +8,12 @@ interface Props {
 }
 
 export function GenesisGate({ children }: Props) {
-  const { agentStatus, showLanding } = useAppState();
+  const { agentStatus, minds, showLanding } = useAppState();
   const dispatch = useAppDispatch();
   const [mode, setMode] = useState<'idle' | 'genesis'>('idle');
 
-  const showGate = showLanding || !agentStatus.connected;
+  const hasMinds = minds.length > 0 || agentStatus.connected;
+  const showGate = showLanding || !hasMinds;
 
   // If in genesis flow, show it
   if (mode === 'genesis') {
@@ -22,7 +23,7 @@ export function GenesisGate({ children }: Props) {
     }} />;
   }
 
-  // Show landing if triggered or no mind connected
+  // Show landing if triggered or no minds loaded
   if (showGate) {
     return (
       <LandingScreen
@@ -30,8 +31,12 @@ export function GenesisGate({ children }: Props) {
         onOpenExisting={async () => {
           const path = await window.electronAPI.agent.selectMindDirectory();
           if (path) {
-            const status = await window.electronAPI.agent.getStatus();
-            dispatch({ type: 'SET_AGENT_STATUS', payload: status });
+            // Refresh minds list
+            const loadedMinds = await window.electronAPI.mind.list();
+            dispatch({ type: 'SET_MINDS', payload: loadedMinds });
+            if (loadedMinds.length > 0) {
+              dispatch({ type: 'SET_ACTIVE_MIND', payload: loadedMinds[loadedMinds.length - 1].mindId });
+            }
             dispatch({ type: 'HIDE_LANDING' });
           }
         }}

--- a/src/renderer/components/genesis/GenesisGate.tsx
+++ b/src/renderer/components/genesis/GenesisGate.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { LandingScreen } from './LandingScreen';
 import { GenesisFlow } from './GenesisFlow';
+import { ChamberLoadingScreen } from './ChamberLoadingScreen';
 
 interface Props {
   children: React.ReactNode;
@@ -12,9 +13,9 @@ export function GenesisGate({ children }: Props) {
   const dispatch = useAppDispatch();
   const [mode, setMode] = useState<'idle' | 'genesis'>('idle');
 
-  // Don't flash landing screen while initial minds check is pending
+  // Show loading screen while initial minds check is pending
   if (!mindsChecked && !showLanding) {
-    return null;
+    return <ChamberLoadingScreen />;
   }
 
   const hasMinds = minds.length > 0 || agentStatus.connected;

--- a/src/renderer/components/genesis/GenesisGate.tsx
+++ b/src/renderer/components/genesis/GenesisGate.tsx
@@ -8,9 +8,14 @@ interface Props {
 }
 
 export function GenesisGate({ children }: Props) {
-  const { agentStatus, minds, showLanding } = useAppState();
+  const { agentStatus, minds, showLanding, mindsChecked } = useAppState();
   const dispatch = useAppDispatch();
   const [mode, setMode] = useState<'idle' | 'genesis'>('idle');
+
+  // Don't flash landing screen while initial minds check is pending
+  if (!mindsChecked && !showLanding) {
+    return null;
+  }
 
   const hasMinds = minds.length > 0 || agentStatus.connected;
   const showGate = showLanding || !hasMinds;

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAppSubscriptions } from '../../hooks/useAppSubscriptions';
 import { TooltipProvider } from '../ui/tooltip';
 import { ActivityBar } from './ActivityBar';
+import { MindSidebar } from './MindSidebar';
 import { SidePanel } from './SidePanel';
 import { ViewRouter } from './ViewRouter';
 
@@ -14,8 +15,9 @@ export function AppShell() {
         {/* Titlebar drag region */}
         <div className="titlebar-drag h-9 shrink-0" />
 
-        {/* Main layout: activity bar | side panel | content */}
+        {/* Main layout: mind sidebar | activity bar | side panel | content */}
         <div className="flex flex-1 min-h-0">
+          <MindSidebar />
           <ActivityBar />
           <SidePanel />
           <main className="flex-1 flex flex-col min-w-0">

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -11,9 +11,6 @@ export function AppShell() {
   return (
     <TooltipProvider>
       <div className="flex flex-col h-screen w-screen bg-background text-foreground">
-        {/* Titlebar drag region */}
-        <div className="titlebar-drag h-9 shrink-0" />
-
         {/* Main layout: activity bar | mind sidebar | content */}
         <div className="flex flex-1 min-h-0">
           <ActivityBar />

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -3,7 +3,6 @@ import { useAppSubscriptions } from '../../hooks/useAppSubscriptions';
 import { TooltipProvider } from '../ui/tooltip';
 import { ActivityBar } from './ActivityBar';
 import { MindSidebar } from './MindSidebar';
-import { SidePanel } from './SidePanel';
 import { ViewRouter } from './ViewRouter';
 
 export function AppShell() {
@@ -15,11 +14,10 @@ export function AppShell() {
         {/* Titlebar drag region */}
         <div className="titlebar-drag h-9 shrink-0" />
 
-        {/* Main layout: mind sidebar | activity bar | side panel | content */}
+        {/* Main layout: activity bar | mind sidebar | content */}
         <div className="flex flex-1 min-h-0">
-          <MindSidebar />
           <ActivityBar />
-          <SidePanel />
+          <MindSidebar />
           <main className="flex-1 flex flex-col min-w-0">
             <ViewRouter />
           </main>

--- a/src/renderer/components/layout/MindSidebar.tsx
+++ b/src/renderer/components/layout/MindSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { cn } from '../../lib/utils';
-import { Plus, X, Bot } from 'lucide-react';
+import { Plus, X, Bot, MessageSquarePlus } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { MindContext } from '../../../shared/types';
 
@@ -74,7 +74,21 @@ export function MindSidebar() {
         ))}
       </div>
 
-      <div className="border-t border-border p-2">
+      <div className="border-t border-border p-2 space-y-1">
+        <button
+          onClick={async () => {
+            if (activeMindId) {
+              await window.electronAPI.chat.newConversation(activeMindId);
+              dispatch({ type: 'NEW_CONVERSATION' });
+              dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+            }
+          }}
+          disabled={!activeMindId}
+          className="w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded flex items-center gap-2 transition-colors disabled:opacity-50"
+        >
+          <MessageSquarePlus size={14} />
+          New Conversation
+        </button>
         <button
           onClick={handleAddMind}
           className="w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded flex items-center gap-2 transition-colors"

--- a/src/renderer/components/layout/MindSidebar.tsx
+++ b/src/renderer/components/layout/MindSidebar.tsx
@@ -1,9 +1,13 @@
-import React from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { cn } from '../../lib/utils';
 import { Plus, X, Bot, MessageSquarePlus } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { MindContext } from '../../../shared/types';
+
+const MIN_WIDTH = 140;
+const MAX_WIDTH = 400;
+const STORAGE_KEY = 'chamber:sidebarWidth';
 
 function statusColor(status: MindContext['status']): string {
   switch (status) {
@@ -18,6 +22,11 @@ function statusColor(status: MindContext['status']): string {
 export function MindSidebar() {
   const { minds, activeMindId } = useAppState();
   const dispatch = useAppDispatch();
+  const [width, setWidth] = useState(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, parseInt(saved, 10))) : 192;
+  });
+  const isResizing = useRef(false);
 
   const handleAddMind = async () => {
     dispatch({ type: 'SHOW_LANDING' });
@@ -35,10 +44,42 @@ export function MindSidebar() {
     dispatch({ type: 'REMOVE_MIND', payload: mindId });
   };
 
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isResizing.current = true;
+    const startX = e.clientX;
+    const startWidth = width;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isResizing.current) return;
+      const newWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, startWidth + ev.clientX - startX));
+      setWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      isResizing.current = false;
+      localStorage.setItem(STORAGE_KEY, String(width));
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [width]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(width));
+  }, [width]);
+
   if (minds.length === 0) return null;
 
   return (
-    <div className="w-48 bg-card/50 border-r border-border flex flex-col shrink-0">
+    <div className="relative bg-card/50 border-r border-border flex flex-col shrink-0" style={{ width }}>
+      {/* Resize handle */}
+      <div
+        onMouseDown={handleMouseDown}
+        className="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-accent/50 active:bg-accent z-10"
+      />
       <div className="px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
         Agents
       </div>

--- a/src/renderer/components/layout/MindSidebar.tsx
+++ b/src/renderer/components/layout/MindSidebar.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useAppState, useAppDispatch } from '../../lib/store';
+import { cn } from '../../lib/utils';
+import { Plus, X, Bot } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import type { MindContext } from '../../../shared/types';
+
+function statusColor(status: MindContext['status']): string {
+  switch (status) {
+    case 'ready': return 'bg-green-500';
+    case 'loading': return 'bg-yellow-500 animate-pulse';
+    case 'error': return 'bg-red-500';
+    case 'unloading': return 'bg-gray-400';
+    default: return 'bg-gray-400';
+  }
+}
+
+export function MindSidebar() {
+  const { minds, activeMindId } = useAppState();
+  const dispatch = useAppDispatch();
+
+  const handleAddMind = async () => {
+    dispatch({ type: 'SHOW_LANDING' });
+  };
+
+  const handleSwitchMind = (mindId: string) => {
+    window.electronAPI.mind.setActive(mindId);
+    dispatch({ type: 'SET_ACTIVE_MIND', payload: mindId });
+    dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  };
+
+  const handleRemoveMind = async (e: React.MouseEvent, mindId: string) => {
+    e.stopPropagation();
+    await window.electronAPI.mind.remove(mindId);
+    dispatch({ type: 'REMOVE_MIND', payload: mindId });
+  };
+
+  if (minds.length === 0) return null;
+
+  return (
+    <div className="w-48 bg-card/50 border-r border-border flex flex-col shrink-0">
+      <div className="px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        Agents
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {minds.map((mind) => (
+          <button
+            key={mind.mindId}
+            onClick={() => handleSwitchMind(mind.mindId)}
+            className={cn(
+              'w-full px-3 py-2 flex items-center gap-2 text-sm transition-colors group',
+              mind.mindId === activeMindId
+                ? 'bg-accent text-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+            )}
+          >
+            <Bot size={16} className="shrink-0" />
+            <div className={cn('w-2 h-2 rounded-full shrink-0', statusColor(mind.status))} />
+            <span className="truncate flex-1 text-left">{mind.identity.name}</span>
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <span
+                  role="button"
+                  onClick={(e) => handleRemoveMind(e, mind.mindId)}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity hover:text-destructive"
+                >
+                  <X size={14} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="right">Remove agent</TooltipContent>
+            </Tooltip>
+          </button>
+        ))}
+      </div>
+
+      <div className="border-t border-border p-2">
+        <button
+          onClick={handleAddMind}
+          className="w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded flex items-center gap-2 transition-colors"
+        >
+          <Plus size={14} />
+          Add Agent
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/layout/MindSidebar.tsx
+++ b/src/renderer/components/layout/MindSidebar.tsx
@@ -58,7 +58,6 @@ export function MindSidebar() {
 
     const onMouseUp = () => {
       isResizing.current = false;
-      localStorage.setItem(STORAGE_KEY, String(width));
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
     };

--- a/src/renderer/components/layout/SidePanel.tsx
+++ b/src/renderer/components/layout/SidePanel.tsx
@@ -50,7 +50,9 @@ function LensViewSideContent() {
 }
 
 export function SidePanel() {
-  const { agentStatus, activeView } = useAppState();
+  const { agentStatus, minds, activeMindId, activeView } = useAppState();
+  const activeMind = minds.find(m => m.mindId === activeMindId);
+  const connected = minds.length > 0 || agentStatus.connected;
   const dispatch = useAppDispatch();
 
   return (
@@ -72,15 +74,15 @@ export function SidePanel() {
         <div className="flex items-center gap-2 text-xs">
           <div className={cn(
             'w-2 h-2 rounded-full',
-            agentStatus.connected ? 'bg-genesis' : 'bg-destructive-foreground'
+            connected ? 'bg-genesis' : 'bg-destructive-foreground'
           )} />
           <span className="text-muted-foreground">
-            {agentStatus.connected ? 'Mind loaded' : 'No mind selected'}
+            {connected ? (activeMind?.identity.name ?? 'Mind loaded') : 'No mind selected'}
           </span>
         </div>
-        {agentStatus.mindPath && (
-          <p className="text-xs text-muted-foreground mt-1 truncate" title={agentStatus.mindPath}>
-            {agentStatus.mindPath.split(/[\\/]/).pop()}
+        {activeMind && (
+          <p className="text-xs text-muted-foreground mt-1 truncate" title={activeMind.mindPath}>
+            {activeMind.mindPath.split(/[\\/]/).pop()}
           </p>
         )}
       </div>

--- a/src/renderer/components/layout/SidePanel.tsx
+++ b/src/renderer/components/layout/SidePanel.tsx
@@ -3,14 +3,16 @@ import { useAppState, useAppDispatch } from '../../lib/store';
 import { cn } from '../../lib/utils';
 
 function ChatSideContent() {
-  const { conversationId } = useAppState();
+  const { activeMindId } = useAppState();
   const dispatch = useAppDispatch();
 
   return (
     <div className="px-3 py-3 space-y-1">
       <button
         onClick={async () => {
-          await window.electronAPI.chat.newConversation(conversationId);
+          if (activeMindId) {
+            await window.electronAPI.chat.newConversation(activeMindId);
+          }
           dispatch({ type: 'NEW_CONVERSATION' });
         }}
         className="w-full text-left px-3 py-2 rounded-md text-sm hover:bg-accent transition-colors flex items-center gap-2"

--- a/src/renderer/hooks/useAgentStatus.ts
+++ b/src/renderer/hooks/useAgentStatus.ts
@@ -2,11 +2,11 @@ import { useEffect, useCallback } from 'react';
 import { useAppState, useAppDispatch } from '../lib/store';
 
 export function useAgentStatus() {
-  const { agentStatus } = useAppState();
+  const { agentStatus, minds } = useAppState();
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    // Load initial status
+    // Load initial agent status (backward compat)
     window.electronAPI.agent.getStatus().then((status) => {
       dispatch({ type: 'SET_AGENT_STATUS', payload: status });
     });
@@ -15,17 +15,40 @@ export function useAgentStatus() {
       dispatch({ type: 'SET_AGENT_STATUS', payload: status });
     });
 
-    return unsub;
+    // Load minds from MindManager
+    window.electronAPI.mind.list().then((loadedMinds) => {
+      if (loadedMinds.length > 0) {
+        dispatch({ type: 'SET_MINDS', payload: loadedMinds });
+        dispatch({ type: 'SET_ACTIVE_MIND', payload: loadedMinds[0].mindId });
+      }
+    });
+
+    // Subscribe to mind changes
+    const unsubMinds = window.electronAPI.mind.onMindChanged((updatedMinds) => {
+      dispatch({ type: 'SET_MINDS', payload: updatedMinds });
+    });
+
+    return () => {
+      unsub();
+      unsubMinds();
+    };
   }, [dispatch]);
 
   const selectMindDirectory = useCallback(async () => {
     const path = await window.electronAPI.agent.selectMindDirectory();
     if (path) {
+      // Refresh minds list after adding
+      const loadedMinds = await window.electronAPI.mind.list();
+      dispatch({ type: 'SET_MINDS', payload: loadedMinds });
+      if (loadedMinds.length > 0) {
+        const newest = loadedMinds[loadedMinds.length - 1];
+        dispatch({ type: 'SET_ACTIVE_MIND', payload: newest.mindId });
+      }
       const status = await window.electronAPI.agent.getStatus();
       dispatch({ type: 'SET_AGENT_STATUS', payload: status });
     }
     return path;
   }, [dispatch]);
 
-  return { agentStatus, selectMindDirectory };
+  return { agentStatus, minds, selectMindDirectory };
 }

--- a/src/renderer/hooks/useAgentStatus.ts
+++ b/src/renderer/hooks/useAgentStatus.ts
@@ -21,6 +21,7 @@ export function useAgentStatus() {
         dispatch({ type: 'SET_MINDS', payload: loadedMinds });
         dispatch({ type: 'SET_ACTIVE_MIND', payload: loadedMinds[0].mindId });
       }
+      dispatch({ type: 'MINDS_CHECKED' });
     });
 
     // Subscribe to mind changes

--- a/src/renderer/hooks/useAppSubscriptions.ts
+++ b/src/renderer/hooks/useAppSubscriptions.ts
@@ -13,8 +13,8 @@ export function useAppSubscriptions() {
 
   // Chat event listener — must stay alive regardless of active view
   useEffect(() => {
-    const unsub = window.electronAPI.chat.onEvent((messageId, event) => {
-      dispatch({ type: 'CHAT_EVENT', payload: { messageId, event } });
+    const unsub = window.electronAPI.chat.onEvent((mindId, messageId, event) => {
+      dispatch({ type: 'CHAT_EVENT', payload: { mindId, messageId, event } });
     });
     return () => { unsub(); };
   }, [dispatch]);

--- a/src/renderer/hooks/useAppSubscriptions.ts
+++ b/src/renderer/hooks/useAppSubscriptions.ts
@@ -6,7 +6,7 @@ import { useAppState, useAppDispatch } from '../lib/store';
  * Mount once in AppShell — never in a view component.
  */
 export function useAppSubscriptions() {
-  const { agentStatus } = useAppState();
+  const { agentStatus, activeMindId } = useAppState();
   const dispatch = useAppDispatch();
   const modelsLoaded = useRef(false);
   const viewsLoaded = useRef(false);
@@ -27,9 +27,10 @@ export function useAppSubscriptions() {
     return () => { unsub(); };
   }, [dispatch]);
 
-  // Fetch models when agent connects
+  // Fetch models when agent connects or active mind changes
   useEffect(() => {
-    if (!agentStatus.connected) {
+    const connected = agentStatus.connected || !!activeMindId;
+    if (!connected) {
       modelsLoaded.current = false;
       viewsLoaded.current = false;
       return;
@@ -67,5 +68,5 @@ export function useAppSubscriptions() {
       };
       loadViews();
     }
-  }, [agentStatus.connected, dispatch]);
+  }, [agentStatus.connected, activeMindId, dispatch]);
 }

--- a/src/renderer/hooks/useAppSubscriptions.ts
+++ b/src/renderer/hooks/useAppSubscriptions.ts
@@ -27,7 +27,11 @@ export function useAppSubscriptions() {
     return () => { unsub(); };
   }, [dispatch]);
 
-  // Fetch models when agent connects or active mind changes
+  // Reload views and models when active mind changes
+  useEffect(() => {
+    modelsLoaded.current = false;
+    viewsLoaded.current = false;
+  }, [activeMindId]);
   useEffect(() => {
     const connected = agentStatus.connected || !!activeMindId;
     if (!connected) {

--- a/src/renderer/hooks/useChatStreaming.test.tsx
+++ b/src/renderer/hooks/useChatStreaming.test.tsx
@@ -20,16 +20,15 @@ describe('useChatStreaming', () => {
     api = installElectronAPI();
   });
 
-  it('sendMessage calls electronAPI.chat.send', async () => {
+  it('sendMessage no-ops when no active mind', async () => {
     const { result } = renderHook(() => useChatStreaming(), { wrapper });
 
     await act(async () => {
       await result.current.sendMessage('Hello');
     });
 
-    expect(api.chat.send).toHaveBeenCalled();
-    const args = (api.chat.send as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(args[1]).toBe('Hello');
+    // No active mind → no-op
+    expect(api.chat.send).not.toHaveBeenCalled();
   });
 
   it('sendMessage no-ops on empty string', async () => {
@@ -42,19 +41,14 @@ describe('useChatStreaming', () => {
     expect(api.chat.send).not.toHaveBeenCalled();
   });
 
-  it('stopStreaming calls electronAPI.chat.stop', async () => {
+  it('stopStreaming no-ops when no active mind', async () => {
     const { result } = renderHook(() => useChatStreaming(), { wrapper });
-
-    // First send a message to set currentMessageId
-    await act(async () => {
-      await result.current.sendMessage('Hello');
-    });
 
     await act(async () => {
       await result.current.stopStreaming();
     });
 
-    expect(api.chat.stop).toHaveBeenCalled();
+    expect(api.chat.stop).not.toHaveBeenCalled();
   });
 
   it('isStreaming reflects state', () => {

--- a/src/renderer/hooks/useChatStreaming.ts
+++ b/src/renderer/hooks/useChatStreaming.ts
@@ -3,12 +3,12 @@ import { useAppState, useAppDispatch } from '../lib/store';
 import { generateId } from '../lib/utils';
 
 export function useChatStreaming() {
-  const { conversationId, isStreaming, selectedModel } = useAppState();
+  const { activeMindId, isStreaming, selectedModel } = useAppState();
   const dispatch = useAppDispatch();
   const currentMessageId = useRef<string | null>(null);
 
   const sendMessage = useCallback(async (content: string) => {
-    if (isStreaming || !content.trim()) return;
+    if (isStreaming || !content.trim() || !activeMindId) return;
 
     const userMessage = {
       id: generateId(),
@@ -24,14 +24,14 @@ export function useChatStreaming() {
       payload: { id: assistantId, timestamp: Date.now() },
     });
 
-    await window.electronAPI.chat.send(conversationId, content.trim(), assistantId, selectedModel ?? undefined);
-  }, [conversationId, isStreaming, selectedModel, dispatch]);
+    await window.electronAPI.chat.send(activeMindId, content.trim(), assistantId, selectedModel ?? undefined);
+  }, [activeMindId, isStreaming, selectedModel, dispatch]);
 
   const stopStreaming = useCallback(async () => {
-    if (currentMessageId.current) {
-      await window.electronAPI.chat.stop(conversationId, currentMessageId.current);
+    if (currentMessageId.current && activeMindId) {
+      await window.electronAPI.chat.stop(activeMindId, currentMessageId.current);
     }
-  }, [conversationId]);
+  }, [activeMindId]);
 
   return { sendMessage, stopStreaming, isStreaming };
 }

--- a/src/renderer/lib/store/reducer.test.ts
+++ b/src/renderer/lib/store/reducer.test.ts
@@ -181,35 +181,89 @@ describe('handleChatEvent', () => {
 // ---------------------------------------------------------------------------
 
 describe('appReducer', () => {
-  it('ADD_USER_MESSAGE adds a user message with text block', () => {
-    const state = appReducer(initialState, { type: 'ADD_USER_MESSAGE', payload: { id: 'u1', content: 'Hello', timestamp: 1000 } });
-    expect(state.messages).toHaveLength(1);
-    expect(state.messages[0]).toMatchObject({ id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'Hello' }] });
+  // Helper: set up a state with an active mind for message tests
+  const mindId = 'test-mind';
+  const withActiveMind: AppState = {
+    ...initialState,
+    minds: [{ mindId, mindPath: 'C:\\test', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }],
+    activeMindId: mindId,
+  };
+  const getMsgs = (s: AppState) => s.messagesByMind[mindId] ?? [];
+
+  it('ADD_USER_MESSAGE adds a user message to active mind', () => {
+    const state = appReducer(withActiveMind, { type: 'ADD_USER_MESSAGE', payload: { id: 'u1', content: 'Hello', timestamp: 1000 } });
+    expect(getMsgs(state)).toHaveLength(1);
+    expect(getMsgs(state)[0]).toMatchObject({ id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'Hello' }] });
   });
 
   it('ADD_ASSISTANT_MESSAGE adds a streaming assistant message', () => {
-    const state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
-    expect(state.messages).toHaveLength(1);
-    expect(state.messages[0]).toMatchObject({ id: 'a1', role: 'assistant', blocks: [], isStreaming: true });
+    const state = appReducer(withActiveMind, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    expect(getMsgs(state)).toHaveLength(1);
+    expect(getMsgs(state)[0]).toMatchObject({ id: 'a1', role: 'assistant', blocks: [], isStreaming: true });
     expect(state.isStreaming).toBe(true);
   });
 
-  it('CHAT_EVENT delegates to handleChatEvent', () => {
-    let state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
-    state = appReducer(state, { type: 'CHAT_EVENT', payload: { messageId: 'a1', event: makeChatEvent('chunk', { content: 'Hi' }) } });
-    expect(state.messages[0].blocks[0]).toMatchObject({ type: 'text', content: 'Hi' });
+  it('CHAT_EVENT delegates to handleChatEvent for the correct mind', () => {
+    let state = appReducer(withActiveMind, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    state = appReducer(state, { type: 'CHAT_EVENT', payload: { mindId, messageId: 'a1', event: makeChatEvent('chunk', { content: 'Hi' }) } });
+    expect(getMsgs(state)[0].blocks[0]).toMatchObject({ type: 'text', content: 'Hi' });
   });
 
   it('CHAT_EVENT with done sets isStreaming false', () => {
-    let state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
-    state = appReducer(state, { type: 'CHAT_EVENT', payload: { messageId: 'a1', event: makeChatEvent('done') } });
+    let state = appReducer(withActiveMind, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    state = appReducer(state, { type: 'CHAT_EVENT', payload: { mindId, messageId: 'a1', event: makeChatEvent('done') } });
     expect(state.isStreaming).toBe(false);
   });
 
   it('CHAT_EVENT with error sets isStreaming false', () => {
-    let state = appReducer(initialState, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
-    state = appReducer(state, { type: 'CHAT_EVENT', payload: { messageId: 'a1', event: makeChatEvent('error', { message: 'fail' }) } });
+    let state = appReducer(withActiveMind, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+    state = appReducer(state, { type: 'CHAT_EVENT', payload: { mindId, messageId: 'a1', event: makeChatEvent('error', { message: 'fail' }) } });
     expect(state.isStreaming).toBe(false);
+  });
+
+  it('SET_MINDS updates minds array', () => {
+    const minds = [{ mindId: 'a', mindPath: '/a', identity: { name: 'A', systemMessage: '' }, status: 'ready' as const }];
+    const state = appReducer(initialState, { type: 'SET_MINDS', payload: minds });
+    expect(state.minds).toEqual(minds);
+  });
+
+  it('SET_ACTIVE_MIND switches active mind', () => {
+    const state = appReducer(withActiveMind, { type: 'SET_ACTIVE_MIND', payload: 'other-mind' });
+    expect(state.activeMindId).toBe('other-mind');
+  });
+
+  it('ADD_MIND appends a new mind and sets it active if none active', () => {
+    const mind = { mindId: 'new', mindPath: '/new', identity: { name: 'New', systemMessage: '' }, status: 'ready' as const };
+    const state = appReducer(initialState, { type: 'ADD_MIND', payload: mind });
+    expect(state.minds).toHaveLength(1);
+    expect(state.activeMindId).toBe('new');
+  });
+
+  it('ADD_MIND does not duplicate existing mind', () => {
+    const mind = withActiveMind.minds[0];
+    const state = appReducer(withActiveMind, { type: 'ADD_MIND', payload: mind });
+    expect(state.minds).toHaveLength(1);
+  });
+
+  it('REMOVE_MIND removes mind and clears its messages', () => {
+    const stateWithMsgs = { ...withActiveMind, messagesByMind: { [mindId]: [makeMessage([makeTextBlock('hi')])] } };
+    const state = appReducer(stateWithMsgs, { type: 'REMOVE_MIND', payload: mindId });
+    expect(state.minds).toHaveLength(0);
+    expect(state.messagesByMind[mindId]).toBeUndefined();
+    expect(state.activeMindId).toBeNull();
+    expect(state.showLanding).toBe(true);
+  });
+
+  it('REMOVE_MIND falls back active to next mind', () => {
+    const twoMinds: AppState = {
+      ...withActiveMind,
+      minds: [
+        withActiveMind.minds[0],
+        { mindId: 'other', mindPath: '/other', identity: { name: 'Other', systemMessage: '' }, status: 'ready' },
+      ],
+    };
+    const state = appReducer(twoMinds, { type: 'REMOVE_MIND', payload: mindId });
+    expect(state.activeMindId).toBe('other');
   });
 
   it('SET_AGENT_STATUS updates agentStatus', () => {
@@ -258,19 +312,17 @@ describe('appReducer', () => {
     expect(state.showLanding).toBe(false);
   });
 
-  it('CLEAR_MESSAGES empties messages', () => {
-    const withMsgs = { ...initialState, messages: [makeMessage([makeTextBlock('hi')])] };
-    const state = appReducer(withMsgs, { type: 'CLEAR_MESSAGES' });
-    expect(state.messages).toHaveLength(0);
+  it('CLEAR_MESSAGES empties messages for active mind', () => {
+    const stateWithMsgs = { ...withActiveMind, messagesByMind: { [mindId]: [makeMessage([makeTextBlock('hi')])] } };
+    const state = appReducer(stateWithMsgs, { type: 'CLEAR_MESSAGES' });
+    expect(getMsgs(state)).toHaveLength(0);
   });
 
-  it('NEW_CONVERSATION resets messages, streaming, and generates new conversationId', () => {
-    const prev = { ...initialState, messages: [makeMessage([])], isStreaming: true, conversationId: 'old' };
+  it('NEW_CONVERSATION resets messages and streaming for active mind', () => {
+    const prev = { ...withActiveMind, messagesByMind: { [mindId]: [makeMessage([])] }, isStreaming: true };
     const state = appReducer(prev, { type: 'NEW_CONVERSATION' });
-    expect(state.messages).toHaveLength(0);
+    expect(getMsgs(state)).toHaveLength(0);
     expect(state.isStreaming).toBe(false);
-    expect(state.conversationId).not.toBe('old');
-    expect(state.conversationId).toMatch(/^conv-/);
   });
 
   it('unknown action returns state unchanged', () => {

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -210,6 +210,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     case 'HIDE_LANDING':
       return { ...state, showLanding: false };
 
+    case 'MINDS_CHECKED':
+      return { ...state, mindsChecked: true };
+
     case 'CLEAR_MESSAGES':
       return {
         ...state,

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -108,39 +108,79 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
 }
 
 export function appReducer(state: AppState, action: AppAction): AppState {
+  // Helper: get current mind's messages
+  const activeMsgs = () => state.activeMindId ? (state.messagesByMind[state.activeMindId] ?? []) : [];
+  const setActiveMsgs = (msgs: ChatMessage[]) => {
+    if (!state.activeMindId) return state.messagesByMind;
+    return { ...state.messagesByMind, [state.activeMindId]: msgs };
+  };
+
   switch (action.type) {
     case 'ADD_USER_MESSAGE':
       return {
         ...state,
-        messages: [...state.messages, {
+        messagesByMind: setActiveMsgs([...activeMsgs(), {
           id: action.payload.id,
           role: 'user',
           blocks: [{ type: 'text', content: action.payload.content }],
           timestamp: action.payload.timestamp,
-        }],
+        }]),
       };
 
     case 'ADD_ASSISTANT_MESSAGE':
       return {
         ...state,
         isStreaming: true,
-        messages: [...state.messages, {
+        messagesByMind: setActiveMsgs([...activeMsgs(), {
           id: action.payload.id,
           role: 'assistant',
           blocks: [],
           timestamp: action.payload.timestamp,
           isStreaming: true,
-        }],
+        }]),
       };
 
     case 'CHAT_EVENT': {
-      const { messageId, event } = action.payload;
-      const newMessages = handleChatEvent(state.messages, messageId, event);
+      const { mindId, messageId, event } = action.payload;
+      const mindMsgs = state.messagesByMind[mindId] ?? [];
+      const newMessages = handleChatEvent(mindMsgs, messageId, event);
       const isDone = event.type === 'done' || event.type === 'error';
       return {
         ...state,
-        messages: newMessages,
+        messagesByMind: { ...state.messagesByMind, [mindId]: newMessages },
         isStreaming: isDone ? false : state.isStreaming,
+      };
+    }
+
+    case 'SET_MINDS':
+      return { ...state, minds: action.payload };
+
+    case 'SET_ACTIVE_MIND':
+      return { ...state, activeMindId: action.payload, isStreaming: false };
+
+    case 'ADD_MIND': {
+      const exists = state.minds.some(m => m.mindId === action.payload.mindId);
+      if (exists) return state;
+      return {
+        ...state,
+        minds: [...state.minds, action.payload],
+        activeMindId: state.activeMindId ?? action.payload.mindId,
+      };
+    }
+
+    case 'REMOVE_MIND': {
+      const newMinds = state.minds.filter(m => m.mindId !== action.payload);
+      const newMsgsByMind = { ...state.messagesByMind };
+      delete newMsgsByMind[action.payload];
+      const newActive = state.activeMindId === action.payload
+        ? (newMinds.length > 0 ? newMinds[0].mindId : null)
+        : state.activeMindId;
+      return {
+        ...state,
+        minds: newMinds,
+        activeMindId: newActive,
+        messagesByMind: newMsgsByMind,
+        showLanding: newMinds.length === 0,
       };
     }
 
@@ -171,13 +211,19 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, showLanding: false };
 
     case 'CLEAR_MESSAGES':
-      return { ...state, messages: [] };
+      return {
+        ...state,
+        messagesByMind: state.activeMindId
+          ? { ...state.messagesByMind, [state.activeMindId]: [] }
+          : state.messagesByMind,
+      };
 
     case 'NEW_CONVERSATION':
       return {
         ...state,
-        messages: [],
-        conversationId: `conv-${Date.now()}`,
+        messagesByMind: state.activeMindId
+          ? { ...state.messagesByMind, [state.activeMindId]: [] }
+          : state.messagesByMind,
         isStreaming: false,
       };
 

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -14,6 +14,7 @@ export interface AppState {
   activeView: LensView;
   discoveredViews: LensViewManifest[];
   showLanding: boolean;
+  mindsChecked: boolean;
 }
 
 export type AppAction =
@@ -31,6 +32,7 @@ export type AppAction =
   | { type: 'SET_DISCOVERED_VIEWS'; payload: LensViewManifest[] }
   | { type: 'SHOW_LANDING' }
   | { type: 'HIDE_LANDING' }
+  | { type: 'MINDS_CHECKED' }
   | { type: 'CLEAR_MESSAGES' }
   | { type: 'NEW_CONVERSATION' };
 
@@ -53,4 +55,5 @@ export const initialState: AppState = {
   activeView: 'chat',
   discoveredViews: [],
   showLanding: false,
+  mindsChecked: false,
 };

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -1,11 +1,13 @@
-import type { ChatMessage, ChatEvent, AgentStatus, ModelInfo, LensViewManifest, ContentBlock } from '../../../shared/types';
+import type { ChatMessage, ChatEvent, AgentStatus, ModelInfo, LensViewManifest, MindContext, ContentBlock } from '../../../shared/types';
 
 export type LensView = 'chat' | string;
 
 export interface AppState {
-  messages: ChatMessage[];
-  conversationId: string;
+  minds: MindContext[];
+  activeMindId: string | null;
+  messagesByMind: Record<string, ChatMessage[]>;
   isStreaming: boolean;
+  /** @deprecated Use minds array instead */
   agentStatus: AgentStatus;
   availableModels: ModelInfo[];
   selectedModel: string | null;
@@ -17,7 +19,11 @@ export interface AppState {
 export type AppAction =
   | { type: 'ADD_USER_MESSAGE'; payload: { id: string; content: string; timestamp: number } }
   | { type: 'ADD_ASSISTANT_MESSAGE'; payload: { id: string; timestamp: number } }
-  | { type: 'CHAT_EVENT'; payload: { messageId: string; event: ChatEvent } }
+  | { type: 'CHAT_EVENT'; payload: { mindId: string; messageId: string; event: ChatEvent } }
+  | { type: 'SET_MINDS'; payload: MindContext[] }
+  | { type: 'SET_ACTIVE_MIND'; payload: string | null }
+  | { type: 'ADD_MIND'; payload: MindContext }
+  | { type: 'REMOVE_MIND'; payload: string }
   | { type: 'SET_AGENT_STATUS'; payload: AgentStatus }
   | { type: 'SET_AVAILABLE_MODELS'; payload: ModelInfo[] }
   | { type: 'SET_SELECTED_MODEL'; payload: string | null }
@@ -29,8 +35,9 @@ export type AppAction =
   | { type: 'NEW_CONVERSATION' };
 
 export const initialState: AppState = {
-  messages: [],
-  conversationId: `conv-${Date.now()}`,
+  minds: [],
+  activeMindId: null,
+  messagesByMind: {},
   isStreaming: false,
   agentStatus: {
     connected: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -66,13 +66,47 @@ export interface AgentStatus {
   extensions: string[];
 }
 
+// ---------------------------------------------------------------------------
+// Mind — multi-mind runtime types
+// ---------------------------------------------------------------------------
+
+export interface MindIdentity {
+  readonly name: string;
+  readonly systemMessage: string;
+}
+
+export type MindStatus = 'loading' | 'ready' | 'error' | 'unloading';
+
+/** Shared mind context — safe for renderer consumption */
+export interface MindContext {
+  readonly mindId: string;
+  readonly mindPath: string;
+  readonly identity: MindIdentity;
+  readonly status: MindStatus;
+  readonly error?: string;
+}
+
+/** Persisted mind record in config */
+export interface MindRecord {
+  id: string;
+  path: string;
+}
+
 export interface ModelInfo {
   id: string;
   name: string;
 }
 
-export interface AppConfig {
+/** @deprecated Use AppConfigV2 — kept for migration */
+export interface AppConfigV1 {
   mindPath: string | null;
+  theme: 'light' | 'dark' | 'system';
+}
+
+export interface AppConfig {
+  version: 2;
+  minds: MindRecord[];
+  activeMindId: string | null;
   theme: 'light' | 'dark' | 'system';
 }
 
@@ -91,12 +125,21 @@ export interface LensViewManifest {
 
 export interface ElectronAPI {
   chat: {
-    send: (conversationId: string, message: string, messageId: string, model?: string) => Promise<void>;
-    stop: (conversationId: string, messageId: string) => Promise<void>;
-    newConversation: (conversationId: string) => Promise<void>;
+    send: (mindId: string, message: string, messageId: string, model?: string) => Promise<void>;
+    stop: (mindId: string, messageId: string) => Promise<void>;
+    newConversation: (mindId: string) => Promise<void>;
     listModels: () => Promise<ModelInfo[]>;
-    onEvent: (callback: (messageId: string, event: ChatEvent) => void) => () => void;
+    onEvent: (callback: (mindId: string, messageId: string, event: ChatEvent) => void) => () => void;
   };
+  mind: {
+    add: (mindPath: string) => Promise<MindContext>;
+    remove: (mindId: string) => Promise<void>;
+    list: () => Promise<MindContext[]>;
+    setActive: (mindId: string) => Promise<void>;
+    selectDirectory: () => Promise<string | null>;
+    onMindChanged: (callback: (minds: MindContext[]) => void) => () => void;
+  };
+  /** @deprecated Use mind: namespace instead */
   agent: {
     getStatus: () => Promise<AgentStatus>;
     selectMindDirectory: () => Promise<string | null>;
@@ -104,10 +147,10 @@ export interface ElectronAPI {
     onStatusChanged: (callback: (status: AgentStatus) => void) => () => void;
   };
   lens: {
-    getViews: () => Promise<LensViewManifest[]>;
-    getViewData: (viewId: string) => Promise<Record<string, unknown> | null>;
-    refreshView: (viewId: string) => Promise<Record<string, unknown> | null>;
-    sendAction: (viewId: string, action: string) => Promise<Record<string, unknown> | null>;
+    getViews: (mindId?: string) => Promise<LensViewManifest[]>;
+    getViewData: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
+    refreshView: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
+    sendAction: (viewId: string, action: string, mindId?: string) => Promise<Record<string, unknown> | null>;
     onViewsChanged: (callback: (views: LensViewManifest[]) => void) => () => void;
   };
   auth: {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -141,6 +141,14 @@ export function mockElectronAPI(): ElectronAPI {
       setMindPath: vi.fn().mockResolvedValue(undefined),
       onStatusChanged: vi.fn().mockReturnValue(() => {}),
     },
+    mind: {
+      add: vi.fn().mockResolvedValue({ mindId: 'test-1234', mindPath: 'C:\\test', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }),
+      remove: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+      setActive: vi.fn().mockResolvedValue(undefined),
+      selectDirectory: vi.fn().mockResolvedValue(null),
+      onMindChanged: vi.fn().mockReturnValue(() => {}),
+    },
     lens: {
       getViews: vi.fn().mockResolvedValue([]),
       getViewData: vi.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Multi-Mind Runtime — Phase 1

Chamber now supports multiple agents loaded simultaneously.

### What's new
- **MindManager** — core service managing mind lifecycle, sessions, extensions per-mind
- **CopilotClientFactory** — one CopilotClient per mind (full isolation, replaces SdkLoader singleton)
- **MindSidebar** — resizable agent list with status indicators, click to switch, add/remove
- **Per-mind lens views** — activity bar updates when switching agents
- **Config persistence** — minds survive restarts (v1→v2 config migration)
- **Chamber loading screen** — green terminal aesthetic while restoring agents
- **ChatService refactored** — thin wrapper delegating to MindManager
- **IPC adapters** — all handlers take mindId, backward compat for old agent: namespace

### Architecture (Uncle Bob reviewed)
- MindManager is the aggregate root (owns Map<mindId, InternalMindContext>)
- Constructor injection throughout, no module-scoped globals
- 13 review findings addressed (race condition guard, DIP fixes, DRY, naming)

### Tests
- 249 tests passing across 37 test files
- TDD throughout: ConfigService, CopilotClientFactory, IdentityLoader, ExtensionLoader, ViewDiscovery, MindManager, ChatService, Reducer

### Backlog items captured
- Upgrade genesis-created minds on open
- Landing screen back button
- Lens refresh survives view switching
- Conversation history (spec written)