### PR TITLE
feat: multi-account auth, account-switch UX, landing close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.21.0 (2026-04-16)
+
+### Multi-account GitHub auth
+- **Account selection** - Settings now lists all stored GitHub accounts, keeps the active account selected, and lets you add another account from the same picker.
+- **Active login persistence** - Chamber now persists `activeLogin` in config so auth status resolves the intended credential instead of whichever one keytar returns first.
+- **Full auth reload on switch** - Switching accounts reloads every mind so Copilot clients, chatroom sessions, and task sessions all restart with fresh auth state.
+- **Targeted logout** - Logging out removes only the active credential and returns the app to the signed-out flow without auto-switching to another stored account.
+
+## v0.20.0 (2026-04-15)
+
+### Settings view and logout
+- **Settings navigation** — added a bottom-pinned gear icon in the ActivityBar that opens a dedicated Settings view.
+- **Account section** — Settings now shows the current GitHub login and a logout action in the app UI.
+- **Logout flow** — logging out deletes the stored keytar credential, broadcasts the event to all windows, and returns AuthGate to the sign-in screen.
+
+## v0.19.7 (2026-04-13)
+
+### Lens discovery fix
+- **Late-created lens folders** — Chamber now discovers lens views created after a mind was already loaded instead of requiring a manual reload.
+
 ## v0.19.6 (2026-04-13)
 
 ### Zero Lint / CI Green

--- a/backlog.md
+++ b/backlog.md
@@ -1,72 +1,68 @@
 # Chamber — Backlog
 
+> Rule: `backlog.md` tracks open work only. When an item ships, move it to `CHANGELOG.md` and remove it from this backlog.
+
 ## Now
 
-- [x] **🔴 Session timeout recovery** `bug` `p0` — idle session gives "Session not found" when CLI session gets harvested. Detect stale session errors, auto-create new session transparently, show "reconnecting..." indicator. Replay the failed message after reconnect. *(shipped v0.19.4)*
-- [x] **Lens views invisible until mind reload** `bug`— `ViewDiscovery.startWatching()` bails if `.github/lens/` doesn't exist when the mind loads (line 110). New views created after load are never discovered. Fix: watch `.github/` parent dir and start lens watcher when `lens/` appears, or rescan on `lens:getViews` IPC when cache is empty. *(shipped v0.19.7)*
-- [ ] **Lens watcher doesn't handle deletion** `bug` — deleting a lens folder (e.g. `fleet-tasks/`) leaves the view in Chamber's activity bar. Watcher detects creation but not removal. Fix: handle `unlink`/`unlinkDir` events in `ViewDiscovery` and remove the view from the registry + notify renderer. *(Ian, 2026-04-13)*
-- [ ] **Agent doesn't load SOUL/memory on first message** `bug`— after genesis, saying "hi" doesn't trigger the agent to read SOUL.md and .working-memory files. Agent instructions not being injected into session context.
-- [ ] **New Mind missing extensions/skills** `bug` — genesis bootstrap doesn't install extensions (cron, canvas, idea) or skills (commit, daily-report, etc.). New minds start bare.
-- [ ] **Inject local time/timezone into every prompt** `bug` — agent should know the time without shelling out. Inject `current_datetime` and timezone into each `session.send()`. SDK has a `current_datetime` section in the prompt template.
-- [ ] **"Stuck at thinking" — duplicate agent causes tool name clash** `bug` `p1` — on Ragu's machine, creating a second Alfred agent (same mind folder) causes all extensions to fail: `"External tool name clash: cron_create, ... already registered by another connection"`. The second session can't register cron, canvas, idea, or responses extensions because the first session already owns those tool names. Agent appears stuck at "thinking" with no extensions loaded. Also: `"Failed to load memories: GitHub repository name is required"` (non-blocking, logged as ERROR but stream continues). Fix: prevent duplicate mind sessions, or namespace extension tools per-session; surface extension failures to UI. Logs in q mind `inbox/logs-ra/`. *(Ragu, 2026-04-13)*
-- [ ] **Teams Agency MCP issue** `bug` — Kent reported problem with Teams MCP proxy; shared log in AET SWE Chat. Needs investigation. *(Kent, 2026-04-09)*
-- [ ] **No Start Menu icon** `bug` — installer doesn't create Start Menu shortcut. Likely Electron Forge / Squirrel config in packaging step.
-- [ ] **Upgrade genesis-created minds on open** `bug` — minds created via CLI genesis (not Chamber) may be missing lens defaults, lens skill, and other Chamber-specific bootstrapping. When a mind is opened in Chamber for the first time, detect and run `seedLensDefaults` + `installLensSkill` + any missing capabilities. *(Ian, 2026-04-12)*
-- [x] **Boot screen shows stale version** `bug` — fixed: imports version from package.json dynamically. *(fixed v0.18.0)*
-- [ ] **Landing screen needs a back button** `ux` — when "Add Agent" navigates to the landing screen, there's no way to go back if you change your mind. Add a back/cancel action that returns to the previous chat view. *(Ian, 2026-04-12)*
-- [ ] **Lens refresh survives view switching** `ux` — clicking away from a lens while it's refreshing drops the pending result. The agent still writes the file, but the UI never picks up the new data. Either show a toast when refresh completes, or re-read data when returning to the view. *(Ian, 2026-04-12)*
-- [ ] **Popout should continue conversation** `ux` — popping out an agent starts a fresh chat instead of continuing the current conversation. Messages should transfer to the popout and return when closed. Related to conversation history feature. *(Ian, 2026-04-12)*
-- [x] **Settings view + Logout** `ux` `auth` — ⚙ gear icon bottom-pinned in ActivityBar opens Settings view. Account section shows current login + Logout button. Logout deletes keytar credential, broadcasts to all windows, AuthGate drops to AuthScreen. *(shipped v0.20.0)*
+- **Lens watcher doesn't handle deletion** `bug` — deleting a lens folder (e.g. `fleet-tasks/`) leaves the view in Chamber's activity bar. Watcher detects creation but not removal. Fix: handle `unlink`/`unlinkDir` events in `ViewDiscovery` and remove the view from the registry + notify renderer. *(Ian, 2026-04-13)*
+- **Agent doesn't load SOUL/memory on first message** `bug`— after genesis, saying "hi" doesn't trigger the agent to read SOUL.md and .working-memory files. Agent instructions not being injected into session context.
+- **New Mind missing extensions/skills** `bug` — genesis bootstrap doesn't install extensions (cron, canvas, idea) or skills (commit, daily-report, etc.). New minds start bare.
+- **Inject local time/timezone into every prompt** `bug` — agent should know the time without shelling out. Inject `current_datetime` and timezone into each `session.send()`. SDK has a `current_datetime` section in the prompt template.
+- **"Stuck at thinking" — duplicate agent causes tool name clash** `bug` `p1` — on Ragu's machine, creating a second Alfred agent (same mind folder) causes all extensions to fail: `"External tool name clash: cron_create, ... already registered by another connection"`. The second session can't register cron, canvas, idea, or responses extensions because the first session already owns those tool names. Agent appears stuck at "thinking" with no extensions loaded. Also: `"Failed to load memories: GitHub repository name is required"` (non-blocking, logged as ERROR but stream continues). Fix: prevent duplicate mind sessions, or namespace extension tools per-session; surface extension failures to UI. Logs in q mind `inbox/logs-ra/`. *(Ragu, 2026-04-13)*
+- **Teams Agency MCP issue** `bug` — Kent reported problem with Teams MCP proxy; shared log in AET SWE Chat. Needs investigation. *(Kent, 2026-04-09)*
+- **No Start Menu icon** `bug` — installer doesn't create Start Menu shortcut. Likely Electron Forge / Squirrel config in packaging step.
+- **Upgrade genesis-created minds on open** `bug` — minds created via CLI genesis (not Chamber) may be missing lens defaults, lens skill, and other Chamber-specific bootstrapping. When a mind is opened in Chamber for the first time, detect and run `seedLensDefaults` + `installLensSkill` + any missing capabilities. *(Ian, 2026-04-12)*
+- **Agent links hijack Chamber view** `bug` — clicking a URL from an agent response opens it inside Chamber's webview instead of the external browser, taking over the entire page and forcing a Chamber restart. Links should open in the default OS browser via `shell.openExternal()`. Related to Navigation guards item in Later. *(Ian, 2026-04-15)*
+- **Landing screen needs a back button** `ux` — when "Add Agent" navigates to the landing screen, there's no way to go back if you change your mind. Add a back/cancel action that returns to the previous chat view. *(Ian, 2026-04-12)*
+- **Lens refresh survives view switching** `ux` — clicking away from a lens while it's refreshing drops the pending result. The agent still writes the file, but the UI never picks up the new data. Either show a toast when refresh completes, or re-read data when returning to the view. *(Ian, 2026-04-12)*
+- **Popout should continue conversation** `ux` — popping out an agent starts a fresh chat instead of continuing the current conversation. Messages should transfer to the popout and return when closed. Related to conversation history feature. *(Ian, 2026-04-12)*
 
 ## Next
 
-- [ ] **Switch Account** `ux` `auth` — credential picker dropdown in Settings showing cached GitHub accounts (e.g. `ianphil`, `ianphil_microsoft`). Select to switch without re-auth. "Add Account" triggers device flow to cache a new credential. Requires multi-credential awareness in AuthService. *(Ian, 2026-04-15)*
-- [ ] **Deprecate genesis yellow-pages skill** `arch` — Chamber implements a2a natively and does it much better. The `yellow-pages` skill in genesis is redundant. Remove from genesis `.github/skills/yellow-pages/`. *(Skippy, 2026-04-14)*
-- [ ] **Deprecate genesis responses extension** `arch` — Chamber's a2a implementation supersedes the `responses` extension in genesis `.github/extensions/responses/`. Remove from genesis. *(Skippy, 2026-04-14)*
-- [ ] **Duplicate agent name collision** `bug` — creating a second agent with the same name as an existing one (e.g. "Alfred" twice) has undefined behavior. Detect name collisions during agent creation, either block with an error or auto-suffix. Clarify what happens to routing, IPC channels, and chatroom @mentions when names collide. *(Ian, 2026-04-13)*
-- [ ] **Target Linux / WSL** `platform` — primary platform target should be Linux and WSL, not just Windows. Audit platform-specific code (paths, shell spawning, credential storage, installers) and ensure first-class support. *(Ian, 2026-04-13)*
-- [ ] **Per-agent model selection**`ux` `arch` — each agent should have its own model config (e.g. Moneypenny on Opus, Q on GPT-5.4). Persist per-mind in agent config so it survives restarts. Today all agents use the same model. Need: model picker in agent settings, storage in mind config or agent.md frontmatter, pass model override to `session.send()`. *(Ian, 2026-04-13)*
-- [ ] **Agent management (add/remove/list)** `ux` `arch` — Chamber should support adding and removing agents from the fleet, not just Lens views. Today updating the roster requires manually editing SOUL.md files and reloading agents. Chamber should: add a new agent, remove an agent, view/list current agents and their roles. Natural extension of Chamber's configuration capabilities. *(Ian, 2026-04-13)*
-- [ ] **@mention targeting in chatroom** `ux`— `@AgentName` in a chatroom message should route only to that agent (not broadcast). Parse @mentions from input, filter broadcast participants to only the mentioned agent(s). That agent responds and does work; others stay silent. *(Ian, 2026-04-13)*
-- [ ] **Generic `handleChatEvent<T>`** `quality` — `handleChatEvent` returns `ChatMessage[]` but chatroom reducer casts to `ChatroomMessage[]`. Make function generic to preserve extended types. *(Uncle Bob review, 2026-04-13)*
-- [ ] **Chatroom roundId alignment** `bug` — renderer generates optimistic roundId, service generates a different one. Pass roundId through IPC so both sides agree. *(Uncle Bob review, 2026-04-13)*
-- [ ] **IPC input validation on chatroom:send** `security` — no runtime type guards; renderer could send non-string. Add `typeof message !== 'string'` guard. *(Uncle Bob review, 2026-04-13)*
-- [ ] **DRY session creation in MindManager** `quality` — `createChatroomSession` and `createTaskSession` share ~8 lines of identical body. Extract private `buildSessionForMind(mindId)`. *(Uncle Bob review, 2026-04-13)*
-- [ ] **Chatroom agent timeout visibility** `ux` — 5-min timeout in `sendToAgent` resolves silently with no UI indication. Emit timeout-specific error event. *(Uncle Bob review, 2026-04-13)*
-- [ ] **Chatroom `getLastNRounds` performance** `quality` — uses `Array.includes` in loop (O(n·r)). Replace with `Set`. *(Uncle Bob review, 2026-04-13)*
-- [ ] **Chat history** `ux` — conversations are lost on new conversation or restart. Show past conversations per-mind in MindSidebar, indented under each agent. Data already in `~/.copilot/session-state/`. See [[conversation-history]] for spec. *(Ian, 2026-04-12)*
-- [ ] **Boot screen activity log** `ux` — spinner too passive during genesis/startup; surface log output so user sees real-time progress. *(Kent feedback 2026-04-09)*
-- [ ] **"Open Existing" defaults to ~/agents/** `ux` — folder picker should open to `$HOME/agents/` by default (where `MindScaffold.getDefaultBasePath()` creates minds).
-- [ ] **Surface agent questions in chat** `ux` — #13, `onUserInputRequest` returns "Not available" — agent questions never reach the user.
-- [ ] **Session startup performance** `perf` — pre-warm `getSharedClient()` at app launch (CLI spawn + auth in background while user is on landing screen). Also: session reuse via `resumeSession` API.
-- [ ] **CSP and sandbox** `security` — add Content-Security-Policy via `onHeadersReceived`, enable `sandbox: true`. #1, #2.
-- [ ] **Centralized IPC channel constants** `ipc` — `shared/ipc-channels.ts` with nested semantic namespacing (`IPC.CHAT.SEND`, `IPC.CONFIG.SAVE`).
-- [ ] **Shared ElectronAPI type** `ipc` — single interface in `shared/electron-types.ts`, preload implements, renderer consumes. Kill `as unknown as` cast. #14.
-- [ ] **Zod validation on IPC handlers** `ipc` `security` — schema validation on `config:save` and complex payloads. Preload stays passthrough. #4.
-- [ ] **Test suite** `quality` — Vitest unit → IPC integration → Playwright E2E. No tests exist today.
-- [x] **CI/CD pipeline** `quality` — tag-based release workflow for multi-platform builds. *(shipped v0.19.6)*
-- [x] **ESLint clean + pre-commit hook** `quality` — zero errors/warnings, Husky + lint-staged. *(shipped v0.19.6)*
+- **Deprecate genesis yellow-pages skill** `arch` — Chamber implements a2a natively and does it much better. The `yellow-pages` skill in genesis is redundant. Remove from genesis `.github/skills/yellow-pages/`. *(Skippy, 2026-04-14)*
+- **Deprecate genesis responses extension** `arch` — Chamber's a2a implementation supersedes the `responses` extension in genesis `.github/extensions/responses/`. Remove from genesis. *(Skippy, 2026-04-14)*
+- **Duplicate agent name collision** `bug` — creating a second agent with the same name as an existing one (e.g. "Alfred" twice) has undefined behavior. Detect name collisions during agent creation, either block with an error or auto-suffix. Clarify what happens to routing, IPC channels, and chatroom @mentions when names collide. *(Ian, 2026-04-13)*
+- **Target Linux / WSL** `platform` — primary platform target should be Linux and WSL, not just Windows. Audit platform-specific code (paths, shell spawning, credential storage, installers) and ensure first-class support. *(Ian, 2026-04-13)*
+- **Per-agent model selection**`ux` `arch` — each agent should have its own model config (e.g. Moneypenny on Opus, Q on GPT-5.4). Persist per-mind in agent config so it survives restarts. Today all agents use the same model. Need: model picker in agent settings, storage in mind config or agent.md frontmatter, pass model override to `session.send()`. *(Ian, 2026-04-13)*
+- **Agent management (add/remove/list)** `ux` `arch` — Chamber should support adding and removing agents from the fleet, not just Lens views. Today updating the roster requires manually editing SOUL.md files and reloading agents. Chamber should: add a new agent, remove an agent, view/list current agents and their roles. Natural extension of Chamber's configuration capabilities. *(Ian, 2026-04-13)*
+- **@mention targeting in chatroom** `ux`— `@AgentName` in a chatroom message should route only to that agent (not broadcast). Parse @mentions from input, filter broadcast participants to only the mentioned agent(s). That agent responds and does work; others stay silent. *(Ian, 2026-04-13)*
+- **Generic `handleChatEvent<T>`** `quality` — `handleChatEvent` returns `ChatMessage[]` but chatroom reducer casts to `ChatroomMessage[]`. Make function generic to preserve extended types. *(Uncle Bob review, 2026-04-13)*
+- **Chatroom roundId alignment** `bug` — renderer generates optimistic roundId, service generates a different one. Pass roundId through IPC so both sides agree. *(Uncle Bob review, 2026-04-13)*
+- **IPC input validation on chatroom:send** `security` — no runtime type guards; renderer could send non-string. Add `typeof message !== 'string'` guard. *(Uncle Bob review, 2026-04-13)*
+- **DRY session creation in MindManager** `quality` — `createChatroomSession` and `createTaskSession` share ~8 lines of identical body. Extract private `buildSessionForMind(mindId)`. *(Uncle Bob review, 2026-04-13)*
+- **Chatroom agent timeout visibility** `ux` — 5-min timeout in `sendToAgent` resolves silently with no UI indication. Emit timeout-specific error event. *(Uncle Bob review, 2026-04-13)*
+- **Chatroom `getLastNRounds` performance** `quality` — uses `Array.includes` in loop (O(n·r)). Replace with `Set`. *(Uncle Bob review, 2026-04-13)*
+- **Chat history** `ux` — conversations are lost on new conversation or restart. Show past conversations per-mind in MindSidebar, indented under each agent. Data already in `~/.copilot/session-state/`. See [[conversation-history]] for spec. *(Ian, 2026-04-12)*
+- **Boot screen activity log** `ux` — spinner too passive during genesis/startup; surface log output so user sees real-time progress. *(Kent feedback 2026-04-09)*
+- **"Open Existing" defaults to ~/agents/** `ux` — folder picker should open to `$HOME/agents/` by default (where `MindScaffold.getDefaultBasePath()` creates minds).
+- **Surface agent questions in chat** `ux` — #13, `onUserInputRequest` returns "Not available" — agent questions never reach the user.
+- **Session startup performance** `perf` — pre-warm `getSharedClient()` at app launch (CLI spawn + auth in background while user is on landing screen). Also: session reuse via `resumeSession` API.
+- **CSP and sandbox** `security` — add Content-Security-Policy via `onHeadersReceived`, enable `sandbox: true`. #1, #2.
+- **Centralized IPC channel constants** `ipc` — `shared/ipc-channels.ts` with nested semantic namespacing (`IPC.CHAT.SEND`, `IPC.CONFIG.SAVE`).
+- **Shared ElectronAPI type** `ipc` — single interface in `shared/electron-types.ts`, preload implements, renderer consumes. Kill `as unknown as` cast. #14.
+- **Zod validation on IPC handlers** `ipc` `security` — schema validation on `config:save` and complex payloads. Preload stays passthrough. #4.
+- **Test suite** `quality` — Vitest unit → IPC integration → Playwright E2E. No tests exist today.
 
 ## Later
 
-- [ ] **Unsaved changes indicator + Save button** `ux` — visual when mind has uncommitted changes; "Save" commits for execs who don't know git.
-- [ ] **Multiple assistant personalities** `ux` — multiple agent personas in the voices screen. *(Kent feedback 2026-04-09)*
-- [ ] **Agent alerts / notifications** `ux` — system toasts + taskbar flash via `notify` tool and/or CronMonitor service. Electron `new Notification()` + `BrowserWindow.flashFrame()`.
-- [ ] **Scratch pad / work queue** `ux` — notepad for async handoff. User drops notes while agent is busy; agent triages when idle.
-- [ ] **Agency MCP config** `lens` — Lens editor view over MCP server config.
-- [ ] **Upgrade from genesis UI** `ux` — button/menu for discovering and installing genesis updates without typing a prompt.
-- [ ] **Upgrade to Myelin memory** `arch` — migration from flat-file `.working-memory/` to `shsolomo/myelin` knowledge graph.
-- [ ] **Move Responses API to frontier** `arch` — extract responses extension from genesis to frontier repo.
-- [ ] **Extension lib refactor** `arch` — shared lib for CLI extensions + Lens views.
-- [ ] **Connection health check** `arch` — real SDK health, not synthetic `mindPath !== null`. #12.
-- [ ] **Harden mind path validation** `security` — traversal/symlink checks. #3.
-- [ ] **Permission prompt flow** `security` — replace auto-approve with user prompt. #5.
-- [ ] **Navigation guards** `security` — `will-navigate` + `setWindowOpenHandler` to block arbitrary URL navigation.
-- [ ] **Electron Fuses audit** `security` — verify `RunAsNode: false`, `OnlyLoadAppFromAsar: true`, `EnableEmbeddedAsarIntegrityValidation: true`.
-- [ ] **Per-domain handler modules** `ipc` — split handlers into `registerChatHandlers()`, `registerConfigHandlers()`, etc.
-- [ ] **Listener cleanup audit** `ipc` — verify every `ipcRenderer.on()` returns unsub function. Wire into React effect cleanup.
-- [ ] **Dynamic channels for extensions** `ipc` — chatbox MCP transport pattern for Chamber extensions. Per-instance channels with cleanup on close.
-- [ ] **Lens view load time** `perf` — profile discovery scan, file reads, renderer-side rendering.
-- [ ] **Replace AuthService C# with keytar** `quality` — native module for credential storage, cross-platform.
-- [ ] **Gate console.log** `quality` — debug flag for 50+ log statements. #18.
-- [ ] **Polish pass** `quality` — dark mode toggle, app icon, empty states.
+- **Unsaved changes indicator + Save button** `ux` — visual when mind has uncommitted changes; "Save" commits for execs who don't know git.
+- **Multiple assistant personalities** `ux` — multiple agent personas in the voices screen. *(Kent feedback 2026-04-09)*
+- **Agent alerts / notifications** `ux` — system toasts + taskbar flash via `notify` tool and/or CronMonitor service. Electron `new Notification()` + `BrowserWindow.flashFrame()`.
+- **Scratch pad / work queue** `ux` — notepad for async handoff. User drops notes while agent is busy; agent triages when idle.
+- **Agency MCP config** `lens` — Lens editor view over MCP server config.
+- **Upgrade from genesis UI** `ux` — button/menu for discovering and installing genesis updates without typing a prompt.
+- **Upgrade to Myelin memory** `arch` — migration from flat-file `.working-memory/` to `shsolomo/myelin` knowledge graph.
+- **Move Responses API to frontier** `arch` — extract responses extension from genesis to frontier repo.
+- **Extension lib refactor** `arch` — shared lib for CLI extensions + Lens views.
+- **Connection health check** `arch` — real SDK health, not synthetic `mindPath !== null`. #12.
+- **Harden mind path validation** `security` — traversal/symlink checks. #3.
+- **Permission prompt flow** `security` — replace auto-approve with user prompt. #5.
+- **Navigation guards** `security` — `will-navigate` + `setWindowOpenHandler` to block arbitrary URL navigation.
+- **Electron Fuses audit** `security` — verify `RunAsNode: false`, `OnlyLoadAppFromAsar: true`, `EnableEmbeddedAsarIntegrityValidation: true`.
+- **Per-domain handler modules** `ipc` — split handlers into `registerChatHandlers()`, `registerConfigHandlers()`, etc.
+- **Listener cleanup audit** `ipc` — verify every `ipcRenderer.on()` returns unsub function. Wire into React effect cleanup.
+- **Dynamic channels for extensions** `ipc` — chatbox MCP transport pattern for Chamber extensions. Per-instance channels with cleanup on close.
+- **Lens view load time** `perf` — profile discovery scan, file reads, renderer-side rendering.
+- **Replace AuthService C# with keytar** `quality` — native module for credential storage, cross-platform.
+- **Gate console.log** `quality` — debug flag for 50+ log statements. #18.
+- **Polish pass** `quality` — dark mode toggle, app icon, empty states.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,15 @@ extensionLoader.registerAdapter('canvas', loadCanvasExtension);
 extensionLoader.registerAdapter('cron', loadCronExtension);
 extensionLoader.registerAdapter('idea', loadIdeaExtension);
 const configService = new ConfigService();
-const authService = new AuthService();
+const saveActiveLogin = (login: string | null) => {
+  const config = configService.load();
+  configService.save({ ...config, activeLogin: login });
+};
+const authService = new AuthService(
+  undefined,
+  () => configService.load().activeLogin,
+  saveActiveLogin,
+);
 const scaffold = new MindScaffold();
 const viewDiscovery = new ViewDiscovery();
 
@@ -130,7 +138,7 @@ app.on('ready', async () => {
   });
   setupLensIPC(viewDiscovery, mindManager);
   setupGenesisIPC(mindManager, scaffold);
-  setupAuthIPC(authService);
+  setupAuthIPC(authService, mindManager);
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager);
   setupChatroomIPC(chatroomService);
 
@@ -172,4 +180,3 @@ app.on('before-quit', (e) => {
     .catch(() => { /* noop */ })
     .finally(() => app.quit());
 });
-

--- a/src/main/ipc/auth.test.ts
+++ b/src/main/ipc/auth.test.ts
@@ -10,14 +10,23 @@ vi.mock('electron', () => ({
 import { ipcMain, BrowserWindow } from 'electron';
 import { setupAuthIPC } from './auth';
 import type { AuthService } from '../services/auth';
+import type { MindManager } from '../services/mind';
 
 function createFakeAuth() {
   return {
     getStoredCredential: vi.fn().mockResolvedValue(null),
+    listAccounts: vi.fn().mockResolvedValue([]),
     setProgressHandler: vi.fn(),
     startLogin: vi.fn().mockResolvedValue({ success: true }),
     logout: vi.fn().mockResolvedValue(undefined),
+    setActiveLogin: vi.fn(),
   } as unknown as AuthService;
+}
+
+function createFakeMindManager() {
+  return {
+    reloadAllMinds: vi.fn().mockResolvedValue(undefined),
+  } as unknown as MindManager;
 }
 
 describe('setupAuthIPC', () => {
@@ -25,12 +34,92 @@ describe('setupAuthIPC', () => {
     vi.mocked(ipcMain.handle).mockClear();
   });
 
-  it('registers auth:getStatus, auth:startLogin, and auth:logout handlers', () => {
-    setupAuthIPC(createFakeAuth());
+  it('registers all auth handlers', () => {
+    setupAuthIPC(createFakeAuth(), createFakeMindManager());
     const channels = vi.mocked(ipcMain.handle).mock.calls.map(c => c[0]);
     expect(channels).toContain('auth:getStatus');
+    expect(channels).toContain('auth:listAccounts');
     expect(channels).toContain('auth:startLogin');
+    expect(channels).toContain('auth:switchAccount');
     expect(channels).toContain('auth:logout');
+  });
+
+  it('auth:listAccounts returns authService.listAccounts()', async () => {
+    const fakeAuth = createFakeAuth();
+    fakeAuth.listAccounts = vi.fn().mockResolvedValue([{ login: 'alice' }]);
+
+    setupAuthIPC(fakeAuth, createFakeMindManager());
+
+    const listCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:listAccounts');
+    await expect(listCall![1]({} as never, ...([] as never))).resolves.toEqual([{ login: 'alice' }]);
+  });
+
+  it('auth:switchAccount sets activeLogin via authService, reloads minds, and broadcasts accountSwitched', async () => {
+    const fakeAuth = createFakeAuth();
+    const fakeMindManager = createFakeMindManager();
+    fakeAuth.listAccounts = vi.fn().mockResolvedValue([{ login: 'alice' }, { login: 'bob' }]);
+
+    const mockSend = vi.fn();
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([{ webContents: { send: mockSend } }] as never);
+
+    setupAuthIPC(fakeAuth, fakeMindManager);
+
+    const switchCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:switchAccount');
+    await switchCall![1]({} as never, 'bob');
+
+    expect(fakeAuth.setActiveLogin).toHaveBeenCalledWith('bob');
+    expect(fakeMindManager.reloadAllMinds).toHaveBeenCalled();
+    expect(mockSend).toHaveBeenNthCalledWith(1, 'auth:accountSwitchStarted', { login: 'bob' });
+    expect(mockSend).toHaveBeenNthCalledWith(2, 'auth:accountSwitched', { login: 'bob' });
+  });
+
+  it('auth:switchAccount rejects when account is missing', async () => {
+    const fakeAuth = createFakeAuth();
+    fakeAuth.listAccounts = vi.fn().mockResolvedValue([{ login: 'alice' }]);
+
+    setupAuthIPC(fakeAuth, createFakeMindManager());
+
+    const switchCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:switchAccount');
+    await expect(switchCall![1]({} as never, 'bob')).rejects.toThrow('Account bob is not available');
+  });
+
+  it('auth:startLogin sets activeLogin via authService, reloads minds, and broadcasts accountSwitched after success', async () => {
+    const fakeAuth = createFakeAuth();
+    const fakeMindManager = createFakeMindManager();
+    fakeAuth.startLogin = vi.fn().mockResolvedValue({ success: true, login: 'alice' });
+
+    const mockSend = vi.fn();
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue({ webContents: { send: mockSend } } as never);
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([{ webContents: { send: mockSend } }] as never);
+
+    setupAuthIPC(fakeAuth, fakeMindManager);
+
+    const startLoginCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:startLogin');
+    await expect(startLoginCall![1]({ sender: {} } as never, ...([] as never))).resolves.toEqual({ success: true, login: 'alice' });
+
+    expect(fakeAuth.setActiveLogin).toHaveBeenCalledWith('alice');
+    expect(fakeMindManager.reloadAllMinds).toHaveBeenCalled();
+    expect(mockSend).toHaveBeenNthCalledWith(1, 'auth:accountSwitchStarted', { login: 'alice' });
+    expect(mockSend).toHaveBeenNthCalledWith(2, 'auth:accountSwitched', { login: 'alice' });
+  });
+
+  it('auth:switchAccount still broadcasts accountSwitched when reloadAllMinds rejects', async () => {
+    const fakeAuth = createFakeAuth();
+    const fakeMindManager = createFakeMindManager();
+    fakeMindManager.reloadAllMinds = vi.fn().mockRejectedValue(new Error('disk failure')) as never;
+    fakeAuth.listAccounts = vi.fn().mockResolvedValue([{ login: 'alice' }]);
+
+    const mockSend = vi.fn();
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([{ webContents: { send: mockSend } }] as never);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+    setupAuthIPC(fakeAuth, fakeMindManager);
+
+    const switchCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:switchAccount');
+    await switchCall![1]({} as never, 'alice');
+
+    expect(mockSend).toHaveBeenCalledWith('auth:accountSwitched', { login: 'alice' });
+    consoleSpy.mockRestore();
   });
 
   it('auth:logout handler calls authService.logout and broadcasts to all windows', async () => {
@@ -42,7 +131,7 @@ describe('setupAuthIPC', () => {
     ];
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(mockWindows as never);
 
-    setupAuthIPC(fakeAuth);
+    setupAuthIPC(fakeAuth, createFakeMindManager());
 
     // Find and invoke the auth:logout handler
     const logoutCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:logout');

--- a/src/main/ipc/auth.ts
+++ b/src/main/ipc/auth.ts
@@ -1,8 +1,25 @@
 // Auth IPC handlers
 import { ipcMain, BrowserWindow, shell } from 'electron';
 import { AuthService } from '../services/auth';
+import type { MindManager } from '../services/mind';
 
-export function setupAuthIPC(authService: AuthService): void {
+function broadcast(
+  channel: 'auth:loggedOut' | 'auth:accountSwitchStarted' | 'auth:accountSwitched',
+  payload?: { login: string },
+): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (payload) {
+      win.webContents.send(channel, payload);
+      continue;
+    }
+    win.webContents.send(channel);
+  }
+}
+
+export function setupAuthIPC(
+  authService: AuthService,
+  mindManager: MindManager,
+): void {
 
   ipcMain.handle('auth:getStatus', async () => {
     const cred = await authService.getStoredCredential();
@@ -11,6 +28,8 @@ export function setupAuthIPC(authService: AuthService): void {
       login: cred?.login,
     };
   });
+
+  ipcMain.handle('auth:listAccounts', async () => authService.listAccounts());
 
   ipcMain.handle('auth:startLogin', async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
@@ -24,13 +43,39 @@ export function setupAuthIPC(authService: AuthService): void {
       }
     });
 
-    return authService.startLogin();
+    const result = await authService.startLogin();
+    if (result.success && result.login) {
+      authService.setActiveLogin(result.login);
+      broadcast('auth:accountSwitchStarted', { login: result.login });
+      try {
+        await mindManager.reloadAllMinds();
+      } catch (err) {
+        console.error('[Auth] Failed to reload minds after login:', err);
+      }
+      broadcast('auth:accountSwitched', { login: result.login });
+    }
+
+    return result;
+  });
+
+  ipcMain.handle('auth:switchAccount', async (_event, login: string) => {
+    const accounts = await authService.listAccounts();
+    if (!accounts.some((account) => account.login === login)) {
+      throw new Error(`Account ${login} is not available`);
+    }
+
+    authService.setActiveLogin(login);
+    broadcast('auth:accountSwitchStarted', { login });
+    try {
+      await mindManager.reloadAllMinds();
+    } catch (err) {
+      console.error('[Auth] Failed to reload minds after account switch:', err);
+    }
+    broadcast('auth:accountSwitched', { login });
   });
 
   ipcMain.handle('auth:logout', async () => {
     await authService.logout();
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('auth:loggedOut');
-    }
+    broadcast('auth:loggedOut');
   });
 }

--- a/src/main/services/auth/AuthService.test.ts
+++ b/src/main/services/auth/AuthService.test.ts
@@ -12,7 +12,7 @@ vi.mock('keytar', () => ({
   deletePassword: vi.fn().mockResolvedValue(true),
 }));
 
-import { getCredentialAccount, getLoginFromAccount, resolveStoredCredential, AuthService } from './AuthService';
+import { getCredentialAccount, getLoginFromAccount, AuthService } from './AuthService';
 
 type KeytarModule = typeof import('keytar');
 
@@ -55,42 +55,6 @@ describe('getLoginFromAccount', () => {
   });
 });
 
-describe('resolveStoredCredential', () => {
-  it('returns credential for valid entry', () => {
-    const result = resolveStoredCredential([
-      { account: 'https://github.com:alice', password: 'gho_token123' },
-    ]);
-    expect(result).toEqual({ login: 'alice', account: 'https://github.com:alice', password: 'gho_token123' });
-  });
-
-  it('returns first credential when multiple exist', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(vi.fn());
-    const result = resolveStoredCredential([
-      { account: 'https://github.com:alice', password: 'token1' },
-      { account: 'https://github.com:bob', password: 'token2' },
-    ]);
-    expect(result?.login).toBe('alice');
-    expect(consoleSpy).toHaveBeenCalled();
-    consoleSpy.mockRestore();
-  });
-
-  it('returns null for no valid credentials', () => {
-    expect(resolveStoredCredential([
-      { account: 'https://gitlab.com:alice', password: 'token' },
-    ])).toBeNull();
-  });
-
-  it('returns null for empty array', () => {
-    expect(resolveStoredCredential([])).toBeNull();
-  });
-
-  it('skips entries with empty password', () => {
-    expect(resolveStoredCredential([
-      { account: 'https://github.com:alice', password: '' },
-    ])).toBeNull();
-  });
-});
-
 describe('AuthService.logout', () => {
   it('deletes the stored credential via keytar', async () => {
     const mockKeytar = createMockKeytar({
@@ -108,5 +72,94 @@ describe('AuthService.logout', () => {
     const service = new AuthService(mockKeytar);
     await expect(service.logout()).resolves.toBeUndefined();
     expect(mockKeytar.deletePassword).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthService multi-account', () => {
+  it('listAccounts returns all stored accounts sorted alphabetically', async () => {
+    const mockKeytar = createMockKeytar({
+      findCredentials: vi.fn().mockResolvedValue([
+        { account: 'https://github.com:zebra', password: 'token2' },
+        { account: 'https://github.com:alice', password: 'token1' },
+      ]),
+    });
+
+    const service = new AuthService(mockKeytar);
+    await expect(service.listAccounts()).resolves.toEqual([
+      { login: 'alice' },
+      { login: 'zebra' },
+    ]);
+  });
+
+  it('listAccounts returns empty array when no credentials exist', async () => {
+    const service = new AuthService(createMockKeytar());
+    await expect(service.listAccounts()).resolves.toEqual([]);
+  });
+
+  it('listAccounts filters out malformed accounts', async () => {
+    const mockKeytar = createMockKeytar({
+      findCredentials: vi.fn().mockResolvedValue([
+        { account: 'https://gitlab.com:alice', password: 'token1' },
+        { account: 'https://github.com:bob', password: 'token2' },
+      ]),
+    });
+
+    const service = new AuthService(mockKeytar);
+    await expect(service.listAccounts()).resolves.toEqual([{ login: 'bob' }]);
+  });
+
+  it('getStoredCredential returns the configured active account', async () => {
+    const mockKeytar = createMockKeytar({
+      findCredentials: vi.fn().mockResolvedValue([
+        { account: 'https://github.com:alice', password: 'token1' },
+        { account: 'https://github.com:bob', password: 'token2' },
+      ]),
+    });
+
+    const service = new AuthService(mockKeytar, () => 'bob');
+    await expect(service.getStoredCredential()).resolves.toEqual({ login: 'bob' });
+  });
+
+  it('getStoredCredential falls back to the first stored account when activeLogin is null', async () => {
+    const mockKeytar = createMockKeytar({
+      findCredentials: vi.fn().mockResolvedValue([
+        { account: 'https://github.com:bob', password: 'token2' },
+        { account: 'https://github.com:alice', password: 'token1' },
+      ]),
+    });
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(vi.fn());
+    const service = new AuthService(mockKeytar, () => null);
+
+    await expect(service.getStoredCredential()).resolves.toEqual({ login: 'alice' });
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('getStoredCredential returns null when activeLogin is set but missing', async () => {
+    const mockKeytar = createMockKeytar({
+      findCredentials: vi.fn().mockResolvedValue([
+        { account: 'https://github.com:alice', password: 'token1' },
+      ]),
+    });
+
+    const service = new AuthService(mockKeytar, () => 'bob');
+    await expect(service.getStoredCredential()).resolves.toBeNull();
+  });
+
+  it('logout deletes only the active credential and clears activeLogin', async () => {
+    const mockKeytar = createMockKeytar({
+      findCredentials: vi.fn().mockResolvedValue([
+        { account: 'https://github.com:alice', password: 'token1' },
+        { account: 'https://github.com:bob', password: 'token2' },
+      ]),
+    });
+    const setActiveLogin = vi.fn();
+    const service = new AuthService(mockKeytar, () => 'bob', setActiveLogin);
+
+    await service.logout();
+
+    expect(mockKeytar.deletePassword).toHaveBeenCalledWith('copilot-cli', 'https://github.com:bob');
+    expect(setActiveLogin).toHaveBeenCalledWith(null);
   });
 });

--- a/src/main/services/auth/AuthService.ts
+++ b/src/main/services/auth/AuthService.ts
@@ -49,24 +49,6 @@ export function getLoginFromAccount(account: string): string | null {
   return login || null;
 }
 
-export function resolveStoredCredential(credentials: Array<{ account: string; password: string }>): StoredCredential | null {
-  const matchingCredentials = credentials
-    .map((credential) => {
-      const login = getLoginFromAccount(credential.account);
-      if (!login || !credential.password) return null;
-      return { login, account: credential.account, password: credential.password };
-    })
-    .filter((credential): credential is StoredCredential => credential !== null);
-
-  if (matchingCredentials.length === 0) return null;
-
-  if (matchingCredentials.length > 1) {
-    console.warn(`[Auth] Multiple Copilot credentials found; using ${matchingCredentials[0].account}`);
-  }
-
-  return matchingCredentials[0];
-}
-
 export interface AuthProgress {
   step: 'device_code' | 'polling' | 'authenticated' | 'error';
   userCode?: string;
@@ -137,7 +119,11 @@ export class AuthService {
   private aborted = false;
   private keytar: KeytarModule;
 
-  constructor(keytarModule?: KeytarModule) {
+  constructor(
+    keytarModule?: KeytarModule,
+    private readonly getActiveLogin: () => string | null = () => null,
+    readonly setActiveLogin: (login: string | null) => void = () => undefined,
+  ) {
     this.keytar = keytarModule ?? defaultKeytar;
   }
 
@@ -149,9 +135,18 @@ export class AuthService {
     this.aborted = true;
   }
 
+  async listAccounts(): Promise<Array<{ login: string }>> {
+    try {
+      return (await this.getStoredCredentials()).map(({ login }) => ({ login }));
+    } catch (err) {
+      console.error('[Auth] Failed to list stored credentials:', err);
+      return [];
+    }
+  }
+
   async getStoredCredential(): Promise<{ login: string } | null> {
     try {
-      const credential = resolveStoredCredential(await this.keytar.findCredentials(KEYTAR_SERVICE));
+      const credential = await this.getStoredCredentialEntry();
       return credential ? { login: credential.login } : null;
     } catch (err) {
       console.error('[Auth] Failed to read stored credential:', err);
@@ -164,13 +159,43 @@ export class AuthService {
     this.abort();
 
     try {
-      const credential = resolveStoredCredential(await this.keytar.findCredentials(KEYTAR_SERVICE));
+      const credential = await this.getStoredCredentialEntry();
       if (!credential) return;
       await this.keytar.deletePassword(KEYTAR_SERVICE, credential.account);
+      this.setActiveLogin(null);
       console.log(`[Auth] Deleted credential for ${credential.login}`);
     } catch (err) {
       console.error('[Auth] Failed to delete credential:', err);
     }
+  }
+
+  private async getStoredCredentials(): Promise<StoredCredential[]> {
+    const credentials = await this.keytar.findCredentials(KEYTAR_SERVICE);
+    const storedCredentials = credentials
+      .map((credential) => {
+        const login = getLoginFromAccount(credential.account);
+        if (!login || !credential.password) return null;
+        return { login, account: credential.account, password: credential.password };
+      })
+      .filter((credential): credential is StoredCredential => credential !== null)
+      .sort((a, b) => a.login.localeCompare(b.login));
+
+    return storedCredentials;
+  }
+
+  private async getStoredCredentialEntry(): Promise<StoredCredential | null> {
+    const credentials = await this.getStoredCredentials();
+    if (credentials.length === 0) return null;
+
+    const activeLogin = this.getActiveLogin();
+    if (activeLogin === null) {
+      if (credentials.length > 1) {
+        console.warn(`[Auth] Multiple Copilot credentials found; using ${credentials[0].account}`);
+      }
+      return credentials[0];
+    }
+
+    return credentials.find((credential) => credential.login === activeLogin) ?? null;
   }
 
   private async storeCredential(login: string, token: string): Promise<void> {
@@ -189,7 +214,7 @@ export class AuthService {
       });
 
       const userCode = String(deviceResp.user_code);
-      const verificationUri = String(deviceResp.verification_uri);
+      const verificationUri = String(deviceResp.verification_uri_complete ?? deviceResp.verification_uri);
       const deviceCode = String(deviceResp.device_code);
       let interval = Number(deviceResp.interval) || 5;
       const expiresIn = Number(deviceResp.expires_in) || 900;

--- a/src/main/services/auth/index.ts
+++ b/src/main/services/auth/index.ts
@@ -1,2 +1,2 @@
-export { AuthService, getCredentialAccount, getLoginFromAccount, resolveStoredCredential } from './AuthService';
+export { AuthService, getCredentialAccount, getLoginFromAccount } from './AuthService';
 export type { AuthProgress } from './AuthService';

--- a/src/main/services/config/ConfigService.migration.test.ts
+++ b/src/main/services/config/ConfigService.migration.test.ts
@@ -27,23 +27,24 @@ describe('ConfigService (v1→v2 migration)', () => {
     expect(config.version).toBe(2);
     expect(config.minds).toHaveLength(1);
     expect(config.minds[0].path).toBe('C:\\test\\mind');
+    expect(config.activeLogin).toBeNull();
     expect(config.theme).toBe('light');
   });
 
   it('returns default v2 config when file is missing', () => {
     mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
     const config = svc.load();
-    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, theme: 'dark' });
+    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' });
   });
 
   it('returns default v2 config for invalid JSON', () => {
     mockReadFileSync.mockReturnValue('not json');
     const config = svc.load();
-    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, theme: 'dark' });
+    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' });
   });
 
   it('creates directory and writes v2 config', () => {
-    svc.save({ version: 2, minds: [{ id: 'test-a1b2', path: 'C:\\test' }], activeMindId: 'test-a1b2', theme: 'dark' });
+    svc.save({ version: 2, minds: [{ id: 'test-a1b2', path: 'C:\\test' }], activeMindId: 'test-a1b2', activeLogin: 'alice', theme: 'dark' });
     expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       expect.stringContaining('config.json'),

--- a/src/main/services/config/ConfigService.test.ts
+++ b/src/main/services/config/ConfigService.test.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import { ConfigService } from './ConfigService';
 import type { AppConfig } from '../../../shared/types';
 
-const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, theme: 'dark' };
+const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' };
 
 describe('ConfigService', () => {
   let svc: ConfigService;
@@ -22,9 +22,26 @@ describe('ConfigService', () => {
 
   describe('load', () => {
     it('returns v2 config as-is', () => {
-      const v2: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }], activeMindId: 'q-a1b2', theme: 'light' };
+      const v2: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }], activeMindId: 'q-a1b2', activeLogin: 'alice', theme: 'light' };
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(v2));
       expect(svc.load()).toEqual(v2);
+    });
+
+    it('backfills activeLogin for legacy v2 configs', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }],
+        activeMindId: 'q-a1b2',
+        theme: 'light',
+      }));
+
+      expect(svc.load()).toEqual({
+        version: 2,
+        minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }],
+        activeMindId: 'q-a1b2',
+        activeLogin: null,
+        theme: 'light',
+      });
     });
 
     it('migrates v1 config with mindPath to v2', () => {
@@ -37,6 +54,7 @@ describe('ConfigService', () => {
       expect(result.minds[0].path).toBe('/tmp/agents/q');
       expect(result.minds[0].id).toMatch(/^q-[a-f0-9]{4}$/);
       expect(result.activeMindId).toBe(result.minds[0].id);
+      expect(result.activeLogin).toBeNull();
       expect(result.theme).toBe('light');
     });
 
@@ -67,18 +85,20 @@ describe('ConfigService', () => {
           { id: 'q-c3d4', path: '/tmp/agents/q' },
         ],
         activeMindId: 'q-a1b2',
+        activeLogin: 'alice',
         theme: 'dark',
       };
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(v2));
       const result = svc.load();
       expect(result.minds).toHaveLength(1);
       expect(result.minds[0].id).toBe('q-a1b2');
+      expect(result.activeLogin).toBe('alice');
     });
   });
 
   describe('save', () => {
     it('creates directory and writes v2 JSON', () => {
-      const config: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }], activeMindId: 'q-a1b2', theme: 'dark' };
+      const config: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }], activeMindId: 'q-a1b2', activeLogin: 'alice', theme: 'dark' };
       svc.save(config);
       expect(vi.mocked(fs.mkdirSync)).toHaveBeenCalledWith(expect.any(String), {
         recursive: true,
@@ -87,6 +107,7 @@ describe('ConfigService', () => {
       const parsed = JSON.parse(written);
       expect(parsed.version).toBe(2);
       expect(parsed.minds).toHaveLength(1);
+      expect(parsed.activeLogin).toBe('alice');
     });
   });
 

--- a/src/main/services/config/ConfigService.ts
+++ b/src/main/services/config/ConfigService.ts
@@ -7,7 +7,7 @@ import type { AppConfig, AppConfigV1, MindRecord } from '../../../shared/types';
 const CONFIG_DIR = path.join(os.homedir(), '.chamber');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 
-const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, theme: 'dark' };
+const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' };
 
 export class ConfigService {
   /** @deprecated Use generateMindId() from mind/generateMindId instead */
@@ -30,9 +30,23 @@ export class ConfigService {
 
   private normalize(raw: Record<string, unknown>): AppConfig {
     if (raw.version === 2) {
-      return this.deduplicateMinds(raw as AppConfig);
+      return this.normalizeV2(raw);
     }
     return this.migrateV1(raw as unknown as AppConfigV1);
+  }
+
+  private normalizeV2(raw: Record<string, unknown>): AppConfig {
+    const theme = raw.theme === 'light' || raw.theme === 'dark' || raw.theme === 'system'
+      ? raw.theme
+      : 'dark';
+    const minds = Array.isArray(raw.minds) ? raw.minds as MindRecord[] : [];
+    return this.deduplicateMinds({
+      version: 2,
+      minds,
+      activeMindId: typeof raw.activeMindId === 'string' ? raw.activeMindId : null,
+      activeLogin: typeof raw.activeLogin === 'string' ? raw.activeLogin : null,
+      theme,
+    });
   }
 
   private migrateV1(v1: AppConfigV1): AppConfig {
@@ -44,6 +58,7 @@ export class ConfigService {
       version: 2,
       minds: [{ id, path: v1.mindPath }],
       activeMindId: id,
+      activeLogin: null,
       theme: v1.theme ?? 'dark',
     };
   }

--- a/src/main/services/mind/MindManager.test.ts
+++ b/src/main/services/mind/MindManager.test.ts
@@ -52,9 +52,19 @@ const mockExtensionLoader = {
   cleanupExtensions: vi.fn(),
 };
 
+let currentConfig = {
+  version: 2 as const,
+  minds: [],
+  activeMindId: null,
+  activeLogin: null,
+  theme: 'dark' as const,
+};
+
 const mockConfigService = {
-  load: vi.fn(() => ({ version: 2 as const, minds: [], activeMindId: null, theme: 'dark' as const })),
-  save: vi.fn(),
+  load: vi.fn(() => currentConfig),
+  save: vi.fn((config) => {
+    currentConfig = config;
+  }),
 };
 
 const mockViewDiscovery = {
@@ -71,6 +81,19 @@ describe('MindManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConfigService.load.mockReset();
+    mockConfigService.save.mockReset();
+    mockConfigService.load.mockImplementation(() => currentConfig);
+    mockConfigService.save.mockImplementation((config) => {
+      currentConfig = config;
+    });
+    currentConfig = {
+      version: 2 as const,
+      minds: [],
+      activeMindId: null,
+      activeLogin: null,
+      theme: 'dark' as const,
+    };
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
     manager = new MindManager(
@@ -211,6 +234,7 @@ describe('MindManager', () => {
           { id: 'fox-c3d4', path: '/tmp/agents/fox' },
         ],
         activeMindId: 'q-a1b2',
+        activeLogin: 'alice',
         theme: 'dark',
       });
 
@@ -230,6 +254,7 @@ describe('MindManager', () => {
           { id: 'bad-c3d4', path: '/tmp/agents/bad' },
         ],
         activeMindId: 'good-a1b2',
+        activeLogin: 'alice',
         theme: 'dark',
       });
 
@@ -242,7 +267,7 @@ describe('MindManager', () => {
 
     it('handles empty config gracefully', async () => {
       mockConfigService.load.mockReturnValue({
-        version: 2, minds: [], activeMindId: null, theme: 'dark',
+        version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark',
       });
 
       await manager.restoreFromConfig();
@@ -280,6 +305,7 @@ describe('MindManager', () => {
         version: 2,
         minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }],
         activeMindId: 'q-a1b2',
+        activeLogin: 'alice',
         theme: 'dark',
       });
 
@@ -301,6 +327,7 @@ describe('MindManager', () => {
         version: 2,
         minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }],
         activeMindId: 'q-a1b2',
+        activeLogin: 'alice',
         theme: 'dark',
       });
 
@@ -317,6 +344,7 @@ describe('MindManager', () => {
         version: 2,
         minds: [{ id: 'my-stable-id', path: '/tmp/agents/q' }],
         activeMindId: 'my-stable-id',
+        activeLogin: 'alice',
         theme: 'dark',
       });
 
@@ -569,6 +597,74 @@ describe('MindManager', () => {
     it('works without toolBuilder (backwards compat)', async () => {
       await manager.loadMind('/tmp/agents/q');
       expect(mockCreateSession).toHaveBeenCalled();
+    });
+  });
+
+  describe('reloadAllMinds', () => {
+    it('unloads every loaded mind and restores them from config', async () => {
+      await manager.loadMind('/tmp/agents/q');
+      await manager.loadMind('/tmp/agents/fox');
+
+      await manager.reloadAllMinds();
+
+      expect(mockClientFactory.destroyClient).toHaveBeenCalledTimes(2);
+      expect(manager.listMinds()).toHaveLength(2);
+    });
+
+    it('preserves activeMindId', async () => {
+      const firstMind = await manager.loadMind('/tmp/agents/q');
+      const secondMind = await manager.loadMind('/tmp/agents/fox');
+      manager.setActiveMind(secondMind.mindId);
+
+      await manager.reloadAllMinds();
+
+      expect(manager.getActiveMindId()).toBe(secondMind.mindId);
+      expect(manager.getActiveMindId()).not.toBe(firstMind.mindId);
+    });
+
+    it('creates fresh client instances after reload', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const originalClient = manager.getMind(mind.mindId)?.client;
+
+      await manager.reloadAllMinds();
+
+      const reloadedClient = manager.getMind(mind.mindId)?.client;
+      expect(reloadedClient).toBeDefined();
+      expect(reloadedClient).not.toBe(originalClient);
+    });
+
+    it('preserves activeLogin in persisted config snapshots', async () => {
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [],
+        activeMindId: null,
+        activeLogin: 'alice',
+        theme: 'dark',
+      });
+      await manager.loadMind('/tmp/agents/q');
+
+      await manager.reloadAllMinds();
+
+      expect(mockConfigService.save).toHaveBeenCalledWith(expect.objectContaining({
+        activeLogin: 'alice',
+      }));
+    });
+
+    it('suppresses per-mind config writes during reload — only the snapshot save is written', async () => {
+      await manager.loadMind('/tmp/agents/q');
+      await manager.loadMind('/tmp/agents/fox');
+      mockConfigService.save.mockClear();
+
+      await manager.reloadAllMinds();
+
+      // One snapshot save before restore, then one per re-loaded mind (from loadMind's persistConfig).
+      // The two unloadMind calls should NOT produce saves thanks to the reloading guard.
+      const saveCalls = mockConfigService.save.mock.calls;
+      // First save is the snapshot (contains both minds)
+      expect(saveCalls[0][0].minds).toHaveLength(2);
+      // No save should have an empty minds array (which would be the mid-unload state)
+      const emptyMindsSaves = saveCalls.filter((call: unknown[]) => (call[0] as { minds: unknown[] }).minds.length === 0);
+      expect(emptyMindsSaves).toHaveLength(0);
     });
   });
 });

--- a/src/main/services/mind/MindManager.ts
+++ b/src/main/services/mind/MindManager.ts
@@ -20,6 +20,7 @@ export class MindManager extends EventEmitter {
   private windowByMind = new Map<string, { focus: () => void; close: () => void; on: (event: string, cb: () => void) => void }>();
   private activeMindId: string | null = null;
   private restorePromise: Promise<void> | null = null;
+  private reloading = false;
 
   constructor(
     private readonly clientFactory: CopilotClientFactory,
@@ -192,6 +193,36 @@ export class MindManager extends EventEmitter {
     return this.restorePromise;
   }
 
+  async reloadAllMinds(): Promise<void> {
+    await this.awaitRestore();
+
+    const existingConfig = this.configService.load();
+    const configSnapshot: AppConfig = {
+      version: 2,
+      minds: Array.from(this.minds.values()).map((mind) => ({
+        id: mind.mindId,
+        path: mind.mindPath,
+      })),
+      activeMindId: this.activeMindId,
+      activeLogin: existingConfig.activeLogin,
+      theme: existingConfig.theme,
+    };
+
+    this.reloading = true;
+    try {
+      const loadedMindIds = Array.from(this.minds.keys());
+      for (const mindId of loadedMindIds) {
+        await this.unloadMind(mindId);
+      }
+    } finally {
+      this.reloading = false;
+    }
+
+    this.activeMindId = null;
+    this.configService.save(configSnapshot);
+    await this.restoreFromConfig();
+  }
+
   private async doRestore(): Promise<void> {
     const config = this.configService.load();
     for (const record of config.minds) {
@@ -320,6 +351,8 @@ export class MindManager extends EventEmitter {
   }
 
   private persistConfig(): void {
+    if (this.reloading) return;
+    const existingConfig = this.configService.load();
     const minds: MindRecord[] = Array.from(this.minds.values()).map(m => ({
       id: m.mindId,
       path: m.mindPath,
@@ -328,7 +361,8 @@ export class MindManager extends EventEmitter {
       version: 2,
       minds,
       activeMindId: this.activeMindId,
-      theme: this.configService.load().theme,
+      activeLogin: existingConfig.activeLogin,
+      theme: existingConfig.theme,
     };
     this.configService.save(config);
   }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -33,10 +33,16 @@ const electronAPI: ElectronAPI = {
   },
   auth: {
     getStatus: () => ipcRenderer.invoke('auth:getStatus'),
+    listAccounts: () => ipcRenderer.invoke('auth:listAccounts'),
     startLogin: () => ipcRenderer.invoke('auth:startLogin'),
+    switchAccount: (login) => ipcRenderer.invoke('auth:switchAccount', login),
     logout: () => ipcRenderer.invoke('auth:logout'),
     onProgress: (callback) =>
       createIpcListener(ipcRenderer, 'auth:progress', callback),
+    onAccountSwitchStarted: (callback) =>
+      createIpcListener(ipcRenderer, 'auth:accountSwitchStarted', callback),
+    onAccountSwitched: (callback) =>
+      createIpcListener(ipcRenderer, 'auth:accountSwitched', callback),
     onLoggedOut: (callback) =>
       createIpcListener(ipcRenderer, 'auth:loggedOut', callback),
   },

--- a/src/renderer/components/auth/AuthGate.test.tsx
+++ b/src/renderer/components/auth/AuthGate.test.tsx
@@ -57,10 +57,32 @@ describe('AuthGate', () => {
     });
   });
 
+  it('stays authenticated when auth:accountSwitched fires', async () => {
+    let accountSwitchedCallback: ((data: { login: string }) => void) | undefined;
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.onAccountSwitched as ReturnType<typeof vi.fn>).mockImplementation((cb: (data: { login: string }) => void) => {
+      accountSwitchedCallback = cb;
+      return vi.fn();
+    });
+
+    render(<AuthGate><div>Protected Content</div></AuthGate>);
+    await waitFor(() => {
+      expect(screen.getByText('Protected Content')).toBeTruthy();
+    });
+
+    accountSwitchedCallback!({ login: 'bob' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Protected Content')).toBeTruthy();
+    });
+  });
+
   it('cleans up onLoggedOut listener on unmount', async () => {
     const unsub = vi.fn();
+    const unsubAccountSwitched = vi.fn();
     (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true });
     (api.auth.onLoggedOut as ReturnType<typeof vi.fn>).mockReturnValue(unsub);
+    (api.auth.onAccountSwitched as ReturnType<typeof vi.fn>).mockReturnValue(unsubAccountSwitched);
 
     const { unmount } = render(<AuthGate><div>Protected Content</div></AuthGate>);
     await waitFor(() => {
@@ -69,5 +91,6 @@ describe('AuthGate', () => {
 
     unmount();
     expect(unsub).toHaveBeenCalled();
+    expect(unsubAccountSwitched).toHaveBeenCalled();
   });
 });

--- a/src/renderer/components/auth/AuthGate.tsx
+++ b/src/renderer/components/auth/AuthGate.tsx
@@ -19,6 +19,15 @@ export function AuthGate({ children }: Props) {
   useEffect(() => {
     const unsub = window.electronAPI.auth.onLoggedOut(() => {
       setAuthenticated(false);
+      setChecking(false);
+    });
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    const unsub = window.electronAPI.auth.onAccountSwitched(() => {
+      setAuthenticated(true);
+      setChecking(false);
     });
     return unsub;
   }, []);

--- a/src/renderer/components/genesis/ChamberLoadingScreen.tsx
+++ b/src/renderer/components/genesis/ChamberLoadingScreen.tsx
@@ -1,20 +1,39 @@
 import React, { useState, useEffect } from 'react';
 import { version } from '../../../../package.json';
 
-const BOOT_LINES = [
+const STARTUP_LINES = [
   `> chamber v${version}`,
   '> initializing runtime...',
   '> scanning mind registry...',
 ];
 
-export function ChamberLoadingScreen() {
+function getBootLines(mode: 'startup' | 'switching-account', login?: string | null): string[] {
+  if (mode === 'switching-account') {
+    return [
+      `> chamber v${version}`,
+      `> switching github account${login ? ` to @${login}` : ''}...`,
+      '> reloading minds...',
+    ];
+  }
+
+  return STARTUP_LINES;
+}
+
+interface Props {
+  mode?: 'startup' | 'switching-account';
+  login?: string | null;
+}
+
+export function ChamberLoadingScreen({ mode = 'startup', login }: Props) {
   const [lines, setLines] = useState<string[]>([]);
 
   useEffect(() => {
+    const bootLines = getBootLines(mode, login);
+    setLines([]);
     let i = 0;
     const interval = setInterval(() => {
-      if (i < BOOT_LINES.length) {
-        setLines(prev => [...prev, BOOT_LINES[i]]);
+      if (i < bootLines.length) {
+        setLines(prev => [...prev, bootLines[i]]);
         i++;
       } else {
         clearInterval(interval);
@@ -22,7 +41,7 @@ export function ChamberLoadingScreen() {
     }, 200);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [login, mode]);
 
   return (
     <div className="fixed inset-0 bg-black flex flex-col items-center justify-center z-50">
@@ -35,7 +54,9 @@ export function ChamberLoadingScreen() {
 
       <div className="absolute bottom-12 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3">
         <div className="w-6 h-6 border-2 border-green-500/30 border-t-green-500 rounded-full animate-spin" />
-        <p className="text-xs text-green-500/50 font-mono">waking agents...</p>
+        <p className="text-xs text-green-500/50 font-mono">
+          {mode === 'switching-account' ? 'switching account and waking agents...' : 'waking agents...'}
+        </p>
       </div>
     </div>
   );

--- a/src/renderer/components/genesis/GenesisGate.test.tsx
+++ b/src/renderer/components/genesis/GenesisGate.test.tsx
@@ -62,4 +62,51 @@ describe('GenesisGate', () => {
       expect(api.mind.selectDirectory).toHaveBeenCalled();
     });
   });
+
+  it('shows Chamber loading screen during account switching instead of landing screen', async () => {
+    render(
+      <AppStateProvider testInitialState={{
+        minds: [],
+        mindsChecked: true,
+        runtimePhase: 'switching-account',
+        switchingAccountLogin: 'bob',
+      }}
+      >
+        <GenesisGate><div>App</div></GenesisGate>
+      </AppStateProvider>,
+    );
+
+    expect(screen.getByText('switching account and waking agents...', { exact: false })).toBeTruthy();
+    expect(screen.queryByText('New Agent', { exact: false })).toBeNull();
+    expect(screen.queryByText('App')).toBeNull();
+  });
+
+  it('shows a close button and returns to the app when landing was opened from chat', () => {
+    render(
+      <AppStateProvider testInitialState={{
+        minds: [{ mindId: 'mind-1', mindPath: 'C:\\test\\mind', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }],
+        activeMindId: 'mind-1',
+        mindsChecked: true,
+        showLanding: true,
+      }}
+      >
+        <GenesisGate><div>App</div></GenesisGate>
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(screen.getByText('App')).toBeTruthy();
+    expect(screen.queryByText('New Agent', { exact: false })).toBeNull();
+  });
+
+  it('does not show a close button on first-run empty state', async () => {
+    renderWithProvider(<GenesisGate><div>App</div></GenesisGate>);
+
+    await waitFor(() => {
+      expect(screen.getByText('New Agent', { exact: false })).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('button', { name: /close/i })).toBeNull();
+  });
 });

--- a/src/renderer/components/genesis/GenesisGate.tsx
+++ b/src/renderer/components/genesis/GenesisGate.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export function GenesisGate({ children }: Props) {
-  const { minds, showLanding, mindsChecked } = useAppState();
+  const { minds, showLanding, mindsChecked, runtimePhase, switchingAccountLogin } = useAppState();
   const dispatch = useAppDispatch();
   const [mode, setMode] = useState<'idle' | 'genesis'>('idle');
 
@@ -22,6 +22,10 @@ export function GenesisGate({ children }: Props) {
   // Show loading screen while initial minds check is pending
   if (!mindsChecked && !showLanding) {
     return <ChamberLoadingScreen />;
+  }
+
+  if (runtimePhase === 'switching-account') {
+    return <ChamberLoadingScreen mode="switching-account" login={switchingAccountLogin} />;
   }
 
   const hasMinds = minds.length > 0;
@@ -51,6 +55,7 @@ export function GenesisGate({ children }: Props) {
             dispatch({ type: 'HIDE_LANDING' });
           }
         }}
+        onClose={showLanding && hasMinds ? () => dispatch({ type: 'HIDE_LANDING' }) : undefined}
       />
     );
   }

--- a/src/renderer/components/genesis/LandingScreen.test.tsx
+++ b/src/renderer/components/genesis/LandingScreen.test.tsx
@@ -28,4 +28,21 @@ describe('LandingScreen', () => {
     fireEvent.click(screen.getByText('Open Existing'));
     expect(onOpenExisting).toHaveBeenCalledOnce();
   });
+
+  it('renders a close button when onClose is provided', () => {
+    render(<LandingScreen onNewAgent={vi.fn()} onOpenExisting={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /close/i })).toBeTruthy();
+  });
+
+  it('does not render a close button when onClose is not provided', () => {
+    render(<LandingScreen onNewAgent={vi.fn()} onOpenExisting={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /close/i })).toBeNull();
+  });
+
+  it('clicking close calls onClose', () => {
+    const onClose = vi.fn();
+    render(<LandingScreen onNewAgent={vi.fn()} onOpenExisting={vi.fn()} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
 });

--- a/src/renderer/components/genesis/LandingScreen.tsx
+++ b/src/renderer/components/genesis/LandingScreen.tsx
@@ -1,13 +1,24 @@
 import React from 'react';
+import { X } from 'lucide-react';
 
 interface Props {
   onNewAgent: () => void;
   onOpenExisting: () => void;
+  onClose?: () => void;
 }
 
-export function LandingScreen({ onNewAgent, onOpenExisting }: Props) {
+export function LandingScreen({ onNewAgent, onOpenExisting, onClose }: Props) {
   return (
     <div className="fixed inset-0 bg-background flex flex-col items-center justify-center z-50">
+      {onClose && (
+        <button
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute top-4 right-4 w-10 h-10 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <X size={18} />
+        </button>
+      )}
       <div className="text-center space-y-8">
         <div className="w-20 h-20 rounded-2xl bg-genesis flex items-center justify-center text-3xl font-bold text-primary-foreground mx-auto">
           C

--- a/src/renderer/components/settings/SettingsView.test.tsx
+++ b/src/renderer/components/settings/SettingsView.test.tsx
@@ -11,11 +11,28 @@ describe('SettingsView', () => {
   let api: ReturnType<typeof mockElectronAPI>;
 
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+      configurable: true,
+      value: vi.fn(() => false),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'releasePointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
     api = installElectronAPI();
   });
 
   it('displays the current login', async () => {
     (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'ianphil_microsoft' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'ianphil_microsoft' }]);
     render(<SettingsView />);
     await waitFor(() => {
       expect(screen.getByText('ianphil_microsoft')).toBeTruthy();
@@ -24,6 +41,7 @@ describe('SettingsView', () => {
 
   it('shows "Not signed in" when no login is available', async () => {
     (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: false });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     render(<SettingsView />);
     await waitFor(() => {
       expect(screen.getByText('Not signed in')).toBeTruthy();
@@ -32,6 +50,7 @@ describe('SettingsView', () => {
 
   it('calls auth.logout when Logout button is clicked', async () => {
     (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'ianphil_microsoft' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'ianphil_microsoft' }]);
     render(<SettingsView />);
     await waitFor(() => {
       expect(screen.getByText('ianphil_microsoft')).toBeTruthy();
@@ -43,6 +62,7 @@ describe('SettingsView', () => {
 
   it('renders a Settings heading', async () => {
     (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'alice' }]);
     render(<SettingsView />);
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /settings/i })).toBeTruthy();
@@ -51,6 +71,7 @@ describe('SettingsView', () => {
 
   it('renders an Account section heading', async () => {
     (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'alice' }]);
     render(<SettingsView />);
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /account/i })).toBeTruthy();
@@ -59,9 +80,109 @@ describe('SettingsView', () => {
 
   it('shows error fallback when getStatus rejects', async () => {
     (api.auth.getStatus as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('IPC failed'));
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     render(<SettingsView />);
     await waitFor(() => {
       expect(screen.getByText('Unable to load account info')).toBeTruthy();
+    });
+  });
+
+  it('renders a dropdown when multiple accounts exist', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'alice' }, { login: 'bob' }]);
+
+    render(<SettingsView />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeTruthy();
+    });
+  });
+
+  it('shows accounts sorted alphabetically with Add Account at the bottom', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'zebra' }, { login: 'alice' }]);
+
+    render(<SettingsView />);
+
+    const trigger = await screen.findByRole('combobox');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+    const options = await screen.findAllByRole('option');
+    expect(options.map((option) => option.textContent)).toEqual(['alice', 'zebra', '+ Add Account']);
+  });
+
+  it('preselects the active account', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'bob' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'alice' }, { login: 'bob' }]);
+
+    render(<SettingsView />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox').textContent).toContain('bob');
+    });
+  });
+
+  it('switches accounts when a different account is selected', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'alice' }, { login: 'bob' }]);
+
+    render(<SettingsView />);
+
+    const trigger = await screen.findByRole('combobox');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    fireEvent.click(await screen.findByRole('option', { name: 'bob' }));
+
+    await waitFor(() => {
+      expect(api.auth.switchAccount).toHaveBeenCalledWith('bob');
+    });
+  });
+
+  it('starts device flow when Add Account is clicked', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'alice' }]);
+
+    render(<SettingsView />);
+
+    const trigger = await screen.findByRole('combobox');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    fireEvent.click(await screen.findByRole('option', { name: '+ Add Account' }));
+
+    await waitFor(() => {
+      expect(api.auth.startLogin).toHaveBeenCalled();
+    });
+  });
+
+  it('refreshes account state after auth:accountSwitched', async () => {
+    let onAccountSwitched: (() => void) | undefined;
+    (api.auth.getStatus as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ authenticated: true, login: 'alice' })
+      .mockResolvedValueOnce({ authenticated: true, login: 'bob' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([{ login: 'alice' }, { login: 'bob' }])
+      .mockResolvedValueOnce([{ login: 'alice' }, { login: 'bob' }]);
+    (api.auth.onAccountSwitched as ReturnType<typeof vi.fn>).mockImplementation((callback: () => void) => {
+      onAccountSwitched = callback;
+      return vi.fn();
+    });
+
+    render(<SettingsView />);
+
+    await screen.findByText('alice');
+    onAccountSwitched!();
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox').textContent).toContain('bob');
+    });
+  });
+
+  it('shows a dropdown even when only one account exists', async () => {
+    (api.auth.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ authenticated: true, login: 'alice' });
+    (api.auth.listAccounts as ReturnType<typeof vi.fn>).mockResolvedValue([{ login: 'alice' }]);
+
+    render(<SettingsView />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeTruthy();
     });
   });
 });

--- a/src/renderer/components/settings/SettingsView.tsx
+++ b/src/renderer/components/settings/SettingsView.tsx
@@ -1,26 +1,73 @@
 import React, { useState, useEffect } from 'react';
 import { LogOut } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
+
+const ADD_ACCOUNT_VALUE = '__add-account__';
 
 export function SettingsView() {
   const [login, setLogin] = useState<string | null>(null);
+  const [accounts, setAccounts] = useState<Array<{ login: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    window.electronAPI.auth.getStatus()
-      .then((status) => {
-        if (cancelled) return;
-        setLogin(status.login ?? null);
-        setLoading(false);
-      })
+    const refreshAccountState = async () => {
+      setError(false);
+      const [status, availableAccounts] = await Promise.all([
+        window.electronAPI.auth.getStatus(),
+        window.electronAPI.auth.listAccounts(),
+      ]);
+      if (cancelled) return;
+      setLogin(status.login ?? null);
+      setAccounts([...availableAccounts].sort((a, b) => a.login.localeCompare(b.login)));
+      setLoading(false);
+    };
+
+    refreshAccountState()
       .catch(() => {
         if (cancelled) return;
         setError(true);
         setLoading(false);
       });
-    return () => { cancelled = true; };
+
+    const unsubAccountSwitched = window.electronAPI.auth.onAccountSwitched(() => {
+      void refreshAccountState().catch(() => {
+        if (cancelled) return;
+        setError(true);
+        setLoading(false);
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unsubAccountSwitched();
+    };
   }, []);
+
+  const handleAccountChange = async (value: string) => {
+    if (value === ADD_ACCOUNT_VALUE) {
+      await window.electronAPI.auth.startLogin();
+      return;
+    }
+
+    if (value === login) return;
+
+    const previousLogin = login;
+    setLogin(value);
+    try {
+      await window.electronAPI.auth.switchAccount(value);
+    } catch {
+      setLogin(previousLogin);
+    }
+  };
 
   return (
     <div className="flex-1 overflow-y-auto p-6 max-w-2xl">
@@ -33,11 +80,24 @@ export function SettingsView() {
             <p className="text-sm text-muted-foreground">Loading…</p>
           ) : error ? (
             <p className="text-sm text-destructive">Unable to load account info</p>
-          ) : login ? (
-            <div className="flex items-center justify-between">
+          ) : login || accounts.length > 0 ? (
+            <div className="flex items-center justify-between gap-4">
               <div>
                 <p className="text-sm text-muted-foreground">Signed in as</p>
-                <p className="font-medium">{login}</p>
+                <Select value={login ?? undefined} onValueChange={(value) => { void handleAccountChange(value); }}>
+                  <SelectTrigger className="mt-2 min-w-56">
+                    <SelectValue placeholder="Select account" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {accounts.map((account) => (
+                      <SelectItem key={account.login} value={account.login}>
+                        {account.login}
+                      </SelectItem>
+                    ))}
+                    <SelectSeparator />
+                    <SelectItem value={ADD_ACCOUNT_VALUE}>+ Add Account</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
               <button
                 onClick={() => window.electronAPI.auth.logout()}

--- a/src/renderer/hooks/useAgentStatus.test.tsx
+++ b/src/renderer/hooks/useAgentStatus.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { act, waitFor, renderHook } from '@testing-library/react';
-import { AppStateProvider } from '../lib/store';
+import { AppStateProvider, useAppState } from '../lib/store';
 import { installElectronAPI, mockElectronAPI } from '../../test/helpers';
 import { useAgentStatus } from './useAgentStatus';
 import type { MindContext } from '../../../shared/types';
@@ -87,5 +87,68 @@ describe('useAgentStatus', () => {
     renderHook(() => useAgentStatus(), { wrapper });
     // None of the deprecated agent APIs should be called
     expect(api.mind.list).toHaveBeenCalled(); // uses mind namespace instead
+  });
+
+  it('tracks account switching lifecycle in app state', async () => {
+    let onAccountSwitchStarted: ((data: { login: string }) => void) | undefined;
+    let onAccountSwitched: ((data: { login: string }) => void) | undefined;
+    (api.auth.onAccountSwitchStarted as ReturnType<typeof vi.fn>).mockImplementation((callback: (data: { login: string }) => void) => {
+      onAccountSwitchStarted = callback;
+      return vi.fn();
+    });
+    (api.auth.onAccountSwitched as ReturnType<typeof vi.fn>).mockImplementation((callback: (data: { login: string }) => void) => {
+      onAccountSwitched = callback;
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => {
+      useAgentStatus();
+      return useAppState();
+    }, { wrapper });
+
+    await act(async () => {
+      onAccountSwitchStarted?.({ login: 'bob' });
+    });
+
+    expect(result.current.runtimePhase).toBe('switching-account');
+    expect(result.current.switchingAccountLogin).toBe('bob');
+
+    await act(async () => {
+      onAccountSwitched?.({ login: 'bob' });
+    });
+
+    expect(result.current.runtimePhase).toBe('ready');
+    expect(result.current.switchingAccountLogin).toBeNull();
+  });
+
+  it('dispatches LOGGED_OUT on onLoggedOut — resets runtimePhase without conflating with switch', async () => {
+    let onAccountSwitchStarted: ((data: { login: string }) => void) | undefined;
+    let onLoggedOut: (() => void) | undefined;
+    (api.auth.onAccountSwitchStarted as ReturnType<typeof vi.fn>).mockImplementation((callback: (data: { login: string }) => void) => {
+      onAccountSwitchStarted = callback;
+      return vi.fn();
+    });
+    (api.auth.onLoggedOut as ReturnType<typeof vi.fn>).mockImplementation((callback: () => void) => {
+      onLoggedOut = callback;
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => {
+      useAgentStatus();
+      return useAppState();
+    }, { wrapper });
+
+    // Enter switching state
+    await act(async () => {
+      onAccountSwitchStarted?.({ login: 'alice' });
+    });
+    expect(result.current.runtimePhase).toBe('switching-account');
+
+    // Logout interrupts the switch
+    await act(async () => {
+      onLoggedOut?.();
+    });
+    expect(result.current.runtimePhase).toBe('ready');
+    expect(result.current.switchingAccountLogin).toBeNull();
   });
 });

--- a/src/renderer/hooks/useAgentStatus.ts
+++ b/src/renderer/hooks/useAgentStatus.ts
@@ -19,9 +19,21 @@ export function useAgentStatus() {
     const unsubMinds = window.electronAPI.mind.onMindChanged((updatedMinds) => {
       dispatch({ type: 'SET_MINDS', payload: updatedMinds });
     });
+    const unsubSwitchStarted = window.electronAPI.auth.onAccountSwitchStarted(({ login }) => {
+      dispatch({ type: 'ACCOUNT_SWITCH_STARTED', payload: { login } });
+    });
+    const unsubSwitched = window.electronAPI.auth.onAccountSwitched(() => {
+      dispatch({ type: 'ACCOUNT_SWITCH_COMPLETED' });
+    });
+    const unsubLoggedOut = window.electronAPI.auth.onLoggedOut(() => {
+      dispatch({ type: 'LOGGED_OUT' });
+    });
 
     return () => {
       unsubMinds();
+      unsubSwitchStarted();
+      unsubSwitched();
+      unsubLoggedOut();
     };
   }, [dispatch]);
 

--- a/src/renderer/lib/store/reducer.test.ts
+++ b/src/renderer/lib/store/reducer.test.ts
@@ -312,6 +312,34 @@ describe('appReducer', () => {
     expect(state.showLanding).toBe(false);
   });
 
+  it('ACCOUNT_SWITCH_STARTED enters switching-account runtime phase', () => {
+    const state = appReducer(initialState, { type: 'ACCOUNT_SWITCH_STARTED', payload: { login: 'bob' } });
+    expect(state.runtimePhase).toBe('switching-account');
+    expect(state.switchingAccountLogin).toBe('bob');
+  });
+
+  it('ACCOUNT_SWITCH_COMPLETED clears switching-account runtime phase', () => {
+    const switchingState = {
+      ...initialState,
+      runtimePhase: 'switching-account' as const,
+      switchingAccountLogin: 'bob',
+    };
+    const state = appReducer(switchingState, { type: 'ACCOUNT_SWITCH_COMPLETED' });
+    expect(state.runtimePhase).toBe('ready');
+    expect(state.switchingAccountLogin).toBeNull();
+  });
+
+  it('LOGGED_OUT resets switching state back to ready', () => {
+    const switchingState = {
+      ...initialState,
+      runtimePhase: 'switching-account' as const,
+      switchingAccountLogin: 'bob',
+    };
+    const state = appReducer(switchingState, { type: 'LOGGED_OUT' });
+    expect(state.runtimePhase).toBe('ready');
+    expect(state.switchingAccountLogin).toBeNull();
+  });
+
   it('CLEAR_MESSAGES empties messages for active mind', () => {
     const stateWithMsgs = { ...withActiveMind, messagesByMind: { [mindId]: [makeMessage([makeTextBlock('hi')])] } };
     const state = appReducer(stateWithMsgs, { type: 'CLEAR_MESSAGES' });

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -219,6 +219,28 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     case 'HIDE_LANDING':
       return { ...state, showLanding: false };
 
+    case 'ACCOUNT_SWITCH_STARTED':
+      return {
+        ...state,
+        runtimePhase: 'switching-account',
+        switchingAccountLogin: action.payload.login,
+        showLanding: false,
+      };
+
+    case 'ACCOUNT_SWITCH_COMPLETED':
+      return {
+        ...state,
+        runtimePhase: 'ready',
+        switchingAccountLogin: null,
+      };
+
+    case 'LOGGED_OUT':
+      return {
+        ...state,
+        runtimePhase: 'ready',
+        switchingAccountLogin: null,
+      };
+
     case 'MINDS_CHECKED':
       return { ...state, mindsChecked: true };
 

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -7,6 +7,8 @@ export type LensView = 'chat' | string;
 export interface AppState {
   minds: MindContext[];
   activeMindId: string | null;
+  runtimePhase: 'ready' | 'switching-account';
+  switchingAccountLogin: string | null;
   messagesByMind: Record<string, ChatMessage[]>;
   isStreaming: boolean;
   streamingByMind: Record<string, boolean>;
@@ -35,6 +37,9 @@ export type AppAction =
   | { type: 'SET_DISCOVERED_VIEWS'; payload: LensViewManifest[] }
   | { type: 'SHOW_LANDING' }
   | { type: 'HIDE_LANDING' }
+  | { type: 'ACCOUNT_SWITCH_STARTED'; payload: { login: string } }
+  | { type: 'ACCOUNT_SWITCH_COMPLETED' }
+  | { type: 'LOGGED_OUT' }
   | { type: 'MINDS_CHECKED' }
   | { type: 'CLEAR_MESSAGES' }
   | { type: 'NEW_CONVERSATION' }
@@ -50,6 +55,8 @@ export type AppAction =
 export const initialState: AppState = {
   minds: [],
   activeMindId: null,
+  runtimePhase: 'ready',
+  switchingAccountLogin: null,
   messagesByMind: {},
   isStreaming: false,
   streamingByMind: {},

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -103,6 +103,7 @@ export interface AppConfig {
   version: 2;
   minds: MindRecord[];
   activeMindId: string | null;
+  activeLogin: string | null;
   theme: 'light' | 'dark' | 'system';
 }
 
@@ -145,9 +146,13 @@ export interface ElectronAPI {
   };
   auth: {
     getStatus: () => Promise<{ authenticated: boolean; login?: string }>;
+    listAccounts: () => Promise<Array<{ login: string }>>;
     startLogin: () => Promise<{ success: boolean; login?: string }>;
+    switchAccount: (login: string) => Promise<void>;
     logout: () => Promise<void>;
     onProgress: (callback: (progress: { step: string; userCode?: string; verificationUri?: string; login?: string; error?: string }) => void) => () => void;
+    onAccountSwitchStarted: (callback: (data: { login: string }) => void) => () => void;
+    onAccountSwitched: (callback: (data: { login: string }) => void) => () => void;
     onLoggedOut: (callback: () => void) => () => void;
   };
   genesis: {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -124,9 +124,13 @@ export function mockElectronAPI(): ElectronAPI {
     },
     auth: {
       getStatus: vi.fn().mockResolvedValue({ authenticated: true }),
+      listAccounts: vi.fn().mockResolvedValue([]),
       startLogin: vi.fn().mockResolvedValue({ success: true }),
+      switchAccount: vi.fn().mockResolvedValue(undefined),
       logout: vi.fn().mockResolvedValue(undefined),
       onProgress: vi.fn().mockReturnValue(vi.fn()),
+      onAccountSwitchStarted: vi.fn().mockReturnValue(vi.fn()),
+      onAccountSwitched: vi.fn().mockReturnValue(vi.fn()),
       onLoggedOut: vi.fn().mockReturnValue(vi.fn()),
     },
     genesis: {


### PR DESCRIPTION
## What

- Multi-account GitHub auth with account switching
- Account-switch boot overlay (no more UI flash)
- Landing screen close button (X to return to chat)
- Uncle Bob review fixes: SRP consolidation, error recovery, reload guard, semantic LOGGED_OUT action, dead code removal

## Changes

- **Backend**: activeLogin in config, listAccounts/switchAccount APIs, reloadAllMinds orchestration, single-owner persistence
- **Renderer**: Settings account picker, AuthGate switch handling, GenesisGate loading overlay + close button, runtimePhase state machine
- **Tests**: 532 passing across 56 files
- **Build**: package/make/install verified

## Version

v0.21.0