### PR TITLE
fix: watch .github/ for late lens/ creation (v0.19.7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.19.6",
+      "version": "0.19.7",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main/services/lens/ViewDiscovery.test.ts
+++ b/src/main/services/lens/ViewDiscovery.test.ts
@@ -180,4 +180,63 @@ describe('ViewDiscovery', () => {
       expect(mockClose).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('startWatching — late lens/ creation', () => {
+    it('watches .github/ when lens/ does not exist yet', () => {
+      const mockClose = vi.fn();
+      vi.mocked(fs.watch).mockReturnValue({ close: mockClose } as unknown as fs.FSWatcher);
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.github', 'lens'))) return false;
+        if (s.endsWith('.github')) return true;
+        return false;
+      });
+
+      const onChanged = vi.fn();
+      discovery.startWatching('/tmp/mind', onChanged);
+
+      expect(fs.watch).toHaveBeenCalledWith(
+        path.join('/tmp/mind', '.github'),
+        expect.any(Function),
+      );
+    });
+
+    it('transitions to lens/ watcher when lens/ appears', async () => {
+      const mockClose = vi.fn();
+      let parentCallback: (event: string, filename: string) => void = () => {};
+      vi.mocked(fs.watch).mockImplementation((_path: unknown, ...args: unknown[]) => {
+        const cb = args.find(a => typeof a === 'function') as (event: string, filename: string) => void;
+        if (cb) parentCallback = cb;
+        return { close: mockClose } as unknown as fs.FSWatcher;
+      });
+
+      let lensExists = false;
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.github', 'lens'))) return lensExists;
+        if (s.endsWith('.github')) return true;
+        return false;
+      });
+      mockReaddirSync.mockReturnValue([]);
+
+      const onChanged = vi.fn();
+      discovery.startWatching('/tmp/mind', onChanged);
+
+      // Simulate lens/ directory appearing
+      lensExists = true;
+      parentCallback('rename', 'lens');
+
+      // Allow the scan promise to resolve
+      await vi.waitFor(() => {
+        expect(onChanged).toHaveBeenCalled();
+      });
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('does nothing when .github/ does not exist either', () => {
+      mockExistsSync.mockReturnValue(false);
+      discovery.startWatching('/tmp/mind', vi.fn());
+      expect(fs.watch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/main/services/lens/ViewDiscovery.ts
+++ b/src/main/services/lens/ViewDiscovery.ts
@@ -107,8 +107,32 @@ export class ViewDiscovery {
   startWatching(mindPath: string, onChanged: () => void): void {
     this.stopWatching(mindPath);
     const lensDir = path.join(mindPath, '.github', 'lens');
-    if (!fs.existsSync(lensDir)) return;
 
+    if (fs.existsSync(lensDir)) {
+      this.watchLensDir(mindPath, lensDir, onChanged);
+    } else {
+      // lens/ doesn't exist yet — watch .github/ for its creation
+      const githubDir = path.join(mindPath, '.github');
+      if (!fs.existsSync(githubDir)) return;
+
+      const watchers: fs.FSWatcher[] = [];
+      try {
+        const parentWatcher = fs.watch(githubDir, (_eventType, filename) => {
+          if (filename === 'lens' && fs.existsSync(lensDir)) {
+            parentWatcher.close();
+            this.scan(mindPath).then(() => {
+              this.watchLensDir(mindPath, lensDir, onChanged);
+              onChanged();
+            });
+          }
+        });
+        watchers.push(parentWatcher);
+      } catch { /* watch not supported */ }
+      this.watchersByMind.set(mindPath, watchers);
+    }
+  }
+
+  private watchLensDir(mindPath: string, lensDir: string, onChanged: () => void): void {
     const watchers: fs.FSWatcher[] = [];
     try {
       const watcher = fs.watch(lensDir, { recursive: true }, (_eventType, filename) => {
@@ -118,7 +142,6 @@ export class ViewDiscovery {
       });
       watchers.push(watcher);
     } catch { /* watch not supported */ }
-
     this.watchersByMind.set(mindPath, watchers);
   }
 


### PR DESCRIPTION
Lens watcher fix — watches \.github/\ directory so lens views load correctly when the \lens/\ folder is created after startup.