### PR TITLE
v0.19.3 — Chatroom (Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.19.0 (2026-04-13)
+
+### Chatroom (Phase 5)
+- **ChatroomService** — broadcast user messages to all loaded agents in parallel with isolated per-mind chatroom sessions
+- **Round-based echo prevention** — agents respond to user messages only; previous round context injected as escaped XML `<chatroom-history>`
+- **Session isolation** — chatroom sessions are separate from individual chat sessions (no context bleed)
+- **Mid-round sends** — user can send while agents are still responding; incomplete responses cancelled automatically
+- **Incremental persistence** — chatroom transcript saved to `~/.chamber/chatroom.json` with atomic writes (500 message cap)
+- **ChatroomPanel UI** — single timeline with sender badges, colored agent avatars, participant bar with status indicators
+- **Multi-agent streaming** — multiple agents stream simultaneously with independent progress tracking
+- **Per-agent error isolation** — one agent failing doesn't affect others
+- **ActivityBar navigation** — chatroom icon (Users) between Chat and Lens views
+
 ## v0.18.1 (2026-04-13)
 
 ### Structural Cleanup (Uncle Bob Review)

--- a/backlog.md
+++ b/backlog.md
@@ -17,6 +17,12 @@
 ## Next
 
 - [ ] **@mention targeting in chatroom** `ux` — `@AgentName` in a chatroom message should route only to that agent (not broadcast). Parse @mentions from input, filter broadcast participants to only the mentioned agent(s). That agent responds and does work; others stay silent. *(Ian, 2026-04-13)*
+- [ ] **Generic `handleChatEvent<T>`** `quality` — `handleChatEvent` returns `ChatMessage[]` but chatroom reducer casts to `ChatroomMessage[]`. Make function generic to preserve extended types. *(Uncle Bob review, 2026-04-13)*
+- [ ] **Chatroom roundId alignment** `bug` — renderer generates optimistic roundId, service generates a different one. Pass roundId through IPC so both sides agree. *(Uncle Bob review, 2026-04-13)*
+- [ ] **IPC input validation on chatroom:send** `security` — no runtime type guards; renderer could send non-string. Add `typeof message !== 'string'` guard. *(Uncle Bob review, 2026-04-13)*
+- [ ] **DRY session creation in MindManager** `quality` — `createChatroomSession` and `createTaskSession` share ~8 lines of identical body. Extract private `buildSessionForMind(mindId)`. *(Uncle Bob review, 2026-04-13)*
+- [ ] **Chatroom agent timeout visibility** `ux` — 5-min timeout in `sendToAgent` resolves silently with no UI indication. Emit timeout-specific error event. *(Uncle Bob review, 2026-04-13)*
+- [ ] **Chatroom `getLastNRounds` performance** `quality` — uses `Array.includes` in loop (O(n·r)). Replace with `Set`. *(Uncle Bob review, 2026-04-13)*
 - [ ] **Chat history** `ux` — conversations are lost on new conversation or restart. Show past conversations per-mind in MindSidebar, indented under each agent. Data already in `~/.copilot/session-state/`. See [[conversation-history]] for spec. *(Ian, 2026-04-12)*
 - [ ] **Boot screen activity log** `ux` — spinner too passive during genesis/startup; surface log output so user sees real-time progress. *(Kent feedback 2026-04-09)*
 - [ ] **"Open Existing" defaults to ~/agents/** `ux` — folder picker should open to `$HOME/agents/` by default (where `MindScaffold.getDefaultBasePath()` creates minds).

--- a/backlog.md
+++ b/backlog.md
@@ -16,6 +16,7 @@
 
 ## Next
 
+- [ ] **@mention targeting in chatroom** `ux` — `@AgentName` in a chatroom message should route only to that agent (not broadcast). Parse @mentions from input, filter broadcast participants to only the mentioned agent(s). That agent responds and does work; others stay silent. *(Ian, 2026-04-13)*
 - [ ] **Chat history** `ux` — conversations are lost on new conversation or restart. Show past conversations per-mind in MindSidebar, indented under each agent. Data already in `~/.copilot/session-state/`. See [[conversation-history]] for spec. *(Ian, 2026-04-12)*
 - [ ] **Boot screen activity log** `ux` — spinner too passive during genesis/startup; surface log output so user sees real-time progress. *(Kent feedback 2026-04-09)*
 - [ ] **"Open Existing" defaults to ~/agents/** `ux` — folder picker should open to `$HOME/agents/` by default (where `MindScaffold.getDefaultBasePath()` creates minds).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { MindManager } from './main/services/mind';
 import { ChatService } from './main/services/chat/ChatService';
 import { TurnQueue } from './main/services/chat/TurnQueue';
 import { AgentCardRegistry, MessageRouter, TaskManager, buildSessionTools } from './main/services/a2a';
+import { ChatroomService } from './main/services/chatroom';
 import { loadCanvasExtension } from './main/services/extensions/adapters/canvas';
 import { loadCronExtension } from './main/services/extensions/adapters/cron';
 import { loadIdeaExtension } from './main/services/extensions/adapters/idea';
@@ -25,6 +26,7 @@ import { setupLensIPC } from './main/ipc/lens';
 import { setupGenesisIPC } from './main/ipc/genesis';
 import { setupAuthIPC } from './main/ipc/auth';
 import { setupA2AIPC } from './main/ipc/a2a';
+import { setupChatroomIPC } from './main/ipc/chatroom';
 
 import { EventEmitter } from 'events';
 import { wireLifecycleEvents } from './main/wireLifecycleEvents';
@@ -62,6 +64,7 @@ const mindManager = new MindManager(clientFactory, identityLoader, extensionLoad
 taskManager = new TaskManager(mindManager, agentCardRegistry);
 const chatService = new ChatService(mindManager, turnQueue);
 const messageRouter = new MessageRouter(chatService, agentCardRegistry, a2aEventBus);
+const chatroomService = new ChatroomService(mindManager);
 
 wireLifecycleEvents({ mindManager, agentCardRegistry, taskManager, a2aEventBus });
 
@@ -127,6 +130,7 @@ app.on('ready', async () => {
   setupGenesisIPC(mindManager, scaffold);
   setupAuthIPC(authService);
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager);
+  setupChatroomIPC(chatroomService);
 
   // Window controls
   ipcMain.on('window:minimize', () => mainWindow?.minimize());

--- a/src/main/ipc/chatroom.test.ts
+++ b/src/main/ipc/chatroom.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+  },
+}));
+
+import { ipcMain, BrowserWindow } from 'electron';
+import { setupChatroomIPC } from './chatroom';
+
+function getHandler(channel: string): Function {
+  const calls = (ipcMain.handle as any).mock.calls;
+  const match = calls.find((c: any) => c[0] === channel);
+  if (!match) throw new Error(`No handler registered for ${channel}`);
+  return match[1];
+}
+
+describe('Chatroom IPC', () => {
+  let mockService: EventEmitter & {
+    broadcast: ReturnType<typeof vi.fn>;
+    getHistory: ReturnType<typeof vi.fn>;
+    clearHistory: ReturnType<typeof vi.fn>;
+    stopAll: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const emitter = new EventEmitter();
+    mockService = Object.assign(emitter, {
+      broadcast: vi.fn().mockResolvedValue(undefined),
+      getHistory: vi.fn().mockReturnValue([]),
+      clearHistory: vi.fn().mockResolvedValue(undefined),
+      stopAll: vi.fn(),
+    });
+    setupChatroomIPC(mockService as any);
+  });
+
+  it('chatroom:send invokes broadcast with message and model', async () => {
+    const handler = getHandler('chatroom:send');
+    await handler({}, 'Hello agents', 'gpt-4');
+    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', 'gpt-4');
+  });
+
+  it('chatroom:send works without model', async () => {
+    const handler = getHandler('chatroom:send');
+    await handler({}, 'Hello agents');
+    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', undefined);
+  });
+
+  it('chatroom:history returns result from getHistory', async () => {
+    const messages = [{ id: 'msg-1', role: 'user', blocks: [], timestamp: 1 }];
+    mockService.getHistory.mockReturnValue(messages);
+
+    const handler = getHandler('chatroom:history');
+    const result = await handler({});
+    expect(result).toEqual(messages);
+    expect(mockService.getHistory).toHaveBeenCalled();
+  });
+
+  it('chatroom:clear calls clearHistory', async () => {
+    const handler = getHandler('chatroom:clear');
+    await handler({});
+    expect(mockService.clearHistory).toHaveBeenCalled();
+  });
+
+  it('chatroom:stop calls stopAll', async () => {
+    const handler = getHandler('chatroom:stop');
+    await handler({});
+    expect(mockService.stopAll).toHaveBeenCalled();
+  });
+
+  it('chatroom:event forwarding sends to all windows', () => {
+    const wc1 = { send: vi.fn() };
+    const wc2 = { send: vi.fn() };
+    (BrowserWindow.getAllWindows as any).mockReturnValue([
+      { isDestroyed: () => false, webContents: wc1 },
+      { isDestroyed: () => false, webContents: wc2 },
+    ]);
+
+    const event = { mindId: 'agent-a', mindName: 'Agent A', messageId: 'msg-1', roundId: 'r-1', event: { type: 'chunk', content: 'hi' } };
+    mockService.emit('chatroom:event', event);
+
+    expect(wc1.send).toHaveBeenCalledWith('chatroom:event', event);
+    expect(wc2.send).toHaveBeenCalledWith('chatroom:event', event);
+  });
+
+  it('chatroom:event skips destroyed windows', () => {
+    const wc1 = { send: vi.fn() };
+    const wc2 = { send: vi.fn() };
+    (BrowserWindow.getAllWindows as any).mockReturnValue([
+      { isDestroyed: () => true, webContents: wc1 },
+      { isDestroyed: () => false, webContents: wc2 },
+    ]);
+
+    const event = { mindId: 'agent-a', mindName: 'Agent A', messageId: 'msg-1', roundId: 'r-1', event: { type: 'done' } };
+    mockService.emit('chatroom:event', event);
+
+    expect(wc1.send).not.toHaveBeenCalled();
+    expect(wc2.send).toHaveBeenCalledWith('chatroom:event', event);
+  });
+});

--- a/src/main/ipc/chatroom.ts
+++ b/src/main/ipc/chatroom.ts
@@ -1,0 +1,29 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import type { ChatroomService } from '../services/chatroom/ChatroomService';
+
+export function setupChatroomIPC(chatroomService: ChatroomService): void {
+  ipcMain.handle('chatroom:send', async (_event, message: string, model?: string) => {
+    await chatroomService.broadcast(message, model);
+  });
+
+  ipcMain.handle('chatroom:history', async () => {
+    return chatroomService.getHistory();
+  });
+
+  ipcMain.handle('chatroom:clear', async () => {
+    await chatroomService.clearHistory();
+  });
+
+  ipcMain.handle('chatroom:stop', async () => {
+    chatroomService.stopAll();
+  });
+
+  // Forward chatroom streaming events to all renderer windows
+  chatroomService.on('chatroom:event', (event) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.webContents.send('chatroom:event', event);
+      }
+    }
+  });
+}

--- a/src/main/services/chatroom/ChatroomService.test.ts
+++ b/src/main/services/chatroom/ChatroomService.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock electron app for userData path
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn().mockReturnValue('/mock/userData') },
+}));
+
+// Mock node:fs
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'test-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: any[]) => mockRandomUUID(...args),
+}));
+
+import * as fs from 'node:fs';
+import { ChatroomService, type ChatroomSessionFactory } from './ChatroomService';
+import type { ChatroomMessage, ChatroomStreamEvent } from '../../../shared/chatroom-types';
+import type { MindContext } from '../../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockSession() {
+  const listeners = new Map<string, ((...args: any[]) => void)[]>();
+  return {
+    send: vi.fn(async () => {}),
+    abort: vi.fn(async () => {}),
+    destroy: vi.fn(async () => {}),
+    on: vi.fn((event: string, cb: (...args: any[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event)!.push(cb);
+      const unsub = vi.fn(() => {
+        const cbs = listeners.get(event);
+        if (cbs) {
+          const idx = cbs.indexOf(cb);
+          if (idx >= 0) cbs.splice(idx, 1);
+        }
+      });
+      return unsub;
+    }),
+    _emit(event: string, data: any) {
+      for (const cb of listeners.get(event) ?? []) cb(data);
+    },
+    _listeners: listeners,
+  };
+}
+
+function makeMind(id: string, name: string, status: 'ready' | 'loading' = 'ready'): MindContext {
+  return {
+    mindId: id,
+    mindPath: `/minds/${id}`,
+    identity: { name, systemMessage: `I am ${name}` },
+    status,
+  };
+}
+
+function createFactory(minds: MindContext[], sessions: Map<string, ReturnType<typeof createMockSession>>) {
+  const emitter = new EventEmitter();
+  const factory: ChatroomSessionFactory & EventEmitter = Object.assign(emitter, {
+    createChatroomSession: vi.fn(async (mindId: string) => {
+      if (!sessions.has(mindId)) sessions.set(mindId, createMockSession());
+      return sessions.get(mindId)!;
+    }),
+    listMinds: vi.fn(() => minds),
+  });
+  return factory;
+}
+
+/** Simulate a session completing immediately after send */
+function autoIdle(session: ReturnType<typeof createMockSession>) {
+  session.send.mockImplementation(async () => {
+    // Emit a text chunk then idle
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: 'sdk-msg-1', content: 'Hello from agent' },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+/** Simulate a session that never completes (hangs) */
+function neverIdle(session: ReturnType<typeof createMockSession>) {
+  session.send.mockImplementation(async () => {
+    // emit a chunk but never idle
+    setTimeout(() => {
+      session._emit('assistant.message_delta', {
+        data: { messageId: 'sdk-msg-1', deltaContent: 'partial...' },
+      });
+    }, 0);
+  });
+}
+
+function setupCleanFs() {
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  vi.mocked(fs.readFileSync).mockImplementation(() => {
+    throw new Error('ENOENT');
+  });
+}
+
+// Track UUIDs for round/message IDs
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChatroomService', () => {
+  let sessions: Map<string, ReturnType<typeof createMockSession>>;
+  let minds: MindContext[];
+  let factory: ChatroomSessionFactory & EventEmitter;
+  let svc: ChatroomService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupCleanFs();
+    resetUUIDs();
+
+    sessions = new Map();
+    minds = [makeMind('dude', 'The Dude'), makeMind('jarvis', 'Jarvis')];
+    factory = createFactory(minds, sessions);
+    svc = new ChatroomService(factory);
+  });
+
+  // 1. Broadcast fan-out
+  describe('broadcast fan-out', () => {
+    it('broadcasts to all ready minds in parallel', async () => {
+      const dudeSess = createMockSession();
+      const jarvisSess = createMockSession();
+      sessions.set('dude', dudeSess);
+      sessions.set('jarvis', jarvisSess);
+      autoIdle(dudeSess);
+      autoIdle(jarvisSess);
+
+      await svc.broadcast('Hello everyone');
+
+      expect(factory.createChatroomSession).toHaveBeenCalledWith('dude');
+      expect(factory.createChatroomSession).toHaveBeenCalledWith('jarvis');
+      expect(dudeSess.send).toHaveBeenCalledTimes(1);
+      expect(jarvisSess.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // 2. Session isolation
+  describe('session isolation', () => {
+    it('uses createChatroomSession, not primary sessions', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      autoIdle(sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      await svc.broadcast('test');
+
+      expect(factory.createChatroomSession).toHaveBeenCalledWith('dude');
+    });
+  });
+
+  // 3. Session caching
+  describe('session caching', () => {
+    it('reuses sessions across rounds', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      autoIdle(sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      await svc.broadcast('round 1');
+      await svc.broadcast('round 2');
+
+      // createChatroomSession called only once — cached after first
+      expect(factory.createChatroomSession).toHaveBeenCalledTimes(1);
+      expect(sess.send).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // 4. Round context injection
+  describe('round context injection', () => {
+    it('includes XML history from previous rounds in prompt', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      // First round: auto-idle with response
+      autoIdle(sess);
+      await svc.broadcast('First question');
+
+      // Second round: capture prompt
+      autoIdle(sess);
+      await svc.broadcast('Second question');
+
+      const secondPrompt = sess.send.mock.calls[1][0].prompt as string;
+      expect(secondPrompt).toContain('<chatroom-history');
+      expect(secondPrompt).toContain('participants="The Dude"');
+      expect(secondPrompt).toContain('<message sender="You">First question</message>');
+      expect(secondPrompt).toContain('<message sender="The Dude">Hello from agent</message>');
+      expect(secondPrompt).toContain('<message sender="You">Second question</message>');
+    });
+  });
+
+  // 5. XML escaping
+  describe('XML escaping', () => {
+    it('escapes special characters in messages', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      // First round with special chars
+      sess.send.mockImplementation(async () => {
+        setTimeout(() => {
+          sess._emit('assistant.message', {
+            data: { messageId: 'sdk-1', content: 'Use <div> & "quotes"' },
+          });
+          sess._emit('session.idle', {});
+        }, 0);
+      });
+      await svc.broadcast('What about <script> & stuff?');
+
+      // Second round: check prompt has escaped content
+      autoIdle(sess);
+      await svc.broadcast('Follow up');
+
+      const prompt = sess.send.mock.calls[1][0].prompt as string;
+      expect(prompt).toContain('&lt;script&gt; &amp; stuff?');
+      expect(prompt).toContain('&lt;div&gt; &amp; &quot;quotes&quot;');
+    });
+  });
+
+  // 6. Context window — only last 2 rounds
+  describe('context window', () => {
+    it('only includes last 2 rounds in history', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+      autoIdle(sess);
+
+      await svc.broadcast('Round 1');
+      await svc.broadcast('Round 2');
+      await svc.broadcast('Round 3');
+      await svc.broadcast('Round 4');
+
+      const lastPrompt = sess.send.mock.calls[3][0].prompt as string;
+      // Should NOT contain Round 1 (too old)
+      expect(lastPrompt).not.toContain('Round 1');
+      // Should contain Rounds 2 and 3
+      expect(lastPrompt).toContain('Round 2');
+      expect(lastPrompt).toContain('Round 3');
+      expect(lastPrompt).toContain('Round 4');
+    });
+  });
+
+  // 7. Incremental persistence
+  describe('incremental persistence', () => {
+    it('saves user message immediately, agent replies on completion', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      const writeTimestamps: string[] = [];
+      vi.mocked(fs.writeFileSync).mockImplementation((_p, data) => {
+        writeTimestamps.push(data as string);
+      });
+      vi.mocked(fs.renameSync).mockImplementation(() => {});
+
+      autoIdle(sess);
+      await svc.broadcast('Hello');
+
+      // Should have at least 2 writes: one for user message, one after agent reply
+      expect(writeTimestamps.length).toBeGreaterThanOrEqual(2);
+
+      // First write should contain user message but not agent reply
+      const firstWrite = JSON.parse(writeTimestamps[0]);
+      expect(firstWrite.messages.some((m: any) => m.role === 'user')).toBe(true);
+      expect(firstWrite.messages.some((m: any) => m.role === 'assistant')).toBe(false);
+
+      // Last write should contain both
+      const lastWrite = JSON.parse(writeTimestamps[writeTimestamps.length - 1]);
+      expect(lastWrite.messages.some((m: any) => m.role === 'user')).toBe(true);
+      expect(lastWrite.messages.some((m: any) => m.role === 'assistant')).toBe(true);
+    });
+  });
+
+  // 8. Persistence cap
+  describe('persistence cap', () => {
+    it('trims to 500 messages on save', async () => {
+      // Pre-load 499 messages
+      const existingMessages: ChatroomMessage[] = [];
+      for (let i = 0; i < 499; i++) {
+        existingMessages.push({
+          id: `old-${i}`,
+          role: 'user',
+          blocks: [{ type: 'text', content: `msg ${i}` }],
+          timestamp: i,
+          sender: { mindId: 'user', name: 'You' },
+          roundId: `round-${i}`,
+        });
+      }
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ version: 1, messages: existingMessages }),
+      );
+
+      // Only one mind so we don't have dangling sessions
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      autoIdle(sess);
+
+      svc = new ChatroomService(factory);
+
+      await svc.broadcast('New message');
+
+      // Check written data — should be capped at 500
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls;
+      const lastWrite = writeCall[writeCall.length - 1];
+      const written = JSON.parse(lastWrite[1] as string);
+      expect(written.messages.length).toBeLessThanOrEqual(500);
+    });
+  });
+
+  // 9. Persistence loading
+  describe('persistence loading', () => {
+    it('loads existing transcript on construction', async () => {
+      const existing: ChatroomMessage[] = [
+        {
+          id: 'prev-1',
+          role: 'user',
+          blocks: [{ type: 'text', content: 'Old message' }],
+          timestamp: 1000,
+          sender: { mindId: 'user', name: 'You' },
+          roundId: 'old-round',
+        },
+      ];
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ version: 1, messages: existing }),
+      );
+
+      const loaded = new ChatroomService(factory);
+      const history = loaded.getHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0].id).toBe('prev-1');
+    });
+  });
+
+  // 10. Mid-round send
+  describe('mid-round send', () => {
+    it('new broadcast cancels previous round in-flight agents', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      // First round never completes
+      neverIdle(sess);
+      const firstBroadcast = svc.broadcast('First');
+
+      // Wait for send to fire
+      await vi.waitFor(() => expect(sess.send).toHaveBeenCalledTimes(1));
+
+      // Second broadcast should cancel first
+      autoIdle(sess);
+      await svc.broadcast('Second');
+
+      expect(sess.abort).toHaveBeenCalled();
+    });
+  });
+
+  // 11. stopAll
+  describe('stopAll', () => {
+    it('cancels all in-flight agents', async () => {
+      const dudeSess = createMockSession();
+      const jarvisSess = createMockSession();
+      sessions.set('dude', dudeSess);
+      sessions.set('jarvis', jarvisSess);
+      neverIdle(dudeSess);
+      neverIdle(jarvisSess);
+
+      const broadcastPromise = svc.broadcast('Hello');
+
+      // Wait for sends to fire
+      await vi.waitFor(() => {
+        expect(dudeSess.send).toHaveBeenCalled();
+        expect(jarvisSess.send).toHaveBeenCalled();
+      });
+
+      svc.stopAll();
+
+      expect(dudeSess.abort).toHaveBeenCalled();
+      expect(jarvisSess.abort).toHaveBeenCalled();
+
+      // Broadcast should resolve (not hang)
+      await broadcastPromise;
+    });
+  });
+
+  // 12. Participant snapshot
+  describe('participant snapshot', () => {
+    it('uses minds at broadcast time, not later additions', async () => {
+      const dudeSess = createMockSession();
+      sessions.set('dude', dudeSess);
+      autoIdle(dudeSess);
+
+      // Start with only dude
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      const broadcastPromise = svc.broadcast('Hello');
+
+      // Add jarvis mid-broadcast
+      minds.push(makeMind('jarvis', 'Jarvis'));
+
+      await broadcastPromise;
+
+      // Only dude should have been contacted
+      expect(factory.createChatroomSession).toHaveBeenCalledTimes(1);
+      expect(factory.createChatroomSession).toHaveBeenCalledWith('dude');
+    });
+  });
+
+  // 13. Mind unload
+  describe('mind unload', () => {
+    it('cancels in-flight and destroys cached session on mind:unloaded', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      // Start a broadcast that doesn't complete
+      neverIdle(sess);
+      const broadcastPromise = svc.broadcast('Hello');
+
+      await vi.waitFor(() => expect(sess.send).toHaveBeenCalled());
+
+      // Simulate mind unload event
+      (factory as EventEmitter).emit('mind:unloaded', 'dude');
+
+      expect(sess.abort).toHaveBeenCalled();
+      expect(sess.destroy).toHaveBeenCalled();
+
+      // Broadcast should resolve
+      await broadcastPromise;
+    });
+  });
+
+  // 14. Per-agent error isolation
+  describe('per-agent error isolation', () => {
+    it('one agent failing does not affect others', async () => {
+      const dudeSess = createMockSession();
+      const jarvisSess = createMockSession();
+      sessions.set('dude', dudeSess);
+      sessions.set('jarvis', jarvisSess);
+
+      // Dude errors out
+      dudeSess.send.mockImplementation(async () => {
+        setTimeout(() => {
+          dudeSess._emit('session.error', { data: { message: 'dude broke' } });
+        }, 0);
+      });
+
+      // Jarvis succeeds
+      autoIdle(jarvisSess);
+
+      await svc.broadcast('Hello');
+
+      // Jarvis should have completed fine
+      expect(jarvisSess.send).toHaveBeenCalled();
+
+      // History should still have the user message + jarvis reply
+      const history = svc.getHistory();
+      expect(history.some((m) => m.sender.mindId === 'jarvis')).toBe(true);
+    });
+  });
+
+  // 15. 0 agents
+  describe('0 agents', () => {
+    it('broadcast with no ready minds saves user message only', async () => {
+      minds.length = 0;
+
+      await svc.broadcast('Hello nobody');
+
+      const history = svc.getHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0].role).toBe('user');
+      expect(history[0].blocks[0]).toEqual({ type: 'text', content: 'Hello nobody' });
+    });
+  });
+
+  // 16. clearHistory
+  describe('clearHistory', () => {
+    it('clears messages and destroys sessions', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+      autoIdle(sess);
+
+      await svc.broadcast('Hello');
+      expect(svc.getHistory().length).toBeGreaterThan(0);
+
+      await svc.clearHistory();
+
+      expect(svc.getHistory()).toHaveLength(0);
+      expect(sess.destroy).toHaveBeenCalled();
+    });
+  });
+
+  // 17. Event emission
+  describe('event emission', () => {
+    it('emits ChatroomStreamEvents with correct shape', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      const events: ChatroomStreamEvent[] = [];
+      svc.on('chatroom:event', (event: ChatroomStreamEvent) => events.push(event));
+
+      sess.send.mockImplementation(async () => {
+        setTimeout(() => {
+          sess._emit('assistant.message_delta', {
+            data: { messageId: 'sdk-1', deltaContent: 'Hello' },
+          });
+          sess._emit('session.idle', {});
+        }, 0);
+      });
+
+      await svc.broadcast('Hi');
+
+      expect(events.length).toBeGreaterThan(0);
+      const chunkEvent = events.find((e) => e.event.type === 'chunk');
+      expect(chunkEvent).toBeDefined();
+      expect(chunkEvent!.mindId).toBe('dude');
+      expect(chunkEvent!.mindName).toBe('The Dude');
+      expect(chunkEvent!.roundId).toBeTruthy();
+      expect(chunkEvent!.messageId).toBeTruthy();
+    });
+  });
+
+  // Edge: filters non-ready minds
+  describe('filters non-ready minds', () => {
+    it('skips minds that are not status ready', async () => {
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude', 'ready'));
+      minds.push(makeMind('loading-mind', 'Loading', 'loading'));
+
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      autoIdle(sess);
+
+      await svc.broadcast('Hello');
+
+      expect(factory.createChatroomSession).toHaveBeenCalledTimes(1);
+      expect(factory.createChatroomSession).toHaveBeenCalledWith('dude');
+    });
+  });
+});

--- a/src/main/services/chatroom/ChatroomService.ts
+++ b/src/main/services/chatroom/ChatroomService.ts
@@ -63,9 +63,7 @@ export class ChatroomService extends EventEmitter {
   constructor(private readonly sessionFactory: ChatroomSessionFactory) {
     super();
 
-    this.persistDir = path.join(app.getPath('userData'), '..');
-    // ~/.chamber/chatroom.json
-    const chamberDir = path.join(app.getPath('userData'));
+    const chamberDir = app.getPath('userData');
     this.persistDir = chamberDir;
     this.persistPath = path.join(chamberDir, 'chatroom.json');
 

--- a/src/main/services/chatroom/ChatroomService.ts
+++ b/src/main/services/chatroom/ChatroomService.ts
@@ -99,8 +99,8 @@ export class ChatroomService extends EventEmitter {
     // Fan out to all participants in parallel
     await Promise.all(
       participants.map((mind) =>
-        this.sendToAgent(mind, contextPrompt, roundId).catch(() => {
-          // Per-agent errors are isolated
+        this.sendToAgent(mind, contextPrompt, roundId).catch((err) => {
+          console.error(`[Chatroom] Agent ${mind.mindId} failed:`, err);
         }),
       ),
     );

--- a/src/main/services/chatroom/ChatroomService.ts
+++ b/src/main/services/chatroom/ChatroomService.ts
@@ -1,0 +1,411 @@
+import { EventEmitter } from 'events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { app } from 'electron';
+import type { ChatroomMessage, ChatroomTranscript, ChatroomStreamEvent } from '../../../shared/chatroom-types';
+import type { MindContext } from '../../../shared/types';
+import type { CopilotSession } from '../mind';
+
+// ---------------------------------------------------------------------------
+// Interfaces
+// ---------------------------------------------------------------------------
+
+export interface ChatroomSessionFactory {
+  createChatroomSession(mindId: string): Promise<CopilotSession>;
+  listMinds(): MindContext[];
+  on?(event: string, listener: (...args: any[]) => void): any;
+  removeListener?(event: string, listener: (...args: any[]) => void): any;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MAX_MESSAGES = 500;
+
+const XML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+function escapeXml(text: string): string {
+  return text.replace(/[&<>"']/g, (ch) => XML_ESCAPE_MAP[ch]);
+}
+
+function textContent(msg: ChatroomMessage): string {
+  return msg.blocks
+    .filter((b) => b.type === 'text')
+    .map((b) => (b as { content: string }).content)
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// ChatroomService
+// ---------------------------------------------------------------------------
+
+interface InFlightAgent {
+  mindId: string;
+  abort: AbortController;
+  unsubs: (() => void)[];
+}
+
+export class ChatroomService extends EventEmitter {
+  private messages: ChatroomMessage[] = [];
+  private sessionCache = new Map<string, CopilotSession>();
+  private inFlight = new Map<string, InFlightAgent>();
+  private readonly persistPath: string;
+  private readonly persistDir: string;
+
+  constructor(private readonly sessionFactory: ChatroomSessionFactory) {
+    super();
+
+    this.persistDir = path.join(app.getPath('userData'), '..');
+    // ~/.chamber/chatroom.json
+    const chamberDir = path.join(app.getPath('userData'));
+    this.persistDir = chamberDir;
+    this.persistPath = path.join(chamberDir, 'chatroom.json');
+
+    this.loadTranscript();
+    this.listenToFactoryEvents();
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  async broadcast(userMessage: string, _model?: string): Promise<void> {
+    // Cancel any in-flight agents from previous round
+    this.stopAll();
+
+    const roundId = randomUUID();
+
+    // Snapshot participants (only ready minds)
+    const participants = this.sessionFactory
+      .listMinds()
+      .filter((m) => m.status === 'ready');
+
+    // Create and persist user message
+    const userMsg = this.createUserMessage(userMessage, roundId);
+    this.messages.push(userMsg);
+    this.persist();
+
+    if (participants.length === 0) return;
+
+    // Build context prompt for this round
+    const contextPrompt = this.buildPrompt(userMessage, participants, roundId);
+
+    // Fan out to all participants in parallel
+    await Promise.all(
+      participants.map((mind) =>
+        this.sendToAgent(mind, contextPrompt, roundId).catch(() => {
+          // Per-agent errors are isolated
+        }),
+      ),
+    );
+  }
+
+  stopAll(): void {
+    for (const agent of this.inFlight.values()) {
+      agent.abort.abort();
+      for (const unsub of agent.unsubs) unsub();
+      const session = this.sessionCache.get(agent.mindId);
+      if (session) session.abort().catch(() => {});
+    }
+    this.inFlight.clear();
+  }
+
+  getHistory(): ChatroomMessage[] {
+    return [...this.messages];
+  }
+
+  async clearHistory(): Promise<void> {
+    this.messages = [];
+    this.persist();
+
+    // Destroy all cached sessions
+    for (const [id, session] of this.sessionCache) {
+      await session.destroy().catch(() => {});
+    }
+    this.sessionCache.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async sendToAgent(
+    mind: MindContext,
+    prompt: string,
+    roundId: string,
+  ): Promise<void> {
+    const session = await this.getOrCreateSession(mind.mindId);
+    const messageId = randomUUID();
+    const abortController = new AbortController();
+
+    const unsubs: (() => void)[] = [];
+    const agent: InFlightAgent = { mindId: mind.mindId, abort: abortController, unsubs };
+    this.inFlight.set(mind.mindId, agent);
+
+    const guard = (fn: () => void) => {
+      if (!abortController.signal.aborted) fn();
+    };
+
+    const emitEvent = (event: ChatroomStreamEvent['event']) => {
+      guard(() => {
+        this.emit('chatroom:event', {
+          mindId: mind.mindId,
+          mindName: mind.identity.name,
+          messageId,
+          roundId,
+          event,
+        } satisfies ChatroomStreamEvent);
+      });
+    };
+
+    let finalContent = '';
+
+    try {
+      // Subscribe to streaming events
+      unsubs.push(
+        session.on('assistant.message_delta', (e: any) => {
+          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.message', (e: any) => {
+          if (e.data.content) {
+            finalContent = e.data.content;
+            emitEvent({
+              type: 'message_final',
+              sdkMessageId: e.data.messageId,
+              content: e.data.content,
+            });
+          }
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.reasoning_delta', (e: any) => {
+          emitEvent({
+            type: 'reasoning',
+            reasoningId: e.data.reasoningId,
+            content: e.data.deltaContent,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_start', (e: any) => {
+          emitEvent({
+            type: 'tool_start',
+            toolCallId: e.data.toolCallId,
+            toolName: e.data.toolName,
+            args: e.data.arguments,
+            parentToolCallId: e.data.parentToolCallId,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_complete', (e: any) => {
+          emitEvent({
+            type: 'tool_done',
+            toolCallId: e.data.toolCallId,
+            success: e.data.success,
+            result: e.data.result?.content,
+            error: e.data.error?.message,
+          });
+        }),
+      );
+
+      await session.send({ prompt });
+
+      // Wait for idle or error
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(resolve, 300_000);
+
+        const unsubIdle = session.on('session.idle', () => {
+          clearTimeout(timeout);
+          unsubIdle();
+          resolve();
+        });
+        unsubs.push(unsubIdle);
+
+        const unsubError = session.on('session.error', (e: any) => {
+          clearTimeout(timeout);
+          unsubError();
+          reject(new Error(e.data.message));
+        });
+        unsubs.push(unsubError);
+
+        abortController.signal.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeout);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+
+      if (abortController.signal.aborted) return;
+
+      // Persist agent reply
+      if (finalContent) {
+        const agentMsg: ChatroomMessage = {
+          id: messageId,
+          role: 'assistant',
+          blocks: [{ type: 'text', content: finalContent }],
+          timestamp: Date.now(),
+          sender: { mindId: mind.mindId, name: mind.identity.name },
+          roundId,
+        };
+        this.messages.push(agentMsg);
+        this.persist();
+      }
+
+      emitEvent({ type: 'done' });
+    } catch (err) {
+      if (!abortController.signal.aborted) {
+        const message = err instanceof Error ? err.message : String(err);
+        emitEvent({ type: 'error', message });
+      }
+    } finally {
+      for (const unsub of unsubs) unsub();
+      this.inFlight.delete(mind.mindId);
+    }
+  }
+
+  private async getOrCreateSession(mindId: string): Promise<CopilotSession> {
+    let session = this.sessionCache.get(mindId);
+    if (!session) {
+      session = await this.sessionFactory.createChatroomSession(mindId);
+      this.sessionCache.set(mindId, session as CopilotSession);
+    }
+    return session;
+  }
+
+  private createUserMessage(text: string, roundId: string): ChatroomMessage {
+    return {
+      id: randomUUID(),
+      role: 'user',
+      blocks: [{ type: 'text', content: text }],
+      timestamp: Date.now(),
+      sender: { mindId: 'user', name: 'You' },
+      roundId,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Context prompt building
+  // -------------------------------------------------------------------------
+
+  private buildPrompt(
+    currentMessage: string,
+    participants: MindContext[],
+    _roundId: string,
+  ): string {
+    const historyRounds = this.getLastNRounds(2);
+    const participantNames = participants.map((p) => p.identity.name).join(', ');
+
+    if (historyRounds.length === 0) {
+      return `<message sender="You">${escapeXml(currentMessage)}</message>`;
+    }
+
+    let xml = `<chatroom-history participants="${escapeXml(participantNames)}">\n`;
+    for (const msg of historyRounds) {
+      const sender = msg.sender.name;
+      xml += `  <message sender="${escapeXml(sender)}">${escapeXml(textContent(msg))}</message>\n`;
+    }
+    xml += `</chatroom-history>\n`;
+    xml += `Respond only to the following message. The chatroom history above is for context only.\n\n`;
+    xml += `<message sender="You">${escapeXml(currentMessage)}</message>`;
+
+    return xml;
+  }
+
+  private getLastNRounds(n: number): ChatroomMessage[] {
+    // Collect unique roundIds in reverse order, take last n
+    const roundIds: string[] = [];
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      const rid = this.messages[i].roundId;
+      if (!roundIds.includes(rid)) {
+        roundIds.unshift(rid);
+      }
+    }
+
+    // Exclude the current round (it's being built now — its user msg is already in this.messages)
+    // The last roundId is the current round, so take n rounds before it
+    const currentRoundId = roundIds[roundIds.length - 1];
+    const previousRoundIds = roundIds.filter((r) => r !== currentRoundId);
+    const targetRoundIds = previousRoundIds.slice(-n);
+
+    return this.messages.filter((m) => targetRoundIds.includes(m.roundId));
+  }
+
+  // -------------------------------------------------------------------------
+  // Persistence
+  // -------------------------------------------------------------------------
+
+  private loadTranscript(): void {
+    try {
+      if (!fs.existsSync(this.persistPath)) return;
+      const raw = fs.readFileSync(this.persistPath, 'utf-8');
+      const transcript: ChatroomTranscript = JSON.parse(raw);
+      if (transcript.version === 1 && Array.isArray(transcript.messages)) {
+        this.messages = transcript.messages;
+      }
+    } catch {
+      // Corrupt or missing — start fresh
+    }
+  }
+
+  private persist(): void {
+    try {
+      fs.mkdirSync(this.persistDir, { recursive: true });
+      const trimmed = this.messages.slice(-MAX_MESSAGES);
+      this.messages = trimmed;
+      const transcript: ChatroomTranscript = { version: 1, messages: trimmed };
+      const tmpPath = this.persistPath + '.tmp';
+      fs.writeFileSync(tmpPath, JSON.stringify(transcript, null, 2));
+      fs.renameSync(tmpPath, this.persistPath);
+    } catch {
+      // Persistence failure is non-fatal
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Factory event listeners
+  // -------------------------------------------------------------------------
+
+  private listenToFactoryEvents(): void {
+    if (this.sessionFactory.on) {
+      this.sessionFactory.on('mind:unloaded', (mindId: string) => {
+        this.handleMindUnloaded(mindId);
+      });
+    }
+  }
+
+  private handleMindUnloaded(mindId: string): void {
+    // Cancel in-flight if streaming
+    const agent = this.inFlight.get(mindId);
+    if (agent) {
+      agent.abort.abort();
+      for (const unsub of agent.unsubs) unsub();
+      this.inFlight.delete(mindId);
+    }
+
+    // Destroy and remove cached session
+    const session = this.sessionCache.get(mindId);
+    if (session) {
+      session.abort().catch(() => {});
+      session.destroy().catch(() => {});
+      this.sessionCache.delete(mindId);
+    }
+  }
+}

--- a/src/main/services/chatroom/index.ts
+++ b/src/main/services/chatroom/index.ts
@@ -1,0 +1,1 @@
+export { ChatroomService, type ChatroomSessionFactory } from './ChatroomService';

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -261,6 +261,21 @@ export class MindManager extends EventEmitter {
     );
   }
 
+  async createChatroomSession(mindId: string): Promise<CopilotSession> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+
+    const tools = context.extensions.flatMap((e: { tools?: unknown[] }) => e.tools ?? []);
+    const sessionTools = this.toolBuilder ? this.toolBuilder(mindId, tools) : tools;
+
+    return this.createSessionForMind(
+      context.client,
+      context.mindPath,
+      context.identity.systemMessage,
+      sessionTools,
+    );
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async createSessionForMind(
     client: any,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -43,6 +43,13 @@ const electronAPI: ElectronAPI = {
     onProgress: (callback) =>
       createIpcListener(ipcRenderer, 'genesis:progress', callback),
   },
+  chatroom: {
+    send: (message: string, model?: string) => ipcRenderer.invoke('chatroom:send', message, model),
+    history: () => ipcRenderer.invoke('chatroom:history'),
+    clear: () => ipcRenderer.invoke('chatroom:clear'),
+    stop: () => ipcRenderer.invoke('chatroom:stop'),
+    onEvent: (callback) => createIpcListener(ipcRenderer, 'chatroom:event', callback),
+  },
   a2a: {
     onIncoming: (callback: (payload: any) => void) => createIpcListener(ipcRenderer, 'a2a:incoming', callback),
     listAgents: () => ipcRenderer.invoke('a2a:listAgents'),

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -17,9 +17,10 @@ interface Props {
   availableModels: ModelInfo[];
   selectedModel: string | null;
   onModelChange: (model: string) => void;
+  placeholder?: string;
 }
 
-export function ChatInput({ onSend, onStop, isStreaming, disabled, availableModels, selectedModel, onModelChange }: Props) {
+export function ChatInput({ onSend, onStop, isStreaming, disabled, availableModels, selectedModel, onModelChange, placeholder }: Props) {
   const [input, setInput] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -61,7 +62,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
             value={input}
             onChange={handleInput}
             onKeyDown={handleKeyDown}
-            placeholder={disabled ? 'Select a mind directory to start…' : 'Message your agent…'}
+            placeholder={disabled ? 'Select a mind directory to start…' : (placeholder ?? 'Message your agent…')}
             disabled={disabled}
             rows={1}
             className="flex-1 bg-transparent text-sm resize-none outline-none placeholder:text-muted-foreground disabled:opacity-50 max-h-[200px]"

--- a/src/renderer/components/chatroom/ChatroomPanel.test.tsx
+++ b/src/renderer/components/chatroom/ChatroomPanel.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ChatroomPanel } from './ChatroomPanel';
+import { AppStateProvider } from '../../lib/store';
+import type { AppState } from '../../lib/store';
+import type { MindContext } from '../../../shared/types';
+import {
+  installElectronAPI,
+  makeChatroomMessage,
+} from '../../../test/helpers';
+import type { ElectronAPI } from '../../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MIND_A: MindContext = {
+  mindId: 'mind-a',
+  mindPath: 'C:\\agents\\a',
+  identity: { name: 'The Dude', systemMessage: '' },
+  status: 'ready',
+};
+
+const MIND_B: MindContext = {
+  mindId: 'mind-b',
+  mindPath: 'C:\\agents\\b',
+  identity: { name: 'Jarvis', systemMessage: '' },
+  status: 'ready',
+};
+
+function renderPanel(stateOverrides: Partial<AppState> = {}, api?: ElectronAPI) {
+  const mock = installElectronAPI(api);
+  return {
+    mock,
+    ...render(
+      <AppStateProvider testInitialState={stateOverrides}>
+        <ChatroomPanel />
+      </AppStateProvider>,
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChatroomPanel', () => {
+  let api: ElectronAPI;
+
+  beforeEach(() => {
+    api = installElectronAPI();
+  });
+
+  // 1. Empty state with agents present
+  it('renders empty state when no messages and agents are loaded', () => {
+    renderPanel({ minds: [MIND_A] }, api);
+    expect(screen.getByText(/messages you send here go to all agents/i)).toBeTruthy();
+  });
+
+  // 2. Participant bar
+  it('renders participant bar with loaded minds', () => {
+    renderPanel({ minds: [MIND_A, MIND_B] }, api);
+    expect(screen.getByText('The Dude')).toBeTruthy();
+    expect(screen.getByText('Jarvis')).toBeTruthy();
+  });
+
+  // 3. User messages
+  it('renders user messages with "You" sender badge', () => {
+    const userMsg = makeChatroomMessage({
+      id: 'u1',
+      role: 'user',
+      blocks: [{ type: 'text', content: 'hello everyone' }],
+      sender: { mindId: 'user', name: 'You' },
+    });
+    renderPanel({ minds: [MIND_A], chatroomMessages: [userMsg] }, api);
+    expect(screen.getByText('You')).toBeTruthy();
+    expect(screen.getByText('hello everyone')).toBeTruthy();
+  });
+
+  // 4. Agent messages
+  it('renders agent messages with agent name badge', () => {
+    const agentMsg = makeChatroomMessage({
+      id: 'a1',
+      role: 'assistant',
+      blocks: [{ type: 'text', content: 'hey there' }],
+      sender: { mindId: 'mind-a', name: 'The Dude' },
+    });
+    renderPanel({ minds: [MIND_A], chatroomMessages: [agentMsg] }, api);
+    // Sender name appears in the message header
+    expect(screen.getAllByText('The Dude').length).toBeGreaterThanOrEqual(1);
+  });
+
+  // 5. Loads history on mount
+  it('loads history on mount via chatroom.history()', async () => {
+    const historyMsg = makeChatroomMessage({ id: 'h1' });
+    (api.chatroom.history as Mock).mockResolvedValue([historyMsg]);
+
+    await act(async () => {
+      renderPanel({ minds: [MIND_A] }, api);
+    });
+
+    expect(api.chatroom.history).toHaveBeenCalled();
+  });
+
+  // 6. Sends message
+  it('sends message via chatroom.send() on submit', async () => {
+    renderPanel({ minds: [MIND_A] }, api);
+
+    const textarea = screen.getByPlaceholderText('Message the chatroom…');
+    fireEvent.change(textarea, { target: { value: 'hello all' } });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+    });
+
+    expect(api.chatroom.send).toHaveBeenCalledWith('hello all', undefined);
+  });
+
+  // 7. Disabled when no agents
+  it('shows disabled state when no agents loaded', () => {
+    renderPanel({ minds: [] }, api);
+    expect(screen.getByText(/no agents loaded/i)).toBeTruthy();
+  });
+
+  // 8. Streaming indicator
+  it('shows streaming indicator for agents that are streaming', () => {
+    const streamingMsg = makeChatroomMessage({
+      id: 's1',
+      role: 'assistant',
+      blocks: [],
+      isStreaming: true,
+      sender: { mindId: 'mind-a', name: 'The Dude' },
+    });
+    renderPanel(
+      {
+        minds: [MIND_A],
+        chatroomMessages: [streamingMsg],
+        chatroomStreamingByMind: { 'mind-a': true },
+      },
+      api,
+    );
+    // The StreamingMessage component shows "Thinking…" for empty streaming messages
+    expect(screen.getByText('Thinking…')).toBeTruthy();
+  });
+
+  // 9. Subscribes to chatroom events
+  it('subscribes to chatroom events on mount', () => {
+    renderPanel({ minds: [MIND_A] }, api);
+    expect(api.chatroom.onEvent).toHaveBeenCalled();
+  });
+
+  // 10. Stop button calls chatroom.stop()
+  it('calls chatroom.stop() when stop is clicked during streaming', async () => {
+    const streamingMsg = makeChatroomMessage({
+      id: 's1',
+      role: 'assistant',
+      blocks: [{ type: 'text', content: 'partial' }],
+      isStreaming: true,
+      sender: { mindId: 'mind-a', name: 'The Dude' },
+    });
+    renderPanel(
+      {
+        minds: [MIND_A],
+        chatroomMessages: [streamingMsg],
+        chatroomStreamingByMind: { 'mind-a': true },
+      },
+      api,
+    );
+
+    const button = screen.getByRole('button');
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(api.chatroom.stop).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/chatroom/ChatroomPanel.tsx
+++ b/src/renderer/components/chatroom/ChatroomPanel.tsx
@@ -1,0 +1,199 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useAppState, useAppDispatch, getPlainContent } from '../../lib/store';
+import { ChatInput } from '../chat/ChatInput';
+import { StreamingMessage } from '../chat/StreamingMessage';
+import { cn, formatTime } from '../../lib/utils';
+import type { MindContext } from '../../../shared/types';
+import type { ChatroomMessage } from '../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Colour palette for agent badges
+// ---------------------------------------------------------------------------
+
+const AGENT_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
+
+function agentColor(minds: MindContext[], mindId: string): string {
+  const idx = minds.findIndex(m => m.mindId === mindId);
+  return AGENT_COLORS[(idx >= 0 ? idx : 0) % AGENT_COLORS.length];
+}
+
+// ---------------------------------------------------------------------------
+// ParticipantBar
+// ---------------------------------------------------------------------------
+
+function ParticipantBar({ minds, streamingByMind }: { minds: MindContext[]; streamingByMind: Record<string, boolean> }) {
+  if (minds.length === 0) return null;
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-border overflow-x-auto shrink-0">
+      {minds.map((mind, i) => {
+        const streaming = streamingByMind[mind.mindId];
+        return (
+          <span
+            key={mind.mindId}
+            className="inline-flex items-center gap-1.5 text-xs font-medium rounded-full px-2.5 py-1 whitespace-nowrap"
+            style={{ backgroundColor: `${AGENT_COLORS[i % AGENT_COLORS.length]}20`, color: AGENT_COLORS[i % AGENT_COLORS.length] }}
+          >
+            <span className={cn('w-2 h-2 rounded-full', streaming ? 'bg-yellow-400 animate-pulse' : 'bg-green-500')} />
+            {mind.identity.name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChatroomMessageList
+// ---------------------------------------------------------------------------
+
+function ChatroomMessageList({ messages, minds }: { messages: ChatroomMessage[]; minds: MindContext[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isAutoScrolling = useRef(true);
+
+  useEffect(() => {
+    if (isAutoScrolling.current && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleScroll = () => {
+    if (!scrollRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+    isAutoScrolling.current = scrollHeight - scrollTop - clientHeight < 100;
+  };
+
+  return (
+    <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-4 py-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        {messages.map((message) => {
+          const isUser = message.role === 'user';
+          const senderName = message.sender?.name ?? 'Unknown';
+          const color = isUser ? undefined : agentColor(minds, message.sender?.mindId ?? '');
+
+          return (
+            <div key={message.id} className="flex gap-3">
+              {/* Avatar */}
+              <div
+                className={cn(
+                  'w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium shrink-0 mt-0.5',
+                  isUser && 'bg-secondary text-secondary-foreground',
+                )}
+                style={isUser ? undefined : { backgroundColor: color, color: '#fff' }}
+              >
+                {isUser ? 'Y' : senderName.charAt(0).toUpperCase()}
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span
+                    className="text-sm font-medium"
+                    style={isUser ? undefined : { color }}
+                  >
+                    {senderName}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatTime(message.timestamp)}
+                  </span>
+                </div>
+
+                {message.role === 'assistant' ? (
+                  <StreamingMessage blocks={message.blocks} isStreaming={message.isStreaming} />
+                ) : (
+                  <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                    {getPlainContent(message)}
+                  </p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChatroomEmptyState
+// ---------------------------------------------------------------------------
+
+function ChatroomEmptyState({ connected }: { connected: boolean }) {
+  return (
+    <div className="flex-1 flex items-center justify-center px-4">
+      <p className="text-sm text-muted-foreground text-center">
+        {connected
+          ? 'This is the chatroom. Messages you send here go to all agents.'
+          : 'No agents loaded. Add an agent to start chatting.'}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChatroomPanel
+// ---------------------------------------------------------------------------
+
+export function ChatroomPanel() {
+  const { chatroomMessages, minds, chatroomStreamingByMind, availableModels, selectedModel } = useAppState();
+  const dispatch = useAppDispatch();
+  const isStreaming = Object.values(chatroomStreamingByMind).some(Boolean);
+  const connected = minds.length > 0;
+
+  // Load history on mount
+  useEffect(() => {
+    window.electronAPI.chatroom.history().then((messages) => {
+      dispatch({ type: 'SET_CHATROOM_HISTORY', payload: messages });
+    });
+  }, [dispatch]);
+
+  // Subscribe to chatroom events
+  useEffect(() => {
+    const unsub = window.electronAPI.chatroom.onEvent((event) => {
+      dispatch({ type: 'CHATROOM_EVENT', payload: event });
+    });
+    return unsub;
+  }, [dispatch]);
+
+  const handleSend = useCallback(async (content: string) => {
+    const roundId = crypto.randomUUID();
+    dispatch({
+      type: 'CHATROOM_USER_MESSAGE',
+      payload: {
+        id: `user-${roundId}`,
+        role: 'user',
+        blocks: [{ type: 'text', content }],
+        timestamp: Date.now(),
+        sender: { mindId: 'user', name: 'You' },
+        roundId,
+      },
+    });
+    await window.electronAPI.chatroom.send(content, selectedModel ?? undefined);
+  }, [dispatch, selectedModel]);
+
+  const handleStop = useCallback(async () => {
+    await window.electronAPI.chatroom.stop();
+  }, []);
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <ParticipantBar minds={minds} streamingByMind={chatroomStreamingByMind} />
+
+      {chatroomMessages.length === 0 ? (
+        <ChatroomEmptyState connected={connected} />
+      ) : (
+        <ChatroomMessageList messages={chatroomMessages} minds={minds} />
+      )}
+
+      <ChatInput
+        onSend={handleSend}
+        onStop={handleStop}
+        isStreaming={isStreaming}
+        disabled={!connected}
+        availableModels={availableModels}
+        selectedModel={selectedModel}
+        onModelChange={(model) => dispatch({ type: 'SET_SELECTED_MODEL', payload: model })}
+        placeholder="Message the chatroom…"
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/layout/ActivityBar.tsx
+++ b/src/renderer/components/layout/ActivityBar.tsx
@@ -46,6 +46,24 @@ export function ActivityBar() {
           <TooltipContent side="right" sideOffset={8}>Chat</TooltipContent>
         </Tooltip>
 
+        {/* Chatroom — always present */}
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chatroom' })}
+              className={cn(
+                'w-10 h-10 rounded-lg flex items-center justify-center transition-colors',
+                activeView === 'chatroom'
+                  ? 'bg-accent text-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+              )}
+            >
+              <Users size={20} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>Chatroom</TooltipContent>
+        </Tooltip>
+
         {discoveredViews.length > 0 && <Separator className="my-1 w-8" />}
 
         {/* Discovered views */}

--- a/src/renderer/components/layout/ViewRouter.tsx
+++ b/src/renderer/components/layout/ViewRouter.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useAppState } from '../../lib/store';
 import { ChatPanel } from '../chat/ChatPanel';
+import { ChatroomPanel } from '../chatroom/ChatroomPanel';
 import { LensViewRenderer } from '../views/LensViewRenderer';
 
 export function ViewRouter() {
@@ -8,6 +9,10 @@ export function ViewRouter() {
 
   if (activeView === 'chat') {
     return <ChatPanel />;
+  }
+
+  if (activeView === 'chatroom') {
+    return <ChatroomPanel />;
   }
 
   const view = discoveredViews.find(v => v.id === activeView);

--- a/src/renderer/lib/store/context.tsx
+++ b/src/renderer/lib/store/context.tsx
@@ -6,8 +6,8 @@ import { appReducer } from './reducer';
 const AppStateContext = createContext<AppState>(initialState);
 const AppDispatchContext = createContext<Dispatch<AppAction>>(() => {});
 
-export function AppStateProvider({ children }: { children: React.ReactNode }) {
-  const [state, dispatch] = useReducer(appReducer, initialState);
+export function AppStateProvider({ children, testInitialState }: { children: React.ReactNode; testInitialState?: Partial<AppState> }) {
+  const [state, dispatch] = useReducer(appReducer, testInitialState ? { ...initialState, ...testInitialState } : initialState);
 
   return (
     <AppStateContext.Provider value={state}>

--- a/src/renderer/lib/store/reducer.test.ts
+++ b/src/renderer/lib/store/reducer.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 import { handleChatEvent, appReducer, initialState } from '.';
 import type { AppState, AppAction } from '.';
 import type { ChatMessage, ChatEvent } from '../../../shared/types';
+import type { ChatroomMessage, ChatroomStreamEvent } from '../../../shared/chatroom-types';
 import type { Task, TaskStatus, Artifact } from '../../../shared/a2a-types';
 import {
   makeMessage,
@@ -549,5 +550,144 @@ describe('appReducer', () => {
       });
       expect(state.tasksByMind[mindId][0].status.state).toBe('completed');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chatroom actions
+// ---------------------------------------------------------------------------
+
+const makeChatroomMessage = (overrides?: Partial<ChatroomMessage>): ChatroomMessage => ({
+  id: 'msg-1',
+  role: 'user',
+  blocks: [{ type: 'text', content: 'hello' }],
+  timestamp: Date.now(),
+  sender: { mindId: 'user', name: 'You' },
+  roundId: 'round-1',
+  ...overrides,
+});
+
+describe('appReducer — chatroom actions', () => {
+  it('SET_CHATROOM_HISTORY sets chatroomMessages from payload', () => {
+    const msgs = [makeChatroomMessage({ id: 'h1' }), makeChatroomMessage({ id: 'h2' })];
+    const state = appReducer(initialState, { type: 'SET_CHATROOM_HISTORY', payload: msgs });
+    expect(state.chatroomMessages).toEqual(msgs);
+  });
+
+  it('CHATROOM_USER_MESSAGE appends user message with sender and roundId', () => {
+    const msg = makeChatroomMessage({ id: 'u1', sender: { mindId: 'user', name: 'You' }, roundId: 'r1' });
+    const state = appReducer(initialState, { type: 'CHATROOM_USER_MESSAGE', payload: msg });
+    expect(state.chatroomMessages).toHaveLength(1);
+    expect(state.chatroomMessages[0]).toMatchObject({ id: 'u1', sender: { mindId: 'user', name: 'You' }, roundId: 'r1' });
+  });
+
+  it('CHATROOM_AGENT_MESSAGE creates empty streaming assistant message with sender', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_AGENT_MESSAGE',
+      payload: { messageId: 'a1', mindId: 'mind-1', mindName: 'Agent A', roundId: 'r1', timestamp: 1000 },
+    });
+    expect(state.chatroomMessages).toHaveLength(1);
+    const msg = state.chatroomMessages[0];
+    expect(msg.id).toBe('a1');
+    expect(msg.role).toBe('assistant');
+    expect(msg.blocks).toEqual([]);
+    expect(msg.isStreaming).toBe(true);
+    expect(msg.sender).toEqual({ mindId: 'mind-1', name: 'Agent A' });
+    expect(msg.roundId).toBe('r1');
+    expect(state.chatroomStreamingByMind['mind-1']).toBe(true);
+  });
+
+  it('CHATROOM_EVENT chunk appends text to correct agent message', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomMessages: [
+        makeChatroomMessage({ id: 'a1', role: 'assistant', blocks: [], sender: { mindId: 'mind-1', name: 'Agent A' } }),
+      ],
+      chatroomStreamingByMind: { 'mind-1': true },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: { mindId: 'mind-1', mindName: 'Agent A', messageId: 'a1', roundId: 'r1', event: { type: 'chunk', content: 'hello' } },
+    });
+    expect(state.chatroomMessages[0].blocks).toHaveLength(1);
+    expect(state.chatroomMessages[0].blocks[0]).toMatchObject({ type: 'text', content: 'hello' });
+  });
+
+  it('CHATROOM_EVENT done sets chatroomStreamingByMind[mindId] to false', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomMessages: [
+        makeChatroomMessage({ id: 'a1', role: 'assistant', blocks: [], isStreaming: true, sender: { mindId: 'mind-1', name: 'Agent A' } }),
+      ],
+      chatroomStreamingByMind: { 'mind-1': true },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: { mindId: 'mind-1', mindName: 'Agent A', messageId: 'a1', roundId: 'r1', event: { type: 'done' } },
+    });
+    expect(state.chatroomStreamingByMind['mind-1']).toBe(false);
+    expect(state.chatroomMessages[0].isStreaming).toBe(false);
+  });
+
+  it('CHATROOM_EVENT error sets streaming false and appends error text', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomMessages: [
+        makeChatroomMessage({ id: 'a1', role: 'assistant', blocks: [], isStreaming: true, sender: { mindId: 'mind-1', name: 'Agent A' } }),
+      ],
+      chatroomStreamingByMind: { 'mind-1': true },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: { mindId: 'mind-1', mindName: 'Agent A', messageId: 'a1', roundId: 'r1', event: { type: 'error', message: 'boom' } },
+    });
+    expect(state.chatroomStreamingByMind['mind-1']).toBe(false);
+    expect(state.chatroomMessages[0].isStreaming).toBe(false);
+    const textBlocks = state.chatroomMessages[0].blocks.filter(b => b.type === 'text');
+    expect(textBlocks.some(b => b.type === 'text' && b.content.includes('boom'))).toBe(true);
+  });
+
+  it('multi-agent interleave — two agents streaming simultaneously, events update correct messages', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomMessages: [
+        makeChatroomMessage({ id: 'a1', role: 'assistant', blocks: [], isStreaming: true, sender: { mindId: 'mind-1', name: 'Agent A' }, roundId: 'r1' }),
+        makeChatroomMessage({ id: 'a2', role: 'assistant', blocks: [], isStreaming: true, sender: { mindId: 'mind-2', name: 'Agent B' }, roundId: 'r1' }),
+      ],
+      chatroomStreamingByMind: { 'mind-1': true, 'mind-2': true },
+    };
+
+    // Agent A gets a chunk
+    let state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: { mindId: 'mind-1', mindName: 'Agent A', messageId: 'a1', roundId: 'r1', event: { type: 'chunk', content: 'alpha' } },
+    });
+    // Agent B gets a chunk
+    state = appReducer(state, {
+      type: 'CHATROOM_EVENT',
+      payload: { mindId: 'mind-2', mindName: 'Agent B', messageId: 'a2', roundId: 'r1', event: { type: 'chunk', content: 'beta' } },
+    });
+
+    expect(state.chatroomMessages[0].blocks[0]).toMatchObject({ type: 'text', content: 'alpha' });
+    expect(state.chatroomMessages[1].blocks[0]).toMatchObject({ type: 'text', content: 'beta' });
+
+    // Agent A finishes
+    state = appReducer(state, {
+      type: 'CHATROOM_EVENT',
+      payload: { mindId: 'mind-1', mindName: 'Agent A', messageId: 'a1', roundId: 'r1', event: { type: 'done' } },
+    });
+    expect(state.chatroomStreamingByMind['mind-1']).toBe(false);
+    expect(state.chatroomStreamingByMind['mind-2']).toBe(true);
+  });
+
+  it('CHATROOM_CLEAR resets all chatroom state', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomMessages: [makeChatroomMessage()],
+      chatroomStreamingByMind: { 'mind-1': true },
+    };
+    const state = appReducer(base, { type: 'CHATROOM_CLEAR' });
+    expect(state.chatroomMessages).toEqual([]);
+    expect(state.chatroomStreamingByMind).toEqual({});
   });
 });

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, ChatEvent, ContentBlock } from '../../../shared/types';
 import type { Task, TaskState } from '../../../shared/a2a-types';
+import type { ChatroomMessage } from '../../../shared/chatroom-types';
 import type { AppState, AppAction } from './state';
 
 /** Extract plain text from content blocks (for search, accessibility, etc.) */
@@ -310,6 +311,63 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         tasksByMind: { ...state.tasksByMind, [targetMindId]: updatedTasks },
       };
     }
+
+    case 'SET_CHATROOM_HISTORY':
+      return { ...state, chatroomMessages: action.payload };
+
+    case 'CHATROOM_USER_MESSAGE':
+      return { ...state, chatroomMessages: [...state.chatroomMessages, action.payload] };
+
+    case 'CHATROOM_AGENT_MESSAGE': {
+      const { messageId, mindId, mindName, roundId, timestamp } = action.payload;
+      const agentMsg: ChatroomMessage = {
+        id: messageId,
+        role: 'assistant',
+        blocks: [],
+        timestamp,
+        isStreaming: true,
+        sender: { mindId, name: mindName },
+        roundId,
+      };
+      return {
+        ...state,
+        chatroomMessages: [...state.chatroomMessages, agentMsg],
+        chatroomStreamingByMind: { ...state.chatroomStreamingByMind, [mindId]: true },
+      };
+    }
+
+    case 'CHATROOM_EVENT': {
+      const { mindId, mindName, messageId, roundId, event } = action.payload;
+      let messages = state.chatroomMessages;
+
+      // Auto-create placeholder if this is the first event for an unknown message
+      const exists = messages.some(m => m.id === messageId);
+      if (!exists) {
+        const placeholder: ChatroomMessage = {
+          id: messageId,
+          role: 'assistant',
+          blocks: [],
+          timestamp: Date.now(),
+          isStreaming: true,
+          sender: { mindId, name: mindName },
+          roundId,
+        };
+        messages = [...messages, placeholder];
+      }
+
+      const newMessages = handleChatEvent(messages, messageId, event);
+      const isDone = event.type === 'done' || event.type === 'error';
+      return {
+        ...state,
+        chatroomMessages: newMessages as ChatroomMessage[],
+        chatroomStreamingByMind: isDone
+          ? { ...state.chatroomStreamingByMind, [mindId]: false }
+          : { ...state.chatroomStreamingByMind, [mindId]: true },
+      };
+    }
+
+    case 'CHATROOM_CLEAR':
+      return { ...state, chatroomMessages: [], chatroomStreamingByMind: {} };
 
     default:
       return state;

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, ChatEvent, ModelInfo, LensViewManifest, MindContext, ContentBlock } from '../../../shared/types';
 import type { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '../../../shared/a2a-types';
+import type { ChatroomMessage, ChatroomStreamEvent } from '../../../shared/chatroom-types';
 
 export type LensView = 'chat' | string;
 
@@ -16,6 +17,8 @@ export interface AppState {
   showLanding: boolean;
   mindsChecked: boolean;
   tasksByMind: Record<string, Task[]>;
+  chatroomMessages: ChatroomMessage[];
+  chatroomStreamingByMind: Record<string, boolean>;
 }
 
 export type AppAction =
@@ -37,7 +40,12 @@ export type AppAction =
   | { type: 'NEW_CONVERSATION' }
   | { type: 'A2A_INCOMING'; payload: { targetMindId: string; message: Message; replyMessageId: string } }
   | { type: 'TASK_STATUS_UPDATE'; payload: TaskStatusUpdateEvent & { targetMindId: string } }
-  | { type: 'TASK_ARTIFACT_UPDATE'; payload: TaskArtifactUpdateEvent & { targetMindId: string } };
+  | { type: 'TASK_ARTIFACT_UPDATE'; payload: TaskArtifactUpdateEvent & { targetMindId: string } }
+  | { type: 'SET_CHATROOM_HISTORY'; payload: ChatroomMessage[] }
+  | { type: 'CHATROOM_USER_MESSAGE'; payload: ChatroomMessage }
+  | { type: 'CHATROOM_AGENT_MESSAGE'; payload: { messageId: string; mindId: string; mindName: string; roundId: string; timestamp: number } }
+  | { type: 'CHATROOM_EVENT'; payload: ChatroomStreamEvent }
+  | { type: 'CHATROOM_CLEAR' };
 
 export const initialState: AppState = {
   minds: [],
@@ -52,4 +60,6 @@ export const initialState: AppState = {
   showLanding: false,
   mindsChecked: false,
   tasksByMind: {},
+  chatroomMessages: [],
+  chatroomStreamingByMind: {},
 };

--- a/src/shared/chatroom-types.test.ts
+++ b/src/shared/chatroom-types.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { ChatroomMessage, ChatroomTranscript, ChatroomStreamEvent, ChatroomAPI } from './chatroom-types';
+import type { ChatMessage } from './types';
+
+describe('chatroom-types', () => {
+  it('ChatroomMessage extends ChatMessage with required sender and roundId', () => {
+    expectTypeOf<ChatroomMessage>().toMatchTypeOf<ChatMessage>();
+    expectTypeOf<ChatroomMessage['sender']>().toEqualTypeOf<{ mindId: string; name: string }>();
+    expectTypeOf<ChatroomMessage['roundId']>().toEqualTypeOf<string>();
+  });
+
+  it('ChatroomTranscript has versioned shape', () => {
+    expectTypeOf<ChatroomTranscript['version']>().toEqualTypeOf<1>();
+    expectTypeOf<ChatroomTranscript['messages']>().toEqualTypeOf<ChatroomMessage[]>();
+  });
+
+  it('ChatroomStreamEvent carries agent identity and event', () => {
+    expectTypeOf<ChatroomStreamEvent['mindId']>().toBeString();
+    expectTypeOf<ChatroomStreamEvent['mindName']>().toBeString();
+    expectTypeOf<ChatroomStreamEvent['messageId']>().toBeString();
+    expectTypeOf<ChatroomStreamEvent['roundId']>().toBeString();
+  });
+
+  it('ChatroomAPI defines the full IPC surface', () => {
+    expectTypeOf<ChatroomAPI['send']>().toBeFunction();
+    expectTypeOf<ChatroomAPI['history']>().toBeFunction();
+    expectTypeOf<ChatroomAPI['clear']>().toBeFunction();
+    expectTypeOf<ChatroomAPI['stop']>().toBeFunction();
+    expectTypeOf<ChatroomAPI['onEvent']>().toBeFunction();
+  });
+});

--- a/src/shared/chatroom-types.ts
+++ b/src/shared/chatroom-types.ts
@@ -1,0 +1,46 @@
+// Shared chatroom types — used by main, preload, and renderer
+
+import type { ChatMessage, ChatEvent, ContentBlock } from './types';
+
+// ---------------------------------------------------------------------------
+// Chatroom message — ChatMessage with required sender attribution
+// ---------------------------------------------------------------------------
+
+export interface ChatroomMessage extends ChatMessage {
+  sender: { mindId: string; name: string };
+  roundId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Chatroom persistence — JSON file shape
+// ---------------------------------------------------------------------------
+
+export interface ChatroomTranscript {
+  version: 1;
+  messages: ChatroomMessage[];
+}
+
+// ---------------------------------------------------------------------------
+// Chatroom IPC events
+// ---------------------------------------------------------------------------
+
+/** Streaming event from one agent in the chatroom */
+export interface ChatroomStreamEvent {
+  mindId: string;
+  mindName: string;
+  messageId: string;
+  roundId: string;
+  event: ChatEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Chatroom ElectronAPI surface
+// ---------------------------------------------------------------------------
+
+export interface ChatroomAPI {
+  send: (message: string, model?: string) => Promise<void>;
+  history: () => Promise<ChatroomMessage[]>;
+  clear: () => Promise<void>;
+  stop: () => Promise<void>;
+  onEvent: (callback: (event: ChatroomStreamEvent) => void) => () => void;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,5 @@
 import type { Message, AgentCard, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, ListTasksResponse } from './a2a-types';
+import type { ChatroomAPI } from './chatroom-types';
 
 // Shared types across main, preload, and renderer processes
 
@@ -152,8 +153,9 @@ export interface ElectronAPI {
     create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
   };
+  chatroom: ChatroomAPI;
   a2a: {
-    onIncoming: (callback: (payload: { targetMindId: string; message: Message; replyMessageId: string }) => void) => () => void;
+    onIncoming:(callback: (payload: { targetMindId: string; message: Message; replyMessageId: string }) => void) => () => void;
     listAgents: () => Promise<AgentCard[]>;
     onTaskStatusUpdate: (callback: (payload: TaskStatusUpdateEvent & { targetMindId: string }) => void) => () => void;
     onTaskArtifactUpdate: (callback: (payload: TaskArtifactUpdateEvent & { targetMindId: string }) => void) => () => void;

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -149,13 +149,6 @@ export function mockElectronAPI(): ElectronAPI {
       listTasks: vi.fn().mockResolvedValue([]),
       cancelTask: vi.fn().mockResolvedValue(undefined),
     },
-    chatroom: {
-      send: vi.fn().mockResolvedValue(undefined),
-      history: vi.fn().mockResolvedValue([]),
-      clear: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      onEvent: vi.fn().mockReturnValue(() => {}),
-    },
     window: {
       minimize: vi.fn(),
       maximize: vi.fn(),

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -10,6 +10,7 @@ import type {
   LensViewManifest,
   ElectronAPI,
 } from '../shared/types';
+import type { ChatroomMessage, ChatroomStreamEvent } from '../shared/chatroom-types';
 
 // ---------------------------------------------------------------------------
 // ContentBlock factories
@@ -132,6 +133,13 @@ export function mockElectronAPI(): ElectronAPI {
       create: vi.fn().mockResolvedValue({ success: true }),
       onProgress: vi.fn().mockReturnValue(() => {}),
     },
+    chatroom: {
+      send: vi.fn().mockResolvedValue(undefined),
+      history: vi.fn().mockResolvedValue([]),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      onEvent: vi.fn().mockReturnValue(() => {}),
+    },
     a2a: {
       onIncoming: vi.fn().mockReturnValue(() => {}),
       listAgents: vi.fn().mockResolvedValue([]),
@@ -141,11 +149,49 @@ export function mockElectronAPI(): ElectronAPI {
       listTasks: vi.fn().mockResolvedValue([]),
       cancelTask: vi.fn().mockResolvedValue(undefined),
     },
+    chatroom: {
+      send: vi.fn().mockResolvedValue(undefined),
+      history: vi.fn().mockResolvedValue([]),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      onEvent: vi.fn().mockReturnValue(() => {}),
+    },
     window: {
       minimize: vi.fn(),
       maximize: vi.fn(),
       close: vi.fn(),
     },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Chatroom factories
+// ---------------------------------------------------------------------------
+
+export function makeChatroomMessage(
+  overrides?: Partial<ChatroomMessage>,
+): ChatroomMessage {
+  return {
+    id: 'cr-msg-1',
+    role: 'assistant',
+    blocks: [{ type: 'text', content: 'hello from agent' }],
+    timestamp: Date.now(),
+    sender: { mindId: 'mind-1', name: 'Agent One' },
+    roundId: 'round-1',
+    ...overrides,
+  };
+}
+
+export function makeChatroomStreamEvent(
+  overrides?: Partial<ChatroomStreamEvent>,
+): ChatroomStreamEvent {
+  return {
+    mindId: 'mind-1',
+    mindName: 'Agent One',
+    messageId: 'cr-msg-1',
+    roundId: 'round-1',
+    event: { type: 'chunk', content: 'hello' },
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
## Summary
Phase 5 of multi-agent: broadcast chatroom where user messages fan out to all loaded agents in parallel.

### Chatroom (v0.19.0)
- **ChatroomService** — broadcast to all agents via isolated per-mind chatroom sessions
- **Round-based echo prevention** — agents respond to user only; previous round context injected as escaped XML
- **Session isolation** — chatroom sessions separate from DM sessions (no context bleed)
- **Mid-round sends** — user can send while agents respond; incomplete responses cancelled
- **Incremental persistence** — \~/.chamber/chatroom.json\ with atomic writes (500 msg cap)
- **ChatroomPanel UI** — single timeline, sender badges, colored avatars, participant bar
- **Multi-agent streaming** — agents stream simultaneously with independent tracking
- **Per-agent error isolation** — one failure doesn't affect others
- **ActivityBar navigation** — Users icon between Chat and Lens

### Critical fixes (v0.19.1–v0.19.3)
- Remove duplicate chatroom property in mockElectronAPI
- Remove dead persistDir assignment
- Log per-agent broadcast errors instead of swallowing silently

### Stats
- 465 tests passing (47 new)
- 24 files changed, +1905 lines
- Packaged build tested and working