### PR TITLE
fix: detect SDK-wrapped session errors for retry logic (v0.19.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.19.7",
+"version": "0.19.8",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/shared/sessionErrors.test.ts
+++ b/src/shared/sessionErrors.test.ts
@@ -10,6 +10,12 @@ describe('isStaleSessionError', () => {
     expect(isStaleSessionError(new Error('Session not found'))).toBe(true);
   });
 
+  it('returns true for SDK-wrapped "Request session.send failed" message', () => {
+    expect(isStaleSessionError(new Error(
+      'Request session.send failed with message: Session not found: 61e71e99-09af-4ab8-b059-45519b89dba0'
+    ))).toBe(true);
+  });
+
   it('returns false for Error with different message', () => {
     expect(isStaleSessionError(new Error('Network error'))).toBe(false);
   });

--- a/src/shared/sessionErrors.ts
+++ b/src/shared/sessionErrors.ts
@@ -4,5 +4,5 @@
  * instances with message `"Session not found: <sessionId>"`.
  */
 export function isStaleSessionError(err: unknown): boolean {
-  return err instanceof Error && err.message.startsWith('Session not found');
+  return err instanceof Error && err.message.includes('Session not found');
 }


### PR DESCRIPTION
## Problem

\isStaleSessionError()\ used \.startsWith('Session not found')\ but the Copilot SDK wraps the error as:

\\\
Request session.send failed with message: Session not found: <sessionId>
\\\

The detector never matched, so the retry-once logic shipped in v0.19.4 never fired.

## Fix

\.startsWith()\ → \.includes()\. One-line fix, added test case for the SDK-wrapped format.

## Testing

- 483 tests passing
- New test case covers the exact error format from production