### PR TITLE
fix(sdk): spawn CopilotClient with mindPath as cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### SDK
+
+- **CopilotClient runs with the mind folder as `cwd`** — `CopilotClientFactory.createClient` now forwards `mindPath` as the CLI process `cwd`. Previously the CLI inherited Electron's launch directory (often `C:\Windows\System32` when launched from Start Menu), so mind-local config like `.mcp.json`, `.copilot/`, and `AGENTS.md` was never discovered. Each mind now spawns its CLI inside its own folder.
+
 ## v0.23.0 (2026-04-16)
 
 ### Chat: turn-level work log

--- a/src/main/services/sdk/CopilotClientFactory.test.ts
+++ b/src/main/services/sdk/CopilotClientFactory.test.ts
@@ -26,8 +26,12 @@ const mockStart = vi.fn();
 const mockStop = vi.fn();
 
 class FakeCopilotClient {
+  options: Record<string, unknown>;
   start = mockStart;
   stop = mockStop;
+  constructor(options: Record<string, unknown>) {
+    this.options = options;
+  }
 }
 
 vi.mock('./sdkImport', () => ({
@@ -50,6 +54,11 @@ describe('CopilotClientFactory', () => {
       expect(mockStart).toHaveBeenCalledTimes(1);
       expect(client).toBeDefined();
       expect(client.start).toBeDefined();
+    });
+
+    it('passes mindPath as cwd so the CLI discovers .mcp.json from the mind folder', async () => {
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      expect(client.options.cwd).toBe('C:\\agents\\q');
     });
 
     it('creates separate clients for different mind paths', async () => {

--- a/src/main/services/sdk/CopilotClientFactory.ts
+++ b/src/main/services/sdk/CopilotClientFactory.ts
@@ -21,7 +21,6 @@ export class CopilotClientFactory {
   private sdkModule: typeof import('@github/copilot-sdk') | null = null;
 
   async createClient(mindPath: string): Promise<CopilotClient> {
-    void mindPath;
     const sdk = await this.getSdk();
     const modulesDir = resolveNodeModulesDir();
     const cliPath = getCliPathFromModules(modulesDir);
@@ -46,6 +45,7 @@ export class CopilotClientFactory {
 
     const client = new sdk.CopilotClient({
       cliPath: resolvedCliPath,
+      cwd: mindPath,
       logLevel: 'all',
       cliArgs,
     });


### PR DESCRIPTION
Cherry-picked from the (unmerged) Phase 1 contracts branch because it's a real bug fix independent of the rest of that work.

`CopilotClientFactory.createClient` now forwards `mindPath` as the CLI process `cwd`. Previously the CLI inherited Electron's launch directory (often `C:\Windows\System32` when launched from Start Menu), so mind-local config like `.mcp.json`, `.copilot/`, and `AGENTS.md` was never discovered. Each mind now spawns its CLI inside its own folder.

- 1-line source change in `CopilotClientFactory.ts`, `cwd: mindPath`.
- Test added asserting the `cwd` is forwarded.
- CHANGELOG entry.