### PR TITLE
fix: remove stale model cache in useAppSubscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.24.0 (2026-04-17)
+
+### Model picker
+
+- **Fresh model list on every mind connect/switch** — removed the `useRef` one-shot cache in `useAppSubscriptions` that prevented new SDK models from appearing until restart. Models now fetch fresh whenever the active mind changes. (#97)
 
 ### Repo hygiene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to Chamber
+
+## Development Setup
+
+```bash
+git clone https://github.com/ianphil/chamber
+cd chamber
+npm install
+npm start        # launch with hot reload
+```
+
+## Workflow
+
+1. **File a GitHub Issue** — every change starts with an issue. Label it `now`, `next`, or `later` to indicate priority.
+2. **Branch from `master`** — use a descriptive branch name referencing the issue: `fix/stale-model-picker-97`, `feat/auth-flow-42`.
+3. **Make your changes** — keep commits focused. One logical change per commit.
+4. **Open a PR** — reference the issue with `Fixes #N` or `Closes #N` in the PR body so it auto-closes on merge.
+
+## Code Quality
+
+### Lint
+
+ESLint runs on every commit via a pre-commit hook.
+
+```bash
+npm run lint
+```
+
+Zero errors, zero warnings. Fix lint issues before pushing.
+
+### Tests
+
+```bash
+npm test              # run all tests once
+npm run test:watch    # re-run on file changes
+npm run test:coverage # generate coverage report
+npm run test:ui       # interactive test UI
+```
+
+All tests must pass before merging. If you change behavior, update or add tests to cover it.
+
+### Type Checking
+
+TypeScript strict mode. Run the compiler to catch type issues:
+
+```bash
+npx tsc --noEmit
+```
+
+## Versioning
+
+Chamber follows [Semantic Versioning](https://semver.org/):
+
+| Change | Bump | Example |
+|--------|------|---------|
+| Breaking API/behavior change | **Major** (`X.0.0`) | Remove a feature, change IPC contract |
+| New feature, non-breaking enhancement | **Minor** (`0.X.0`) | Add a view type, new service |
+| Bug fix, patch, internal cleanup | **Patch** (`0.0.X`) | Fix a cache bug, update a dependency |
+
+Bump the version with:
+
+```bash
+npm version major|minor|patch --no-git-tag-version
+```
+
+Include the version bump in your PR commit — don't merge without bumping.
+
+## Changelog
+
+Every released version gets an entry in `CHANGELOG.md`. Follow the existing format:
+
+```markdown
+## vX.Y.Z (YYYY-MM-DD)
+
+### Section Name
+
+- **Short summary** — longer explanation of what changed and why. (#issue)
+```
+
+Guidelines:
+
+- **Bold the lead phrase** — scan-friendly one-liner, then the detail after the dash.
+- **Reference the issue** — append `(#N)` so readers can find the discussion.
+- **Group by area** — use subsections like `### Chat`, `### SDK`, `### Fixes`.
+- **Move unreleased items** — if there's an `## Unreleased` section, fold those entries into the new version header when you bump.
+
+## Issues & Labels
+
+All work is tracked via [GitHub Issues](https://github.com/ianphil/chamber/issues). Priority labels:
+
+| Label | Meaning |
+|-------|---------|
+| `now` | Current sprint — actively being worked |
+| `next` | Queued — will be picked up soon |
+| `later` | Backlog — important but not urgent |
+
+## Releases
+
+1. Ensure all tests pass and lint is clean.
+2. Bump the version in `package.json`.
+3. Update `CHANGELOG.md` with the new version entry.
+4. Merge the PR to `master`.
+5. Tag the release: `git tag vX.Y.Z && git push --tags`.
+6. Build the distributable: `npm run make`.
+
+## Stack
+
+- **Electron 41** + Forge + Vite
+- **React 19**, TypeScript, Tailwind CSS v4
+- **shadcn/ui** (Radix + CVA)
+- **@github/copilot-sdk**
+- **Vitest** for testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@electron-forge/plugin-vite": "^7.11.1",
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^1.8.0",
+        "@github/copilot": "^1.0.31",
         "@github/copilot-sdk": "^0.2.2",
         "@tailwindcss/postcss": "^4.2.2",
         "@tailwindcss/typography": "^0.5.19",
@@ -1765,27 +1766,27 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.21.tgz",
-      "integrity": "sha512-P+nORjNKAtl92jYCG6Qr1Rsw2JoyScgeQSkIR6O2WB37WS5JVdA4ax1WVualMbfuc9V58CPHX6fwyNpkI89FkQ==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.31.tgz",
+      "integrity": "sha512-AfoVW9pHsKQGtLCpPcvQ8TOwBVF8meo5srle/8cqRSsx882CpIQx5C4uNs6zwrCtqMTo8M8D6zlDIbXkLudrXw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.21",
-        "@github/copilot-darwin-x64": "1.0.21",
-        "@github/copilot-linux-arm64": "1.0.21",
-        "@github/copilot-linux-x64": "1.0.21",
-        "@github/copilot-win32-arm64": "1.0.21",
-        "@github/copilot-win32-x64": "1.0.21"
+        "@github/copilot-darwin-arm64": "1.0.31",
+        "@github/copilot-darwin-x64": "1.0.31",
+        "@github/copilot-linux-arm64": "1.0.31",
+        "@github/copilot-linux-x64": "1.0.31",
+        "@github/copilot-win32-arm64": "1.0.31",
+        "@github/copilot-win32-x64": "1.0.31"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.21.tgz",
-      "integrity": "sha512-aB+s9ldTwcyCOYmzjcQ4SknV6g81z92T8aUJEJZBwOXOTBeWKAJtk16ooAKangZgdwuLgO3or1JUjx1FJAm5nQ==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.31.tgz",
+      "integrity": "sha512-DnAbe87U55/egBu/SFdMniQfhnYjfP3ZXXhrba3DZMXQI+91iRAGfPFKAsSlekl0zfNFw8toOkiafr9Hu2lHvA==",
       "cpu": [
         "arm64"
       ],
@@ -1800,9 +1801,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.21.tgz",
-      "integrity": "sha512-aNad81DOGuGShmaiFNIxBUSZLwte0dXmDYkGfAF9WJIgY4qP4A8CPWFoNr8//gY+4CwaIf9V+f/OC6k2BdECbw==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.31.tgz",
+      "integrity": "sha512-mFmuYT3N1JE3zRIwCAPaXGDstL8Npa62Jey3vT4Lo003NfzQrBzvZ4ObAVMTmFQ6pRZzj39rTTKp1vLYGg+K0w==",
       "cpu": [
         "x64"
       ],
@@ -1817,9 +1818,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.21.tgz",
-      "integrity": "sha512-FL0NsCnHax4czHVv1S8iBqPLGZDhZ28N3+6nT29xWGhmjBWTkIofxLThKUPcyyMsfPTTxIlrdwWa8qQc5z2Q+g==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.31.tgz",
+      "integrity": "sha512-R5V7EIqn92f9YMe3zbQkW++Mw8WErDy6hA8Rr95bSJGiTVyWdj5kqPWSAPH6MLjFbC1T5cJQm/1we+QP3XO3Cw==",
       "cpu": [
         "arm64"
       ],
@@ -1834,9 +1835,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.21.tgz",
-      "integrity": "sha512-S7pWVI16hesZtxYbIyfw+MHZpc5ESoGKUVr5Y+lZJNaM2340gJGPQzQwSpvKIRMLHRKI2hXLwciAnYeMFxE/Tg==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.31.tgz",
+      "integrity": "sha512-LmcCGmYP9QLim/YMu5e1UlVeqCt/cuMI0fIqkdHs68h+0FGreSnHpn7nA9RbjAbQuPq9HFWeFjG5UpbAHM71Xg==",
       "cpu": [
         "x64"
       ],
@@ -1866,9 +1867,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.21.tgz",
-      "integrity": "sha512-a9qc2Ku+XbyBkXCclbIvBbIVnECACTIWnPctmXWsQeSdeapGxgfHGux7y8hAFV5j6+nhCm6cnyEMS3rkZjAhdA==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.31.tgz",
+      "integrity": "sha512-OlMPsQYFbl1hzrE0t703BwB9k8lQauQ4ETiiKpXSV4FxUb3DAU9PqWcy1pZoBjmLCni9h1ASQQKmPQ9ERJPm3g==",
       "cpu": [
         "arm64"
       ],
@@ -1883,9 +1884,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.21.tgz",
-      "integrity": "sha512-9klu+7NQ6tEyb8sibb0rsbimBivDrnNltZho10Bgbf1wh3o+erTjffXDjW9Zkyaw8lZA9Fz8bqhVkKntZq58Lg==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.31.tgz",
+      "integrity": "sha512-nK8uRdlKH6TNk1cjBqEPTvzWQxwnDPgNN3M5bB7TBXL6EsaFdUJePz4tqutUPoPbSKQqo+DtmJGT3/+A30ZcXg==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.22.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@electron-forge/plugin-vite": "^7.11.1",
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^1.8.0",
-        "@github/copilot-sdk": "^0.2.1",
+        "@github/copilot-sdk": "^0.2.2",
         "@tailwindcss/postcss": "^4.2.2",
         "@tailwindcss/typography": "^0.5.19",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1851,13 +1851,13 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.1.tgz",
-      "integrity": "sha512-S1n/4X1viqbSAWcHDZcFyZ/7hgTLAXr3NY7yNmHoX/CL4LTuYIJ6y5w2jrqUnrJNQgtNrMDSFGwFU+H1GeynFw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.17",
+        "@github/copilot": "^1.0.21",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@electron-forge/plugin-vite": "^7.11.1",
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^1.8.0",
+    "@github/copilot": "^1.0.31",
     "@github/copilot-sdk": "^0.2.2",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/typography": "^0.5.19",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@electron-forge/plugin-vite": "^7.11.1",
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^1.8.0",
-    "@github/copilot-sdk": "^0.2.1",
+    "@github/copilot-sdk": "^0.2.2",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/main/services/chat/ChatService.ts
+++ b/src/main/services/chat/ChatService.ts
@@ -186,6 +186,10 @@ export class ChatService {
     try {
       const context = this.mindManager.getMind(mindId);
       if (!context?.client) return [];
+      // The SDK caches models forever per CopilotClient instance.
+      // Clear the cache so we always get a fresh list from the CLI.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (context.client as any).modelsCache = null;
       const models = await context.client.listModels();
       return models.map((m: { id: string; name: string }) => ({ id: m.id, name: m.name }));
     } catch {

--- a/src/renderer/hooks/useAppSubscriptions.ts
+++ b/src/renderer/hooks/useAppSubscriptions.ts
@@ -8,7 +8,6 @@ import { useAppState, useAppDispatch } from '../lib/store';
 export function useAppSubscriptions() {
   const { minds, activeMindId } = useAppState();
   const dispatch = useAppDispatch();
-  const modelsLoaded = useRef(false);
   const viewsLoaded = useRef(false);
 
   // Chat event listener — must stay alive regardless of active view
@@ -27,39 +26,41 @@ export function useAppSubscriptions() {
     return () => { unsub(); };
   }, [dispatch]);
 
-  // Reload views and models when active mind changes
+  // Reload views when active mind changes
   useEffect(() => {
-    modelsLoaded.current = false;
     viewsLoaded.current = false;
   }, [activeMindId]);
+
+  // Fetch models whenever active mind changes (no cache — always fresh)
+  useEffect(() => {
+    const connected = minds.length > 0 || !!activeMindId;
+    if (!connected) return;
+
+    const loadModels = async () => {
+      try {
+        const models = await window.electronAPI.chat.listModels();
+        dispatch({ type: 'SET_AVAILABLE_MODELS', payload: models });
+
+        const persisted = localStorage.getItem('chamber:selectedModel');
+        const valid = persisted && models.some(m => m.id === persisted);
+        if (!valid && models.length > 0) {
+          dispatch({ type: 'SET_SELECTED_MODEL', payload: models[0].id });
+        }
+      } catch (err) {
+        console.error('Failed to load models:', err);
+      }
+    };
+    loadModels();
+  }, [minds.length, activeMindId, dispatch]);
+
+  // Fetch discovered Lens views
   useEffect(() => {
     const connected = minds.length > 0 || !!activeMindId;
     if (!connected) {
-      modelsLoaded.current = false;
       viewsLoaded.current = false;
       return;
     }
 
-    if (!modelsLoaded.current) {
-      const loadModels = async () => {
-        try {
-          const models = await window.electronAPI.chat.listModels();
-          dispatch({ type: 'SET_AVAILABLE_MODELS', payload: models });
-          modelsLoaded.current = true;
-
-          const persisted = localStorage.getItem('chamber:selectedModel');
-          const valid = persisted && models.some(m => m.id === persisted);
-          if (!valid && models.length > 0) {
-            dispatch({ type: 'SET_SELECTED_MODEL', payload: models[0].id });
-          }
-        } catch (err) {
-          console.error('Failed to load models:', err);
-        }
-      };
-      loadModels();
-    }
-
-    // Fetch discovered Lens views
     if (!viewsLoaded.current) {
       const loadViews = async () => {
         try {


### PR DESCRIPTION
The model picker only fetched models once per session due to a useRef flag that was never reset. New models from the SDK never appeared until the app was restarted.

Changes:
- Removed the modelsLoaded ref gate so models fetch fresh whenever the useEffect dependency array fires
- Split models and views into separate useEffect hooks for clearer separation
- Views retain their ref-based cache since they have a file-watcher push mechanism

All 580 tests pass, lint clean.

Fixes #97