### PR TITLE
v0.17.0 — A2A Messages (Phase 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,24 +47,21 @@ const viewDiscovery = new ViewDiscovery();
 
 // --- Services (business rules, all dependencies injected) ---
 
-// A2A services — declared first, assigned after MindManager (avoids circular dep)
-let messageRouter: MessageRouter;
-let agentCardRegistry: AgentCardRegistry;
-
-// A2A IPC event bus — shared between MessageRouter (emits) and IPC adapter (listens)
 const a2aEventBus = new EventEmitter();
+const agentCardRegistry = new AgentCardRegistry();
+const turnQueue = new TurnQueue();
 
-// ToolBuilder callback — closes over A2A services, assigned before minds load
+// ToolBuilder callback — closes over services created below
 const toolBuilder = (mindId: string, extensionTools: unknown[]) =>
   buildSessionTools(mindId, extensionTools as any, messageRouter, agentCardRegistry);
 
 const mindManager = new MindManager(clientFactory, identityLoader, extensionLoader, configService, viewDiscovery, toolBuilder);
-const turnQueue = new TurnQueue();
 const chatService = new ChatService(mindManager, turnQueue);
+const messageRouter = new MessageRouter(chatService, agentCardRegistry, a2aEventBus);
 
-// Now wire A2A
-agentCardRegistry = new AgentCardRegistry(mindManager);
-messageRouter = new MessageRouter(chatService, agentCardRegistry, a2aEventBus);
+// Wire AgentCardRegistry to MindManager lifecycle (registry doesn't know about MindManager)
+mindManager.on('mind:loaded', (ctx: any) => agentCardRegistry.register(ctx));
+mindManager.on('mind:unloaded', (mindId: string) => agentCardRegistry.unregister(mindId));
 
 // Wire Lens refresh to use the mind's session
 viewDiscovery.setRefreshHandler({

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ import { MindScaffold } from './main/services/genesis';
 import { ViewDiscovery } from './main/services/lens';
 import { MindManager } from './main/services/mind/MindManager';
 import { ChatService } from './main/services/chat/ChatService';
+import { TurnQueue } from './main/services/chat/TurnQueue';
+import { AgentCardRegistry, MessageRouter, buildSessionTools } from './main/services/a2a';
 import { loadCanvasExtension } from './main/services/extensions/adapters/canvas';
 import { loadCronExtension } from './main/services/extensions/adapters/cron';
 import { loadIdeaExtension } from './main/services/extensions/adapters/idea';
@@ -22,6 +24,9 @@ import { setupMindIPC } from './main/ipc/mind';
 import { setupLensIPC } from './main/ipc/lens';
 import { setupGenesisIPC } from './main/ipc/genesis';
 import { setupAuthIPC } from './main/ipc/auth';
+import { setupA2AIPC } from './main/ipc/a2a';
+
+import { EventEmitter } from 'events';
 
 if (started) {
   app.quit();
@@ -42,8 +47,24 @@ const viewDiscovery = new ViewDiscovery();
 
 // --- Services (business rules, all dependencies injected) ---
 
-const mindManager = new MindManager(clientFactory, identityLoader, extensionLoader, configService, viewDiscovery);
-const chatService = new ChatService(mindManager);
+// A2A services — declared first, assigned after MindManager (avoids circular dep)
+let messageRouter: MessageRouter;
+let agentCardRegistry: AgentCardRegistry;
+
+// A2A IPC event bus — shared between MessageRouter (emits) and IPC adapter (listens)
+const a2aEventBus = new EventEmitter();
+
+// ToolBuilder callback — closes over A2A services, assigned before minds load
+const toolBuilder = (mindId: string, extensionTools: unknown[]) =>
+  buildSessionTools(mindId, extensionTools as any, messageRouter, agentCardRegistry);
+
+const mindManager = new MindManager(clientFactory, identityLoader, extensionLoader, configService, viewDiscovery, toolBuilder);
+const turnQueue = new TurnQueue();
+const chatService = new ChatService(mindManager, turnQueue);
+
+// Now wire A2A
+agentCardRegistry = new AgentCardRegistry(mindManager);
+messageRouter = new MessageRouter(chatService, agentCardRegistry, a2aEventBus);
 
 // Wire Lens refresh to use the mind's session
 viewDiscovery.setRefreshHandler({
@@ -106,6 +127,7 @@ app.on('ready', async () => {
   setupLensIPC(viewDiscovery, mindManager);
   setupGenesisIPC(mindManager, scaffold);
   setupAuthIPC(authService);
+  setupA2AIPC(a2aEventBus, agentCardRegistry);
 
   // Window controls
   ipcMain.on('window:minimize', () => mainWindow?.minimize());

--- a/src/main/integration/a2a-flow.test.ts
+++ b/src/main/integration/a2a-flow.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { TurnQueue } from '../services/chat/TurnQueue';
+import { ChatService } from '../services/chat/ChatService';
+import { AgentCardRegistry } from '../services/a2a/AgentCardRegistry';
+import { MessageRouter } from '../services/a2a/MessageRouter';
+import { buildSessionTools } from '../services/a2a/tools';
+import type { SendMessageRequest } from '../services/a2a/types';
+
+// --- Mock SDK primitives ---
+
+function makeMockSession() {
+  return {
+    send: vi.fn(async () => {}),
+    abort: vi.fn(async () => {}),
+    on: vi.fn((event: string, cb?: any) => {
+      // Fire session.idle immediately after send
+      if (event === 'session.idle' && cb) {
+        setTimeout(() => cb(), 0);
+      }
+      return vi.fn();
+    }),
+  };
+}
+
+function makeMockMindManager() {
+  const sessions = new Map<string, ReturnType<typeof makeMockSession>>();
+  const emitter = new EventEmitter();
+
+  const mgr = Object.assign(emitter, {
+    getMind: vi.fn((mindId: string) => {
+      if (!sessions.has(mindId)) return undefined;
+      return {
+        session: sessions.get(mindId),
+        client: { listModels: vi.fn(async () => []) },
+      };
+    }),
+    recreateSession: vi.fn(async () => {}),
+    _addMind(mindId: string, name: string, mindPath: string) {
+      sessions.set(mindId, makeMockSession());
+      emitter.emit('mind:loaded', {
+        mindId,
+        mindPath,
+        identity: { name, systemMessage: `I am ${name}` },
+        status: 'ready',
+      });
+    },
+  });
+
+  return mgr;
+}
+
+describe('A2A Integration', () => {
+  let mindManager: ReturnType<typeof makeMockMindManager>;
+  let turnQueue: TurnQueue;
+  let chatService: ChatService;
+  let agentCardRegistry: AgentCardRegistry;
+  let messageRouter: MessageRouter;
+  let a2aEventBus: EventEmitter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mindManager = makeMockMindManager();
+    turnQueue = new TurnQueue();
+    chatService = new ChatService(mindManager as any, turnQueue);
+    agentCardRegistry = new AgentCardRegistry(mindManager as any);
+    a2aEventBus = new EventEmitter();
+    messageRouter = new MessageRouter(chatService, agentCardRegistry, a2aEventBus);
+
+    // Load two minds
+    mindManager._addMind('agent-a', 'Agent A', 'C:\\agents\\a');
+    mindManager._addMind('agent-b', 'Agent B', 'C:\\agents\\b');
+  });
+
+  it('end-to-end: Agent A sends message to Agent B', async () => {
+    // Verify registry has both agents
+    expect(agentCardRegistry.getCards()).toHaveLength(2);
+    expect(agentCardRegistry.getCard('agent-a')).toBeTruthy();
+    expect(agentCardRegistry.getCard('agent-b')).toBeTruthy();
+
+    // Build tools for Agent A
+    const tools = buildSessionTools('agent-a', [], messageRouter, agentCardRegistry);
+    const sendTool = tools.find(t => t.name === 'a2a_send_message')!;
+
+    // Track a2a:incoming
+    const incomingEvents: unknown[] = [];
+    a2aEventBus.on('a2a:incoming', (payload) => incomingEvents.push(payload));
+
+    // Agent A sends message to Agent B
+    const result = await sendTool.handler({ recipient: 'agent-b', message: 'Hello from A' }) as any;
+
+    // Verify response
+    expect(result.message).toBeDefined();
+    expect(result.message.contextId).toBeTruthy();
+    expect(result.message.parts[0].text).toBe('Hello from A');
+
+    // Verify a2a:incoming was emitted
+    expect(incomingEvents).toHaveLength(1);
+    const incoming = incomingEvents[0] as any;
+    expect(incoming.targetMindId).toBe('agent-b');
+    expect(incoming.replyMessageId).toBeTruthy();
+
+    // Verify ChatService was called for Agent B
+    const bSession = mindManager.getMind('agent-b')!.session;
+    expect(bSession.send).toHaveBeenCalled();
+    const prompt = bSession.send.mock.calls[0][0].prompt;
+    expect(prompt).toContain('<agent-message');
+    expect(prompt).toContain('from-name="agent-a"');
+    expect(prompt).toContain('Hello from A');
+  });
+
+  it('end-to-end: message queues behind active turn', async () => {
+    const order: string[] = [];
+
+    // Start a long-running user turn on Agent B
+    const bSession = mindManager.getMind('agent-b')!.session;
+    let resolveUserTurn: () => void;
+    const userTurnDone = new Promise<void>(r => { resolveUserTurn = r; });
+
+    bSession.send.mockImplementationOnce(async () => {
+      order.push('user-turn-start');
+      await userTurnDone;
+      order.push('user-turn-end');
+    });
+
+    // Fire session.idle after send completes
+    bSession.on.mockImplementation((event: string, cb?: any) => {
+      if (event === 'session.idle' && cb) {
+        userTurnDone.then(() => setTimeout(() => cb(), 0));
+      }
+      return vi.fn();
+    });
+
+    // Start user chat (don't await yet)
+    const userChatPromise = chatService.sendMessage('agent-b', 'User message', 'user-msg-1', vi.fn());
+
+    // Give the user turn a moment to start
+    await new Promise(r => setTimeout(r, 10));
+
+    // Now Agent A sends A2A message — should queue behind user turn
+    bSession.send.mockImplementationOnce(async () => {
+      order.push('a2a-turn');
+    });
+    bSession.on.mockImplementation((event: string, cb?: any) => {
+      if (event === 'session.idle' && cb) {
+        setTimeout(() => cb(), 0);
+      }
+      return vi.fn();
+    });
+
+    const a2aPromise = messageRouter.sendMessage({
+      recipient: 'agent-b',
+      message: {
+        messageId: 'msg-a2a',
+        role: 'user',
+        parts: [{ text: 'A2A message' }],
+        metadata: { fromId: 'agent-a', fromName: 'Agent A', hopCount: 0 },
+      },
+      configuration: { returnImmediately: false },
+    });
+
+    // Resolve user turn
+    resolveUserTurn!();
+    await userChatPromise;
+    await a2aPromise;
+
+    expect(order[0]).toBe('user-turn-start');
+    expect(order[1]).toBe('user-turn-end');
+    expect(order[2]).toBe('a2a-turn');
+  });
+
+  it('end-to-end: hop count prevents message loop', async () => {
+    const request: SendMessageRequest = {
+      recipient: 'agent-b',
+      message: {
+        messageId: 'msg-loop',
+        role: 'user',
+        parts: [{ text: 'Loop' }],
+        metadata: { fromId: 'agent-a', fromName: 'Agent A', hopCount: 6 },
+      },
+    };
+
+    await expect(messageRouter.sendMessage(request)).rejects.toThrow(/hop count/i);
+  });
+});

--- a/src/main/integration/a2a-flow.test.ts
+++ b/src/main/integration/a2a-flow.test.ts
@@ -63,9 +63,13 @@ describe('A2A Integration', () => {
     mindManager = makeMockMindManager();
     turnQueue = new TurnQueue();
     chatService = new ChatService(mindManager as any, turnQueue);
-    agentCardRegistry = new AgentCardRegistry(mindManager as any);
+    agentCardRegistry = new AgentCardRegistry();
     a2aEventBus = new EventEmitter();
     messageRouter = new MessageRouter(chatService, agentCardRegistry, a2aEventBus);
+
+    // Wire registry to mind lifecycle (mirrors main.ts)
+    mindManager.on('mind:loaded', (ctx: any) => agentCardRegistry.register(ctx));
+    mindManager.on('mind:unloaded', (mindId: string) => agentCardRegistry.unregister(mindId));
 
     // Load two minds
     mindManager._addMind('agent-a', 'Agent A', 'C:\\agents\\a');
@@ -170,16 +174,33 @@ describe('A2A Integration', () => {
   });
 
   it('end-to-end: hop count prevents message loop', async () => {
-    const request: SendMessageRequest = {
+    const contextId = 'ctx-loop-test';
+
+    // Send MAX_HOPS messages on the same contextId — each increments the counter
+    for (let i = 0; i < 5; i++) {
+      await messageRouter.sendMessage({
+        recipient: 'agent-b',
+        message: {
+          messageId: `msg-loop-${i}`,
+          role: 'user',
+          parts: [{ text: `Loop ${i}` }],
+          contextId,
+          metadata: { fromId: 'agent-a', fromName: 'Agent A' },
+        },
+        configuration: { returnImmediately: true },
+      });
+    }
+
+    // The 6th message should be rejected (contextHops is now 5, which exceeds MAX_HOPS)
+    await expect(messageRouter.sendMessage({
       recipient: 'agent-b',
       message: {
-        messageId: 'msg-loop',
+        messageId: 'msg-loop-6',
         role: 'user',
-        parts: [{ text: 'Loop' }],
-        metadata: { fromId: 'agent-a', fromName: 'Agent A', hopCount: 6 },
+        parts: [{ text: 'Loop 6' }],
+        contextId,
+        metadata: { fromId: 'agent-a', fromName: 'Agent A' },
       },
-    };
-
-    await expect(messageRouter.sendMessage(request)).rejects.toThrow(/hop count/i);
+    })).rejects.toThrow(/hop count/i);
   });
 });

--- a/src/main/ipc/a2a.test.ts
+++ b/src/main/ipc/a2a.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+  },
+}));
+
+import { ipcMain, BrowserWindow } from 'electron';
+import { setupA2AIPC } from './a2a';
+
+const mockRegistry = {
+  getCards: vi.fn(() => [
+    { mindId: 'agent-a', name: 'Agent A' },
+    { mindId: 'agent-b', name: 'Agent B' },
+  ]),
+};
+
+describe('A2A IPC', () => {
+  let ipcEmitter: EventEmitter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcEmitter = new EventEmitter();
+    setupA2AIPC(ipcEmitter, mockRegistry as any);
+  });
+
+  it('a2a:incoming forwards to all windows', () => {
+    const mockWebContents1 = { send: vi.fn() };
+    const mockWebContents2 = { send: vi.fn() };
+    (BrowserWindow.getAllWindows as any).mockReturnValue([
+      { webContents: mockWebContents1 },
+      { webContents: mockWebContents2 },
+    ]);
+
+    const payload = {
+      targetMindId: 'agent-b',
+      message: { messageId: 'msg-1', role: 'user', parts: [{ text: 'Hello' }] },
+      replyMessageId: 'reply-1',
+    };
+    ipcEmitter.emit('a2a:incoming', payload);
+
+    expect(mockWebContents1.send).toHaveBeenCalledWith('a2a:incoming', payload);
+    expect(mockWebContents2.send).toHaveBeenCalledWith('a2a:incoming', payload);
+  });
+
+  it('a2a:incoming payload includes message and replyMessageId', () => {
+    const mockWebContents = { send: vi.fn() };
+    (BrowserWindow.getAllWindows as any).mockReturnValue([{ webContents: mockWebContents }]);
+
+    const payload = {
+      targetMindId: 'agent-b',
+      message: { messageId: 'msg-1', role: 'user', parts: [{ text: 'Test' }], metadata: { fromId: 'agent-a', fromName: 'Agent A' } },
+      replyMessageId: 'reply-msg-1',
+    };
+    ipcEmitter.emit('a2a:incoming', payload);
+
+    const sent = mockWebContents.send.mock.calls[0];
+    expect(sent[0]).toBe('a2a:incoming');
+    expect(sent[1]).toHaveProperty('message');
+    expect(sent[1]).toHaveProperty('replyMessageId', 'reply-msg-1');
+    expect(sent[1]).toHaveProperty('targetMindId', 'agent-b');
+  });
+
+  it('a2a:listAgents returns cards from registry', async () => {
+    const handleCalls = (ipcMain.handle as any).mock.calls;
+    const listHandler = handleCalls.find((c: any) => c[0] === 'a2a:listAgents');
+    expect(listHandler).toBeDefined();
+
+    const result = await listHandler[1]({});
+    expect(result).toEqual([
+      { mindId: 'agent-a', name: 'Agent A' },
+      { mindId: 'agent-b', name: 'Agent B' },
+    ]);
+    expect(mockRegistry.getCards).toHaveBeenCalled();
+  });
+});

--- a/src/main/ipc/a2a.ts
+++ b/src/main/ipc/a2a.ts
@@ -1,0 +1,23 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import type { EventEmitter } from 'events';
+import type { AgentCardRegistry } from '../services/a2a/AgentCardRegistry';
+
+export function setupA2AIPC(ipcEmitter: EventEmitter, agentCardRegistry: AgentCardRegistry): void {
+  // Forward a2a:incoming events to all renderer windows
+  ipcEmitter.on('a2a:incoming', (payload) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('a2a:incoming', payload);
+    }
+  });
+
+  // Forward A2A chat events (streaming from target agent) to all renderer windows
+  ipcEmitter.on('a2a:chat-event', (payload: { mindId: string; messageId: string; event: unknown }) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('chat:event', payload.mindId, payload.messageId, payload.event);
+    }
+  });
+
+  ipcMain.handle('a2a:listAgents', async () => {
+    return agentCardRegistry.getCards();
+  });
+}

--- a/src/main/services/a2a/AgentCardRegistry.test.ts
+++ b/src/main/services/a2a/AgentCardRegistry.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { MindContext } from '../../../shared/types';
+
+// Mock fs before importing the module under test
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readdirSync: vi.fn(() => []),
+    readFileSync: vi.fn(() => ''),
+  };
+});
+
+import * as fs from 'fs';
+import { AgentCardRegistry } from './AgentCardRegistry';
+
+function makeMindContext(overrides: Partial<MindContext> = {}): MindContext {
+  return {
+    mindId: 'q-123',
+    mindPath: 'C:\\src\\q',
+    identity: { name: 'Q', systemMessage: 'I am Q' },
+    status: 'ready',
+    ...overrides,
+  } as MindContext;
+}
+
+describe('AgentCardRegistry', () => {
+  let emitter: EventEmitter;
+  let registry: AgentCardRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emitter = new EventEmitter();
+    registry = new AgentCardRegistry(emitter);
+  });
+
+  it('registers card when mind:loaded fires', () => {
+    emitter.emit('mind:loaded', makeMindContext());
+    const card = registry.getCard('q-123');
+    expect(card).not.toBeNull();
+    expect(card!.name).toBe('Q');
+  });
+
+  it('AgentCard has all required A2A fields', () => {
+    emitter.emit('mind:loaded', makeMindContext());
+    const card = registry.getCard('q-123')!;
+
+    expect(card.name).toBe('Q');
+    expect(card.description).toBeTruthy();
+    expect(card.version).toBeTruthy();
+    expect(card.supportedInterfaces.length).toBeGreaterThan(0);
+    expect(card.capabilities).toEqual(expect.objectContaining({ streaming: true }));
+    expect(card.defaultInputModes).toContain('text/plain');
+    expect(card.defaultOutputModes).toContain('text/plain');
+    expect(Array.isArray(card.skills)).toBe(true);
+    expect(card.mindId).toBe('q-123');
+  });
+
+  it('supportedInterfaces uses IN_PROCESS binding', () => {
+    emitter.emit('mind:loaded', makeMindContext());
+    const iface = registry.getCard('q-123')!.supportedInterfaces[0];
+
+    expect(iface.protocolBinding).toBe('IN_PROCESS');
+    expect(iface.protocolVersion).toBe('1.0');
+  });
+
+  it('removes card when mind:unloaded fires', () => {
+    emitter.emit('mind:loaded', makeMindContext());
+    expect(registry.getCard('q-123')).not.toBeNull();
+
+    emitter.emit('mind:unloaded', 'q-123');
+    expect(registry.getCard('q-123')).toBeNull();
+  });
+
+  it('getCards() returns all registered cards', () => {
+    emitter.emit('mind:loaded', makeMindContext({ mindId: 'a', identity: { name: 'A', systemMessage: '' } }));
+    emitter.emit('mind:loaded', makeMindContext({ mindId: 'b', identity: { name: 'B', systemMessage: '' } }));
+    emitter.emit('mind:loaded', makeMindContext({ mindId: 'c', identity: { name: 'C', systemMessage: '' } }));
+
+    expect(registry.getCards()).toHaveLength(3);
+  });
+
+  it('getCardByName() resolves by identity name', () => {
+    emitter.emit('mind:loaded', makeMindContext({ mindId: 'q-123', identity: { name: 'Q', systemMessage: '' } }));
+    const card = registry.getCardByName('Q');
+
+    expect(card).not.toBeNull();
+    expect(card!.mindId).toBe('q-123');
+  });
+
+  it('getCardByName() returns null for ambiguous names', () => {
+    emitter.emit('mind:loaded', makeMindContext({ mindId: 'q-1', identity: { name: 'Q', systemMessage: '' } }));
+    emitter.emit('mind:loaded', makeMindContext({ mindId: 'q-2', identity: { name: 'Q', systemMessage: '' } }));
+
+    expect(registry.getCardByName('Q')).toBeNull();
+  });
+
+  it('discovers skills from .github/skills/ directories', () => {
+    const mindPath = 'C:\\src\\q';
+    const skillsDir = `${mindPath}\\.github\\skills`;
+
+    vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith('.github\\skills')) return true;
+      if (s.endsWith('commit\\SKILL.md')) return true;
+      if (s.endsWith('teams\\SKILL.md')) return true;
+      return false;
+    });
+
+    vi.mocked(fs.readdirSync).mockImplementation(((p: string) => {
+      if (String(p).endsWith('.github\\skills')) {
+        return [
+          { name: 'commit', isDirectory: () => true },
+          { name: 'teams', isDirectory: () => true },
+        ] as unknown as fs.Dirent[];
+      }
+      return [];
+    }) as typeof fs.readdirSync);
+
+    vi.mocked(fs.readFileSync).mockImplementation(((p: string) => {
+      if (String(p).endsWith('commit\\SKILL.md')) return '# Commit\nCommits changes to git.';
+      if (String(p).endsWith('teams\\SKILL.md')) return '# Teams\nSend messages via Teams.';
+      return '';
+    }) as typeof fs.readFileSync);
+
+    emitter.emit('mind:loaded', makeMindContext({ mindPath }));
+    const card = registry.getCard('q-123')!;
+
+    expect(card.skills).toHaveLength(2);
+
+    const commit = card.skills.find((s) => s.id === 'commit')!;
+    expect(commit.name).toBe('Commit');
+    expect(commit.description).toBe('Commits changes to git.');
+    expect(commit.tags).toContain('commit');
+
+    const teams = card.skills.find((s) => s.id === 'teams')!;
+    expect(teams.name).toBe('Teams');
+    expect(teams.description).toBe('Send messages via Teams.');
+    expect(teams.tags).toContain('teams');
+  });
+});

--- a/src/main/services/a2a/AgentCardRegistry.test.ts
+++ b/src/main/services/a2a/AgentCardRegistry.test.ts
@@ -37,14 +37,14 @@ describe('AgentCardRegistry', () => {
   });
 
   it('registers card when mind:loaded fires', () => {
-    emitter.emit('mind:loaded', makeMindContext());
+    registry.register(makeMindContext());
     const card = registry.getCard('q-123');
     expect(card).not.toBeNull();
     expect(card!.name).toBe('Q');
   });
 
   it('AgentCard has all required A2A fields', () => {
-    emitter.emit('mind:loaded', makeMindContext());
+    registry.register(makeMindContext());
     const card = registry.getCard('q-123')!;
 
     expect(card.name).toBe('Q');
@@ -59,7 +59,7 @@ describe('AgentCardRegistry', () => {
   });
 
   it('supportedInterfaces uses IN_PROCESS binding', () => {
-    emitter.emit('mind:loaded', makeMindContext());
+    registry.register(makeMindContext());
     const iface = registry.getCard('q-123')!.supportedInterfaces[0];
 
     expect(iface.protocolBinding).toBe('IN_PROCESS');
@@ -67,23 +67,23 @@ describe('AgentCardRegistry', () => {
   });
 
   it('removes card when mind:unloaded fires', () => {
-    emitter.emit('mind:loaded', makeMindContext());
+    registry.register(makeMindContext());
     expect(registry.getCard('q-123')).not.toBeNull();
 
-    emitter.emit('mind:unloaded', 'q-123');
+    registry.unregister('q-123');
     expect(registry.getCard('q-123')).toBeNull();
   });
 
   it('getCards() returns all registered cards', () => {
-    emitter.emit('mind:loaded', makeMindContext({ mindId: 'a', identity: { name: 'A', systemMessage: '' } }));
-    emitter.emit('mind:loaded', makeMindContext({ mindId: 'b', identity: { name: 'B', systemMessage: '' } }));
-    emitter.emit('mind:loaded', makeMindContext({ mindId: 'c', identity: { name: 'C', systemMessage: '' } }));
+    registry.register(makeMindContext({ mindId: 'a', identity: { name: 'A', systemMessage: '' } }));
+    registry.register(makeMindContext({ mindId: 'b', identity: { name: 'B', systemMessage: '' } }));
+    registry.register(makeMindContext({ mindId: 'c', identity: { name: 'C', systemMessage: '' } }));
 
     expect(registry.getCards()).toHaveLength(3);
   });
 
   it('getCardByName() resolves by identity name', () => {
-    emitter.emit('mind:loaded', makeMindContext({ mindId: 'q-123', identity: { name: 'Q', systemMessage: '' } }));
+    registry.register(makeMindContext({ mindId: 'q-123', identity: { name: 'Q', systemMessage: '' } }));
     const card = registry.getCardByName('Q');
 
     expect(card).not.toBeNull();
@@ -91,8 +91,8 @@ describe('AgentCardRegistry', () => {
   });
 
   it('getCardByName() returns null for ambiguous names', () => {
-    emitter.emit('mind:loaded', makeMindContext({ mindId: 'q-1', identity: { name: 'Q', systemMessage: '' } }));
-    emitter.emit('mind:loaded', makeMindContext({ mindId: 'q-2', identity: { name: 'Q', systemMessage: '' } }));
+    registry.register(makeMindContext({ mindId: 'q-1', identity: { name: 'Q', systemMessage: '' } }));
+    registry.register(makeMindContext({ mindId: 'q-2', identity: { name: 'Q', systemMessage: '' } }));
 
     expect(registry.getCardByName('Q')).toBeNull();
   });
@@ -125,7 +125,7 @@ describe('AgentCardRegistry', () => {
       return '';
     }) as typeof fs.readFileSync);
 
-    emitter.emit('mind:loaded', makeMindContext({ mindPath }));
+    registry.register(makeMindContext({ mindPath }));
     const card = registry.getCard('q-123')!;
 
     expect(card.skills).toHaveLength(2);
@@ -141,3 +141,4 @@ describe('AgentCardRegistry', () => {
     expect(teams.tags).toContain('teams');
   });
 });
+

--- a/src/main/services/a2a/AgentCardRegistry.ts
+++ b/src/main/services/a2a/AgentCardRegistry.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentCard, AgentSkill } from './types';
+import type { MindContext } from '../../../shared/types';
+
+export class AgentCardRegistry {
+  private cards = new Map<string, AgentCard>();
+
+  constructor(mindManager: EventEmitter) {
+    mindManager.on('mind:loaded', (ctx: MindContext) => this.register(ctx));
+    mindManager.on('mind:unloaded', (mindId: string) => this.unregister(mindId));
+  }
+
+  getCard(mindId: string): AgentCard | null {
+    return this.cards.get(mindId) ?? null;
+  }
+
+  getCards(): AgentCard[] {
+    return [...this.cards.values()];
+  }
+
+  getCardByName(name: string): AgentCard | null {
+    const matches = this.getCards().filter((c) => c.name === name);
+    return matches.length === 1 ? matches[0] : null;
+  }
+
+  private register(ctx: MindContext): void {
+    const skills = this.discoverSkills(ctx.mindPath);
+    const description = this.extractDescription(ctx.identity.systemMessage, ctx.identity.name);
+
+    const card: AgentCard = {
+      name: ctx.identity.name,
+      description,
+      version: '1.0.0',
+      supportedInterfaces: [
+        { url: 'in-process', protocolBinding: 'IN_PROCESS', protocolVersion: '1.0' },
+      ],
+      capabilities: { streaming: true },
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills,
+      mindId: ctx.mindId,
+    };
+    this.cards.set(ctx.mindId, card);
+  }
+
+  private unregister(mindId: string): void {
+    this.cards.delete(mindId);
+  }
+
+  private discoverSkills(mindPath: string): AgentSkill[] {
+    const skillsDir = path.join(mindPath, '.github', 'skills');
+    if (!fs.existsSync(skillsDir)) return [];
+
+    const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isDirectory())
+      .map((e) => {
+        const skillMd = path.join(skillsDir, e.name, 'SKILL.md');
+        if (!fs.existsSync(skillMd)) return null;
+        const content = fs.readFileSync(skillMd, 'utf-8');
+        const name = this.extractSkillName(content, e.name);
+        const description = this.extractSkillDescription(content);
+        return { id: e.name, name, description, tags: [e.name] } as AgentSkill;
+      })
+      .filter((s): s is AgentSkill => s !== null);
+  }
+
+  private extractDescription(systemMessage: string, fallbackName: string): string {
+    const lines = systemMessage.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) return trimmed;
+    }
+    return `${fallbackName} agent`;
+  }
+
+  private extractSkillName(content: string, fallback: string): string {
+    const match = content.match(/^#\s+(.+)/m);
+    return match ? match[1].trim() : fallback;
+  }
+
+  private extractSkillDescription(content: string): string {
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) return trimmed;
+    }
+    return '';
+  }
+}

--- a/src/main/services/a2a/AgentCardRegistry.ts
+++ b/src/main/services/a2a/AgentCardRegistry.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentCard, AgentSkill } from './types';
@@ -6,11 +5,6 @@ import type { MindContext } from '../../../shared/types';
 
 export class AgentCardRegistry {
   private cards = new Map<string, AgentCard>();
-
-  constructor(mindManager: EventEmitter) {
-    mindManager.on('mind:loaded', (ctx: MindContext) => this.register(ctx));
-    mindManager.on('mind:unloaded', (mindId: string) => this.unregister(mindId));
-  }
 
   getCard(mindId: string): AgentCard | null {
     return this.cards.get(mindId) ?? null;
@@ -25,7 +19,7 @@ export class AgentCardRegistry {
     return matches.length === 1 ? matches[0] : null;
   }
 
-  private register(ctx: MindContext): void {
+  register(ctx: MindContext): void {
     const skills = this.discoverSkills(ctx.mindPath);
     const description = this.extractDescription(ctx.identity.systemMessage, ctx.identity.name);
 
@@ -45,7 +39,7 @@ export class AgentCardRegistry {
     this.cards.set(ctx.mindId, card);
   }
 
-  private unregister(mindId: string): void {
+  unregister(mindId: string): void {
     this.cards.delete(mindId);
   }
 

--- a/src/main/services/a2a/MessageRouter.test.ts
+++ b/src/main/services/a2a/MessageRouter.test.ts
@@ -93,32 +93,38 @@ describe('MessageRouter', () => {
     expect(res.message!.contextId).toBe('ctx-123');
   });
 
-  it('sendMessage() rejects when hopCount exceeds MAX_HOPS', async () => {
+  it('sendMessage() rejects when context hops exceed MAX_HOPS', async () => {
     mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
-    const req = makeRequest('target-1', 'loop', {
-      message: {
-        messageId: 'msg-loop',
-        role: 'user',
-        parts: [{ text: 'loop' }],
-        metadata: { fromId: 'a', fromName: 'A', hopCount: 6 },
-      },
-    });
-    await expect(router.sendMessage(req)).rejects.toThrow(/hop count/i);
+    const contextId = 'ctx-loop';
+
+    // Send 5 messages — each increments the context hop counter
+    for (let i = 0; i < 5; i++) {
+      await router.sendMessage(makeRequest('target-1', `msg-${i}`, {
+        message: { messageId: `msg-${i}`, role: 'user', parts: [{ text: `msg-${i}` }], contextId, metadata: { fromId: 'a', fromName: 'A' } },
+      }));
+    }
+
+    // 6th should be rejected (contextHops is now 5, exceeds MAX_HOPS)
+    await expect(router.sendMessage(makeRequest('target-1', 'too many', {
+      message: { messageId: 'msg-6', role: 'user', parts: [{ text: 'too many' }], contextId, metadata: { fromId: 'a', fromName: 'A' } },
+    }))).rejects.toThrow(/hop count/i);
   });
 
-  it('sendMessage() increments hopCount before delivery', async () => {
+  it('sendMessage() increments hop count per contextId', async () => {
     mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
-    const req = makeRequest('target-1', 'ping', {
-      message: {
-        messageId: 'msg-hop',
-        role: 'user',
-        parts: [{ text: 'ping' }],
-        metadata: { fromId: 'a', fromName: 'A', hopCount: 2 },
-      },
-    });
-    await router.sendMessage(req);
-    const xmlPrompt = mockChatService.sendMessage.mock.calls[0][1] as string;
-    expect(xmlPrompt).toContain('hop-count="3"');
+    const contextId = 'ctx-hop-track';
+
+    await router.sendMessage(makeRequest('target-1', 'first', {
+      message: { messageId: 'msg-1', role: 'user', parts: [{ text: 'first' }], contextId, metadata: { fromId: 'a', fromName: 'A' } },
+    }));
+    // First message: hopCount should be 1
+    expect(mockChatService.sendMessage.mock.calls[0][1]).toContain('hop-count="1"');
+
+    await router.sendMessage(makeRequest('target-1', 'second', {
+      message: { messageId: 'msg-2', role: 'user', parts: [{ text: 'second' }], contextId, metadata: { fromId: 'a', fromName: 'A' } },
+    }));
+    // Second message: hopCount should be 2
+    expect(mockChatService.sendMessage.mock.calls[1][1]).toContain('hop-count="2"');
   });
 
   it('sendMessage() emits a2a:incoming before delivery', async () => {

--- a/src/main/services/a2a/MessageRouter.test.ts
+++ b/src/main/services/a2a/MessageRouter.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { MessageRouter } from './MessageRouter';
+import type { AgentCard, SendMessageRequest } from './types';
+
+const mockRegistry = {
+  getCard: vi.fn() as any,
+  getCards: vi.fn() as any,
+  getCardByName: vi.fn() as any,
+};
+
+const mockChatService = {
+  sendMessage: vi.fn(async () => {}),
+};
+
+function makeCard(overrides: Partial<AgentCard> & { mindId: string; name: string }): AgentCard {
+  return {
+    description: 'Test agent',
+    version: '1.0.0',
+    supportedInterfaces: [{ url: 'in-process', protocolBinding: 'IN_PROCESS', protocolVersion: '1.0' }],
+    capabilities: { streaming: true },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    ...overrides,
+  };
+}
+
+function makeRequest(recipient: string, text: string, opts?: Partial<SendMessageRequest>): SendMessageRequest {
+  return {
+    recipient,
+    message: {
+      messageId: 'msg-test-1',
+      role: 'user',
+      parts: [{ text, mediaType: 'text/plain' }],
+      metadata: { fromId: 'sender-1', fromName: 'Sender', hopCount: 0 },
+      ...opts?.message,
+    },
+    configuration: { returnImmediately: true, ...opts?.configuration },
+    ...opts,
+  };
+}
+
+describe('MessageRouter', () => {
+  let router: MessageRouter;
+  let emitter: EventEmitter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emitter = new EventEmitter();
+    router = new MessageRouter(mockChatService as any, mockRegistry as any, emitter);
+  });
+
+  it('sendMessage() resolves recipient by mindId', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'hello');
+    const res = await router.sendMessage(req);
+    expect(mockRegistry.getCard).toHaveBeenCalledWith('target-1');
+    expect(res.message).toBeDefined();
+  });
+
+  it('sendMessage() resolves recipient by name via registry', async () => {
+    mockRegistry.getCard.mockReturnValue(null);
+    mockRegistry.getCardByName.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('Target', 'hello');
+    const res = await router.sendMessage(req);
+    expect(mockRegistry.getCardByName).toHaveBeenCalledWith('Target');
+    expect(res.message).toBeDefined();
+  });
+
+  it('sendMessage() rejects unknown recipient', async () => {
+    mockRegistry.getCard.mockReturnValue(null);
+    mockRegistry.getCardByName.mockReturnValue(null);
+    const req = makeRequest('nobody', 'hello');
+    await expect(router.sendMessage(req)).rejects.toThrow('Unknown recipient: nobody');
+  });
+
+  it('sendMessage() assigns contextId on first message', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'hello');
+    // Ensure no contextId on request
+    delete req.message.contextId;
+    const res = await router.sendMessage(req);
+    expect(res.message!.contextId).toMatch(/^ctx-/);
+  });
+
+  it('sendMessage() reuses contextId on follow-up', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'follow-up', {
+      message: { messageId: 'msg-2', role: 'user', parts: [{ text: 'follow-up' }], contextId: 'ctx-123' },
+    });
+    const res = await router.sendMessage(req);
+    expect(res.message!.contextId).toBe('ctx-123');
+  });
+
+  it('sendMessage() rejects when hopCount exceeds MAX_HOPS', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'loop', {
+      message: {
+        messageId: 'msg-loop',
+        role: 'user',
+        parts: [{ text: 'loop' }],
+        metadata: { fromId: 'a', fromName: 'A', hopCount: 6 },
+      },
+    });
+    await expect(router.sendMessage(req)).rejects.toThrow(/hop count/i);
+  });
+
+  it('sendMessage() increments hopCount before delivery', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'ping', {
+      message: {
+        messageId: 'msg-hop',
+        role: 'user',
+        parts: [{ text: 'ping' }],
+        metadata: { fromId: 'a', fromName: 'A', hopCount: 2 },
+      },
+    });
+    await router.sendMessage(req);
+    const xmlPrompt = mockChatService.sendMessage.mock.calls[0][1] as string;
+    expect(xmlPrompt).toContain('hop-count="3"');
+  });
+
+  it('sendMessage() emits a2a:incoming before delivery', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+
+    const events: any[] = [];
+    emitter.on('a2a:incoming', (payload) => events.push(payload));
+
+    // Track ordering: record when event fires vs when chatService is called
+    let eventFiredBeforeChat = false;
+    mockChatService.sendMessage.mockImplementation(async () => {
+      eventFiredBeforeChat = events.length > 0;
+    });
+
+    const req = makeRequest('target-1', 'hi');
+    await router.sendMessage(req);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].targetMindId).toBe('target-1');
+    expect(events[0].message).toBeDefined();
+    expect(events[0].replyMessageId).toMatch(/^msg-/);
+    expect(eventFiredBeforeChat).toBe(true);
+  });
+
+  it('sendMessage() delivers via ChatService', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'deliver me');
+    await router.sendMessage(req);
+
+    expect(mockChatService.sendMessage).toHaveBeenCalledTimes(1);
+    const [mindId, xmlPrompt, messageId, emitFn] = mockChatService.sendMessage.mock.calls[0];
+    expect(mindId).toBe('target-1');
+    expect(xmlPrompt).toContain('<agent-message');
+    expect(messageId).toMatch(/^msg-/);
+    expect(typeof emitFn).toBe('function');
+  });
+
+  it('sendMessage() returns SendMessageResponse with message', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'response check');
+    const res = await router.sendMessage(req);
+
+    expect(res.message).toBeDefined();
+    expect(res.message!.messageId).toBe('msg-test-1');
+    expect(res.message!.role).toBe('user');
+    expect(res.message!.parts[0].text).toBe('response check');
+    expect(res.message!.contextId).toBeDefined();
+  });
+
+  it('XML prompt contains structured envelope', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+    const req = makeRequest('target-1', 'structured test', {
+      message: {
+        messageId: 'msg-xml',
+        role: 'user',
+        parts: [{ text: 'structured test', mediaType: 'text/plain' }],
+        metadata: { fromId: 'sender-1', fromName: 'Sender', hopCount: 0 },
+      },
+    });
+    await router.sendMessage(req);
+
+    const xmlPrompt = mockChatService.sendMessage.mock.calls[0][1] as string;
+    expect(xmlPrompt).toContain('<agent-message');
+    expect(xmlPrompt).toContain('from-id="sender-1"');
+    expect(xmlPrompt).toContain('from-name="Sender"');
+    expect(xmlPrompt).toContain('message-id="msg-xml"');
+    expect(xmlPrompt).toContain('<content>structured test</content>');
+    expect(xmlPrompt).toContain('</agent-message>');
+  });
+
+  it('sendMessage() returns immediately when returnImmediately is true', async () => {
+    mockRegistry.getCard.mockReturnValue(makeCard({ mindId: 'target-1', name: 'Target' }));
+
+    // Make chatService.sendMessage hang until we resolve it
+    let resolveDelivery!: () => void;
+    const deliveryPromise = new Promise<void>((resolve) => {
+      resolveDelivery = resolve;
+    });
+    mockChatService.sendMessage.mockReturnValue(deliveryPromise);
+
+    const req = makeRequest('target-1', 'fire and forget', {
+      configuration: { returnImmediately: true },
+    });
+
+    // Router should resolve before chatService finishes
+    const res = await router.sendMessage(req);
+    expect(res.message).toBeDefined();
+
+    // ChatService was called but hasn't resolved yet
+    expect(mockChatService.sendMessage).toHaveBeenCalledTimes(1);
+
+    // Clean up
+    resolveDelivery();
+    await deliveryPromise;
+  });
+});

--- a/src/main/services/a2a/MessageRouter.ts
+++ b/src/main/services/a2a/MessageRouter.ts
@@ -1,19 +1,19 @@
-import { EventEmitter } from 'events';
 import type { SendMessageRequest, SendMessageResponse, Message } from './types';
 import type { AgentCardRegistry } from './AgentCardRegistry';
 import type { ChatService } from '../chat/ChatService';
+import type { EventEmitter } from 'events';
 import { generateMessageId, generateContextId, serializeMessageToXml } from './helpers';
 
 const MAX_HOPS = 5;
 
-export class MessageRouter extends EventEmitter {
+export class MessageRouter {
+  private contextHops = new Map<string, number>();
+
   constructor(
     private readonly chatService: ChatService,
     private readonly registry: AgentCardRegistry,
     private readonly ipcEmitter: EventEmitter,
-  ) {
-    super();
-  }
+  ) {}
 
   async sendMessage(request: SendMessageRequest): Promise<SendMessageResponse> {
     // 1. Resolve recipient — try by mindId first, then by name
@@ -23,22 +23,24 @@ export class MessageRouter extends EventEmitter {
     }
     const targetMindId = card.mindId;
 
-    // 2. Validate hop count
-    const hopCount = (request.message.metadata?.hopCount as number) ?? 0;
-    if (hopCount > MAX_HOPS) {
-      throw new Error(`Message exceeded maximum hop count (${MAX_HOPS})`);
-    }
-
-    // 3. Assign/preserve contextId
+    // 2. Assign/preserve contextId
     const contextId = request.message.contextId || generateContextId();
 
-    // 4. Build the delivery message (with incremented hop count)
+    // 3. Resolve hop count from context tracking (not message metadata)
+    const currentHops = this.contextHops.get(contextId) ?? 0;
+    if (currentHops >= MAX_HOPS) {
+      throw new Error(`Message exceeded maximum hop count (${MAX_HOPS})`);
+    }
+    const nextHops = currentHops + 1;
+    this.contextHops.set(contextId, nextHops);
+
+    // 4. Build the delivery message
     const deliveryMessage: Message = {
       ...request.message,
       contextId,
       metadata: {
         ...request.message.metadata,
-        hopCount: hopCount + 1,
+        hopCount: nextHops,
       },
     };
 
@@ -70,6 +72,10 @@ export class MessageRouter extends EventEmitter {
 
     if (!returnImmediately) {
       await deliveryPromise;
+    } else {
+      deliveryPromise.catch((err) => {
+        console.error(`[MessageRouter] Delivery failed for ${targetMindId}:`, err);
+      });
     }
 
     // 8. Return response

--- a/src/main/services/a2a/MessageRouter.ts
+++ b/src/main/services/a2a/MessageRouter.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from 'events';
+import type { SendMessageRequest, SendMessageResponse, Message } from './types';
+import type { AgentCardRegistry } from './AgentCardRegistry';
+import type { ChatService } from '../chat/ChatService';
+import { generateMessageId, generateContextId, serializeMessageToXml } from './helpers';
+
+const MAX_HOPS = 5;
+
+export class MessageRouter extends EventEmitter {
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly registry: AgentCardRegistry,
+    private readonly ipcEmitter: EventEmitter,
+  ) {
+    super();
+  }
+
+  async sendMessage(request: SendMessageRequest): Promise<SendMessageResponse> {
+    // 1. Resolve recipient — try by mindId first, then by name
+    const card = this.registry.getCard(request.recipient) ?? this.registry.getCardByName(request.recipient);
+    if (!card?.mindId) {
+      throw new Error(`Unknown recipient: ${request.recipient}`);
+    }
+    const targetMindId = card.mindId;
+
+    // 2. Validate hop count
+    const hopCount = (request.message.metadata?.hopCount as number) ?? 0;
+    if (hopCount > MAX_HOPS) {
+      throw new Error(`Message exceeded maximum hop count (${MAX_HOPS})`);
+    }
+
+    // 3. Assign/preserve contextId
+    const contextId = request.message.contextId || generateContextId();
+
+    // 4. Build the delivery message (with incremented hop count)
+    const deliveryMessage: Message = {
+      ...request.message,
+      contextId,
+      metadata: {
+        ...request.message.metadata,
+        hopCount: hopCount + 1,
+      },
+    };
+
+    // 5. Serialize to XML for model injection
+    const xmlPrompt = serializeMessageToXml(deliveryMessage);
+    const replyMessageId = generateMessageId();
+
+    // 6. Emit a2a:incoming for renderer (before delivery)
+    this.ipcEmitter.emit('a2a:incoming', {
+      targetMindId,
+      message: deliveryMessage,
+      replyMessageId,
+    });
+
+    // 7. Deliver via ChatService — emit callback forwards events via IPC bus
+    const returnImmediately = request.configuration?.returnImmediately !== false;
+    const deliveryPromise = this.chatService.sendMessage(
+      targetMindId,
+      xmlPrompt,
+      replyMessageId,
+      (event) => {
+        this.ipcEmitter.emit('a2a:chat-event', {
+          mindId: targetMindId,
+          messageId: replyMessageId,
+          event,
+        });
+      },
+    );
+
+    if (!returnImmediately) {
+      await deliveryPromise;
+    }
+
+    // 8. Return response
+    return {
+      message: {
+        ...deliveryMessage,
+        contextId,
+      },
+    };
+  }
+}

--- a/src/main/services/a2a/helpers.ts
+++ b/src/main/services/a2a/helpers.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from 'crypto';
+import type { Message } from './types';
+
+export function generateMessageId(): string {
+  return `msg-${randomUUID()}`;
+}
+
+export function generateContextId(): string {
+  return `ctx-${randomUUID()}`;
+}
+
+export function createTextMessage(
+  fromId: string,
+  text: string,
+  opts?: { contextId?: string; fromName?: string; hopCount?: number },
+): Message {
+  return {
+    messageId: generateMessageId(),
+    contextId: opts?.contextId,
+    role: 'user',
+    parts: [{ text, mediaType: 'text/plain' }],
+    metadata: {
+      fromId,
+      fromName: opts?.fromName ?? fromId,
+      hopCount: opts?.hopCount ?? 0,
+    },
+  };
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function serializeMessageToXml(message: Message): string {
+  const fromId = (message.metadata?.fromId as string) ?? '';
+  const fromName = (message.metadata?.fromName as string) ?? '';
+  const hopCount = (message.metadata?.hopCount as number) ?? 0;
+  const textContent = message.parts.find((p) => p.text)?.text ?? '';
+
+  return `<agent-message from-id="${escapeXml(fromId)}" from-name="${escapeXml(fromName)}" message-id="${escapeXml(message.messageId)}" context-id="${escapeXml(message.contextId ?? '')}" hop-count="${hopCount}" role="${message.role}">
+  <content>${escapeXml(textContent)}</content>
+</agent-message>`;
+}

--- a/src/main/services/a2a/index.ts
+++ b/src/main/services/a2a/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './helpers';
+export { AgentCardRegistry } from './AgentCardRegistry';
+export { MessageRouter } from './MessageRouter';
+export { buildSessionTools } from './tools';

--- a/src/main/services/a2a/tools.test.ts
+++ b/src/main/services/a2a/tools.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildSessionTools } from './tools';
+
+const mockRouter = {
+  sendMessage: vi.fn(async (req: any) => ({
+    message: {
+      messageId: req.message.messageId,
+      contextId: 'ctx-assigned',
+      role: 'user',
+      parts: req.message.parts,
+    },
+  })),
+};
+
+const mockRegistry = {
+  getCard: vi.fn(),
+  getCards: vi.fn(() => [
+    {
+      mindId: 'mind-a',
+      name: 'Agent A',
+      description: 'First agent',
+      version: '1.0.0',
+      supportedInterfaces: [
+        { url: 'in-process', protocolBinding: 'IN_PROCESS', protocolVersion: '1.0' },
+      ],
+      capabilities: { streaming: true },
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [],
+    },
+    {
+      mindId: 'mind-b',
+      name: 'Agent B',
+      description: 'Second agent',
+      version: '1.0.0',
+      supportedInterfaces: [
+        { url: 'in-process', protocolBinding: 'IN_PROCESS', protocolVersion: '1.0' },
+      ],
+      capabilities: { streaming: true },
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [],
+    },
+    {
+      mindId: 'mind-c',
+      name: 'Agent C',
+      description: 'Third agent',
+      version: '1.0.0',
+      supportedInterfaces: [
+        { url: 'in-process', protocolBinding: 'IN_PROCESS', protocolVersion: '1.0' },
+      ],
+      capabilities: { streaming: true },
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [],
+    },
+  ]),
+  getCardByName: vi.fn(),
+};
+
+const extensionTools = [
+  { name: 'canvas_show', description: 'Show canvas', handler: vi.fn() },
+  { name: 'cron_create', description: 'Create cron', handler: vi.fn() },
+];
+
+describe('A2A Tools', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('buildSessionTools() merges extension tools with A2A tools', () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    expect(tools.length).toBe(4); // 2 extension + 2 A2A
+  });
+
+  it('buildSessionTools() includes send_message and list_agents', () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('a2a_send_message');
+    expect(names).toContain('a2a_list_agents');
+  });
+
+  it('send_message tool has correct parameter schema', () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const sendTool = tools.find((t) => t.name === 'a2a_send_message')!;
+    expect(sendTool.parameters).toBeDefined();
+    const params = sendTool.parameters as any;
+    expect(params.properties.recipient).toBeDefined();
+    expect(params.properties.message).toBeDefined();
+    expect(params.required).toContain('recipient');
+    expect(params.required).toContain('message');
+  });
+
+  it('send_message handler constructs conformant A2A Message', async () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const sendTool = tools.find((t) => t.name === 'a2a_send_message')!;
+    await sendTool.handler({ recipient: 'mind-b', message: 'Hello B' });
+
+    expect(mockRouter.sendMessage).toHaveBeenCalledTimes(1);
+    const req = mockRouter.sendMessage.mock.calls[0][0];
+    expect(req.message.role).toBe('user');
+    expect(req.message.parts[0].text).toBe('Hello B');
+    expect(req.message.parts[0].mediaType).toBe('text/plain');
+    expect(req.message.metadata.fromId).toBe('mind-a');
+    expect(req.message.metadata.hopCount).toBe(0);
+  });
+
+  it('send_message handler constructs SendMessageRequest with returnImmediately', async () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const sendTool = tools.find((t) => t.name === 'a2a_send_message')!;
+    await sendTool.handler({ recipient: 'mind-b', message: 'Hello' });
+
+    const req = mockRouter.sendMessage.mock.calls[0][0];
+    expect(req.recipient).toBe('mind-b');
+    expect(req.configuration.returnImmediately).toBe(true);
+  });
+
+  it('send_message handler returns SendMessageResponse shape', async () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const sendTool = tools.find((t) => t.name === 'a2a_send_message')!;
+    const result = await sendTool.handler({ recipient: 'mind-b', message: 'Hello' });
+
+    expect(result).toHaveProperty('message');
+    expect((result as any).message.contextId).toBe('ctx-assigned');
+  });
+
+  it('send_message handler passes context_id when provided', async () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const sendTool = tools.find((t) => t.name === 'a2a_send_message')!;
+    await sendTool.handler({
+      recipient: 'mind-b',
+      message: 'Follow up',
+      context_id: 'ctx-existing',
+    });
+
+    const req = mockRouter.sendMessage.mock.calls[0][0];
+    expect(req.message.contextId).toBe('ctx-existing');
+  });
+
+  it('list_agents returns AgentCards excluding self', async () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const listTool = tools.find((t) => t.name === 'a2a_list_agents')!;
+    const result = await listTool.handler({});
+
+    expect(Array.isArray(result)).toBe(true);
+    const agents = result as any[];
+    expect(agents.length).toBe(2); // 3 total minus self (mind-a)
+    expect(agents.every((a: any) => a.mindId !== 'mind-a')).toBe(true);
+  });
+
+  it('list_agents returns full A2A AgentCard shape', async () => {
+    const tools = buildSessionTools(
+      'mind-a',
+      extensionTools as any,
+      mockRouter as any,
+      mockRegistry as any,
+    );
+    const listTool = tools.find((t) => t.name === 'a2a_list_agents')!;
+    const result = (await listTool.handler({})) as any[];
+
+    const card = result[0];
+    expect(card).toHaveProperty('name');
+    expect(card).toHaveProperty('description');
+    expect(card).toHaveProperty('skills');
+    expect(card).toHaveProperty('supportedInterfaces');
+    expect(card).toHaveProperty('mindId');
+  });
+
+  it('tools are mind-scoped via closure', async () => {
+    const toolsA = buildSessionTools('mind-a', [], mockRouter as any, mockRegistry as any);
+    const toolsB = buildSessionTools('mind-b', [], mockRouter as any, mockRegistry as any);
+
+    const sendA = toolsA.find((t) => t.name === 'a2a_send_message')!;
+    const sendB = toolsB.find((t) => t.name === 'a2a_send_message')!;
+
+    await sendA.handler({ recipient: 'mind-c', message: 'From A' });
+    await sendB.handler({ recipient: 'mind-c', message: 'From B' });
+
+    expect(mockRouter.sendMessage.mock.calls[0][0].message.metadata.fromId).toBe('mind-a');
+    expect(mockRouter.sendMessage.mock.calls[1][0].message.metadata.fromId).toBe('mind-b');
+  });
+});

--- a/src/main/services/a2a/tools.ts
+++ b/src/main/services/a2a/tools.ts
@@ -1,0 +1,64 @@
+import type { MessageRouter } from './MessageRouter';
+import type { AgentCardRegistry } from './AgentCardRegistry';
+import { createTextMessage } from './helpers';
+
+interface SessionTool {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function buildSessionTools(
+  mindId: string,
+  extensionTools: SessionTool[],
+  messageRouter: MessageRouter,
+  agentCardRegistry: AgentCardRegistry,
+): SessionTool[] {
+  const sendMessage: SessionTool = {
+    name: 'a2a_send_message',
+    description:
+      'Send an A2A message to another agent loaded in Chamber. The message is delivered asynchronously — you will not receive the response. Use a2a_list_agents first to discover available agents.',
+    parameters: {
+      type: 'object',
+      properties: {
+        recipient: { type: 'string', description: 'The mindId or name of the target agent' },
+        message: { type: 'string', description: 'The message content to send' },
+        context_id: {
+          type: 'string',
+          description: 'Optional context ID to continue an existing conversation',
+        },
+      },
+      required: ['recipient', 'message'],
+    },
+    handler: async (args) => {
+      const { recipient, message: text, context_id } = args as {
+        recipient: string;
+        message: string;
+        context_id?: string;
+      };
+      const a2aMessage = createTextMessage(mindId, text, {
+        contextId: context_id,
+        hopCount: 0,
+      });
+      const response = await messageRouter.sendMessage({
+        recipient,
+        message: a2aMessage,
+        configuration: { returnImmediately: true },
+      });
+      return response;
+    },
+  };
+
+  const listAgents: SessionTool = {
+    name: 'a2a_list_agents',
+    description:
+      'List all available agents loaded in Chamber that you can communicate with via a2a_send_message, including their capabilities and skills.',
+    parameters: { type: 'object', properties: {} },
+    handler: async () => {
+      return agentCardRegistry.getCards().filter((c) => c.mindId !== mindId);
+    },
+  };
+
+  return [...extensionTools, sendMessage, listAgents];
+}

--- a/src/main/services/a2a/tools.ts
+++ b/src/main/services/a2a/tools.ts
@@ -18,7 +18,7 @@ export function buildSessionTools(
   const sendMessage: SessionTool = {
     name: 'a2a_send_message',
     description:
-      'Send an A2A message to another agent loaded in Chamber. The message is delivered asynchronously — you will not receive the response. Use a2a_list_agents first to discover available agents.',
+      'Send a message to another agent in this workspace. Messages are delivered to the other agent\'s conversation. Call a2a_list_agents first if you don\'t know the recipient\'s ID.',
     parameters: {
       type: 'object',
       properties: {
@@ -39,7 +39,6 @@ export function buildSessionTools(
       };
       const a2aMessage = createTextMessage(mindId, text, {
         contextId: context_id,
-        hopCount: 0,
       });
       const response = await messageRouter.sendMessage({
         recipient,
@@ -53,7 +52,7 @@ export function buildSessionTools(
   const listAgents: SessionTool = {
     name: 'a2a_list_agents',
     description:
-      'List all available agents loaded in Chamber that you can communicate with via a2a_send_message, including their capabilities and skills.',
+      'List other agents in this workspace that you can talk to. Returns their names, descriptions, and skills. Use this when the user asks about other agents or wants to send a message to one.',
     parameters: { type: 'object', properties: {} },
     handler: async () => {
       return agentCardRegistry.getCards().filter((c) => c.mindId !== mindId);

--- a/src/main/services/a2a/types.test.ts
+++ b/src/main/services/a2a/types.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import type { Part, Message } from './types';
+import {
+  generateMessageId,
+  generateContextId,
+  createTextMessage,
+  serializeMessageToXml,
+} from './helpers';
+
+describe('A2A Types', () => {
+  describe('createTextMessage', () => {
+    it('produces conformant Message with required fields', () => {
+      const msg = createTextMessage('sender-1', 'Hello');
+      expect(msg.messageId).toBeTruthy();
+      expect(typeof msg.messageId).toBe('string');
+      expect(msg.role).toBe('user');
+      expect(msg.parts).toHaveLength(1);
+      expect(msg.parts[0].text).toBe('Hello');
+      expect(msg.parts[0].mediaType).toBe('text/plain');
+      expect(msg.metadata).toBeDefined();
+      expect(msg.metadata?.fromId).toBe('sender-1');
+    });
+
+    it('includes contextId when provided', () => {
+      const msg = createTextMessage('sender-1', 'Hello', { contextId: 'ctx-123' });
+      expect(msg.contextId).toBe('ctx-123');
+    });
+
+    it('includes hopCount in metadata defaulting to 0', () => {
+      const msg = createTextMessage('sender-1', 'Hello');
+      expect(msg.metadata?.hopCount).toBe(0);
+    });
+  });
+
+  describe('Part', () => {
+    it('supports text content', () => {
+      const part: Part = { text: 'hello', mediaType: 'text/plain' };
+      expect(part.text).toBe('hello');
+      expect(part.mediaType).toBe('text/plain');
+    });
+
+    it('supports data content', () => {
+      const part: Part = { data: { key: 'value' }, mediaType: 'application/json' };
+      expect(part.data).toEqual({ key: 'value' });
+      expect(part.mediaType).toBe('application/json');
+    });
+  });
+
+  describe('serializeMessageToXml', () => {
+    it('produces valid XML envelope', () => {
+      const msg = createTextMessage('agent-1', 'Test content', {
+        contextId: 'ctx-42',
+        fromName: 'Agent One',
+      });
+      const xml = serializeMessageToXml(msg);
+      expect(xml).toContain('<agent-message');
+      expect(xml).toContain('from-id="agent-1"');
+      expect(xml).toContain('from-name="Agent One"');
+      expect(xml).toContain(`message-id="${msg.messageId}"`);
+      expect(xml).toContain('context-id="ctx-42"');
+      expect(xml).toContain('hop-count="0"');
+      expect(xml).toContain('<content>Test content</content>');
+    });
+
+    it('escapes special characters in content', () => {
+      const msg = createTextMessage('s', 'a < b > c & d "e"');
+      const xml = serializeMessageToXml(msg);
+      expect(xml).toContain('a &lt; b &gt; c &amp; d &quot;e&quot;');
+    });
+
+    it('handles message without contextId', () => {
+      const msg = createTextMessage('s', 'hi');
+      delete msg.contextId;
+      const xml = serializeMessageToXml(msg);
+      expect(xml).toContain('context-id=""');
+      expect(xml).not.toContain('undefined');
+    });
+  });
+
+  describe('generateMessageId', () => {
+    it('produces unique IDs', () => {
+      const id1 = generateMessageId();
+      const id2 = generateMessageId();
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('generateContextId', () => {
+    it('produces unique IDs with ctx- prefix', () => {
+      const id = generateContextId();
+      expect(id.startsWith('ctx-')).toBe(true);
+    });
+  });
+});

--- a/src/main/services/a2a/types.ts
+++ b/src/main/services/a2a/types.ts
@@ -1,0 +1,115 @@
+export type Role = 'user' | 'agent';
+
+export interface Part {
+  text?: string;
+  raw?: Uint8Array;
+  url?: string;
+  data?: unknown;
+  mediaType?: string;
+  filename?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Message {
+  messageId: string;
+  contextId?: string;
+  taskId?: string;
+  role: Role;
+  parts: Part[];
+  metadata?: Record<string, unknown>;
+  extensions?: string[];
+  referenceTaskIds?: string[];
+}
+
+export interface SendMessageRequest {
+  recipient: string;
+  message: Message;
+  configuration?: SendMessageConfiguration;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SendMessageConfiguration {
+  acceptedOutputModes?: string[];
+  historyLength?: number;
+  returnImmediately?: boolean;
+}
+
+export interface SendMessageResponse {
+  task?: Task;
+  message?: Message;
+}
+
+export interface Task {
+  id: string;
+  contextId?: string;
+  status: TaskStatus;
+  artifacts?: Artifact[];
+  history?: Message[];
+  metadata?: Record<string, unknown>;
+}
+
+export type TaskState =
+  | 'submitted'
+  | 'working'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'input-required'
+  | 'rejected'
+  | 'auth-required';
+
+export interface TaskStatus {
+  state: TaskState;
+  message?: Message;
+  timestamp?: string;
+}
+
+export interface Artifact {
+  artifactId: string;
+  name?: string;
+  description?: string;
+  parts: Part[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface AgentCard {
+  name: string;
+  description: string;
+  supportedInterfaces: AgentInterface[];
+  provider?: AgentProvider;
+  version: string;
+  documentationUrl?: string;
+  capabilities: AgentCapabilities;
+  defaultInputModes: string[];
+  defaultOutputModes: string[];
+  skills: AgentSkill[];
+  /** Chamber-specific: the mindId for in-process routing */
+  mindId?: string;
+}
+
+export interface AgentSkill {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  examples?: string[];
+  inputModes?: string[];
+  outputModes?: string[];
+}
+
+export interface AgentCapabilities {
+  streaming?: boolean;
+  pushNotifications?: boolean;
+}
+
+export interface AgentInterface {
+  url: string;
+  protocolBinding: string;
+  tenant?: string;
+  protocolVersion: string;
+}
+
+export interface AgentProvider {
+  url: string;
+  organization: string;
+}

--- a/src/main/services/chat/ChatService.test.ts
+++ b/src/main/services/chat/ChatService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ChatService } from './ChatService';
+import { TurnQueue } from './TurnQueue';
 
 const mockSession = {
   send: vi.fn(async () => {}),
@@ -20,10 +21,12 @@ const mockMindManager = {
 
 describe('ChatService', () => {
   let svc: ChatService;
+  let turnQueue: TurnQueue;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    svc = new ChatService(mockMindManager as any);
+    turnQueue = new TurnQueue();
+    svc = new ChatService(mockMindManager as any, turnQueue);
   });
 
   describe('sendMessage', () => {
@@ -75,6 +78,60 @@ describe('ChatService', () => {
     it('returns empty array for invalid mind', async () => {
       const models = await svc.listModels('nonexistent');
       expect(models).toEqual([]);
+    });
+  });
+
+  describe('TurnQueue integration', () => {
+    it('routes sendMessage through TurnQueue', async () => {
+      const enqueueSpy = vi.spyOn(turnQueue, 'enqueue');
+      mockSession.on.mockImplementation((eventOrCb: any, cb?: any) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          setTimeout(() => cb(), 0);
+        }
+        return vi.fn();
+      });
+      const emit = vi.fn();
+      await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+      expect(enqueueSpy).toHaveBeenCalledWith('valid-mind', expect.any(Function));
+    });
+
+    it('concurrent sends to same mind are serialized', async () => {
+      const order: string[] = [];
+      let idleCallbacks: (() => void)[] = [];
+
+      mockSession.on.mockImplementation((eventOrCb: any, cb?: any) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          idleCallbacks.push(cb);
+        }
+        return vi.fn();
+      });
+
+      mockSession.send.mockImplementation(async ({ prompt }: { prompt: string }) => {
+        order.push(`send-${prompt}`);
+      });
+
+      const emit1 = vi.fn();
+      const emit2 = vi.fn();
+      const p1 = svc.sendMessage('valid-mind', 'first', 'msg-1', emit1);
+      const p2 = svc.sendMessage('valid-mind', 'second', 'msg-2', emit2);
+
+      // Let microtasks settle so first send starts
+      await new Promise((r) => setTimeout(r, 10));
+      expect(order).toEqual(['send-first']);
+
+      // Complete first message
+      idleCallbacks.shift()?.();
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Now second should have started
+      expect(order).toEqual(['send-first', 'send-second']);
+
+      // Complete second message
+      idleCallbacks.shift()?.();
+      await Promise.all([p1, p2]);
+
+      expect(emit1).toHaveBeenCalledWith({ type: 'done' });
+      expect(emit2).toHaveBeenCalledWith({ type: 'done' });
     });
   });
 });

--- a/src/main/services/chat/ChatService.ts
+++ b/src/main/services/chat/ChatService.ts
@@ -3,11 +3,15 @@
 
 import type { MindManager } from '../mind/MindManager';
 import type { ChatEvent, ModelInfo } from '../../../shared/types';
+import { TurnQueue } from './TurnQueue';
 
 export class ChatService {
   private abortControllers = new Map<string, AbortController>();
 
-  constructor(private readonly mindManager: MindManager) {}
+  constructor(
+    private readonly mindManager: MindManager,
+    private readonly turnQueue: TurnQueue = new TurnQueue(),
+  ) {}
 
   async sendMessage(
     mindId: string,
@@ -16,123 +20,125 @@ export class ChatService {
     emit: (event: ChatEvent) => void,
     model?: string,
   ): Promise<void> {
-    const abortController = new AbortController();
-    this.abortControllers.set(mindId, abortController);
+    return this.turnQueue.enqueue(mindId, async () => {
+      const abortController = new AbortController();
+      this.abortControllers.set(mindId, abortController);
 
-    const unsubs: (() => void)[] = [];
-    const guard = (fn: () => void) => { if (!abortController.signal.aborted) fn(); };
+      const unsubs: (() => void)[] = [];
+      const guard = (fn: () => void) => { if (!abortController.signal.aborted) fn(); };
 
-    try {
-      const context = this.mindManager.getMind(mindId);
-      if (!context?.session) {
-        throw new Error(`Mind ${mindId} not found or has no session`);
+      try {
+        const context = this.mindManager.getMind(mindId);
+        if (!context?.session) {
+          throw new Error(`Mind ${mindId} not found or has no session`);
+        }
+        const session = context.session;
+
+        // Text streaming
+        unsubs.push(session.on('assistant.message_delta', (event: any) => {
+          guard(() => emit({
+            type: 'chunk',
+            sdkMessageId: event.data.messageId,
+            content: event.data.deltaContent,
+          }));
+        }));
+
+        // Final assistant message
+        unsubs.push(session.on('assistant.message', (event: any) => {
+          guard(() => {
+            if (event.data.content) {
+              emit({
+                type: 'message_final',
+                sdkMessageId: event.data.messageId,
+                content: event.data.content,
+              });
+            }
+          });
+        }));
+
+        // Reasoning
+        unsubs.push(session.on('assistant.reasoning_delta', (event: any) => {
+          guard(() => emit({
+            type: 'reasoning',
+            reasoningId: event.data.reasoningId,
+            content: event.data.deltaContent,
+          }));
+        }));
+
+        // Tool execution
+        unsubs.push(session.on('tool.execution_start', (event: any) => {
+          guard(() => emit({
+            type: 'tool_start',
+            toolCallId: event.data.toolCallId,
+            toolName: event.data.toolName,
+            args: event.data.arguments as Record<string, unknown> | undefined,
+            parentToolCallId: event.data.parentToolCallId,
+          }));
+        }));
+
+        unsubs.push(session.on('tool.execution_progress', (event: any) => {
+          guard(() => emit({
+            type: 'tool_progress',
+            toolCallId: event.data.toolCallId,
+            message: event.data.progressMessage,
+          }));
+        }));
+
+        unsubs.push(session.on('tool.execution_partial_result', (event: any) => {
+          guard(() => emit({
+            type: 'tool_output',
+            toolCallId: event.data.toolCallId,
+            output: event.data.partialOutput,
+          }));
+        }));
+
+        unsubs.push(session.on('tool.execution_complete', (event: any) => {
+          guard(() => emit({
+            type: 'tool_done',
+            toolCallId: event.data.toolCallId,
+            success: event.data.success,
+            result: event.data.result?.content,
+            error: event.data.error?.message,
+          }));
+        }));
+
+        await session.send({ prompt });
+
+        // Wait for idle
+        await new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(resolve, 300_000);
+
+          const unsubIdle = session.on('session.idle', () => {
+            clearTimeout(timeout);
+            unsubIdle();
+            resolve();
+          });
+          unsubs.push(unsubIdle);
+
+          const unsubError = session.on('session.error', (event: any) => {
+            clearTimeout(timeout);
+            unsubError();
+            reject(new Error(event.data.message));
+          });
+          unsubs.push(unsubError);
+
+          abortController.signal.addEventListener('abort', () => {
+            clearTimeout(timeout);
+            resolve();
+          }, { once: true });
+        });
+
+        if (abortController.signal.aborted) return;
+        emit({ type: 'done' });
+      } catch (err) {
+        if (abortController.signal.aborted) return;
+        const message = err instanceof Error ? err.message : String(err);
+        emit({ type: 'error', message });
+      } finally {
+        for (const unsub of unsubs) unsub();
+        this.abortControllers.delete(mindId);
       }
-      const session = context.session;
-
-      // Text streaming
-      unsubs.push(session.on('assistant.message_delta', (event: any) => {
-        guard(() => emit({
-          type: 'chunk',
-          sdkMessageId: event.data.messageId,
-          content: event.data.deltaContent,
-        }));
-      }));
-
-      // Final assistant message
-      unsubs.push(session.on('assistant.message', (event: any) => {
-        guard(() => {
-          if (event.data.content) {
-            emit({
-              type: 'message_final',
-              sdkMessageId: event.data.messageId,
-              content: event.data.content,
-            });
-          }
-        });
-      }));
-
-      // Reasoning
-      unsubs.push(session.on('assistant.reasoning_delta', (event: any) => {
-        guard(() => emit({
-          type: 'reasoning',
-          reasoningId: event.data.reasoningId,
-          content: event.data.deltaContent,
-        }));
-      }));
-
-      // Tool execution
-      unsubs.push(session.on('tool.execution_start', (event: any) => {
-        guard(() => emit({
-          type: 'tool_start',
-          toolCallId: event.data.toolCallId,
-          toolName: event.data.toolName,
-          args: event.data.arguments as Record<string, unknown> | undefined,
-          parentToolCallId: event.data.parentToolCallId,
-        }));
-      }));
-
-      unsubs.push(session.on('tool.execution_progress', (event: any) => {
-        guard(() => emit({
-          type: 'tool_progress',
-          toolCallId: event.data.toolCallId,
-          message: event.data.progressMessage,
-        }));
-      }));
-
-      unsubs.push(session.on('tool.execution_partial_result', (event: any) => {
-        guard(() => emit({
-          type: 'tool_output',
-          toolCallId: event.data.toolCallId,
-          output: event.data.partialOutput,
-        }));
-      }));
-
-      unsubs.push(session.on('tool.execution_complete', (event: any) => {
-        guard(() => emit({
-          type: 'tool_done',
-          toolCallId: event.data.toolCallId,
-          success: event.data.success,
-          result: event.data.result?.content,
-          error: event.data.error?.message,
-        }));
-      }));
-
-      await session.send({ prompt });
-
-      // Wait for idle
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(resolve, 300_000);
-
-        const unsubIdle = session.on('session.idle', () => {
-          clearTimeout(timeout);
-          unsubIdle();
-          resolve();
-        });
-        unsubs.push(unsubIdle);
-
-        const unsubError = session.on('session.error', (event: any) => {
-          clearTimeout(timeout);
-          unsubError();
-          reject(new Error(event.data.message));
-        });
-        unsubs.push(unsubError);
-
-        abortController.signal.addEventListener('abort', () => {
-          clearTimeout(timeout);
-          resolve();
-        }, { once: true });
-      });
-
-      if (abortController.signal.aborted) return;
-      emit({ type: 'done' });
-    } catch (err) {
-      if (abortController.signal.aborted) return;
-      const message = err instanceof Error ? err.message : String(err);
-      emit({ type: 'error', message });
-    } finally {
-      for (const unsub of unsubs) unsub();
-      this.abortControllers.delete(mindId);
-    }
+    });
   }
 
   async cancelMessage(mindId: string, messageId: string): Promise<void> {

--- a/src/main/services/chat/ChatService.ts
+++ b/src/main/services/chat/ChatService.ts
@@ -10,7 +10,7 @@ export class ChatService {
 
   constructor(
     private readonly mindManager: MindManager,
-    private readonly turnQueue: TurnQueue = new TurnQueue(),
+    private readonly turnQueue: TurnQueue,
   ) {}
 
   async sendMessage(

--- a/src/main/services/chat/TurnQueue.test.ts
+++ b/src/main/services/chat/TurnQueue.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TurnQueue } from './TurnQueue';
+
+describe('TurnQueue', () => {
+  let queue: TurnQueue;
+
+  beforeEach(() => {
+    queue = new TurnQueue();
+  });
+
+  it('executes a single enqueued function', async () => {
+    const fn = vi.fn(async () => 42);
+    const result = await queue.enqueue('mind-1', fn);
+    expect(fn).toHaveBeenCalledOnce();
+    expect(result).toBe(42);
+  });
+
+  it('serializes concurrent enqueues for the same mindId', async () => {
+    const order: string[] = [];
+
+    const p1 = queue.enqueue('mind-1', async () => {
+      order.push('start-1');
+      await new Promise((r) => setTimeout(r, 50));
+      order.push('end-1');
+    });
+
+    const p2 = queue.enqueue('mind-1', async () => {
+      order.push('start-2');
+      await new Promise((r) => setTimeout(r, 10));
+      order.push('end-2');
+    });
+
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(['start-1', 'end-1', 'start-2', 'end-2']);
+  });
+
+  it('runs enqueues for different mindIds in parallel', async () => {
+    const order: string[] = [];
+
+    const p1 = queue.enqueue('mind-A', async () => {
+      order.push('start-A');
+      await new Promise((r) => setTimeout(r, 50));
+      order.push('end-A');
+    });
+
+    const p2 = queue.enqueue('mind-B', async () => {
+      order.push('start-B');
+      await new Promise((r) => setTimeout(r, 50));
+      order.push('end-B');
+    });
+
+    await Promise.all([p1, p2]);
+    // Both should start before either finishes
+    expect(order.indexOf('start-A')).toBeLessThan(order.indexOf('end-A'));
+    expect(order.indexOf('start-B')).toBeLessThan(order.indexOf('end-B'));
+    expect(order.indexOf('start-B')).toBeLessThan(order.indexOf('end-A'));
+  });
+
+  it('propagates errors without blocking the queue', async () => {
+    const p1 = queue.enqueue('mind-1', async () => {
+      throw new Error('boom');
+    });
+
+    await expect(p1).rejects.toThrow('boom');
+
+    const result = await queue.enqueue('mind-1', async () => 'ok');
+    expect(result).toBe('ok');
+  });
+
+  it('reports busy state per mind', async () => {
+    expect(queue.isBusy('mind-1')).toBe(false);
+
+    let resolve!: () => void;
+    const blocker = new Promise<void>((r) => { resolve = r; });
+
+    const p = queue.enqueue('mind-1', () => blocker);
+
+    // Allow microtask to start the fn
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(queue.isBusy('mind-1')).toBe(true);
+    expect(queue.isBusy('mind-2')).toBe(false);
+
+    resolve();
+    await p;
+
+    expect(queue.isBusy('mind-1')).toBe(false);
+  });
+});

--- a/src/main/services/chat/TurnQueue.ts
+++ b/src/main/services/chat/TurnQueue.ts
@@ -1,0 +1,30 @@
+export class TurnQueue {
+  private chains = new Map<string, Promise<void>>();
+  private active = new Set<string>();
+
+  enqueue<T>(mindId: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.chains.get(mindId) ?? Promise.resolve();
+
+    const { promise, resolve, reject } = Promise.withResolvers<T>();
+
+    const next = previous.then(async () => {
+      this.active.add(mindId);
+      try {
+        resolve(await fn());
+      } catch (err) {
+        reject(err);
+      } finally {
+        this.active.delete(mindId);
+      }
+    });
+
+    // Chain always resolves so subsequent enqueues aren't blocked by errors
+    this.chains.set(mindId, next.then(() => {}, () => {}));
+
+    return promise;
+  }
+
+  isBusy(mindId: string): boolean {
+    return this.active.has(mindId);
+  }
+}

--- a/src/main/services/mind/MindManager.test.ts
+++ b/src/main/services/mind/MindManager.test.ts
@@ -355,4 +355,98 @@ describe('MindManager', () => {
       expect(unwindowed).toHaveBeenCalledWith(mind.mindId);
     });
   });
+
+  describe('ToolBuilder integration', () => {
+    it('doLoadMind() calls toolBuilder with mindId and extension tools', async () => {
+      const toolBuilder = vi.fn((mindId: string, extTools: unknown[]) => [...extTools, { name: 'send_message' }, { name: 'list_agents' }]);
+      const mgr = new MindManager(
+        mockClientFactory as any,
+        mockIdentityLoader as any,
+        mockExtensionLoader as any,
+        mockConfigService as any,
+        mockViewDiscovery as any,
+        toolBuilder,
+      );
+
+      const mockTool = { name: 'canvas_show' };
+      mockExtensionLoader.loadTools.mockResolvedValueOnce({ tools: [mockTool], loaded: [{ tools: [mockTool] }] });
+
+      await mgr.loadMind('C:\\agents\\q');
+
+      expect(toolBuilder).toHaveBeenCalledTimes(1);
+      expect(toolBuilder).toHaveBeenCalledWith(
+        expect.stringMatching(/^q-/),
+        [mockTool],
+      );
+    });
+
+    it('doLoadMind() passes toolBuilder result to createSessionForMind', async () => {
+      const a2aTool = { name: 'send_message' };
+      const toolBuilder = vi.fn((_mindId: string, extTools: unknown[]) => [...extTools, a2aTool]);
+      const mgr = new MindManager(
+        mockClientFactory as any,
+        mockIdentityLoader as any,
+        mockExtensionLoader as any,
+        mockConfigService as any,
+        mockViewDiscovery as any,
+        toolBuilder,
+      );
+
+      await mgr.loadMind('C:\\agents\\q');
+
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tools: expect.arrayContaining([a2aTool]),
+        }),
+      );
+    });
+
+    it('recreateSession() calls toolBuilder to rebuild tools', async () => {
+      const toolBuilder = vi.fn((_mindId: string, extTools: unknown[]) => [...extTools, { name: 'a2a' }]);
+      const mgr = new MindManager(
+        mockClientFactory as any,
+        mockIdentityLoader as any,
+        mockExtensionLoader as any,
+        mockConfigService as any,
+        mockViewDiscovery as any,
+        toolBuilder,
+      );
+
+      const mind = await mgr.loadMind('C:\\agents\\q');
+      toolBuilder.mockClear();
+
+      await mgr.recreateSession(mind.mindId);
+
+      expect(toolBuilder).toHaveBeenCalledTimes(1);
+      expect(toolBuilder).toHaveBeenCalledWith(mind.mindId, expect.any(Array));
+    });
+
+    it('recreateSession() passes fresh tools to new session', async () => {
+      const toolBuilder = vi.fn((_mindId: string, extTools: unknown[]) => [...extTools, { name: 'fresh_tool' }]);
+      const mgr = new MindManager(
+        mockClientFactory as any,
+        mockIdentityLoader as any,
+        mockExtensionLoader as any,
+        mockConfigService as any,
+        mockViewDiscovery as any,
+        toolBuilder,
+      );
+
+      const mind = await mgr.loadMind('C:\\agents\\q');
+      mockCreateSession.mockClear();
+
+      await mgr.recreateSession(mind.mindId);
+
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tools: expect.arrayContaining([{ name: 'fresh_tool' }]),
+        }),
+      );
+    });
+
+    it('works without toolBuilder (backwards compat)', async () => {
+      await manager.loadMind('C:\\agents\\q');
+      expect(mockCreateSession).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -26,6 +26,7 @@ export class MindManager extends EventEmitter {
     private readonly extensionLoader: ExtensionLoader,
     private readonly configService: ConfigService,
     private readonly viewDiscovery: ViewDiscovery,
+    private readonly toolBuilder?: (mindId: string, extensionTools: unknown[]) => unknown[],
   ) {
     super();
   }
@@ -69,8 +70,11 @@ export class MindManager extends EventEmitter {
     // Load extensions
     const { tools, loaded } = await this.extensionLoader.loadTools(mindPath);
 
+    // Apply toolBuilder (merges A2A tools) if provided
+    const sessionTools = this.toolBuilder ? this.toolBuilder(id, tools) : tools;
+
     // Create session
-    const session = await this.createSessionForMind(client, mindPath, identity.systemMessage, tools);
+    const session = await this.createSessionForMind(client, mindPath, identity.systemMessage, sessionTools);
 
     const context: InternalMindContext = {
       mindId: id,
@@ -169,8 +173,9 @@ export class MindManager extends EventEmitter {
     if (!context) throw new Error(`Mind ${mindId} not found`);
 
     const tools = context.extensions.flatMap((e: { tools?: unknown[] }) => e.tools ?? []);
+    const sessionTools = this.toolBuilder ? this.toolBuilder(mindId, tools) : tools;
     context.session = await this.createSessionForMind(
-      context.client, context.mindPath, context.identity.systemMessage, tools,
+      context.client, context.mindPath, context.identity.systemMessage, sessionTools,
     );
   }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -53,6 +53,10 @@ const electronAPI: ElectronAPI = {
     load: () => ipcRenderer.invoke('config:load'),
     save: (config) => ipcRenderer.invoke('config:save', config),
   },
+  a2a: {
+    onIncoming: (callback: (payload: any) => void) => createIpcListener(ipcRenderer, 'a2a:incoming', callback),
+    listAgents: () => ipcRenderer.invoke('a2a:listAgents'),
+  },
   window: {
     minimize: () => ipcRenderer.send('window:minimize'),
     maximize: () => ipcRenderer.send('window:maximize'),

--- a/src/renderer/components/chat/SenderBadge.test.tsx
+++ b/src/renderer/components/chat/SenderBadge.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SenderBadge } from './SenderBadge';
+
+describe('SenderBadge', () => {
+  it('renders sender name', () => {
+    render(<SenderBadge name="Agent Q" />);
+    expect(screen.getByText('from Agent Q')).toBeTruthy();
+  });
+
+  it('renders arrow icon', () => {
+    render(<SenderBadge name="Agent Q" />);
+    expect(screen.getByText('↪')).toBeTruthy();
+  });
+
+  it('applies genesis styling', () => {
+    const { container } = render(<SenderBadge name="Q" />);
+    const badge = container.firstElementChild!;
+    expect(badge.className).toContain('text-genesis');
+  });
+});

--- a/src/renderer/components/chat/SenderBadge.tsx
+++ b/src/renderer/components/chat/SenderBadge.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface Props {
+  name: string;
+}
+
+export function SenderBadge({ name }: Props) {
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-genesis bg-genesis/10 rounded-full px-2 py-0.5 mb-1">
+      <span>↪</span>
+      <span>from {name}</span>
+    </span>
+  );
+}

--- a/src/renderer/hooks/useAppSubscriptions.ts
+++ b/src/renderer/hooks/useAppSubscriptions.ts
@@ -73,4 +73,12 @@ export function useAppSubscriptions() {
       loadViews();
     }
   }, [agentStatus.connected, activeMindId, dispatch]);
+
+  // A2A incoming message listener
+  useEffect(() => {
+    const unsub = window.electronAPI.a2a.onIncoming((payload) => {
+      dispatch({ type: 'A2A_INCOMING', payload });
+    });
+    return () => { unsub(); };
+  }, [dispatch]);
 }

--- a/src/renderer/lib/store/reducer.test.ts
+++ b/src/renderer/lib/store/reducer.test.ts
@@ -329,4 +329,90 @@ describe('appReducer', () => {
     const state = appReducer(initialState, { type: 'BOGUS' } as unknown as AppAction);
     expect(state).toBe(initialState);
   });
+
+  // -------------------------------------------------------------------------
+  // A2A_INCOMING
+  // -------------------------------------------------------------------------
+
+  describe('A2A_INCOMING', () => {
+    const a2aPayload = (overrides?: Partial<{ targetMindId: string; message: any; replyMessageId: string }>) => ({
+      targetMindId: mindId,
+      message: {
+        messageId: 'msg-a2a-1',
+        role: 'user',
+        parts: [{ text: 'Hello from Agent A', mediaType: 'text/plain' }],
+        metadata: { fromId: 'agent-a', fromName: 'Agent A', hopCount: 1 },
+      },
+      replyMessageId: 'reply-1',
+      ...overrides,
+    });
+
+    it('inserts sender message with attribution into target mind', () => {
+      const state = appReducer(withActiveMind, { type: 'A2A_INCOMING', payload: a2aPayload() });
+      const msgs = state.messagesByMind[mindId]!;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].role).toBe('user');
+      expect(msgs[0].sender).toEqual({ mindId: 'agent-a', name: 'Agent A' });
+      expect(msgs[0].blocks[0]).toMatchObject({ type: 'text', content: 'Hello from Agent A' });
+    });
+
+    it('inserts assistant reply placeholder', () => {
+      const state = appReducer(withActiveMind, { type: 'A2A_INCOMING', payload: a2aPayload() });
+      const msgs = state.messagesByMind[mindId]!;
+      expect(msgs[1].id).toBe('reply-1');
+      expect(msgs[1].role).toBe('assistant');
+      expect(msgs[1].isStreaming).toBe(true);
+    });
+
+    it('sets streamingByMind for target mind', () => {
+      const state = appReducer(withActiveMind, { type: 'A2A_INCOMING', payload: a2aPayload() });
+      expect(state.streamingByMind[mindId]).toBe(true);
+    });
+
+    it('sets global isStreaming true when target is active mind', () => {
+      const state = appReducer(withActiveMind, { type: 'A2A_INCOMING', payload: a2aPayload() });
+      expect(state.isStreaming).toBe(true);
+    });
+
+    it('does not set global isStreaming when target is not active mind', () => {
+      const state = appReducer(withActiveMind, {
+        type: 'A2A_INCOMING',
+        payload: a2aPayload({ targetMindId: 'other-mind' }),
+      });
+      expect(state.isStreaming).toBe(false);
+      expect(state.streamingByMind['other-mind']).toBe(true);
+    });
+
+    it('appends to existing messages in target mind', () => {
+      const stateWithMsgs = {
+        ...withActiveMind,
+        messagesByMind: { [mindId]: [makeMessage([makeTextBlock('existing')])] },
+      };
+      const state = appReducer(stateWithMsgs, { type: 'A2A_INCOMING', payload: a2aPayload() });
+      expect(state.messagesByMind[mindId]).toHaveLength(3);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // streamingByMind tracking
+  // -------------------------------------------------------------------------
+
+  describe('streamingByMind', () => {
+    it('ADD_ASSISTANT_MESSAGE sets streamingByMind for active mind', () => {
+      const state = appReducer(withActiveMind, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+      expect(state.streamingByMind[mindId]).toBe(true);
+    });
+
+    it('CHAT_EVENT done clears streamingByMind for that mind', () => {
+      let state = appReducer(withActiveMind, { type: 'ADD_ASSISTANT_MESSAGE', payload: { id: 'a1', timestamp: 1000 } });
+      state = appReducer(state, { type: 'CHAT_EVENT', payload: { mindId, messageId: 'a1', event: makeChatEvent('done') } });
+      expect(state.streamingByMind[mindId]).toBe(false);
+    });
+
+    it('NEW_CONVERSATION clears streamingByMind for active mind', () => {
+      const prev = { ...withActiveMind, streamingByMind: { [mindId]: true }, isStreaming: true };
+      const state = appReducer(prev, { type: 'NEW_CONVERSATION' });
+      expect(state.streamingByMind[mindId]).toBe(false);
+    });
+  });
 });

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -131,6 +131,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       return {
         ...state,
         isStreaming: true,
+        streamingByMind: state.activeMindId
+          ? { ...state.streamingByMind, [state.activeMindId]: true }
+          : state.streamingByMind,
         messagesByMind: setActiveMsgs([...activeMsgs(), {
           id: action.payload.id,
           role: 'assistant',
@@ -145,10 +148,14 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const mindMsgs = state.messagesByMind[mindId] ?? [];
       const newMessages = handleChatEvent(mindMsgs, messageId, event);
       const isDone = event.type === 'done' || event.type === 'error';
+      const newStreamingByMind = isDone
+        ? { ...state.streamingByMind, [mindId]: false }
+        : state.streamingByMind;
       return {
         ...state,
         messagesByMind: { ...state.messagesByMind, [mindId]: newMessages },
         isStreaming: isDone ? false : state.isStreaming,
+        streamingByMind: newStreamingByMind,
       };
     }
 
@@ -156,7 +163,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, minds: action.payload };
 
     case 'SET_ACTIVE_MIND':
-      return { ...state, activeMindId: action.payload, isStreaming: false };
+      return { ...state, activeMindId: action.payload, isStreaming: false, streamingByMind: state.streamingByMind };
 
     case 'ADD_MIND': {
       const exists = state.minds.some(m => m.mindId === action.payload.mindId);
@@ -228,7 +235,45 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           ? { ...state.messagesByMind, [state.activeMindId]: [] }
           : state.messagesByMind,
         isStreaming: false,
+        streamingByMind: state.activeMindId
+          ? { ...state.streamingByMind, [state.activeMindId]: false }
+          : state.streamingByMind,
       };
+
+    case 'A2A_INCOMING': {
+      const { targetMindId, message, replyMessageId } = action.payload;
+      const targetMsgs = state.messagesByMind[targetMindId] ?? [];
+      const senderMessage: ChatMessage = {
+        id: message.messageId ?? `a2a-${Date.now()}`,
+        role: 'user',
+        blocks: (message.parts ?? []).map((p: any) => ({
+          type: 'text' as const,
+          content: p.text ?? '',
+        })),
+        timestamp: Date.now(),
+        sender: {
+          mindId: message.metadata?.fromId ?? targetMindId,
+          name: message.metadata?.fromName ?? 'Unknown Agent',
+        },
+      };
+      const replyPlaceholder: ChatMessage = {
+        id: replyMessageId,
+        role: 'assistant',
+        blocks: [],
+        timestamp: Date.now(),
+        isStreaming: true,
+      };
+      const isActiveMind = targetMindId === state.activeMindId;
+      return {
+        ...state,
+        messagesByMind: {
+          ...state.messagesByMind,
+          [targetMindId]: [...targetMsgs, senderMessage, replyPlaceholder],
+        },
+        streamingByMind: { ...state.streamingByMind, [targetMindId]: true },
+        isStreaming: isActiveMind ? true : state.isStreaming,
+      };
+    }
 
     default:
       return state;

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -246,14 +246,14 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const senderMessage: ChatMessage = {
         id: message.messageId ?? `a2a-${Date.now()}`,
         role: 'user',
-        blocks: (message.parts ?? []).map((p: any) => ({
+        blocks: (message.parts ?? []).map((p) => ({
           type: 'text' as const,
           content: p.text ?? '',
         })),
         timestamp: Date.now(),
         sender: {
-          mindId: message.metadata?.fromId ?? targetMindId,
-          name: message.metadata?.fromName ?? 'Unknown Agent',
+          mindId: (message.metadata?.fromId as string) ?? 'unknown',
+          name: (message.metadata?.fromName as string) ?? 'Unknown Agent',
         },
       };
       const replyPlaceholder: ChatMessage = {

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ChatEvent, AgentStatus, ModelInfo, LensViewManifest, MindContext, ContentBlock } from '../../../shared/types';
+import type { Message } from '../../../shared/a2a-types';
 
 export type LensView = 'chat' | string;
 
@@ -36,7 +37,7 @@ export type AppAction =
   | { type: 'MINDS_CHECKED' }
   | { type: 'CLEAR_MESSAGES' }
   | { type: 'NEW_CONVERSATION' }
-  | { type: 'A2A_INCOMING'; payload: { targetMindId: string; message: any; replyMessageId: string } };
+  | { type: 'A2A_INCOMING'; payload: { targetMindId: string; message: Message; replyMessageId: string } };
 
 export const initialState: AppState = {
   minds: [],

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -7,6 +7,7 @@ export interface AppState {
   activeMindId: string | null;
   messagesByMind: Record<string, ChatMessage[]>;
   isStreaming: boolean;
+  streamingByMind: Record<string, boolean>;
   /** @deprecated Use minds array instead */
   agentStatus: AgentStatus;
   availableModels: ModelInfo[];
@@ -34,13 +35,15 @@ export type AppAction =
   | { type: 'HIDE_LANDING' }
   | { type: 'MINDS_CHECKED' }
   | { type: 'CLEAR_MESSAGES' }
-  | { type: 'NEW_CONVERSATION' };
+  | { type: 'NEW_CONVERSATION' }
+  | { type: 'A2A_INCOMING'; payload: { targetMindId: string; message: any; replyMessageId: string } };
 
 export const initialState: AppState = {
   minds: [],
   activeMindId: null,
   messagesByMind: {},
   isStreaming: false,
+  streamingByMind: {},
   agentStatus: {
     connected: false,
     mindPath: null,

--- a/src/shared/a2a-types.ts
+++ b/src/shared/a2a-types.ts
@@ -1,0 +1,4 @@
+// Shared A2A types — re-exported from the service layer for use at the IPC boundary.
+// These are protocol types (from A2A v1.0 spec), not service internals.
+
+export type { Role, Part, Message, AgentCard, AgentSkill } from '../main/services/a2a/types';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,6 +54,7 @@ export interface ChatMessage {
   blocks: ContentBlock[];
   timestamp: number;
   isStreaming?: boolean;
+  sender?: { mindId: string; name: string };
 }
 
 export interface AgentStatus {
@@ -169,6 +170,10 @@ export interface ElectronAPI {
   config: {
     load: () => Promise<AppConfig>;
     save: (config: AppConfig) => Promise<void>;
+  };
+  a2a: {
+    onIncoming: (callback: (payload: { targetMindId: string; message: any; replyMessageId: string }) => void) => () => void;
+    listAgents: () => Promise<any[]>;
   };
   window: {
     minimize: () => void;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,5 @@
+import type { Message, AgentCard } from './a2a-types';
+
 // Shared types across main, preload, and renderer processes
 
 // ---------------------------------------------------------------------------
@@ -172,8 +174,8 @@ export interface ElectronAPI {
     save: (config: AppConfig) => Promise<void>;
   };
   a2a: {
-    onIncoming: (callback: (payload: { targetMindId: string; message: any; replyMessageId: string }) => void) => () => void;
-    listAgents: () => Promise<any[]>;
+    onIncoming: (callback: (payload: { targetMindId: string; message: Message; replyMessageId: string }) => void) => () => void;
+    listAgents: () => Promise<AgentCard[]>;
   };
   window: {
     minimize: () => void;

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -172,6 +172,10 @@ export function mockElectronAPI(): ElectronAPI {
       load: vi.fn().mockResolvedValue({ mindPath: null, theme: 'dark' }),
       save: vi.fn().mockResolvedValue(undefined),
     },
+    a2a: {
+      onIncoming: vi.fn().mockReturnValue(() => {}),
+      listAgents: vi.fn().mockResolvedValue([]),
+    },
     window: {
       minimize: vi.fn(),
       maximize: vi.fn(),


### PR DESCRIPTION
In-process agent-to-agent messaging conforming to A2A v1.0 protocol.

## New Services
- **TurnQueue** — per-mind turn serialization prevents session.send() races
- **AgentCardRegistry** — A2A-conformant AgentCards from mind metadata
- **MessageRouter** — mirrors SendMessage RPC with contextId, hop-count, XML envelope
- **A2A tools** — a2a_send_message + a2a_list_agents injected via buildSessionTools()
- **A2A IPC** — a2a:incoming events to renderer, a2a:listAgents handler
- **SenderBadge** — sender attribution in chat UI

## A2A Conformity
- Message, Part, Role, AgentCard, AgentSkill match proto spec exactly
- SendMessageRequest/Response mirror SendMessage RPC
- AgentInterface uses protocolBinding: IN_PROCESS (spec extension point)
- contextId server-generated, hop-count tracked per context

## Tests
325 tests (70 new, all TDD). Includes 3 integration tests (e2e flow, queue ordering, loop prevention).

## Review Fixes Applied
- Hop-count tracked per contextId (was broken — hard-coded 0)
- Fire-and-forget .catch() prevents unhandled rejections
- AgentCardRegistry decoupled from EventEmitter (all const in composition root)
- Dead EventEmitter inheritance removed from MessageRouter
- A2A types shared at IPC boundary (no more any)
