### PR TITLE
v0.16.0 — Agent Windowing (Phase 2)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -11,6 +11,7 @@
 - [ ] **Upgrade genesis-created minds on open** `bug` — minds created via CLI genesis (not Chamber) may be missing lens defaults, lens skill, and other Chamber-specific bootstrapping. When a mind is opened in Chamber for the first time, detect and run `seedLensDefaults` + `installLensSkill` + any missing capabilities. *(Ian, 2026-04-12)*
 - [ ] **Landing screen needs a back button** `ux` — when "Add Agent" navigates to the landing screen, there's no way to go back if you change your mind. Add a back/cancel action that returns to the previous chat view. *(Ian, 2026-04-12)*
 - [ ] **Lens refresh survives view switching** `ux` — clicking away from a lens while it's refreshing drops the pending result. The agent still writes the file, but the UI never picks up the new data. Either show a toast when refresh completes, or re-read data when returning to the view. *(Ian, 2026-04-12)*
+- [ ] **Popout should continue conversation** `ux` — popping out an agent starts a fresh chat instead of continuing the current conversation. Messages should transfer to the popout and return when closed. Related to conversation history feature. *(Ian, 2026-04-12)*
 
 ## Next
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,14 @@ const createWindow = () => {
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.webContents.openDevTools({ mode: 'bottom' });
   }
+
+  // When main window closes, close all popout windows too
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.close();
+    }
+  });
 };
 
 app.on('ready', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,7 +90,11 @@ const createWindow = () => {
 app.on('ready', async () => {
   // --- IPC adapters (thin, parameter-injected) ---
   setupChatIPC(chatService, mindManager);
-  setupMindIPC(mindManager);
+  setupMindIPC(mindManager, {
+    preloadPath: path.join(__dirname, 'preload.js'),
+    devServerUrl: MAIN_WINDOW_VITE_DEV_SERVER_URL || undefined,
+    rendererPath: MAIN_WINDOW_VITE_DEV_SERVER_URL ? undefined : path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`),
+  });
   setupLensIPC(viewDiscovery, mindManager);
   setupGenesisIPC(mindManager, scaffold);
   setupAuthIPC(authService);

--- a/src/main/ipc/mind.ts
+++ b/src/main/ipc/mind.ts
@@ -157,15 +157,16 @@ export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): v
   });
 
   // Emit mind changes to all windows
-  mindManager.on('mind:loaded', () => {
+  const broadcastMinds = () => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('mind:changed', mindManager.listMinds());
+      if (!win.isDestroyed()) {
+        win.webContents.send('mind:changed', mindManager.listMinds());
+      }
     }
-  });
+  };
 
-  mindManager.on('mind:unloaded', () => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('mind:changed', mindManager.listMinds());
-    }
-  });
+  mindManager.on('mind:loaded', broadcastMinds);
+  mindManager.on('mind:unloaded', broadcastMinds);
+  mindManager.on('mind:windowed', broadcastMinds);
+  mindManager.on('mind:unwindowed', broadcastMinds);
 }

--- a/src/main/ipc/mind.ts
+++ b/src/main/ipc/mind.ts
@@ -4,7 +4,13 @@ import * as path from 'path';
 import * as os from 'os';
 import type { MindManager } from '../services/mind/MindManager';
 
-export function setupMindIPC(mindManager: MindManager): void {
+export interface MindIPCConfig {
+  preloadPath: string;
+  devServerUrl?: string;
+  rendererPath?: string;
+}
+
+export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): void {
   ipcMain.handle('mind:add', async (event, mindPath: string) => {
     return mindManager.loadMind(mindPath);
   });
@@ -37,6 +43,55 @@ export function setupMindIPC(mindManager: MindManager): void {
 
     if (result.canceled || result.filePaths.length === 0) return null;
     return result.filePaths[0];
+  });
+
+  ipcMain.handle('mind:openWindow', async (_event, mindId: string) => {
+    // If already popped out, focus existing window
+    const existing = mindManager.getWindow(mindId);
+    if (existing) {
+      existing.focus();
+      return;
+    }
+
+    // Verify mind exists
+    const mind = mindManager.getMind(mindId);
+    if (!mind) return;
+
+    // Create popout window
+    const win = new BrowserWindow({
+      width: 900,
+      height: 700,
+      minWidth: 500,
+      minHeight: 400,
+      title: `${mind.identity.name} — Chamber`,
+      titleBarStyle: 'hiddenInset',
+      titleBarOverlay: process.platform === 'win32' ? {
+        color: '#09090b',
+        symbolColor: '#fafafa',
+        height: 36,
+      } : undefined,
+      backgroundColor: '#09090b',
+      webPreferences: {
+        preload: config.preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: false,
+      },
+    });
+
+    // Load same renderer with popout query params
+    if (config.devServerUrl) {
+      win.loadURL(`${config.devServerUrl}?mindId=${mindId}&popout=true`);
+    } else if (config.rendererPath) {
+      win.loadFile(config.rendererPath, { query: { mindId, popout: 'true' } });
+    }
+
+    mindManager.attachWindow(mindId, win);
+
+    // Notify all windows about the state change
+    for (const w of BrowserWindow.getAllWindows()) {
+      w.webContents.send('mind:changed', mindManager.listMinds());
+    }
   });
 
   // Backward compat: renderer still calls agent:getStatus during startup

--- a/src/main/services/mind/MindManager.test.ts
+++ b/src/main/services/mind/MindManager.test.ts
@@ -290,8 +290,69 @@ describe('MindManager', () => {
       const promise2 = manager.loadMind('C:\\agents\\q');
       const [mind1, mind2] = await Promise.all([promise1, promise2]);
       expect(mind1.mindId).toBe(mind2.mindId);
-      // Only one client created despite two concurrent calls
       expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('window management', () => {
+    it('attachWindow associates a window with a mind', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      const mockWin = { focus: vi.fn(), close: vi.fn(), on: vi.fn() };
+      manager.attachWindow(mind.mindId, mockWin);
+      expect(manager.isWindowed(mind.mindId)).toBe(true);
+      expect(manager.getWindow(mind.mindId)).toBe(mockWin);
+    });
+
+    it('detachWindow removes association, mind stays loaded', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      const mockWin = { focus: vi.fn(), close: vi.fn(), on: vi.fn() };
+      manager.attachWindow(mind.mindId, mockWin);
+      manager.detachWindow(mind.mindId);
+      expect(manager.isWindowed(mind.mindId)).toBe(false);
+      expect(manager.getWindow(mind.mindId)).toBeNull();
+      expect(manager.getMind(mind.mindId)).toBeDefined();
+    });
+
+    it('getWindow returns null for non-windowed mind', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      expect(manager.getWindow(mind.mindId)).toBeNull();
+    });
+
+    it('listMinds includes windowed flag', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      expect(manager.listMinds()[0].windowed).toBe(false);
+      manager.attachWindow(mind.mindId, { focus: vi.fn(), close: vi.fn(), on: vi.fn() });
+      expect(manager.listMinds()[0].windowed).toBe(true);
+    });
+
+    it('auto-detaches on window close event', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      let closeHandler: (() => void) | null = null;
+      const mockWin = {
+        focus: vi.fn(),
+        close: vi.fn(),
+        on: vi.fn((event: string, cb: () => void) => { if (event === 'closed') closeHandler = cb; }),
+      };
+      manager.attachWindow(mind.mindId, mockWin);
+      expect(manager.isWindowed(mind.mindId)).toBe(true);
+
+      // Simulate window close
+      closeHandler!();
+      expect(manager.isWindowed(mind.mindId)).toBe(false);
+    });
+
+    it('emits mind:windowed and mind:unwindowed events', async () => {
+      const mind = await manager.loadMind('C:\\agents\\q');
+      const windowed = vi.fn();
+      const unwindowed = vi.fn();
+      manager.on('mind:windowed', windowed);
+      manager.on('mind:unwindowed', unwindowed);
+
+      manager.attachWindow(mind.mindId, { focus: vi.fn(), close: vi.fn(), on: vi.fn() });
+      expect(windowed).toHaveBeenCalledWith(mind.mindId);
+
+      manager.detachWindow(mind.mindId);
+      expect(unwindowed).toHaveBeenCalledWith(mind.mindId);
     });
   });
 });

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -17,6 +17,7 @@ export class MindManager extends EventEmitter {
   private minds = new Map<string, InternalMindContext>();
   private pathToId = new Map<string, string>();
   private loading = new Map<string, Promise<MindContext>>();
+  private windowByMind = new Map<string, { focus: () => void; close: () => void; on: (event: string, cb: () => void) => void }>();
   private activeMindId: string | null = null;
 
   constructor(
@@ -141,6 +142,28 @@ export class MindManager extends EventEmitter {
     return this.activeMindId;
   }
 
+  // --- Window management ---
+
+  attachWindow(mindId: string, win: { focus: () => void; close: () => void; on: (event: string, cb: () => void) => void }): void {
+    if (!this.minds.has(mindId)) return;
+    this.windowByMind.set(mindId, win);
+    win.on('closed', () => this.detachWindow(mindId));
+    this.emit('mind:windowed', mindId);
+  }
+
+  detachWindow(mindId: string): void {
+    this.windowByMind.delete(mindId);
+    this.emit('mind:unwindowed', mindId);
+  }
+
+  getWindow(mindId: string): { focus: () => void; close: () => void } | null {
+    return this.windowByMind.get(mindId) ?? null;
+  }
+
+  isWindowed(mindId: string): boolean {
+    return this.windowByMind.has(mindId);
+  }
+
   async recreateSession(mindId: string): Promise<void> {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
@@ -199,6 +222,7 @@ export class MindManager extends EventEmitter {
       identity: ctx.identity,
       status: ctx.status,
       error: ctx.error,
+      windowed: this.windowByMind.has(ctx.mindId),
     };
   }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -19,6 +19,7 @@ const electronAPI: ElectronAPI = {
     list: () => ipcRenderer.invoke('mind:list'),
     setActive: (mindId) => ipcRenderer.invoke('mind:setActive', mindId),
     selectDirectory: () => ipcRenderer.invoke('mind:selectDirectory'),
+    openWindow: (mindId) => ipcRenderer.invoke('mind:openWindow', mindId),
     onMindChanged: (callback) => createIpcListener(ipcRenderer, 'mind:changed', callback),
   },
   agent: {

--- a/src/renderer/components/genesis/GenesisGate.tsx
+++ b/src/renderer/components/genesis/GenesisGate.tsx
@@ -13,6 +13,12 @@ export function GenesisGate({ children }: Props) {
   const dispatch = useAppDispatch();
   const [mode, setMode] = useState<'idle' | 'genesis'>('idle');
 
+  // Popout windows skip the gate entirely
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('popout') === 'true') {
+    return <>{children}</>;
+  }
+
   // Show loading screen while initial minds check is pending
   if (!mindsChecked && !showLanding) {
     return <ChamberLoadingScreen />;

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -1,12 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useAppSubscriptions } from '../../hooks/useAppSubscriptions';
+import { useAppDispatch, useAppState } from '../../lib/store';
 import { TooltipProvider } from '../ui/tooltip';
 import { ActivityBar } from './ActivityBar';
 import { MindSidebar } from './MindSidebar';
 import { ViewRouter } from './ViewRouter';
 
+function usePopoutParams() {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    isPopout: params.get('popout') === 'true',
+    popoutMindId: params.get('mindId'),
+  };
+}
+
 export function AppShell() {
   useAppSubscriptions();
+  const { isPopout, popoutMindId } = usePopoutParams();
+  const { minds } = useAppState();
+  const dispatch = useAppDispatch();
+
+  // In popout mode, lock to the specified mind
+  useEffect(() => {
+    if (isPopout && popoutMindId && minds.length > 0) {
+      dispatch({ type: 'SET_ACTIVE_MIND', payload: popoutMindId });
+    }
+  }, [isPopout, popoutMindId, minds.length, dispatch]);
+
+  // Popout mode: just chat, no sidebar or activity bar
+  if (isPopout) {
+    return (
+      <TooltipProvider>
+        <div className="flex flex-col h-screen w-screen bg-background text-foreground">
+          <div className="flex flex-1 min-h-0">
+            <main className="flex-1 flex flex-col min-w-0">
+              <ViewRouter />
+            </main>
+          </div>
+        </div>
+      </TooltipProvider>
+    );
+  }
 
   return (
     <TooltipProvider>

--- a/src/renderer/components/layout/MindSidebar.tsx
+++ b/src/renderer/components/layout/MindSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { cn } from '../../lib/utils';
-import { Plus, X, Bot, MessageSquarePlus } from 'lucide-react';
+import { Plus, X, Bot, MessageSquarePlus, ExternalLink } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { MindContext } from '../../../shared/types';
 
@@ -32,10 +32,20 @@ export function MindSidebar() {
     dispatch({ type: 'SHOW_LANDING' });
   };
 
-  const handleSwitchMind = (mindId: string) => {
-    window.electronAPI.mind.setActive(mindId);
-    dispatch({ type: 'SET_ACTIVE_MIND', payload: mindId });
-    dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  const handleSwitchMind = (mind: MindContext) => {
+    if (mind.windowed) {
+      // Focus the popout window instead of switching in main
+      window.electronAPI.mind.openWindow(mind.mindId);
+    } else {
+      window.electronAPI.mind.setActive(mind.mindId);
+      dispatch({ type: 'SET_ACTIVE_MIND', payload: mind.mindId });
+      dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+    }
+  };
+
+  const handlePopout = async (e: React.MouseEvent, mindId: string) => {
+    e.stopPropagation();
+    await window.electronAPI.mind.openWindow(mindId);
   };
 
   const handleRemoveMind = async (e: React.MouseEvent, mindId: string) => {
@@ -87,29 +97,56 @@ export function MindSidebar() {
         {minds.map((mind) => (
           <button
             key={mind.mindId}
-            onClick={() => handleSwitchMind(mind.mindId)}
+            onClick={() => handleSwitchMind(mind)}
             className={cn(
               'w-full px-3 py-2 flex items-center gap-2 text-sm transition-colors group',
-              mind.mindId === activeMindId
-                ? 'bg-accent text-foreground'
-                : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+              mind.windowed
+                ? 'text-muted-foreground/60 italic'
+                : mind.mindId === activeMindId
+                  ? 'bg-accent text-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
             )}
           >
             <Bot size={16} className="shrink-0" />
             <div className={cn('w-2 h-2 rounded-full shrink-0', statusColor(mind.status))} />
             <span className="truncate flex-1 text-left">{mind.identity.name}</span>
-            <Tooltip delayDuration={300}>
-              <TooltipTrigger asChild>
-                <span
-                  role="button"
-                  onClick={(e) => handleRemoveMind(e, mind.mindId)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity hover:text-destructive"
-                >
-                  <X size={14} />
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="right">Remove agent</TooltipContent>
-            </Tooltip>
+            {mind.windowed ? (
+              <Tooltip delayDuration={300}>
+                <TooltipTrigger asChild>
+                  <span className="text-muted-foreground/50">
+                    <ExternalLink size={12} />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="right">In separate window</TooltipContent>
+              </Tooltip>
+            ) : (
+              <>
+                <Tooltip delayDuration={300}>
+                  <TooltipTrigger asChild>
+                    <span
+                      role="button"
+                      onClick={(e) => handlePopout(e, mind.mindId)}
+                      className="opacity-0 group-hover:opacity-100 transition-opacity hover:text-foreground"
+                    >
+                      <ExternalLink size={12} />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">Open in window</TooltipContent>
+                </Tooltip>
+                <Tooltip delayDuration={300}>
+                  <TooltipTrigger asChild>
+                    <span
+                      role="button"
+                      onClick={(e) => handleRemoveMind(e, mind.mindId)}
+                      className="opacity-0 group-hover:opacity-100 transition-opacity hover:text-destructive"
+                    >
+                      <X size={14} />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">Remove agent</TooltipContent>
+                </Tooltip>
+              </>
+            )}
           </button>
         ))}
       </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -84,6 +84,7 @@ export interface MindContext {
   readonly identity: MindIdentity;
   readonly status: MindStatus;
   readonly error?: string;
+  readonly windowed?: boolean;
 }
 
 /** Persisted mind record in config */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -138,6 +138,7 @@ export interface ElectronAPI {
     list: () => Promise<MindContext[]>;
     setActive: (mindId: string) => Promise<void>;
     selectDirectory: () => Promise<string | null>;
+    openWindow: (mindId: string) => Promise<void>;
     onMindChanged: (callback: (minds: MindContext[]) => void) => () => void;
   };
   /** @deprecated Use mind: namespace instead */

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -147,6 +147,7 @@ export function mockElectronAPI(): ElectronAPI {
       list: vi.fn().mockResolvedValue([]),
       setActive: vi.fn().mockResolvedValue(undefined),
       selectDirectory: vi.fn().mockResolvedValue(null),
+      openWindow: vi.fn().mockResolvedValue(undefined),
       onMindChanged: vi.fn().mockReturnValue(() => {}),
     },
     lens: {


### PR DESCRIPTION
## Agent Windowing — Phase 2

Pop out any agent into its own window for focused chat.

### What's new
- **Pop-out button** — hover over agent in sidebar, click ↗ to open in new window
- **Popout mode** — clean chat-only view (no sidebar/activity bar), locked to one agent
- **Window tracking** — MindManager tracks which agents are windowed
- **Sidebar indicators** — windowed agents show ↗ icon, italic text, click focuses the window
- **Lifecycle** — closing popout returns agent to sidebar, closing main window closes all popouts

### Architecture
- MindManager: attachWindow/detachWindow/getWindow/isWindowed
- Same renderer with \?mindId=xxx&popout=true\ query params
- Broadcast mind state changes to all windows on attach/detach
- GenesisGate bypassed in popout mode

### Tests
- 255 tests passing
- 6 new window management tests on MindManager

### Backlog captured
- Popout should continue conversation (not start fresh)