### PR TITLE
feat: enable MCP config discovery from mind directories (v0.19.9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-"version": "0.19.8",
+"version": "0.19.9",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -288,6 +288,7 @@ export class MindManager extends EventEmitter {
   ): Promise<CopilotSession> {
     return client.createSession({
       workingDirectory: mindPath,
+      enableConfigDiscovery: true,
       tools,
       systemMessage: {
         mode: 'customize',


### PR DESCRIPTION
Adds \nableConfigDiscovery: true\ to session creation. The SDK auto-discovers \.mcp.json\ from each mind's \workingDirectory\, so agents can define MCP servers by dropping a config file in their mind root.

Enables the workflow described in https://gist.github.com/ianphil/c2d2af715ea802d7b093d8347db5eb37