### PR TITLE
Add 5 orchestration strategies for managed multi-agent group chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.25.0 (2026-04-18)
+
+### Chatroom: orchestration strategies
+
+- **5 orchestration modes** — Concurrent (parallel fan-out), Sequential (round-robin with accumulated context), GroupChat (moderator-directed with speaker selection), Handoff (agent-to-agent delegation with transcript), Magentic (manager-driven task ledger with step budget).
+- **OrchestrationStrategy interface** — pluggable strategy pattern with `OrchestrationContext` adapter; adding a new mode requires zero changes to ChatroomService.
+- **OrchestrationPicker UI** — mode selector with per-mode config dialogs (moderator, initial agent, manager, max hops/steps).
+- **Shared stream-agent infrastructure** — extracted duplicated SDK event wiring, stale session retry, and send timeout into `stream-agent.ts`; shared XML/JSON helpers in `shared.ts`.
+- **Approval gate** — configurable tool execution review gate for orchestrated sessions.
+- **Structured observability** — event emission with parameter redaction for orchestration audit trails.
+
+### Bug fixes
+
+- **Session idle race condition** — `session.idle` and `session.error` listeners now register BEFORE `session.send()` in both ChatService and all 5 strategies, preventing missed events that caused 5-minute hangs.
+- **Send timeout guard** — 30-second timeout on `session.send()` itself; if the call hangs (dead WebSocket), throws a stale session error triggering retry with a fresh session.
+- **TypingIndicator alignment** — chatroom typing indicator now left-aligns with message content instead of centering.
+
 ## v0.24.0 (2026-04-17)
 
 ### Model picker

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Chamber is where that happens. Your agent wakes up, finds its voice, and prepare
 - **Self-extending** — the agent has a Lens skill. Ask it to "create a view for my cron jobs" and it builds one.
 - **Activity bar** — VS Code-style icon strip. Icons appear as views are discovered.
 - **Streaming chat** — real-time responses with markdown, tool calls, and reasoning blocks.
+- **Chatroom** — multi-agent group chat with 5 orchestration modes: Concurrent (all agents respond in parallel), Sequential (round-robin), GroupChat (moderator-directed), Handoff (agent-to-agent delegation), and Magentic (manager-driven task ledger).
 - **Model picker** — choose your model, persisted across sessions.
 - **Agent identity** — chat shows the agent's name. This is their chamber.
 
@@ -49,9 +50,17 @@ Select a mind directory from the sidebar. The agent connects, views appear, and 
 Electron Main Process
 ├── SdkLoader        — singleton CopilotClient, auto-install SDK
 ├── ChatService      — streaming sessions, background prompts
+├── ChatroomService  — multi-agent broadcast, orchestration strategy dispatch
+│   └── orchestration/
+│       ├── stream-agent.ts  — shared SDK event wiring + stale session retry
+│       ├── shared.ts        — XML/JSON helpers shared across strategies
+│       ├── ConcurrentStrategy, SequentialStrategy, GroupChatStrategy,
+│       │   HandoffStrategy, MagenticStrategy
+│       ├── approval-gate.ts — tool execution review gate
+│       └── observability.ts — structured event emission with redaction
 ├── ViewDiscovery    — scans .github/lens/ for view.json, file watcher
 ├── ExtensionLoader  — canvas, cron, IDEA adapters
-└── IPC Handlers     — chat, agent, lens, config channels
+└── IPC Handlers     — chat, chatroom, agent, lens, config channels
 
 Preload Bridge
 └── contextBridge    — narrow typed API (chat, agent, lens, config, window)
@@ -61,7 +70,8 @@ React Renderer
 ├── SidePanel        — contextual per view (chat, lens metadata)
 ├── ViewRouter       — routes to ChatPanel or LensViewRenderer
 ├── Lens components  — Form, Table, Briefing, Detail, StatusBoard, Timeline, Editor
-└── Chat components  — MessageList, ChatInput, StreamingMessage, WelcomeScreen
+├── Chat components  — MessageList, ChatInput, StreamingMessage, WelcomeScreen
+└── Chatroom components — ChatroomPanel, OrchestrationPicker, ParticipantBar
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
-        "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -52,6 +51,7 @@
         "eslint-plugin-import": "^2.32.0",
         "jsdom": "^29.0.2",
         "postcss": "^8.5.9",
+        "rehype-highlight": "^7.0.2",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.7.0",
         "vite": "^5.4.21",
@@ -123,7 +123,6 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -304,6 +303,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -352,6 +352,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -798,6 +799,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1537,6 +1539,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1554,6 +1573,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1569,6 +1605,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1766,27 +1819,27 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.31.tgz",
-      "integrity": "sha512-AfoVW9pHsKQGtLCpPcvQ8TOwBVF8meo5srle/8cqRSsx882CpIQx5C4uNs6zwrCtqMTo8M8D6zlDIbXkLudrXw==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.32.tgz",
+      "integrity": "sha512-ydEYAztJQa1sLQw+WPmnkkt3Sf/k2Smn/7szzYvt1feUOdNIak1gHpQhKcgPr2w252gjVLRWjOiynoeLVW0Fbw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.31",
-        "@github/copilot-darwin-x64": "1.0.31",
-        "@github/copilot-linux-arm64": "1.0.31",
-        "@github/copilot-linux-x64": "1.0.31",
-        "@github/copilot-win32-arm64": "1.0.31",
-        "@github/copilot-win32-x64": "1.0.31"
+        "@github/copilot-darwin-arm64": "1.0.32",
+        "@github/copilot-darwin-x64": "1.0.32",
+        "@github/copilot-linux-arm64": "1.0.32",
+        "@github/copilot-linux-x64": "1.0.32",
+        "@github/copilot-win32-arm64": "1.0.32",
+        "@github/copilot-win32-x64": "1.0.32"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.31.tgz",
-      "integrity": "sha512-DnAbe87U55/egBu/SFdMniQfhnYjfP3ZXXhrba3DZMXQI+91iRAGfPFKAsSlekl0zfNFw8toOkiafr9Hu2lHvA==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.32.tgz",
+      "integrity": "sha512-RtGHpnrbP1eVtpzitLqC0jkBlo63PJiByv6W/NTtLw4ZAllumb5kMk8JaTtydKl9DCOHA0wfXbG5/JkGXuQ81g==",
       "cpu": [
         "arm64"
       ],
@@ -1801,9 +1854,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.31.tgz",
-      "integrity": "sha512-mFmuYT3N1JE3zRIwCAPaXGDstL8Npa62Jey3vT4Lo003NfzQrBzvZ4ObAVMTmFQ6pRZzj39rTTKp1vLYGg+K0w==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.32.tgz",
+      "integrity": "sha512-eyF6uy8gcZ4m/0UdM9UoykMDotZ8hZPJ1xIg0iHy4wrNtkYOaAspAoVpOkm50ODOQAHJ5PVV+9LuT6IoeL+wHQ==",
       "cpu": [
         "x64"
       ],
@@ -1818,9 +1871,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.31.tgz",
-      "integrity": "sha512-R5V7EIqn92f9YMe3zbQkW++Mw8WErDy6hA8Rr95bSJGiTVyWdj5kqPWSAPH6MLjFbC1T5cJQm/1we+QP3XO3Cw==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.32.tgz",
+      "integrity": "sha512-acRAu5ehFPnw3hQSIxcmi7wzv8PAYd+nqdxZXizOi++en3QWgez7VEXiKLe9Ukf50iiGReg19yvWV4iDOGC0HQ==",
       "cpu": [
         "arm64"
       ],
@@ -1835,9 +1888,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.31.tgz",
-      "integrity": "sha512-LmcCGmYP9QLim/YMu5e1UlVeqCt/cuMI0fIqkdHs68h+0FGreSnHpn7nA9RbjAbQuPq9HFWeFjG5UpbAHM71Xg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.32.tgz",
+      "integrity": "sha512-lw86YDwkTKwmeVpfnPErDe9DhemrOHN+l92xOU9wQSH5/d+HguXwRb3e4cQjlxsGLS+/fWRGtwf+u2fbQ37avw==",
       "cpu": [
         "x64"
       ],
@@ -1867,9 +1920,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.31.tgz",
-      "integrity": "sha512-OlMPsQYFbl1hzrE0t703BwB9k8lQauQ4ETiiKpXSV4FxUb3DAU9PqWcy1pZoBjmLCni9h1ASQQKmPQ9ERJPm3g==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.32.tgz",
+      "integrity": "sha512-+eZpuzgBbLHMIzltH541wfbbMy0HEdG91ISzRae3qPCssf3Ad85sat6k7FWTRBSZBFrN7z4yMQm5gROqDJYGSA==",
       "cpu": [
         "arm64"
       ],
@@ -1884,9 +1937,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.31.tgz",
-      "integrity": "sha512-nK8uRdlKH6TNk1cjBqEPTvzWQxwnDPgNN3M5bB7TBXL6EsaFdUJePz4tqutUPoPbSKQqo+DtmJGT3/+A30ZcXg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.32.tgz",
+      "integrity": "sha512-R6SW1dsEVmPMhrN/WRTetS4gVxcuYcxi2zfDPOfcjW3W0iD0Vwpt3MlqwBaU2UL36j+rnTnmiOA+g82FIBCYVg==",
       "cpu": [
         "x64"
       ],
@@ -2246,6 +2299,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -2567,6 +2621,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5492,8 +5547,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
@@ -5670,6 +5724,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5680,6 +5735,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5763,6 +5819,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -6294,6 +6351,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -6610,6 +6668,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7171,6 +7230,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8172,8 +8232,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8634,17 +8693,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -8941,6 +8989,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9131,6 +9180,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10315,6 +10365,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
       "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -10355,6 +10406,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
       "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -11290,8 +11342,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -11939,6 +11990,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -11975,7 +12027,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -14100,7 +14151,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -14116,7 +14166,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14341,6 +14390,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14350,6 +14400,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14362,8 +14413,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -14686,6 +14736,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
       "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -15175,6 +15226,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15961,7 +16013,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -16217,6 +16270,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16522,6 +16576,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16615,6 +16670,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
       "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -16717,6 +16773,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -16975,6 +17032,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -17059,6 +17117,397 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
@@ -17105,6 +17554,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17237,6 +17687,7 @@
       "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-import": "^2.32.0",
     "jsdom": "^29.0.2",
     "postcss": "^8.5.9",
+    "rehype-highlight": "^7.0.2",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.7.0",
     "vite": "^5.4.21",
@@ -66,7 +67,6 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
-    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main/ipc/chatroom.ts
+++ b/src/main/ipc/chatroom.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import type { ChatroomService } from '../services/chatroom/ChatroomService';
-import type { OrchestrationMode, GroupChatConfig } from '../../shared/chatroom-types';
+import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig } from '../../shared/chatroom-types';
 
 export function setupChatroomIPC(chatroomService: ChatroomService): void {
   ipcMain.handle('chatroom:send', async (_event, message: string, model?: string) => {
@@ -19,7 +19,7 @@ export function setupChatroomIPC(chatroomService: ChatroomService): void {
     chatroomService.stopAll();
   });
 
-  ipcMain.handle('chatroom:set-orchestration', async (_event, mode: OrchestrationMode, config?: GroupChatConfig) => {
+  ipcMain.handle('chatroom:set-orchestration', async (_event, mode: OrchestrationMode, config?: GroupChatConfig | HandoffConfig | MagenticConfig) => {
     chatroomService.setOrchestration(mode, config);
   });
 

--- a/src/main/ipc/chatroom.ts
+++ b/src/main/ipc/chatroom.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import type { ChatroomService } from '../services/chatroom/ChatroomService';
+import type { OrchestrationMode, GroupChatConfig } from '../../shared/chatroom-types';
 
 export function setupChatroomIPC(chatroomService: ChatroomService): void {
   ipcMain.handle('chatroom:send', async (_event, message: string, model?: string) => {
@@ -16,6 +17,14 @@ export function setupChatroomIPC(chatroomService: ChatroomService): void {
 
   ipcMain.handle('chatroom:stop', async () => {
     chatroomService.stopAll();
+  });
+
+  ipcMain.handle('chatroom:set-orchestration', async (_event, mode: OrchestrationMode, config?: GroupChatConfig) => {
+    chatroomService.setOrchestration(mode, config);
+  });
+
+  ipcMain.handle('chatroom:get-orchestration', async () => {
+    return chatroomService.getOrchestration();
   });
 
   // Forward chatroom streaming events to all renderer windows

--- a/src/main/services/chat/ChatService.ts
+++ b/src/main/services/chat/ChatService.ts
@@ -132,10 +132,8 @@ export class ChatService {
         }));
       }));
 
-      await session.send({ prompt });
-
-      // Wait for idle
-      await new Promise<void>((resolve, reject) => {
+      // Set up idle/error listeners BEFORE send to avoid missing events
+      const turnDone = new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(resolve, 300_000);
 
         const unsubIdle = session.on('session.idle', () => {
@@ -157,6 +155,20 @@ export class ChatService {
           resolve();
         }, { once: true });
       });
+
+      // Send with a timeout guard — if send() itself hangs, treat as stale
+      let sendTimerId: ReturnType<typeof setTimeout> | undefined;
+      const sendTimeout = new Promise<never>((_, reject) => {
+        sendTimerId = setTimeout(() => reject(new Error('Session not found')), 30_000);
+      });
+      try {
+        await Promise.race([session.send({ prompt }), sendTimeout]);
+      } finally {
+        clearTimeout(sendTimerId);
+      }
+
+      // Wait for idle (listener already active since before send)
+      await turnDone;
 
       if (abortController.signal.aborted) return;
       emit({ type: 'done' });

--- a/src/main/services/chatroom/ChatroomService.test.ts
+++ b/src/main/services/chatroom/ChatroomService.test.ts
@@ -654,4 +654,61 @@ describe('ChatroomService', () => {
       expect(factory.createChatroomSession).toHaveBeenCalledWith('dude');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Orchestration mode management
+  // -------------------------------------------------------------------------
+
+  describe('orchestration mode', () => {
+    it('defaults to concurrent mode', () => {
+      const { mode, config } = svc.getOrchestration();
+      expect(mode).toBe('concurrent');
+      expect(config).toBeNull();
+    });
+
+    it('setOrchestration changes mode', () => {
+      svc.setOrchestration('sequential');
+      expect(svc.getOrchestration().mode).toBe('sequential');
+    });
+
+    it('setOrchestration stores group chat config', () => {
+      const config = {
+        moderatorMindId: 'dude',
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      };
+      svc.setOrchestration('group-chat', config);
+      const { mode, config: storedConfig } = svc.getOrchestration();
+      expect(mode).toBe('group-chat');
+      expect(storedConfig).toEqual(config);
+    });
+
+    it('mode persists across rounds', async () => {
+      svc.setOrchestration('sequential');
+
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      autoIdle(sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      await svc.broadcast('round 1');
+      await svc.broadcast('round 2');
+
+      // Mode should still be sequential
+      expect(svc.getOrchestration().mode).toBe('sequential');
+    });
+
+    it('switching mode clears group chat config when not group-chat', () => {
+      svc.setOrchestration('group-chat', {
+        moderatorMindId: 'dude',
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      });
+      svc.setOrchestration('concurrent');
+      expect(svc.getOrchestration().config).toBeNull();
+    });
+  });
 });

--- a/src/main/services/chatroom/ChatroomService.test.ts
+++ b/src/main/services/chatroom/ChatroomService.test.ts
@@ -177,7 +177,7 @@ describe('ChatroomService', () => {
 
   // 3. Session caching
   describe('session caching', () => {
-    it('reuses sessions across rounds', async () => {
+    it('creates fresh sessions between rounds (stopAll clears cache)', async () => {
       const sess = createMockSession();
       sessions.set('dude', sess);
       autoIdle(sess);
@@ -187,9 +187,8 @@ describe('ChatroomService', () => {
       await svc.broadcast('round 1');
       await svc.broadcast('round 2');
 
-      // createChatroomSession called only once — cached after first
-      expect(factory.createChatroomSession).toHaveBeenCalledTimes(1);
-      expect(sess.send).toHaveBeenCalledTimes(2);
+      // stopAll between rounds clears cache — session created once per round
+      expect(factory.createChatroomSession).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/main/services/chatroom/ChatroomService.ts
+++ b/src/main/services/chatroom/ChatroomService.ts
@@ -9,6 +9,8 @@ import type {
   ChatroomStreamEvent,
   OrchestrationMode,
   GroupChatConfig,
+  HandoffConfig,
+  MagenticConfig,
 } from '../../../shared/chatroom-types';
 import type { MindContext } from '../../../shared/types';
 import type { CopilotSession } from '../mind';
@@ -61,6 +63,8 @@ export class ChatroomService extends EventEmitter {
   private activeStrategy: OrchestrationStrategy | null = null;
   private orchestrationMode: OrchestrationMode = 'concurrent';
   private groupChatConfig: GroupChatConfig | null = null;
+  private handoffConfig: HandoffConfig | null = null;
+  private magneticConfig: MagenticConfig | null = null;
   private readonly persistPath: string;
   private readonly persistDir: string;
 
@@ -98,16 +102,36 @@ export class ChatroomService extends EventEmitter {
 
     if (participants.length === 0) return;
 
+    console.log(`[Chatroom] broadcast mode="${this.orchestrationMode}" participants=${participants.length} handoffConfig=${JSON.stringify(this.handoffConfig)} magneticConfig=${JSON.stringify(this.magneticConfig)}`);
+
     // Create strategy for current orchestration mode
-    const strategy = createStrategy(this.orchestrationMode, this.groupChatConfig ?? undefined);
+    let strategy: OrchestrationStrategy;
+    try {
+      strategy = createStrategy(
+        this.orchestrationMode,
+        this.groupChatConfig ?? undefined,
+        this.handoffConfig ?? undefined,
+        this.magneticConfig ?? undefined,
+      );
+    } catch (err) {
+      console.error(`[Chatroom] Failed to create strategy for mode "${this.orchestrationMode}":`, err);
+      this.emit('chatroom:event', {
+        mindId: 'system',
+        mindName: 'System',
+        messageId: randomUUID(),
+        roundId,
+        event: { type: 'error', message: `Orchestration error: ${err instanceof Error ? err.message : String(err)}` },
+      } satisfies ChatroomStreamEvent);
+      return;
+    }
     this.activeStrategy = strategy;
 
     // Build context adapter for strategies
     const contextAdapter: OrchestrationContext = {
       getOrCreateSession: (mindId: string) => this.getOrCreateSession(mindId),
       evictSession: (mindId: string) => this.evictSession(mindId),
-      buildBasePrompt: (msg: string, parts: MindContext[]) =>
-        this.buildPrompt(msg, parts, roundId),
+      buildBasePrompt: (msg: string, parts: MindContext[], forMind?: MindContext) =>
+        this.buildPrompt(msg, parts, roundId, forMind),
       emitEvent: (event: ChatroomStreamEvent) => this.emit('chatroom:event', event),
       persistMessage: (message: ChatroomMessage) => {
         this.messages.push(message);
@@ -117,7 +141,18 @@ export class ChatroomService extends EventEmitter {
       orchestrationMode: this.orchestrationMode,
     };
 
-    await strategy.execute(userMessage, participants, roundId, contextAdapter);
+    try {
+      await strategy.execute(userMessage, participants, roundId, contextAdapter);
+    } catch (err) {
+      console.error(`[Chatroom] Strategy "${this.orchestrationMode}" execution failed:`, err);
+      this.emit('chatroom:event', {
+        mindId: 'system',
+        mindName: 'System',
+        messageId: randomUUID(),
+        roundId,
+        event: { type: 'error', message: `Orchestration error: ${err instanceof Error ? err.message : String(err)}` },
+      } satisfies ChatroomStreamEvent);
+    }
   }
 
   stopAll(): void {
@@ -125,19 +160,32 @@ export class ChatroomService extends EventEmitter {
       this.activeStrategy.stop();
       this.activeStrategy = null;
     }
-    // Also abort cached sessions for safety
+    // Abort and evict all cached sessions so next round gets fresh ones
     for (const [, session] of this.sessionCache) {
       session.abort().catch(() => { /* noop */ });
     }
+    this.sessionCache.clear();
   }
 
-  setOrchestration(mode: OrchestrationMode, config?: GroupChatConfig): void {
+  setOrchestration(mode: OrchestrationMode, config?: GroupChatConfig | HandoffConfig | MagenticConfig): void {
     this.orchestrationMode = mode;
-    this.groupChatConfig = config ?? null;
+    this.groupChatConfig = null;
+    this.handoffConfig = null;
+    this.magneticConfig = null;
+    if (mode === 'group-chat' && config && 'moderatorMindId' in config && 'maxTurns' in config) {
+      this.groupChatConfig = config as GroupChatConfig;
+    } else if (mode === 'handoff' && config && 'maxHandoffHops' in config) {
+      this.handoffConfig = config as HandoffConfig;
+    } else if (mode === 'magentic' && config && 'managerMindId' in config && 'maxSteps' in config) {
+      this.magneticConfig = config as MagenticConfig;
+    }
   }
 
-  getOrchestration(): { mode: OrchestrationMode; config: GroupChatConfig | null } {
-    return { mode: this.orchestrationMode, config: this.groupChatConfig };
+  getOrchestration(): { mode: OrchestrationMode; config: GroupChatConfig | HandoffConfig | MagenticConfig | null } {
+    return {
+      mode: this.orchestrationMode,
+      config: this.groupChatConfig ?? this.handoffConfig ?? this.magneticConfig,
+    };
   }
 
   getHistory(): ChatroomMessage[] {
@@ -192,16 +240,23 @@ export class ChatroomService extends EventEmitter {
     currentMessage: string,
     participants: MindContext[],
     roundId: string,
+    forMind?: MindContext,
   ): string {
     void roundId;
     const historyRounds = this.getLastNRounds(2);
     const participantNames = participants.map((p) => p.identity.name).join(', ');
 
+    // Identity reminder so each agent stays in character
+    const identityPrefix = forMind
+      ? `<identity>You are ${escapeXml(forMind.identity.name)}. Stay in character. Respond as this persona would — use their voice, perspective, and expertise. Do not break character or sound like the other participants.</identity>\n\n`
+      : '';
+
     if (historyRounds.length === 0) {
-      return `<message sender="You">${escapeXml(currentMessage)}</message>`;
+      return `${identityPrefix}<message sender="You">${escapeXml(currentMessage)}</message>`;
     }
 
-    let xml = `<chatroom-history participants="${escapeXml(participantNames)}">\n`;
+    let xml = identityPrefix;
+    xml += `<chatroom-history participants="${escapeXml(participantNames)}">\n`;
     for (const msg of historyRounds) {
       const sender = msg.sender.name;
       xml += `  <message sender="${escapeXml(sender)}">${escapeXml(textContent(msg))}</message>\n`;

--- a/src/main/services/chatroom/ChatroomService.ts
+++ b/src/main/services/chatroom/ChatroomService.ts
@@ -3,10 +3,17 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { app } from 'electron';
-import type { ChatroomMessage, ChatroomTranscript, ChatroomStreamEvent } from '../../../shared/chatroom-types';
+import type {
+  ChatroomMessage,
+  ChatroomTranscript,
+  ChatroomStreamEvent,
+  OrchestrationMode,
+  GroupChatConfig,
+} from '../../../shared/chatroom-types';
 import type { MindContext } from '../../../shared/types';
 import type { CopilotSession } from '../mind';
-import { isStaleSessionError } from '../../../shared/sessionErrors';
+import { createStrategy } from './orchestration';
+import type { OrchestrationStrategy, OrchestrationContext } from './orchestration';
 
 // ---------------------------------------------------------------------------
 // Interfaces
@@ -48,16 +55,12 @@ function textContent(msg: ChatroomMessage): string {
 // ChatroomService
 // ---------------------------------------------------------------------------
 
-interface InFlightAgent {
-  mindId: string;
-  abort: AbortController;
-  unsubs: (() => void)[];
-}
-
 export class ChatroomService extends EventEmitter {
   private messages: ChatroomMessage[] = [];
   private sessionCache = new Map<string, CopilotSession>();
-  private inFlight = new Map<string, InFlightAgent>();
+  private activeStrategy: OrchestrationStrategy | null = null;
+  private orchestrationMode: OrchestrationMode = 'concurrent';
+  private groupChatConfig: GroupChatConfig | null = null;
   private readonly persistPath: string;
   private readonly persistDir: string;
 
@@ -95,27 +98,46 @@ export class ChatroomService extends EventEmitter {
 
     if (participants.length === 0) return;
 
-    // Build context prompt for this round
-    const contextPrompt = this.buildPrompt(userMessage, participants, roundId);
+    // Create strategy for current orchestration mode
+    const strategy = createStrategy(this.orchestrationMode, this.groupChatConfig ?? undefined);
+    this.activeStrategy = strategy;
 
-    // Fan out to all participants in parallel
-    await Promise.all(
-      participants.map((mind) =>
-        this.sendToAgent(mind, contextPrompt, roundId).catch((err) => {
-          console.error(`[Chatroom] Agent ${mind.mindId} failed:`, err);
-        }),
-      ),
-    );
+    // Build context adapter for strategies
+    const contextAdapter: OrchestrationContext = {
+      getOrCreateSession: (mindId: string) => this.getOrCreateSession(mindId),
+      evictSession: (mindId: string) => this.evictSession(mindId),
+      buildBasePrompt: (msg: string, parts: MindContext[]) =>
+        this.buildPrompt(msg, parts, roundId),
+      emitEvent: (event: ChatroomStreamEvent) => this.emit('chatroom:event', event),
+      persistMessage: (message: ChatroomMessage) => {
+        this.messages.push(message);
+        this.persist();
+      },
+      getHistory: () => [...this.messages],
+      orchestrationMode: this.orchestrationMode,
+    };
+
+    await strategy.execute(userMessage, participants, roundId, contextAdapter);
   }
 
   stopAll(): void {
-    for (const agent of this.inFlight.values()) {
-      agent.abort.abort();
-      for (const unsub of agent.unsubs) unsub();
-      const session = this.sessionCache.get(agent.mindId);
-      if (session) session.abort().catch(() => { /* noop */ });
+    if (this.activeStrategy) {
+      this.activeStrategy.stop();
+      this.activeStrategy = null;
     }
-    this.inFlight.clear();
+    // Also abort cached sessions for safety
+    for (const [, session] of this.sessionCache) {
+      session.abort().catch(() => { /* noop */ });
+    }
+  }
+
+  setOrchestration(mode: OrchestrationMode, config?: GroupChatConfig): void {
+    this.orchestrationMode = mode;
+    this.groupChatConfig = config ?? null;
+  }
+
+  getOrchestration(): { mode: OrchestrationMode; config: GroupChatConfig | null } {
+    return { mode: this.orchestrationMode, config: this.groupChatConfig };
   }
 
   getHistory(): ChatroomMessage[] {
@@ -137,170 +159,6 @@ export class ChatroomService extends EventEmitter {
   // Internals
   // -------------------------------------------------------------------------
 
-  private async sendToAgent(
-    mind: MindContext,
-    prompt: string,
-    roundId: string,
-  ): Promise<void> {
-    const session = await this.getOrCreateSession(mind.mindId);
-    try {
-      await this.streamToAgent(session, mind, prompt, roundId);
-    } catch (err) {
-      if (!isStaleSessionError(err)) throw err;
-
-      // Stale session — evict cache, get a fresh session, retry once
-      this.sessionCache.delete(mind.mindId);
-      const freshSession = await this.getOrCreateSession(mind.mindId);
-      await this.streamToAgent(freshSession, mind, prompt, roundId);
-    }
-  }
-
-  private async streamToAgent(
-    session: CopilotSession,
-    mind: MindContext,
-    prompt: string,
-    roundId: string,
-  ): Promise<void> {
-    const messageId = randomUUID();
-    const abortController = new AbortController();
-
-    const unsubs: (() => void)[] = [];
-    const agent: InFlightAgent = { mindId: mind.mindId, abort: abortController, unsubs };
-    this.inFlight.set(mind.mindId, agent);
-
-    const guard = (fn: () => void) => {
-      if (!abortController.signal.aborted) fn();
-    };
-
-    const emitEvent = (event: ChatroomStreamEvent['event']) => {
-      guard(() => {
-        this.emit('chatroom:event', {
-          mindId: mind.mindId,
-          mindName: mind.identity.name,
-          messageId,
-          roundId,
-          event,
-        } satisfies ChatroomStreamEvent);
-      });
-    };
-
-    let finalContent = '';
-
-    try {
-      // Subscribe to streaming events
-      unsubs.push(
-        session.on('assistant.message_delta', (e) => {
-          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.message', (e) => {
-          if (e.data.content) {
-            finalContent = e.data.content;
-            emitEvent({
-              type: 'message_final',
-              sdkMessageId: e.data.messageId,
-              content: e.data.content,
-            });
-          }
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.reasoning_delta', (e) => {
-          emitEvent({
-            type: 'reasoning',
-            reasoningId: e.data.reasoningId,
-            content: e.data.deltaContent,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_start', (e) => {
-          emitEvent({
-            type: 'tool_start',
-            toolCallId: e.data.toolCallId,
-            toolName: e.data.toolName,
-            args: e.data.arguments,
-            parentToolCallId: e.data.parentToolCallId,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_complete', (e) => {
-          emitEvent({
-            type: 'tool_done',
-            toolCallId: e.data.toolCallId,
-            success: e.data.success,
-            result: e.data.result?.content,
-            error: e.data.error?.message,
-          });
-        }),
-      );
-
-      await session.send({ prompt });
-
-      // Wait for idle or error
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(resolve, 300_000);
-
-        const unsubIdle = session.on('session.idle', () => {
-          clearTimeout(timeout);
-          unsubIdle();
-          resolve();
-        });
-        unsubs.push(unsubIdle);
-
-        const unsubError = session.on('session.error', (e) => {
-          clearTimeout(timeout);
-          unsubError();
-          reject(new Error(e.data.message));
-        });
-        unsubs.push(unsubError);
-
-        abortController.signal.addEventListener(
-          'abort',
-          () => {
-            clearTimeout(timeout);
-            resolve();
-          },
-          { once: true },
-        );
-      });
-
-      if (abortController.signal.aborted) return;
-
-      // Persist agent reply
-      if (finalContent) {
-        const agentMsg: ChatroomMessage = {
-          id: messageId,
-          role: 'assistant',
-          blocks: [{ type: 'text', content: finalContent }],
-          timestamp: Date.now(),
-          sender: { mindId: mind.mindId, name: mind.identity.name },
-          roundId,
-        };
-        this.messages.push(agentMsg);
-        this.persist();
-      }
-
-      emitEvent({ type: 'done' });
-    } catch (err) {
-      if (!abortController.signal.aborted) {
-        // Let stale-session errors propagate for retry in sendToAgent
-        if (isStaleSessionError(err)) throw err;
-        const message = err instanceof Error ? err.message : String(err);
-        emitEvent({ type: 'error', message });
-      }
-    } finally {
-      for (const unsub of unsubs) unsub();
-      this.inFlight.delete(mind.mindId);
-    }
-  }
-
   private async getOrCreateSession(mindId: string): Promise<CopilotSession> {
     let session = this.sessionCache.get(mindId);
     if (!session) {
@@ -308,6 +166,11 @@ export class ChatroomService extends EventEmitter {
       this.sessionCache.set(mindId, session as CopilotSession);
     }
     return session;
+  }
+
+  /** Evict a cached session (called by strategies on stale-session errors) */
+  evictSession(mindId: string): void {
+    this.sessionCache.delete(mindId);
   }
 
   private createUserMessage(text: string, roundId: string): ChatroomMessage {
@@ -413,12 +276,10 @@ export class ChatroomService extends EventEmitter {
   }
 
   private handleMindUnloaded(mindId: string): void {
-    // Cancel in-flight if streaming
-    const agent = this.inFlight.get(mindId);
-    if (agent) {
-      agent.abort.abort();
-      for (const unsub of agent.unsubs) unsub();
-      this.inFlight.delete(mindId);
+    // Cancel active strategy if running
+    if (this.activeStrategy) {
+      this.activeStrategy.stop();
+      this.activeStrategy = null;
     }
 
     // Destroy and remove cached session

--- a/src/main/services/chatroom/index.ts
+++ b/src/main/services/chatroom/index.ts
@@ -1,1 +1,3 @@
 export { ChatroomService, type ChatroomSessionFactory } from './ChatroomService';
+export { createStrategy } from './orchestration';
+export type { OrchestrationStrategy, OrchestrationContext } from './orchestration';

--- a/src/main/services/chatroom/orchestration/BaseStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/BaseStrategy.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BaseStrategy } from './types';
+import type { OrchestrationContext } from './types';
+import type { MindContext } from '../../../../shared/types';
+import { SequentialStrategy } from './SequentialStrategy';
+import { HandoffStrategy } from './HandoffStrategy';
+import { GroupChatStrategy } from './GroupChatStrategy';
+import { MagenticStrategy } from './MagenticStrategy';
+
+// ---------------------------------------------------------------------------
+// Concrete test subclass — exposes protected members for testing
+// ---------------------------------------------------------------------------
+
+class TestStrategy extends BaseStrategy {
+  readonly mode = 'sequential' as const;
+
+  // Expose protected members for testing
+  public callBegin() { return this.begin(); }
+  public get testIsAborted() { return this.isAborted; }
+  public get testAbortController() { return this.abortController; }
+  public get testUnsubs() { return this.currentUnsubs; }
+  public set testUnsubs(v: (() => void)[]) { this.currentUnsubs = v; }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async execute(_msg: string, _p: MindContext[], _r: string, _c: OrchestrationContext): Promise<void> {
+    // no-op for testing base class
+  }
+}
+
+describe('BaseStrategy', () => {
+  it('begin() creates a fresh AbortController', () => {
+    const strategy = new TestStrategy();
+    expect(strategy.testAbortController).toBeNull();
+
+    const controller = strategy.callBegin();
+
+    expect(controller).toBeInstanceOf(AbortController);
+    expect(strategy.testAbortController).toBe(controller);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it('isAborted is false before begin()', () => {
+    const strategy = new TestStrategy();
+    expect(strategy.testIsAborted).toBe(false);
+  });
+
+  it('isAborted is false after begin()', () => {
+    const strategy = new TestStrategy();
+    strategy.callBegin();
+    expect(strategy.testIsAborted).toBe(false);
+  });
+
+  it('isAborted is true after stop()', () => {
+    const strategy = new TestStrategy();
+    strategy.callBegin();
+    strategy.stop();
+    expect(strategy.testIsAborted).toBe(true);
+  });
+
+  it('stop() aborts the controller', () => {
+    const strategy = new TestStrategy();
+    const controller = strategy.callBegin();
+    expect(controller.signal.aborted).toBe(false);
+
+    strategy.stop();
+
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('stop() calls all unsub functions and clears the array', () => {
+    const strategy = new TestStrategy();
+    strategy.callBegin();
+
+    const unsub1 = vi.fn();
+    const unsub2 = vi.fn();
+    const unsub3 = vi.fn();
+    strategy.testUnsubs = [unsub1, unsub2, unsub3];
+
+    strategy.stop();
+
+    expect(unsub1).toHaveBeenCalledOnce();
+    expect(unsub2).toHaveBeenCalledOnce();
+    expect(unsub3).toHaveBeenCalledOnce();
+    expect(strategy.testUnsubs).toEqual([]);
+  });
+
+  it('stop() is safe to call before begin() (no controller)', () => {
+    const strategy = new TestStrategy();
+    // Should not throw
+    expect(() => strategy.stop()).not.toThrow();
+  });
+
+  it('stop() is idempotent — safe to call multiple times', () => {
+    const strategy = new TestStrategy();
+    strategy.callBegin();
+    const unsub = vi.fn();
+    strategy.testUnsubs = [unsub];
+
+    strategy.stop();
+    strategy.stop();
+
+    // unsub called only once (array was cleared after first stop)
+    expect(unsub).toHaveBeenCalledOnce();
+  });
+
+  it('begin() replaces previous controller', () => {
+    const strategy = new TestStrategy();
+    const first = strategy.callBegin();
+    const second = strategy.callBegin();
+
+    expect(first).not.toBe(second);
+    expect(strategy.testAbortController).toBe(second);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inheritance verification — all four strategies extend BaseStrategy
+// ---------------------------------------------------------------------------
+
+describe('BaseStrategy inheritance', () => {
+  it('SequentialStrategy inherits stop() from BaseStrategy', () => {
+    const strategy = new SequentialStrategy();
+    expect(strategy).toBeInstanceOf(BaseStrategy);
+    expect(strategy.stop).toBe(BaseStrategy.prototype.stop);
+  });
+
+  it('HandoffStrategy inherits stop() from BaseStrategy', () => {
+    const strategy = new HandoffStrategy({ maxHandoffHops: 5 });
+    expect(strategy).toBeInstanceOf(BaseStrategy);
+    expect(strategy.stop).toBe(BaseStrategy.prototype.stop);
+  });
+
+  it('GroupChatStrategy inherits stop() from BaseStrategy', () => {
+    const strategy = new GroupChatStrategy({
+      moderatorMindId: 'mod',
+      maxTurns: 10,
+      minRounds: 1,
+      maxSpeakerRepeats: 3,
+    });
+    expect(strategy).toBeInstanceOf(BaseStrategy);
+    expect(strategy.stop).toBe(BaseStrategy.prototype.stop);
+  });
+
+  it('MagenticStrategy inherits stop() from BaseStrategy', () => {
+    const strategy = new MagenticStrategy({
+      managerMindId: 'mgr',
+      maxSteps: 10,
+    });
+    expect(strategy).toBeInstanceOf(BaseStrategy);
+    expect(strategy.stop).toBe(BaseStrategy.prototype.stop);
+  });
+});

--- a/src/main/services/chatroom/orchestration/ConcurrentStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/ConcurrentStrategy.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'test-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { ConcurrentStrategy } from './ConcurrentStrategy';
+import type { OrchestrationContext } from './types';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockSession() {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      const list = listeners.get(event);
+      if (!list) throw new Error('expected listener list');
+      list.push(cb);
+      const unsub = vi.fn(() => {
+        const cbs = listeners.get(event);
+        if (cbs) {
+          const idx = cbs.indexOf(cb);
+          if (idx >= 0) cbs.splice(idx, 1);
+        }
+      });
+      return unsub;
+    }),
+    _emit(event: string, data: unknown) {
+      for (const cb of listeners.get(event) ?? []) cb(data);
+    },
+    _listeners: listeners,
+  };
+}
+
+function autoIdle(session: ReturnType<typeof createMockSession>) {
+  session.send.mockImplementation(async () => {
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: 'sdk-msg-1', content: 'Hello from agent' },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+function makeMind(id: string, name: string): MindContext {
+  return {
+    mindId: id,
+    mindPath: `/minds/${id}`,
+    identity: { name, systemMessage: `I am ${name}` },
+    status: 'ready',
+  };
+}
+
+function createContext(
+  sessions: Map<string, ReturnType<typeof createMockSession>>,
+  overrides?: Partial<OrchestrationContext>,
+): OrchestrationContext {
+  const events: ChatroomStreamEvent[] = [];
+  const messages: ChatroomMessage[] = [];
+  return {
+    getOrCreateSession: vi.fn(async (mindId: string) => {
+      if (!sessions.has(mindId)) sessions.set(mindId, createMockSession());
+      return sessions.get(mindId)!;
+    }),
+    evictSession: vi.fn((mindId: string) => {
+      sessions.delete(mindId);
+    }),
+    buildBasePrompt: vi.fn((_msg: string, _parts: MindContext[]) => 'test prompt'),
+    emitEvent: vi.fn((event: ChatroomStreamEvent) => events.push(event)),
+    persistMessage: vi.fn((msg: ChatroomMessage) => messages.push(msg)),
+    getHistory: vi.fn(() => []),
+    orchestrationMode: 'concurrent',
+    ...overrides,
+  };
+}
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConcurrentStrategy', () => {
+  let sessions: Map<string, ReturnType<typeof createMockSession>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+    sessions = new Map();
+  });
+
+  it('fans out to all participants in parallel', async () => {
+    const dudeSess = createMockSession();
+    const jarvisSess = createMockSession();
+    sessions.set('dude', dudeSess);
+    sessions.set('jarvis', jarvisSess);
+    autoIdle(dudeSess);
+    autoIdle(jarvisSess);
+
+    const strategy = new ConcurrentStrategy();
+    const ctx = createContext(sessions);
+    const minds = [makeMind('dude', 'The Dude'), makeMind('jarvis', 'Jarvis')];
+
+    await strategy.execute('Hello everyone', minds, 'round-1', ctx);
+
+    expect(ctx.getOrCreateSession).toHaveBeenCalledWith('dude');
+    expect(ctx.getOrCreateSession).toHaveBeenCalledWith('jarvis');
+    expect(dudeSess.send).toHaveBeenCalledTimes(1);
+    expect(jarvisSess.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing with 0 participants', async () => {
+    const strategy = new ConcurrentStrategy();
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Hello', [], 'round-1', ctx);
+
+    expect(ctx.getOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('persists agent messages on completion', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    autoIdle(sess);
+
+    const strategy = new ConcurrentStrategy();
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Hello', [makeMind('dude', 'The Dude')], 'round-1', ctx);
+
+    expect(ctx.persistMessage).toHaveBeenCalledTimes(1);
+    const msg = (ctx.persistMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as ChatroomMessage;
+    expect(msg.role).toBe('assistant');
+    expect(msg.sender.mindId).toBe('dude');
+    expect(msg.orchestrationMode).toBe('concurrent');
+  });
+
+  it('emits done event for each agent', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    autoIdle(sess);
+
+    const strategy = new ConcurrentStrategy();
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Hello', [makeMind('dude', 'The Dude')], 'round-1', ctx);
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    expect(events.some((e) => e.event.type === 'done')).toBe(true);
+  });
+
+  it('one agent failing does not affect others', async () => {
+    const dudeSess = createMockSession();
+    const jarvisSess = createMockSession();
+    sessions.set('dude', dudeSess);
+    sessions.set('jarvis', jarvisSess);
+
+    dudeSess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        dudeSess._emit('session.error', { data: { message: 'dude broke' } });
+      }, 0);
+    });
+    autoIdle(jarvisSess);
+
+    const strategy = new ConcurrentStrategy();
+    const ctx = createContext(sessions);
+    const minds = [makeMind('dude', 'The Dude'), makeMind('jarvis', 'Jarvis')];
+
+    await strategy.execute('Hello', minds, 'round-1', ctx);
+
+    expect(jarvisSess.send).toHaveBeenCalled();
+    expect(ctx.persistMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop cancels in-flight agents', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    // Never idle — send hangs
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('assistant.message_delta', {
+          data: { messageId: 'sdk-1', deltaContent: 'partial...' },
+        });
+      }, 0);
+    });
+
+    const strategy = new ConcurrentStrategy();
+    const ctx = createContext(sessions);
+
+    const promise = strategy.execute('Hello', [makeMind('dude', 'The Dude')], 'round-1', ctx);
+
+    await vi.waitFor(() => expect(sess.send).toHaveBeenCalled());
+    strategy.stop();
+
+    await promise; // Should resolve without hanging
+  });
+
+  it('mode property is concurrent', () => {
+    const strategy = new ConcurrentStrategy();
+    expect(strategy.mode).toBe('concurrent');
+  });
+});

--- a/src/main/services/chatroom/orchestration/ConcurrentStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/ConcurrentStrategy.test.ts
@@ -76,7 +76,7 @@ function createContext(
     evictSession: vi.fn((mindId: string) => {
       sessions.delete(mindId);
     }),
-    buildBasePrompt: vi.fn((_msg: string, _parts: MindContext[]) => 'test prompt'),
+    buildBasePrompt: vi.fn(() => 'test prompt'),
     emitEvent: vi.fn((event: ChatroomStreamEvent) => events.push(event)),
     persistMessage: vi.fn((msg: ChatroomMessage) => messages.push(msg)),
     getHistory: vi.fn(() => []),

--- a/src/main/services/chatroom/orchestration/ConcurrentStrategy.ts
+++ b/src/main/services/chatroom/orchestration/ConcurrentStrategy.ts
@@ -1,9 +1,8 @@
-import { randomUUID } from 'node:crypto';
 import type { MindContext } from '../../../../shared/types';
-import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
 import type { OrchestrationStrategy, OrchestrationContext } from './types';
-import { isStaleSessionError } from '../../../../shared/sessionErrors';
 import type { CopilotSession } from '../../mind';
+import { isStaleSessionError } from '../../../../shared/sessionErrors';
+import { streamAgentTurn } from './stream-agent';
 
 // ---------------------------------------------------------------------------
 // In-flight agent tracking
@@ -31,14 +30,13 @@ export class ConcurrentStrategy implements OrchestrationStrategy {
   ): Promise<void> {
     if (participants.length === 0) return;
 
-    const contextPrompt = context.buildBasePrompt(userMessage, participants);
-
     await Promise.all(
-      participants.map((mind) =>
-        this.sendToAgent(mind, contextPrompt, roundId, context).catch((err) => {
-          console.error(`[Chatroom] Agent ${mind.mindId} failed:`, err);
-        }),
-      ),
+      participants.map((mind) => {
+        const prompt = context.buildBasePrompt(userMessage, participants, mind);
+        return this.sendToAgent(mind, prompt, roundId, context).catch((err) => {
+          console.error(`[Chatroom:Concurrent] Agent ${mind.mindId} failed:`, err);
+        });
+      }),
     );
   }
 
@@ -60,158 +58,69 @@ export class ConcurrentStrategy implements OrchestrationStrategy {
     roundId: string,
     context: OrchestrationContext,
   ): Promise<void> {
-    const session = await context.getOrCreateSession(mind.mindId);
-    try {
-      await this.streamToAgent(session, mind, prompt, roundId, context);
-    } catch (err) {
-      if (!isStaleSessionError(err)) throw err;
-      // Stale session — evict cache, get a fresh session, retry once
-      context.evictSession(mind.mindId);
-      const freshSession = await context.getOrCreateSession(mind.mindId);
-      await this.streamToAgent(freshSession, mind, prompt, roundId, context);
-    }
-  }
-
-  private async streamToAgent(
-    session: CopilotSession,
-    mind: MindContext,
-    prompt: string,
-    roundId: string,
-    context: OrchestrationContext,
-  ): Promise<void> {
-    const messageId = randomUUID();
     const abortController = new AbortController();
-
     const unsubs: (() => void)[] = [];
     const agent: InFlightAgent = { mindId: mind.mindId, abort: abortController, unsubs };
     this.inFlight.set(mind.mindId, agent);
 
-    const guard = (fn: () => void) => {
-      if (!abortController.signal.aborted) fn();
-    };
-
-    const emitEvent = (event: ChatroomStreamEvent['event']) => {
-      guard(() => {
-        context.emitEvent({
-          mindId: mind.mindId,
-          mindName: mind.identity.name,
-          messageId,
-          roundId,
-          event,
-        } satisfies ChatroomStreamEvent);
-      });
-    };
-
-    let finalContent = '';
-
-    try {
-      unsubs.push(
-        session.on('assistant.message_delta', (e) => {
-          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.message', (e) => {
-          if (e.data.content) {
-            finalContent = e.data.content;
-            emitEvent({
-              type: 'message_final',
-              sdkMessageId: e.data.messageId,
-              content: e.data.content,
-            });
-          }
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.reasoning_delta', (e) => {
-          emitEvent({
-            type: 'reasoning',
-            reasoningId: e.data.reasoningId,
-            content: e.data.deltaContent,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_start', (e) => {
-          emitEvent({
-            type: 'tool_start',
-            toolCallId: e.data.toolCallId,
-            toolName: e.data.toolName,
-            args: e.data.arguments,
-            parentToolCallId: e.data.parentToolCallId,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_complete', (e) => {
-          emitEvent({
-            type: 'tool_done',
-            toolCallId: e.data.toolCallId,
-            success: e.data.success,
-            result: e.data.result?.content,
-            error: e.data.error?.message,
-          });
-        }),
-      );
-
-      await session.send({ prompt });
-
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(resolve, 300_000);
-
-        const unsubIdle = session.on('session.idle', () => {
-          clearTimeout(timeout);
-          unsubIdle();
-          resolve();
-        });
-        unsubs.push(unsubIdle);
-
-        const unsubError = session.on('session.error', (e) => {
-          clearTimeout(timeout);
-          unsubError();
-          reject(new Error(e.data.message));
-        });
-        unsubs.push(unsubError);
-
-        abortController.signal.addEventListener(
-          'abort',
-          () => {
-            clearTimeout(timeout);
-            resolve();
-          },
-          { once: true },
-        );
-      });
-
-      if (abortController.signal.aborted) return;
-
-      if (finalContent) {
-        const agentMsg: ChatroomMessage = {
-          id: messageId,
-          role: 'assistant',
-          blocks: [{ type: 'text', content: finalContent }],
-          timestamp: Date.now(),
-          sender: { mindId: mind.mindId, name: mind.identity.name },
-          roundId,
+    const run = async (session: CopilotSession) => {
+      try {
+        const { finalContent, messageId } = await streamAgentTurn({
+          session, mind, prompt, roundId, context,
+          abortSignal: abortController.signal,
+          unsubs,
           orchestrationMode: 'concurrent',
-        };
-        context.persistMessage(agentMsg);
-      }
+        });
 
-      emitEvent({ type: 'done' });
-    } catch (err) {
-      if (!abortController.signal.aborted) {
-        if (isStaleSessionError(err)) throw err;
-        const message = err instanceof Error ? err.message : String(err);
-        emitEvent({ type: 'error', message });
+        if (abortController.signal.aborted) return;
+
+        if (finalContent) {
+          context.persistMessage({
+            id: messageId,
+            role: 'assistant',
+            blocks: [{ type: 'text', content: finalContent }],
+            timestamp: Date.now(),
+            sender: { mindId: mind.mindId, name: mind.identity.name },
+            roundId,
+            orchestrationMode: 'concurrent',
+          });
+        }
+
+        if (!abortController.signal.aborted) {
+          context.emitEvent({
+            mindId: mind.mindId,
+            mindName: mind.identity.name,
+            messageId,
+            roundId,
+            event: { type: 'done' },
+          });
+        }
+      } catch (err) {
+        if (!abortController.signal.aborted) {
+          if (isStaleSessionError(err)) throw err;
+          const message = err instanceof Error ? err.message : String(err);
+          context.emitEvent({
+            mindId: mind.mindId,
+            mindName: mind.identity.name,
+            messageId: '',
+            roundId,
+            event: { type: 'error', message },
+          });
+        }
+      } finally {
+        for (const unsub of unsubs) unsub();
+        this.inFlight.delete(mind.mindId);
       }
-    } finally {
-      for (const unsub of unsubs) unsub();
-      this.inFlight.delete(mind.mindId);
+    };
+
+    const session = await context.getOrCreateSession(mind.mindId);
+    try {
+      await run(session);
+    } catch (err) {
+      if (!isStaleSessionError(err)) throw err;
+      context.evictSession(mind.mindId);
+      const freshSession = await context.getOrCreateSession(mind.mindId);
+      await run(freshSession);
     }
   }
 }

--- a/src/main/services/chatroom/orchestration/ConcurrentStrategy.ts
+++ b/src/main/services/chatroom/orchestration/ConcurrentStrategy.ts
@@ -1,0 +1,217 @@
+import { randomUUID } from 'node:crypto';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import { isStaleSessionError } from '../../../../shared/sessionErrors';
+import type { CopilotSession } from '../../mind';
+
+// ---------------------------------------------------------------------------
+// In-flight agent tracking
+// ---------------------------------------------------------------------------
+
+interface InFlightAgent {
+  mindId: string;
+  abort: AbortController;
+  unsubs: (() => void)[];
+}
+
+// ---------------------------------------------------------------------------
+// ConcurrentStrategy — fan out to all participants in parallel
+// ---------------------------------------------------------------------------
+
+export class ConcurrentStrategy implements OrchestrationStrategy {
+  readonly mode = 'concurrent' as const;
+  private inFlight = new Map<string, InFlightAgent>();
+
+  async execute(
+    userMessage: string,
+    participants: MindContext[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    if (participants.length === 0) return;
+
+    const contextPrompt = context.buildBasePrompt(userMessage, participants);
+
+    await Promise.all(
+      participants.map((mind) =>
+        this.sendToAgent(mind, contextPrompt, roundId, context).catch((err) => {
+          console.error(`[Chatroom] Agent ${mind.mindId} failed:`, err);
+        }),
+      ),
+    );
+  }
+
+  stop(): void {
+    for (const agent of this.inFlight.values()) {
+      agent.abort.abort();
+      for (const unsub of agent.unsubs) unsub();
+    }
+    this.inFlight.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async sendToAgent(
+    mind: MindContext,
+    prompt: string,
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    const session = await context.getOrCreateSession(mind.mindId);
+    try {
+      await this.streamToAgent(session, mind, prompt, roundId, context);
+    } catch (err) {
+      if (!isStaleSessionError(err)) throw err;
+      // Stale session — evict cache, get a fresh session, retry once
+      context.evictSession(mind.mindId);
+      const freshSession = await context.getOrCreateSession(mind.mindId);
+      await this.streamToAgent(freshSession, mind, prompt, roundId, context);
+    }
+  }
+
+  private async streamToAgent(
+    session: CopilotSession,
+    mind: MindContext,
+    prompt: string,
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    const messageId = randomUUID();
+    const abortController = new AbortController();
+
+    const unsubs: (() => void)[] = [];
+    const agent: InFlightAgent = { mindId: mind.mindId, abort: abortController, unsubs };
+    this.inFlight.set(mind.mindId, agent);
+
+    const guard = (fn: () => void) => {
+      if (!abortController.signal.aborted) fn();
+    };
+
+    const emitEvent = (event: ChatroomStreamEvent['event']) => {
+      guard(() => {
+        context.emitEvent({
+          mindId: mind.mindId,
+          mindName: mind.identity.name,
+          messageId,
+          roundId,
+          event,
+        } satisfies ChatroomStreamEvent);
+      });
+    };
+
+    let finalContent = '';
+
+    try {
+      unsubs.push(
+        session.on('assistant.message_delta', (e) => {
+          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.message', (e) => {
+          if (e.data.content) {
+            finalContent = e.data.content;
+            emitEvent({
+              type: 'message_final',
+              sdkMessageId: e.data.messageId,
+              content: e.data.content,
+            });
+          }
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.reasoning_delta', (e) => {
+          emitEvent({
+            type: 'reasoning',
+            reasoningId: e.data.reasoningId,
+            content: e.data.deltaContent,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_start', (e) => {
+          emitEvent({
+            type: 'tool_start',
+            toolCallId: e.data.toolCallId,
+            toolName: e.data.toolName,
+            args: e.data.arguments,
+            parentToolCallId: e.data.parentToolCallId,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_complete', (e) => {
+          emitEvent({
+            type: 'tool_done',
+            toolCallId: e.data.toolCallId,
+            success: e.data.success,
+            result: e.data.result?.content,
+            error: e.data.error?.message,
+          });
+        }),
+      );
+
+      await session.send({ prompt });
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(resolve, 300_000);
+
+        const unsubIdle = session.on('session.idle', () => {
+          clearTimeout(timeout);
+          unsubIdle();
+          resolve();
+        });
+        unsubs.push(unsubIdle);
+
+        const unsubError = session.on('session.error', (e) => {
+          clearTimeout(timeout);
+          unsubError();
+          reject(new Error(e.data.message));
+        });
+        unsubs.push(unsubError);
+
+        abortController.signal.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeout);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+
+      if (abortController.signal.aborted) return;
+
+      if (finalContent) {
+        const agentMsg: ChatroomMessage = {
+          id: messageId,
+          role: 'assistant',
+          blocks: [{ type: 'text', content: finalContent }],
+          timestamp: Date.now(),
+          sender: { mindId: mind.mindId, name: mind.identity.name },
+          roundId,
+          orchestrationMode: 'concurrent',
+        };
+        context.persistMessage(agentMsg);
+      }
+
+      emitEvent({ type: 'done' });
+    } catch (err) {
+      if (!abortController.signal.aborted) {
+        if (isStaleSessionError(err)) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        emitEvent({ type: 'error', message });
+      }
+    } finally {
+      for (const unsub of unsubs) unsub();
+      this.inFlight.delete(mind.mindId);
+    }
+  }
+}

--- a/src/main/services/chatroom/orchestration/GroupChatStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/GroupChatStrategy.test.ts
@@ -1,0 +1,508 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'test-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { GroupChatStrategy } from './GroupChatStrategy';
+import type { OrchestrationContext } from './types';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage, GroupChatConfig } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockSession() {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      const list = listeners.get(event);
+      if (!list) throw new Error('expected listener list');
+      list.push(cb);
+      const unsub = vi.fn(() => {
+        const cbs = listeners.get(event);
+        if (cbs) {
+          const idx = cbs.indexOf(cb);
+          if (idx >= 0) cbs.splice(idx, 1);
+        }
+      });
+      return unsub;
+    }),
+    _emit(event: string, data: unknown) {
+      for (const cb of listeners.get(event) ?? []) cb(data);
+    },
+    _listeners: listeners,
+  };
+}
+
+function autoIdleWith(session: ReturnType<typeof createMockSession>, content: string) {
+  session.send.mockImplementation(async () => {
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: 'sdk-msg-1', content },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+function makeMind(id: string, name: string): MindContext {
+  return {
+    mindId: id,
+    mindPath: `/minds/${id}`,
+    identity: { name, systemMessage: `I am ${name}` },
+    status: 'ready',
+  };
+}
+
+function makeConfig(overrides?: Partial<GroupChatConfig>): GroupChatConfig {
+  return {
+    moderatorMindId: 'mod',
+    maxTurns: 10,
+    minRounds: 1,
+    maxSpeakerRepeats: 3,
+    ...overrides,
+  };
+}
+
+function createContext(
+  sessions: Map<string, ReturnType<typeof createMockSession>>,
+  overrides?: Partial<OrchestrationContext>,
+): OrchestrationContext {
+  return {
+    getOrCreateSession: vi.fn(async (mindId: string) => {
+      if (!sessions.has(mindId)) sessions.set(mindId, createMockSession());
+      return sessions.get(mindId)!;
+    }),
+    evictSession: vi.fn((mindId: string) => {
+      sessions.delete(mindId);
+    }),
+    buildBasePrompt: vi.fn((_msg: string, _parts: MindContext[]) => '<message sender="You">test</message>'),
+    emitEvent: vi.fn(),
+    persistMessage: vi.fn(),
+    getHistory: vi.fn(() => []),
+    orchestrationMode: 'group-chat',
+    ...overrides,
+  };
+}
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
+}
+
+// Moderator JSON helper
+function moderatorResponse(nextSpeaker: string, action: 'direct' | 'close' = 'direct', direction = '') {
+  return JSON.stringify({ next_speaker: nextSpeaker, direction, action });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GroupChatStrategy', () => {
+  let sessions: Map<string, ReturnType<typeof createMockSession>>;
+  const moderator = makeMind('mod', 'Moderator');
+  const agentA = makeMind('a', 'Cortana');
+  const agentB = makeMind('b', 'Jarvis');
+  const participants = [moderator, agentA, agentB];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+    sessions = new Map();
+  });
+
+  it('moderator receives structured XML prompt', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+
+    // Agent A speaks first
+    autoIdleWith(aSess, 'Cortana speaks');
+
+    // Moderator decides to close after first speaker (all heard + minRounds=1 with only 1 speaker needed)
+    // But we have 2 speakers so this won't close yet. Let's set maxTurns=1 as safety cap.
+    let moderatorPrompt = '';
+    modSess.send.mockImplementation(async (opts: { prompt: string }) => {
+      moderatorPrompt = opts.prompt;
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: 'sdk-mod', content: moderatorResponse('Jarvis') },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ maxTurns: 1 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('What should we do?', participants, 'round-1', ctx);
+
+    expect(moderatorPrompt).toContain('<group-chat-moderation');
+    expect(moderatorPrompt).toContain('Cortana');
+  });
+
+  it('moderator JSON response is parsed to extract next_speaker', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana speaks');
+    autoIdleWith(bSess, 'Jarvis speaks');
+
+    // Turn 1: Cortana speaks, moderator directs Jarvis
+    // Turn 2: Jarvis speaks, moderator closes
+    let turnCount = 0;
+    modSess.send.mockImplementation(async () => {
+      turnCount++;
+      const content = turnCount === 1
+        ? moderatorResponse('Jarvis')
+        : moderatorResponse('', 'close');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ minRounds: 1 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    // Both speakers should have been called
+    expect(aSess.send).toHaveBeenCalled();
+    expect(bSess.send).toHaveBeenCalled();
+  });
+
+  it('safety rail: max turns enforced', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+
+    autoIdleWith(aSess, 'Cortana speaks');
+
+    // Moderator always directs back to Cortana
+    modSess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: 'sdk-mod', content: moderatorResponse('Cortana') },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ maxTurns: 3 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    // Agent A (Cortana) should be called at most maxTurns times
+    expect(aSess.send.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it('max speaker repeats enforced — falls back to least spoken', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana');
+    autoIdleWith(bSess, 'Jarvis');
+
+    // Moderator always picks Cortana (should trigger max repeat fallback)
+    let turnCount = 0;
+    modSess.send.mockImplementation(async () => {
+      turnCount++;
+      const content = turnCount >= 5
+        ? moderatorResponse('', 'close')
+        : moderatorResponse('Cortana');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ maxTurns: 6, maxSpeakerRepeats: 2 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    // Jarvis should have been called at some point (fallback from max repeats)
+    expect(bSess.send).toHaveBeenCalled();
+  });
+
+  it('cannot close before all participants heard (minRounds enforced)', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana speaks');
+    autoIdleWith(bSess, 'Jarvis speaks');
+
+    // Moderator tries to close immediately after first speaker
+    let turnCount = 0;
+    modSess.send.mockImplementation(async () => {
+      turnCount++;
+      // Always try to close
+      const content = moderatorResponse('', 'close');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ minRounds: 1, maxTurns: 10 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    // Both speakers must have spoken (minRounds=1 means everyone heard once)
+    expect(aSess.send).toHaveBeenCalled();
+    expect(bSess.send).toHaveBeenCalled();
+  });
+
+  it('convergence: moderator "close" terminates loop and emits convergence event', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana');
+    autoIdleWith(bSess, 'Jarvis');
+
+    let turnCount = 0;
+    modSess.send.mockImplementation(async () => {
+      turnCount++;
+      let content: string;
+      if (turnCount === 1) content = moderatorResponse('Jarvis');
+      else content = moderatorResponse('', 'close');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ minRounds: 1 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const convergence = events.filter((e) => e.event.type === 'orchestration:convergence');
+    expect(convergence.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('unknown next_speaker falls back to first unheard participant', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana');
+    autoIdleWith(bSess, 'Jarvis');
+
+    let turnCount = 0;
+    modSess.send.mockImplementation(async () => {
+      turnCount++;
+      let content: string;
+      if (turnCount === 1) content = moderatorResponse('NonExistentAgent');
+      else content = moderatorResponse('', 'close');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ minRounds: 1, maxTurns: 5 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    // Should still have called at least one speaker (fallback)
+    const totalSpeakerCalls = aSess.send.mock.calls.length + bSess.send.mock.calls.length;
+    expect(totalSpeakerCalls).toBeGreaterThan(0);
+  });
+
+  it('moderator parse failure falls back to next unheard participant', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana');
+    autoIdleWith(bSess, 'Jarvis');
+
+    let turnCount = 0;
+    modSess.send.mockImplementation(async () => {
+      turnCount++;
+      const content = turnCount <= 2
+        ? 'I think we should talk more'  // Unparseable — no JSON
+        : moderatorResponse('', 'close');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ minRounds: 1, maxTurns: 5 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    // Both speakers should have been reached via fallback
+    expect(aSess.send).toHaveBeenCalled();
+    expect(bSess.send).toHaveBeenCalled();
+  });
+
+  it('synthesis step sends full transcript to moderator', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana');
+    autoIdleWith(bSess, 'Jarvis');
+
+    let turnCount = 0;
+    modSess.send.mockImplementation(async (opts: { prompt: string }) => {
+      turnCount++;
+      let content: string;
+      if (turnCount === 1) content = moderatorResponse('Jarvis');
+      else content = moderatorResponse('', 'close');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ minRounds: 1 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const synthesis = events.filter((e) => e.event.type === 'orchestration:synthesis');
+    expect(synthesis.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits orchestration:* events at correct points', async () => {
+    const modSess = createMockSession();
+    const aSess = createMockSession();
+    const bSess = createMockSession();
+    sessions.set('mod', modSess);
+    sessions.set('a', aSess);
+    sessions.set('b', bSess);
+
+    autoIdleWith(aSess, 'Cortana');
+    autoIdleWith(bSess, 'Jarvis');
+
+    let turnCount = 0;
+    modSess.send.mockImplementation(async () => {
+      turnCount++;
+      const content = turnCount === 1
+        ? moderatorResponse('Jarvis')
+        : moderatorResponse('', 'close');
+      setTimeout(() => {
+        modSess._emit('assistant.message', {
+          data: { messageId: `sdk-mod-${turnCount}`, content },
+        });
+        modSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const config = makeConfig({ minRounds: 1 });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Question?', participants, 'round-1', ctx);
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const eventTypes = events.map((e) => e.event.type);
+
+    expect(eventTypes).toContain('orchestration:turn-start');
+    expect(eventTypes).toContain('orchestration:moderator-decision');
+    expect(eventTypes).toContain('orchestration:convergence');
+    expect(eventTypes).toContain('orchestration:synthesis');
+  });
+
+  it('returns early if moderator mind not found', async () => {
+    const config = makeConfig({ moderatorMindId: 'nonexistent' });
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Hello', participants, 'round-1', ctx);
+
+    expect(ctx.getOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('does nothing with 0 participants', async () => {
+    const config = makeConfig();
+    const strategy = new GroupChatStrategy(config);
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Hello', [], 'round-1', ctx);
+
+    expect(ctx.getOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('mode property is group-chat', () => {
+    const strategy = new GroupChatStrategy(makeConfig());
+    expect(strategy.mode).toBe('group-chat');
+  });
+});

--- a/src/main/services/chatroom/orchestration/GroupChatStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/GroupChatStrategy.test.ts
@@ -9,7 +9,7 @@ vi.mock('node:crypto', () => ({
 import { GroupChatStrategy } from './GroupChatStrategy';
 import type { OrchestrationContext } from './types';
 import type { MindContext } from '../../../../shared/types';
-import type { ChatroomStreamEvent, ChatroomMessage, GroupChatConfig } from '../../../../shared/chatroom-types';
+import type { ChatroomStreamEvent, GroupChatConfig } from '../../../../shared/chatroom-types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -84,7 +84,7 @@ function createContext(
     evictSession: vi.fn((mindId: string) => {
       sessions.delete(mindId);
     }),
-    buildBasePrompt: vi.fn((_msg: string, _parts: MindContext[]) => '<message sender="You">test</message>'),
+    buildBasePrompt: vi.fn(() => '<message sender="You">test</message>'),
     emitEvent: vi.fn(),
     persistMessage: vi.fn(),
     getHistory: vi.fn(() => []),
@@ -124,11 +124,14 @@ describe('GroupChatStrategy', () => {
   it('moderator receives structured XML prompt', async () => {
     const modSess = createMockSession();
     const aSess = createMockSession();
+    const bSess = createMockSession();
     sessions.set('mod', modSess);
     sessions.set('a', aSess);
+    sessions.set('b', bSess);
 
-    // Agent A speaks first
+    // Both speakers must have sessions — moderator may pick either
     autoIdleWith(aSess, 'Cortana speaks');
+    autoIdleWith(bSess, 'Jarvis speaks');
 
     // Moderator decides to close after first speaker (all heard + minRounds=1 with only 1 speaker needed)
     // But we have 2 speakers so this won't close yet. Let's set maxTurns=1 as safety cap.
@@ -413,7 +416,7 @@ describe('GroupChatStrategy', () => {
     autoIdleWith(bSess, 'Jarvis');
 
     let turnCount = 0;
-    modSess.send.mockImplementation(async (opts: { prompt: string }) => {
+    modSess.send.mockImplementation(async () => {
       turnCount++;
       let content: string;
       if (turnCount === 1) content = moderatorResponse('Jarvis');

--- a/src/main/services/chatroom/orchestration/GroupChatStrategy.ts
+++ b/src/main/services/chatroom/orchestration/GroupChatStrategy.ts
@@ -2,7 +2,8 @@ import type { MindContext } from '../../../../shared/types';
 import type {
   GroupChatConfig,
 } from '../../../../shared/chatroom-types';
-import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import type { OrchestrationContext } from './types';
+import { BaseStrategy } from './types';
 import { escapeXml, textContent, extractJsonObject } from './shared';
 import { sendToAgentWithRetry } from './stream-agent';
 
@@ -47,13 +48,12 @@ interface TranscriptTurn {
 // GroupChatStrategy — moderated sequential turn-taking
 // ---------------------------------------------------------------------------
 
-export class GroupChatStrategy implements OrchestrationStrategy {
+export class GroupChatStrategy extends BaseStrategy {
   readonly mode = 'group-chat' as const;
-  private abortController: AbortController | null = null;
-  private currentUnsubs: (() => void)[] = [];
   private readonly config: GroupChatConfig;
 
   constructor(config: GroupChatConfig) {
+    super();
     this.config = config;
   }
 
@@ -65,7 +65,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
   ): Promise<void> {
     if (participants.length === 0) return;
 
-    this.abortController = new AbortController();
+    this.begin();
 
     const moderator = participants.find((p) => p.mindId === this.config.moderatorMindId);
     if (!moderator) {
@@ -125,7 +125,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
         prompt: openingPrompt,
         roundId,
         context,
-        abortSignal: this.abortController.signal,
+        abortSignal: this.abortController!.signal,
         unsubs: this.currentUnsubs,
         orchestrationMode: 'group-chat',
       }));
@@ -163,7 +163,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
     }
 
     for (let turn = 0; turn < this.config.maxTurns; turn++) {
-      if (this.abortController.signal.aborted) break;
+      if (this.isAborted) break;
 
       turnNumber = turn + 1;
       const speaker = nextSpeakerMind;
@@ -198,7 +198,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
           prompt: speakerPrompt,
           roundId,
           context,
-          abortSignal: this.abortController.signal,
+          abortSignal: this.abortController!.signal,
           unsubs: this.currentUnsubs,
           orchestrationMode: 'group-chat',
         }));
@@ -219,7 +219,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
         spokeMindIds.add(speaker.mindId);
       }
 
-      if (this.abortController.signal.aborted) break;
+      if (this.isAborted) break;
 
       // ── Moderator decision ──
       const completedRounds = Math.min(
@@ -243,7 +243,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
           prompt: moderatorPrompt,
           roundId,
           context,
-          abortSignal: this.abortController.signal,
+          abortSignal: this.abortController!.signal,
           unsubs: this.currentUnsubs,
           orchestrationMode: 'group-chat',
         }));
@@ -334,12 +334,6 @@ export class GroupChatStrategy implements OrchestrationStrategy {
         nextSpeakerMind = nextUnheard();
       }
     }
-  }
-
-  stop(): void {
-    this.abortController?.abort();
-    for (const unsub of this.currentUnsubs) unsub();
-    this.currentUnsubs = [];
   }
 
   // -------------------------------------------------------------------------
@@ -452,7 +446,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
     roundId: string,
     context: OrchestrationContext,
   ): Promise<void> {
-    if (this.abortController?.signal.aborted) return;
+    if (this.isAborted) return;
 
     const participantNames = participants.map((p) => p.identity.name).join(', ');
 

--- a/src/main/services/chatroom/orchestration/GroupChatStrategy.ts
+++ b/src/main/services/chatroom/orchestration/GroupChatStrategy.ts
@@ -1,0 +1,653 @@
+import { randomUUID } from 'node:crypto';
+import type { MindContext } from '../../../../shared/types';
+import type {
+  ChatroomStreamEvent,
+  ChatroomMessage,
+  GroupChatConfig,
+} from '../../../../shared/chatroom-types';
+import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import { isStaleSessionError } from '../../../../shared/sessionErrors';
+import type { CopilotSession } from '../../mind';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const XML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+function escapeXml(text: string): string {
+  return text.replace(/[&<>"']/g, (ch) => XML_ESCAPE_MAP[ch]);
+}
+
+function textContent(msg: ChatroomMessage): string {
+  return msg.blocks
+    .filter((b) => b.type === 'text')
+    .map((b) => (b as { content: string }).content)
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// Moderator response parsing
+// ---------------------------------------------------------------------------
+
+interface ModeratorDecision {
+  nextSpeaker: string;
+  direction: string;
+  action: 'direct' | 'close';
+}
+
+function parseModeratorResponse(text: string): ModeratorDecision | null {
+  // Try to extract JSON from the response (may be wrapped in markdown code fences)
+  const jsonMatch = text.match(/\{[\s\S]*?"next_speaker"[\s\S]*?\}/);
+  if (!jsonMatch) return null;
+
+  try {
+    const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+    const nextSpeaker = typeof parsed.next_speaker === 'string' ? parsed.next_speaker : '';
+    const direction = typeof parsed.direction === 'string' ? parsed.direction : '';
+    const action = parsed.action === 'close' ? 'close' as const : 'direct' as const;
+    return { nextSpeaker, direction, action };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transcript turn tracking
+// ---------------------------------------------------------------------------
+
+interface TranscriptTurn {
+  speaker: string;
+  speakerMindId: string;
+  content: string;
+  turnNumber: number;
+  isModerator: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// GroupChatStrategy — moderated sequential turn-taking
+// ---------------------------------------------------------------------------
+
+export class GroupChatStrategy implements OrchestrationStrategy {
+  readonly mode = 'group-chat' as const;
+  private abortController: AbortController | null = null;
+  private currentUnsubs: (() => void)[] = [];
+  private config: GroupChatConfig;
+
+  constructor(config: GroupChatConfig) {
+    this.config = config;
+  }
+
+  async execute(
+    userMessage: string,
+    participants: MindContext[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    if (participants.length === 0) return;
+
+    this.abortController = new AbortController();
+
+    const moderator = participants.find((p) => p.mindId === this.config.moderatorMindId);
+    if (!moderator) {
+      console.error('[GroupChat] Moderator mind not found among participants');
+      return;
+    }
+
+    // Non-moderator participants
+    const speakers = participants.filter((p) => p.mindId !== this.config.moderatorMindId);
+    if (speakers.length === 0) return;
+
+    const transcript: TranscriptTurn[] = [];
+    const speakerCounts = new Map<string, number>();
+    const spokeMindIds = new Set<string>();
+    let turnNumber = 0;
+
+    // Helper: find participant by name (case-insensitive)
+    const findSpeaker = (name: string): MindContext | undefined =>
+      speakers.find((s) => s.identity.name.toLowerCase() === name.toLowerCase());
+
+    // Helper: find next unheard speaker
+    const nextUnheard = (): MindContext =>
+      speakers.find((s) => !spokeMindIds.has(s.mindId)) ?? speakers[0];
+
+    // Helper: check if all speakers heard in current cycle
+    const allHeardInCycle = (round: number): boolean => {
+      const minSpeaks = round;
+      return speakers.every((s) => (speakerCounts.get(s.mindId) ?? 0) >= minSpeaks);
+    };
+
+    // ── Main deliberation loop ──
+
+    // Opening: Moderator frames the discussion and picks first speaker
+    const openingPrompt = this.buildModeratorPrompt(
+      userMessage,
+      speakers,
+      transcript,
+      spokeMindIds,
+      'open',
+    );
+
+    context.emitEvent({
+      mindId: moderator.mindId,
+      mindName: moderator.identity.name,
+      messageId: '',
+      roundId,
+      event: {
+        type: 'orchestration:moderator-decision',
+        data: { action: 'open', phase: 'open' },
+      },
+    });
+
+    const openingResponse = await this.invokeSpeaker(
+      moderator,
+      openingPrompt,
+      roundId,
+      context,
+    );
+
+    const openingText = openingResponse ? textContent(openingResponse) : '';
+    const openingDecision = parseModeratorResponse(openingText);
+
+    // Record opening in transcript
+    transcript.push({
+      speaker: moderator.identity.name,
+      speakerMindId: moderator.mindId,
+      content: openingText,
+      turnNumber: 0,
+      isModerator: true,
+    });
+
+    let nextSpeakerMind: MindContext;
+    let nextDirection = '';
+    if (openingDecision?.nextSpeaker) {
+      const found = findSpeaker(openingDecision.nextSpeaker);
+      nextSpeakerMind = found ?? speakers[0];
+      nextDirection = openingDecision.direction;
+    } else {
+      nextSpeakerMind = speakers[0];
+    }
+
+    for (let turn = 0; turn < this.config.maxTurns; turn++) {
+      if (this.abortController.signal.aborted) break;
+
+      turnNumber = turn + 1;
+      const speaker = nextSpeakerMind;
+
+      // Emit turn-start
+      context.emitEvent({
+        mindId: speaker.mindId,
+        mindName: speaker.identity.name,
+        messageId: '',
+        roundId,
+        event: {
+          type: 'orchestration:turn-start',
+          data: { speaker: speaker.identity.name, speakerMindId: speaker.mindId, turnNumber },
+        },
+      });
+
+      // Build speaker prompt with full transcript context + moderator direction
+      const speakerPrompt = this.buildSpeakerPrompt(
+        userMessage,
+        participants,
+        transcript,
+        context,
+        nextDirection,
+      );
+
+      // Invoke speaker
+      const response = await this.invokeSpeaker(
+        speaker,
+        speakerPrompt,
+        roundId,
+        context,
+      );
+
+      if (response) {
+        transcript.push({
+          speaker: speaker.identity.name,
+          speakerMindId: speaker.mindId,
+          content: textContent(response),
+          turnNumber,
+          isModerator: false,
+        });
+        speakerCounts.set(speaker.mindId, (speakerCounts.get(speaker.mindId) ?? 0) + 1);
+        spokeMindIds.add(speaker.mindId);
+      }
+
+      if (this.abortController.signal.aborted) break;
+
+      // ── Moderator decision ──
+      const completedRounds = Math.min(
+        ...speakers.map((s) => speakerCounts.get(s.mindId) ?? 0),
+      );
+      const canClose = completedRounds >= this.config.minRounds && allHeardInCycle(this.config.minRounds);
+      const phase = canClose ? 'may_close' : 'moderate';
+
+      const moderatorPrompt = this.buildModeratorPrompt(
+        userMessage,
+        speakers,
+        transcript,
+        spokeMindIds,
+        phase,
+      );
+
+      const moderatorResponse = await this.invokeSpeaker(
+        moderator,
+        moderatorPrompt,
+        roundId,
+        context,
+      );
+
+      const moderatorText = moderatorResponse ? textContent(moderatorResponse) : '';
+      const decision = parseModeratorResponse(moderatorText);
+
+      // Record moderator turn
+      transcript.push({
+        speaker: moderator.identity.name,
+        speakerMindId: moderator.mindId,
+        content: moderatorText,
+        turnNumber,
+        isModerator: true,
+      });
+
+      // Emit moderator decision event
+      context.emitEvent({
+        mindId: moderator.mindId,
+        mindName: moderator.identity.name,
+        messageId: '',
+        roundId,
+        event: {
+          type: 'orchestration:moderator-decision',
+          data: {
+            nextSpeaker: decision?.nextSpeaker ?? '',
+            action: decision?.action ?? 'direct',
+            direction: decision?.direction ?? '',
+            phase,
+          },
+        },
+      });
+
+      // Check for convergence
+      if (decision?.action === 'close' && canClose) {
+        // Emit convergence event
+        context.emitEvent({
+          mindId: moderator.mindId,
+          mindName: moderator.identity.name,
+          messageId: '',
+          roundId,
+          event: {
+            type: 'orchestration:convergence',
+            data: { totalTurns: turnNumber, completedRounds },
+          },
+        });
+
+        // Synthesis step: send full transcript to moderator for summary
+        await this.invokeSynthesis(
+          moderator,
+          userMessage,
+          participants,
+          transcript,
+          roundId,
+          context,
+        );
+
+        break;
+      }
+
+      // Determine next speaker
+      nextDirection = decision?.direction ?? '';
+      if (decision?.nextSpeaker) {
+        const found = findSpeaker(decision.nextSpeaker);
+        if (found) {
+          // Check max speaker repeats
+          const count = speakerCounts.get(found.mindId) ?? 0;
+          if (count >= this.config.maxSpeakerRepeats) {
+            // Fall back to least-spoken participant
+            nextSpeakerMind = this.leastSpoken(speakers, speakerCounts);
+          } else {
+            nextSpeakerMind = found;
+          }
+        } else {
+          // Unknown speaker name — fall back to next unheard
+          nextSpeakerMind = nextUnheard();
+        }
+      } else {
+        // No decision parsed — fall back to next unheard
+        nextSpeakerMind = nextUnheard();
+      }
+    }
+  }
+
+  stop(): void {
+    this.abortController?.abort();
+    for (const unsub of this.currentUnsubs) unsub();
+    this.currentUnsubs = [];
+  }
+
+  // -------------------------------------------------------------------------
+  // Prompt building
+  // -------------------------------------------------------------------------
+
+  private buildSpeakerPrompt(
+    userMessage: string,
+    participants: MindContext[],
+    transcript: TranscriptTurn[],
+    context: OrchestrationContext,
+    moderatorDirection?: string,
+  ): string {
+    const basePrompt = context.buildBasePrompt(userMessage, participants);
+
+    if (transcript.length === 0 && !moderatorDirection) {
+      return basePrompt;
+    }
+
+    let xml = '';
+
+    if (transcript.length > 0) {
+      xml += `<group-chat-transcript>\n`;
+      for (const turn of transcript) {
+        xml += `  <turn speaker="${escapeXml(turn.speaker)}" turn="${turn.turnNumber}">${escapeXml(turn.content)}</turn>\n`;
+      }
+      xml += `</group-chat-transcript>\n`;
+    }
+
+    if (moderatorDirection) {
+      xml += `<moderator-direction>${escapeXml(moderatorDirection)}</moderator-direction>\n`;
+      xml += `The moderator has asked you to specifically address: ${escapeXml(moderatorDirection)}\n`;
+    }
+
+    xml += `You are participating in a moderated group discussion. Respond to the conversation above and address the user's question.\n\n`;
+
+    return xml + basePrompt;
+  }
+
+  private buildModeratorPrompt(
+    userMessage: string,
+    speakers: MindContext[],
+    transcript: TranscriptTurn[],
+    spokeMindIds: Set<string>,
+    phase: 'open' | 'moderate' | 'may_close',
+  ): string {
+    const participantNames = speakers.map((s) => s.identity.name).join(', ');
+    const spokenNames = speakers
+      .filter((s) => spokeMindIds.has(s.mindId))
+      .map((s) => s.identity.name)
+      .join(', ');
+    const remainingNames = speakers
+      .filter((s) => !spokeMindIds.has(s.mindId))
+      .map((s) => s.identity.name)
+      .join(', ');
+
+    let xml = `<group-chat-moderation participants="${escapeXml(participantNames)}" phase="${phase}">\n`;
+    xml += `  <user-question>${escapeXml(userMessage)}</user-question>\n`;
+
+    if (transcript.length > 0) {
+      xml += `  <transcript>\n`;
+      for (const turn of transcript) {
+        xml += `    <turn speaker="${escapeXml(turn.speaker)}" turn="${turn.turnNumber}">${escapeXml(turn.content)}</turn>\n`;
+      }
+      xml += `  </transcript>\n`;
+    }
+
+    xml += `  <roles-spoken>${escapeXml(spokenNames || 'none')}</roles-spoken>\n`;
+    xml += `  <roles-remaining>${escapeXml(remainingNames || 'all: ' + participantNames)}</roles-remaining>\n`;
+
+    xml += `  <instruction>\n`;
+    xml += `    YOU ARE THE MODERATOR. Your ONLY job right now is to decide who speaks next.\n`;
+    xml += `    DO NOT answer the user's question yourself. DO NOT provide analysis.\n`;
+    xml += `    You MUST respond with ONLY a JSON object — no other text, no markdown, no explanation.\n\n`;
+
+    if (phase === 'open') {
+      xml += `    This is the OPENING of the discussion. Pick who should speak FIRST and what angle they should address.\n`;
+      xml += `    Choose the participant whose expertise is most relevant to the question.\n`;
+    } else if (phase === 'may_close') {
+      xml += `    All participants have spoken at least the minimum number of rounds.\n`;
+      xml += `    If the key issues are sufficiently debated, set action to "close".\n`;
+      xml += `    Otherwise, direct a specific follow-up to a participant who should elaborate.\n`;
+    } else {
+      if (remainingNames) {
+        xml += `    Participants not yet heard: ${escapeXml(remainingNames)}. Prioritize them.\n`;
+      }
+      xml += `    Based on the transcript, identify the most important gap or unresolved tension.\n`;
+      xml += `    Direct the next speaker to address something SPECIFIC — not a generic "share your thoughts".\n`;
+    }
+
+    xml += `\n    RESPOND WITH EXACTLY THIS JSON FORMAT AND NOTHING ELSE:\n`;
+    xml += `    {"next_speaker": "exact participant name", "direction": "specific topic or question for them", "action": "direct"}\n`;
+    xml += `    Or to end: {"next_speaker": "", "direction": "summary of why closing", "action": "close"}\n`;
+    xml += `  </instruction>\n`;
+    xml += `</group-chat-moderation>`;
+
+    return xml;
+  }
+
+  // -------------------------------------------------------------------------
+  // Synthesis step
+  // -------------------------------------------------------------------------
+
+  private async invokeSynthesis(
+    moderator: MindContext,
+    userMessage: string,
+    participants: MindContext[],
+    transcript: TranscriptTurn[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    if (this.abortController?.signal.aborted) return;
+
+    const participantNames = participants.map((p) => p.identity.name).join(', ');
+
+    let xml = `<group-chat-synthesis participants="${escapeXml(participantNames)}">\n`;
+    xml += `  <user-question>${escapeXml(userMessage)}</user-question>\n`;
+    xml += `  <transcript>\n`;
+    for (const turn of transcript) {
+      xml += `    <turn speaker="${escapeXml(turn.speaker)}" turn="${turn.turnNumber}">${escapeXml(turn.content)}</turn>\n`;
+    }
+    xml += `  </transcript>\n`;
+    xml += `  <instruction>Synthesize the deliberation above into a concise summary. Highlight areas of agreement, disagreement, and the final recommendation.</instruction>\n`;
+    xml += `</group-chat-synthesis>`;
+
+    context.emitEvent({
+      mindId: moderator.mindId,
+      mindName: moderator.identity.name,
+      messageId: '',
+      roundId,
+      event: {
+        type: 'orchestration:synthesis',
+        data: { synthesizer: moderator.identity.name },
+      },
+    });
+
+    await this.invokeSpeaker(moderator, xml, roundId, context);
+  }
+
+  // -------------------------------------------------------------------------
+  // Agent communication (shared with sequential pattern)
+  // -------------------------------------------------------------------------
+
+  private async invokeSpeaker(
+    mind: MindContext,
+    prompt: string,
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<ChatroomMessage | null> {
+    const session = await context.getOrCreateSession(mind.mindId);
+    try {
+      return await this.streamToAgent(session, mind, prompt, roundId, context);
+    } catch (err) {
+      if (!isStaleSessionError(err)) throw err;
+      context.evictSession(mind.mindId);
+      const freshSession = await context.getOrCreateSession(mind.mindId);
+      return await this.streamToAgent(freshSession, mind, prompt, roundId, context);
+    }
+  }
+
+  private async streamToAgent(
+    session: CopilotSession,
+    mind: MindContext,
+    prompt: string,
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<ChatroomMessage | null> {
+    const messageId = randomUUID();
+    const unsubs: (() => void)[] = [];
+    this.currentUnsubs = unsubs;
+
+    const emitEvent = (event: ChatroomStreamEvent['event']) => {
+      if (!this.abortController?.signal.aborted) {
+        context.emitEvent({
+          mindId: mind.mindId,
+          mindName: mind.identity.name,
+          messageId,
+          roundId,
+          event,
+        } satisfies ChatroomStreamEvent);
+      }
+    };
+
+    let finalContent = '';
+
+    try {
+      unsubs.push(
+        session.on('assistant.message_delta', (e) => {
+          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.message', (e) => {
+          if (e.data.content) {
+            finalContent = e.data.content;
+            emitEvent({
+              type: 'message_final',
+              sdkMessageId: e.data.messageId,
+              content: e.data.content,
+            });
+          }
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.reasoning_delta', (e) => {
+          emitEvent({
+            type: 'reasoning',
+            reasoningId: e.data.reasoningId,
+            content: e.data.deltaContent,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_start', (e) => {
+          emitEvent({
+            type: 'tool_start',
+            toolCallId: e.data.toolCallId,
+            toolName: e.data.toolName,
+            args: e.data.arguments,
+            parentToolCallId: e.data.parentToolCallId,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_complete', (e) => {
+          emitEvent({
+            type: 'tool_done',
+            toolCallId: e.data.toolCallId,
+            success: e.data.success,
+            result: e.data.result?.content,
+            error: e.data.error?.message,
+          });
+        }),
+      );
+
+      await session.send({ prompt });
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(resolve, 300_000);
+
+        const unsubIdle = session.on('session.idle', () => {
+          clearTimeout(timeout);
+          unsubIdle();
+          resolve();
+        });
+        unsubs.push(unsubIdle);
+
+        const unsubError = session.on('session.error', (e) => {
+          clearTimeout(timeout);
+          unsubError();
+          reject(new Error(e.data.message));
+        });
+        unsubs.push(unsubError);
+
+        if (this.abortController) {
+          this.abortController.signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+            { once: true },
+          );
+        }
+      });
+
+      if (this.abortController?.signal.aborted) return null;
+
+      if (finalContent) {
+        const agentMsg: ChatroomMessage = {
+          id: messageId,
+          role: 'assistant',
+          blocks: [{ type: 'text', content: finalContent }],
+          timestamp: Date.now(),
+          sender: { mindId: mind.mindId, name: mind.identity.name },
+          roundId,
+          orchestrationMode: 'group-chat',
+        };
+        context.persistMessage(agentMsg);
+        emitEvent({ type: 'done' });
+        return agentMsg;
+      }
+
+      emitEvent({ type: 'done' });
+      return null;
+    } catch (err) {
+      if (!this.abortController?.signal.aborted) {
+        if (isStaleSessionError(err)) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        emitEvent({ type: 'error', message });
+      }
+      return null;
+    } finally {
+      for (const unsub of unsubs) unsub();
+      this.currentUnsubs = [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private leastSpoken(
+    speakers: MindContext[],
+    counts: Map<string, number>,
+  ): MindContext {
+    let min = Infinity;
+    let result = speakers[0];
+    for (const s of speakers) {
+      const count = counts.get(s.mindId) ?? 0;
+      if (count < min) {
+        min = count;
+        result = s;
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/services/chatroom/orchestration/GroupChatStrategy.ts
+++ b/src/main/services/chatroom/orchestration/GroupChatStrategy.ts
@@ -1,36 +1,10 @@
-import { randomUUID } from 'node:crypto';
 import type { MindContext } from '../../../../shared/types';
 import type {
-  ChatroomStreamEvent,
-  ChatroomMessage,
   GroupChatConfig,
 } from '../../../../shared/chatroom-types';
 import type { OrchestrationStrategy, OrchestrationContext } from './types';
-import { isStaleSessionError } from '../../../../shared/sessionErrors';
-import type { CopilotSession } from '../../mind';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const XML_ESCAPE_MAP: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&apos;',
-};
-
-function escapeXml(text: string): string {
-  return text.replace(/[&<>"']/g, (ch) => XML_ESCAPE_MAP[ch]);
-}
-
-function textContent(msg: ChatroomMessage): string {
-  return msg.blocks
-    .filter((b) => b.type === 'text')
-    .map((b) => (b as { content: string }).content)
-    .join('');
-}
+import { escapeXml, textContent, extractJsonObject } from './shared';
+import { sendToAgentWithRetry } from './stream-agent';
 
 // ---------------------------------------------------------------------------
 // Moderator response parsing
@@ -43,12 +17,11 @@ interface ModeratorDecision {
 }
 
 function parseModeratorResponse(text: string): ModeratorDecision | null {
-  // Try to extract JSON from the response (may be wrapped in markdown code fences)
-  const jsonMatch = text.match(/\{[\s\S]*?"next_speaker"[\s\S]*?\}/);
-  if (!jsonMatch) return null;
+  const jsonStr = extractJsonObject(text);
+  if (!jsonStr) return null;
 
   try {
-    const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+    const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
     const nextSpeaker = typeof parsed.next_speaker === 'string' ? parsed.next_speaker : '';
     const direction = typeof parsed.direction === 'string' ? parsed.direction : '';
     const action = parsed.action === 'close' ? 'close' as const : 'direct' as const;
@@ -78,7 +51,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
   readonly mode = 'group-chat' as const;
   private abortController: AbortController | null = null;
   private currentUnsubs: (() => void)[] = [];
-  private config: GroupChatConfig;
+  private readonly config: GroupChatConfig;
 
   constructor(config: GroupChatConfig) {
     this.config = config;
@@ -96,7 +69,7 @@ export class GroupChatStrategy implements OrchestrationStrategy {
 
     const moderator = participants.find((p) => p.mindId === this.config.moderatorMindId);
     if (!moderator) {
-      console.error('[GroupChat] Moderator mind not found among participants');
+      console.error('[Chatroom:GroupChat] Moderator mind not found among participants');
       return;
     }
 
@@ -145,12 +118,27 @@ export class GroupChatStrategy implements OrchestrationStrategy {
       },
     });
 
-    const openingResponse = await this.invokeSpeaker(
-      moderator,
-      openingPrompt,
-      roundId,
-      context,
-    );
+    let openingResponse;
+    try {
+      ({ message: openingResponse } = await sendToAgentWithRetry({
+        mind: moderator,
+        prompt: openingPrompt,
+        roundId,
+        context,
+        abortSignal: this.abortController.signal,
+        unsubs: this.currentUnsubs,
+        orchestrationMode: 'group-chat',
+      }));
+    } catch (err) {
+      context.emitEvent({
+        mindId: moderator.mindId,
+        mindName: moderator.identity.name,
+        messageId: '',
+        roundId,
+        event: { type: 'error', message: `Moderator failed: ${err instanceof Error ? err.message : String(err)}` },
+      });
+      return;
+    }
 
     const openingText = openingResponse ? textContent(openingResponse) : '';
     const openingDecision = parseModeratorResponse(openingText);
@@ -199,15 +187,25 @@ export class GroupChatStrategy implements OrchestrationStrategy {
         transcript,
         context,
         nextDirection,
+        speaker,
       );
 
       // Invoke speaker
-      const response = await this.invokeSpeaker(
-        speaker,
-        speakerPrompt,
-        roundId,
-        context,
-      );
+      let response;
+      try {
+        ({ message: response } = await sendToAgentWithRetry({
+          mind: speaker,
+          prompt: speakerPrompt,
+          roundId,
+          context,
+          abortSignal: this.abortController.signal,
+          unsubs: this.currentUnsubs,
+          orchestrationMode: 'group-chat',
+        }));
+      } catch (err) {
+        console.error(`[Chatroom:GroupChat] Speaker ${speaker.mindId} failed:`, err);
+        continue; // Skip this turn, let moderator pick next speaker
+      }
 
       if (response) {
         transcript.push({
@@ -238,12 +236,21 @@ export class GroupChatStrategy implements OrchestrationStrategy {
         phase,
       );
 
-      const moderatorResponse = await this.invokeSpeaker(
-        moderator,
-        moderatorPrompt,
-        roundId,
-        context,
-      );
+      let moderatorResponse;
+      try {
+        ({ message: moderatorResponse } = await sendToAgentWithRetry({
+          mind: moderator,
+          prompt: moderatorPrompt,
+          roundId,
+          context,
+          abortSignal: this.abortController.signal,
+          unsubs: this.currentUnsubs,
+          orchestrationMode: 'group-chat',
+        }));
+      } catch (err) {
+        console.error(`[Chatroom:GroupChat] Moderator decision failed:`, err);
+        break; // Can't continue without moderator direction
+      }
 
       const moderatorText = moderatorResponse ? textContent(moderatorResponse) : '';
       const decision = parseModeratorResponse(moderatorText);
@@ -289,14 +296,18 @@ export class GroupChatStrategy implements OrchestrationStrategy {
         });
 
         // Synthesis step: send full transcript to moderator for summary
-        await this.invokeSynthesis(
-          moderator,
-          userMessage,
-          participants,
-          transcript,
-          roundId,
-          context,
-        );
+        try {
+          await this.invokeSynthesis(
+            moderator,
+            userMessage,
+            participants,
+            transcript,
+            roundId,
+            context,
+          );
+        } catch (err) {
+          console.error(`[Chatroom:GroupChat] Synthesis failed:`, err);
+        }
 
         break;
       }
@@ -341,8 +352,9 @@ export class GroupChatStrategy implements OrchestrationStrategy {
     transcript: TranscriptTurn[],
     context: OrchestrationContext,
     moderatorDirection?: string,
+    forMind?: MindContext,
   ): string {
-    const basePrompt = context.buildBasePrompt(userMessage, participants);
+    const basePrompt = context.buildBasePrompt(userMessage, participants, forMind);
 
     if (transcript.length === 0 && !moderatorDirection) {
       return basePrompt;
@@ -465,170 +477,15 @@ export class GroupChatStrategy implements OrchestrationStrategy {
       },
     });
 
-    await this.invokeSpeaker(moderator, xml, roundId, context);
-  }
-
-  // -------------------------------------------------------------------------
-  // Agent communication (shared with sequential pattern)
-  // -------------------------------------------------------------------------
-
-  private async invokeSpeaker(
-    mind: MindContext,
-    prompt: string,
-    roundId: string,
-    context: OrchestrationContext,
-  ): Promise<ChatroomMessage | null> {
-    const session = await context.getOrCreateSession(mind.mindId);
-    try {
-      return await this.streamToAgent(session, mind, prompt, roundId, context);
-    } catch (err) {
-      if (!isStaleSessionError(err)) throw err;
-      context.evictSession(mind.mindId);
-      const freshSession = await context.getOrCreateSession(mind.mindId);
-      return await this.streamToAgent(freshSession, mind, prompt, roundId, context);
-    }
-  }
-
-  private async streamToAgent(
-    session: CopilotSession,
-    mind: MindContext,
-    prompt: string,
-    roundId: string,
-    context: OrchestrationContext,
-  ): Promise<ChatroomMessage | null> {
-    const messageId = randomUUID();
-    const unsubs: (() => void)[] = [];
-    this.currentUnsubs = unsubs;
-
-    const emitEvent = (event: ChatroomStreamEvent['event']) => {
-      if (!this.abortController?.signal.aborted) {
-        context.emitEvent({
-          mindId: mind.mindId,
-          mindName: mind.identity.name,
-          messageId,
-          roundId,
-          event,
-        } satisfies ChatroomStreamEvent);
-      }
-    };
-
-    let finalContent = '';
-
-    try {
-      unsubs.push(
-        session.on('assistant.message_delta', (e) => {
-          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.message', (e) => {
-          if (e.data.content) {
-            finalContent = e.data.content;
-            emitEvent({
-              type: 'message_final',
-              sdkMessageId: e.data.messageId,
-              content: e.data.content,
-            });
-          }
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.reasoning_delta', (e) => {
-          emitEvent({
-            type: 'reasoning',
-            reasoningId: e.data.reasoningId,
-            content: e.data.deltaContent,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_start', (e) => {
-          emitEvent({
-            type: 'tool_start',
-            toolCallId: e.data.toolCallId,
-            toolName: e.data.toolName,
-            args: e.data.arguments,
-            parentToolCallId: e.data.parentToolCallId,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_complete', (e) => {
-          emitEvent({
-            type: 'tool_done',
-            toolCallId: e.data.toolCallId,
-            success: e.data.success,
-            result: e.data.result?.content,
-            error: e.data.error?.message,
-          });
-        }),
-      );
-
-      await session.send({ prompt });
-
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(resolve, 300_000);
-
-        const unsubIdle = session.on('session.idle', () => {
-          clearTimeout(timeout);
-          unsubIdle();
-          resolve();
-        });
-        unsubs.push(unsubIdle);
-
-        const unsubError = session.on('session.error', (e) => {
-          clearTimeout(timeout);
-          unsubError();
-          reject(new Error(e.data.message));
-        });
-        unsubs.push(unsubError);
-
-        if (this.abortController) {
-          this.abortController.signal.addEventListener(
-            'abort',
-            () => {
-              clearTimeout(timeout);
-              resolve();
-            },
-            { once: true },
-          );
-        }
-      });
-
-      if (this.abortController?.signal.aborted) return null;
-
-      if (finalContent) {
-        const agentMsg: ChatroomMessage = {
-          id: messageId,
-          role: 'assistant',
-          blocks: [{ type: 'text', content: finalContent }],
-          timestamp: Date.now(),
-          sender: { mindId: mind.mindId, name: mind.identity.name },
-          roundId,
-          orchestrationMode: 'group-chat',
-        };
-        context.persistMessage(agentMsg);
-        emitEvent({ type: 'done' });
-        return agentMsg;
-      }
-
-      emitEvent({ type: 'done' });
-      return null;
-    } catch (err) {
-      if (!this.abortController?.signal.aborted) {
-        if (isStaleSessionError(err)) throw err;
-        const message = err instanceof Error ? err.message : String(err);
-        emitEvent({ type: 'error', message });
-      }
-      return null;
-    } finally {
-      for (const unsub of unsubs) unsub();
-      this.currentUnsubs = [];
-    }
+    await sendToAgentWithRetry({
+      mind: moderator,
+      prompt: xml,
+      roundId,
+      context,
+      abortSignal: this.abortController?.signal ?? new AbortController().signal,
+      unsubs: this.currentUnsubs,
+      orchestrationMode: 'group-chat',
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/services/chatroom/orchestration/HandoffStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/HandoffStrategy.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'test-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { HandoffStrategy } from './HandoffStrategy';
+import type { OrchestrationContext } from './types';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helpers — consistent with existing test patterns
+// ---------------------------------------------------------------------------
+
+function createMockSession() {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      const list = listeners.get(event);
+      if (!list) throw new Error('expected listener list');
+      list.push(cb);
+      const unsub = vi.fn(() => {
+        const cbs = listeners.get(event);
+        if (cbs) {
+          const idx = cbs.indexOf(cb);
+          if (idx >= 0) cbs.splice(idx, 1);
+        }
+      });
+      return unsub;
+    }),
+    _emit(event: string, data: unknown) {
+      for (const cb of listeners.get(event) ?? []) cb(data);
+    },
+    _listeners: listeners,
+  };
+}
+
+function autoIdleWith(session: ReturnType<typeof createMockSession>, content: string) {
+  session.send.mockImplementation(async () => {
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: 'sdk-msg-1', content },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+function makeMind(id: string, name: string): MindContext {
+  return {
+    mindId: id,
+    mindPath: `/minds/${id}`,
+    identity: { name, systemMessage: `I am ${name}` },
+    status: 'ready',
+  };
+}
+
+function createContext(
+  sessions: Map<string, ReturnType<typeof createMockSession>>,
+  overrides?: Partial<OrchestrationContext>,
+): OrchestrationContext {
+  const events: ChatroomStreamEvent[] = [];
+  const messages: ChatroomMessage[] = [];
+  return {
+    getOrCreateSession: vi.fn(async (mindId: string) => {
+      if (!sessions.has(mindId)) sessions.set(mindId, createMockSession());
+      return sessions.get(mindId)!;
+    }),
+    evictSession: vi.fn((mindId: string) => {
+      sessions.delete(mindId);
+    }),
+    buildBasePrompt: vi.fn(() => '<message sender="You">test</message>'),
+    emitEvent: vi.fn((event: ChatroomStreamEvent) => events.push(event)),
+    persistMessage: vi.fn((msg: ChatroomMessage) => messages.push(msg)),
+    getHistory: vi.fn(() => []),
+    orchestrationMode: 'handoff',
+    _events: events,
+    _messages: messages,
+    ...overrides,
+  } as OrchestrationContext & { _events: ChatroomStreamEvent[]; _messages: ChatroomMessage[] };
+}
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HandoffStrategy', () => {
+  let sessions: Map<string, ReturnType<typeof createMockSession>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+    sessions = new Map();
+  });
+
+  it('starts with initial agent and terminates on "done"', async () => {
+    const sess = createMockSession();
+    sessions.set('agent-a', sess);
+    autoIdleWith(sess, 'I handled it. {"action": "done", "reason": "task complete"}');
+
+    const strategy = new HandoffStrategy({ maxHandoffHops: 5 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('agent-a', 'Alpha'), makeMind('agent-b', 'Beta')];
+
+    await strategy.execute('Help me', minds, 'round-1', ctx);
+
+    expect(sess.send).toHaveBeenCalledTimes(1);
+    // Should have emitted a handoff-terminated event with DONE reason
+    const terminatedEvents = (ctx as unknown as { _events: ChatroomStreamEvent[] })._events.filter(
+      (e) => e.event.type === 'orchestration:handoff-terminated',
+    );
+    expect(terminatedEvents).toHaveLength(1);
+    expect((terminatedEvents[0].event as { data: Record<string, unknown> }).data.reason).toBe('DONE');
+  });
+
+  it('hands off from agent A to agent B', async () => {
+    const sessA = createMockSession();
+    const sessB = createMockSession();
+    sessions.set('agent-a', sessA);
+    sessions.set('agent-b', sessB);
+
+    autoIdleWith(sessA, 'I need help. {"action": "handoff", "target_agent": "Beta", "reason": "Beta knows this", "task_context": "need expertise"}');
+    autoIdleWith(sessB, 'I handled it. {"action": "done", "reason": "resolved"}');
+
+    const strategy = new HandoffStrategy({ maxHandoffHops: 5 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('agent-a', 'Alpha'), makeMind('agent-b', 'Beta')];
+
+    await strategy.execute('Help me', minds, 'round-1', ctx);
+
+    expect(sessA.send).toHaveBeenCalledTimes(1);
+    expect(sessB.send).toHaveBeenCalledTimes(1);
+
+    // Should have emitted a handoff event
+    const handoffEvents = (ctx as unknown as { _events: ChatroomStreamEvent[] })._events.filter(
+      (e) => e.event.type === 'orchestration:handoff',
+    );
+    expect(handoffEvents).toHaveLength(1);
+    expect((handoffEvents[0].event as { data: Record<string, unknown> }).data.from).toBe('Alpha');
+    expect((handoffEvents[0].event as { data: Record<string, unknown> }).data.to).toBe('Beta');
+  });
+
+  it('enforces maxHandoffHops limit', async () => {
+    // Set up agents that always hand off to each other
+    const sessA = createMockSession();
+    const sessB = createMockSession();
+    const sessC = createMockSession();
+    sessions.set('agent-a', sessA);
+    sessions.set('agent-b', sessB);
+    sessions.set('agent-c', sessC);
+
+    // Each agent always hands off to the next unique agent (A→B→C→done but with maxHops=2)
+    autoIdleWith(sessA, '{"action": "handoff", "target_agent": "Beta", "reason": "need Beta"}');
+    autoIdleWith(sessB, '{"action": "handoff", "target_agent": "Gamma", "reason": "need Gamma"}');
+    autoIdleWith(sessC, '{"action": "handoff", "target_agent": "Alpha", "reason": "need Alpha"}');
+
+    const strategy = new HandoffStrategy({ maxHandoffHops: 2 });
+    const ctx = createContext(sessions);
+    const minds = [
+      makeMind('agent-a', 'Alpha'),
+      makeMind('agent-b', 'Beta'),
+      makeMind('agent-c', 'Gamma'),
+    ];
+
+    await strategy.execute('Help', minds, 'round-1', ctx);
+
+    // Should have been capped at 2 hops
+    expect(sessA.send).toHaveBeenCalledTimes(1);
+    expect(sessB.send).toHaveBeenCalledTimes(1);
+    expect(sessC.send).not.toHaveBeenCalled();
+
+    const terminatedEvents = (ctx as unknown as { _events: ChatroomStreamEvent[] })._events.filter(
+      (e) => e.event.type === 'orchestration:handoff-terminated',
+    );
+    expect(terminatedEvents).toHaveLength(1);
+    expect((terminatedEvents[0].event as { data: Record<string, unknown> }).data.reason).toBe('MAX_HOPS');
+  });
+
+  it('detects loops (A→B→A)', async () => {
+    const sessA = createMockSession();
+    const sessB = createMockSession();
+    sessions.set('agent-a', sessA);
+    sessions.set('agent-b', sessB);
+
+    autoIdleWith(sessA, '{"action": "handoff", "target_agent": "Beta", "reason": "need Beta"}');
+    autoIdleWith(sessB, '{"action": "handoff", "target_agent": "Alpha", "reason": "need Alpha back"}');
+
+    const strategy = new HandoffStrategy({ maxHandoffHops: 10 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('agent-a', 'Alpha'), makeMind('agent-b', 'Beta')];
+
+    await strategy.execute('Help', minds, 'round-1', ctx);
+
+    // A→B→(A is loop) — should detect loop before invoking A again
+    expect(sessA.send).toHaveBeenCalledTimes(1);
+    expect(sessB.send).toHaveBeenCalledTimes(1);
+
+    const terminatedEvents = (ctx as unknown as { _events: ChatroomStreamEvent[] })._events.filter(
+      (e) => e.event.type === 'orchestration:handoff-terminated',
+    );
+    expect(terminatedEvents).toHaveLength(1);
+    expect((terminatedEvents[0].event as { data: Record<string, unknown> }).data.reason).toBe('LOOP_DETECTED');
+  });
+
+  it('preserves conversational context across handoffs', async () => {
+    const sessA = createMockSession();
+    const sessB = createMockSession();
+    sessions.set('agent-a', sessA);
+    sessions.set('agent-b', sessB);
+
+    autoIdleWith(sessA, 'Alpha analysis here. {"action": "handoff", "target_agent": "Beta", "reason": "expertise needed"}');
+
+    let betaPrompt = '';
+    sessB.send.mockImplementation(async (opts: { prompt: string }) => {
+      betaPrompt = opts.prompt;
+      setTimeout(() => {
+        sessB._emit('assistant.message', {
+          data: { messageId: 'sdk-2', content: '{"action": "done", "reason": "complete"}' },
+        });
+        sessB._emit('session.idle', {});
+      }, 0);
+    });
+
+    const strategy = new HandoffStrategy({ maxHandoffHops: 5 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('agent-a', 'Alpha'), makeMind('agent-b', 'Beta')];
+
+    await strategy.execute('Analyze this', minds, 'round-1', ctx);
+
+    // Beta's prompt should contain Alpha's response as transcript context
+    expect(betaPrompt).toContain('<handoff-transcript>');
+    expect(betaPrompt).toContain('Alpha');
+    expect(betaPrompt).toContain('Alpha analysis here');
+  });
+
+  it('uses configured initialMindId', async () => {
+    const sessA = createMockSession();
+    const sessB = createMockSession();
+    sessions.set('agent-a', sessA);
+    sessions.set('agent-b', sessB);
+
+    autoIdleWith(sessB, '{"action": "done", "reason": "done"}');
+
+    const strategy = new HandoffStrategy({ initialMindId: 'agent-b', maxHandoffHops: 5 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('agent-a', 'Alpha'), makeMind('agent-b', 'Beta')];
+
+    await strategy.execute('Help', minds, 'round-1', ctx);
+
+    // Should have started with Beta, not Alpha
+    expect(sessA.send).not.toHaveBeenCalled();
+    expect(sessB.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop() aborts in-flight execution', async () => {
+    const sess = createMockSession();
+    sessions.set('agent-a', sess);
+
+    // Session send resolves but never emits idle — simulates long-running agent
+    sess.send.mockImplementation(async () => {
+      // Don't emit idle — wait for abort
+    });
+
+    const strategy = new HandoffStrategy({ maxHandoffHops: 5 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('agent-a', 'Alpha')];
+
+    // Start execution — stop after the send has been called
+    const executePromise = strategy.execute('Help', minds, 'round-1', ctx);
+
+    // Wait for send to be called, then stop
+    await vi.waitFor(() => expect(sess.send).toHaveBeenCalled());
+    strategy.stop();
+
+    await executePromise;
+
+    // Should not have persisted any message
+    expect(ctx.persistMessage).not.toHaveBeenCalled();
+  });
+
+  it('handles no participants gracefully', async () => {
+    const strategy = new HandoffStrategy({ maxHandoffHops: 5 });
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Help', [], 'round-1', ctx);
+
+    // Should be a no-op
+    expect(ctx.emitEvent).not.toHaveBeenCalled();
+  });
+
+  it('handles agent error without crashing', async () => {
+    const sess = createMockSession();
+    sessions.set('agent-a', sess);
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('session.error', { data: { message: 'agent crashed' } });
+      }, 0);
+    });
+
+    const strategy = new HandoffStrategy({ maxHandoffHops: 5 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('agent-a', 'Alpha')];
+
+    // Should not throw
+    await strategy.execute('Help', minds, 'round-1', ctx);
+
+    const terminatedEvents = (ctx as unknown as { _events: ChatroomStreamEvent[] })._events.filter(
+      (e) => e.event.type === 'orchestration:handoff-terminated',
+    );
+    expect(terminatedEvents).toHaveLength(1);
+    expect((terminatedEvents[0].event as { data: Record<string, unknown> }).data.reason).toBe('ERROR');
+  });
+});

--- a/src/main/services/chatroom/orchestration/HandoffStrategy.ts
+++ b/src/main/services/chatroom/orchestration/HandoffStrategy.ts
@@ -4,7 +4,8 @@ import type {
   HandoffConfig,
   HandoffTerminationReason,
 } from '../../../../shared/chatroom-types';
-import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import type { OrchestrationContext } from './types';
+import { BaseStrategy } from './types';
 import { ObservabilityEmitter } from './observability';
 import { escapeXml, extractJsonObject, stripControlJson } from './shared';
 import { sendToAgentWithRetry } from './stream-agent';
@@ -52,13 +53,12 @@ interface HandoffTurn {
 // HandoffStrategy — agent-to-agent delegation with safety limits
 // ---------------------------------------------------------------------------
 
-export class HandoffStrategy implements OrchestrationStrategy {
+export class HandoffStrategy extends BaseStrategy {
   readonly mode = 'handoff' as const;
-  private abortController: AbortController | null = null;
-  private currentUnsubs: (() => void)[] = [];
   private readonly config: HandoffConfig;
 
   constructor(config: HandoffConfig) {
+    super();
     this.config = config;
   }
 
@@ -70,7 +70,7 @@ export class HandoffStrategy implements OrchestrationStrategy {
   ): Promise<void> {
     if (participants.length === 0) return;
 
-    this.abortController = new AbortController();
+    this.begin();
 
     const obs = new ObservabilityEmitter('handoff');
     obs.start({ participantCount: participants.length, maxHops: this.config.maxHandoffHops });
@@ -88,7 +88,7 @@ export class HandoffStrategy implements OrchestrationStrategy {
       participants.find((p) => p.identity.name.toLowerCase() === name.toLowerCase());
 
     for (let hop = 0; hop < this.config.maxHandoffHops; hop++) {
-      if (this.abortController.signal.aborted) {
+      if (this.isAborted) {
         terminationReason = 'CANCELLED';
         break;
       }
@@ -151,7 +151,7 @@ export class HandoffStrategy implements OrchestrationStrategy {
           prompt,
           roundId,
           context,
-          abortSignal: this.abortController.signal,
+          abortSignal: this.abortController!.signal,
           unsubs: this.currentUnsubs,
           orchestrationMode: 'handoff',
           transformContent: (raw) => stripControlJson(raw, (a) => a === 'handoff' || a === 'done'),
@@ -174,7 +174,7 @@ export class HandoffStrategy implements OrchestrationStrategy {
       }
 
       if (!response) {
-        terminationReason = this.abortController.signal.aborted ? 'CANCELLED' : 'ERROR';
+        terminationReason = this.isAborted ? 'CANCELLED' : 'ERROR';
         break;
       }
 
@@ -264,12 +264,6 @@ export class HandoffStrategy implements OrchestrationStrategy {
     }
 
     obs.end({ terminationReason, totalHops: visitedSequence.length });
-  }
-
-  stop(): void {
-    this.abortController?.abort();
-    for (const unsub of this.currentUnsubs) unsub();
-    this.currentUnsubs = [];
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/services/chatroom/orchestration/HandoffStrategy.ts
+++ b/src/main/services/chatroom/orchestration/HandoffStrategy.ts
@@ -1,0 +1,327 @@
+import type { MindContext } from '../../../../shared/types';
+import type {
+  ChatroomMessage,
+  HandoffConfig,
+  HandoffTerminationReason,
+} from '../../../../shared/chatroom-types';
+import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import { ObservabilityEmitter } from './observability';
+import { escapeXml, extractJsonObject, stripControlJson } from './shared';
+import { sendToAgentWithRetry } from './stream-agent';
+
+// ---------------------------------------------------------------------------
+// Handoff response parsing
+// ---------------------------------------------------------------------------
+
+interface HandoffDecision {
+  action: 'handoff' | 'done';
+  targetAgent?: string;
+  reason: string;
+  taskContext?: string;
+}
+
+function parseHandoffResponse(text: string): HandoffDecision | null {
+  const json = extractJsonObject(text);
+  if (!json) return null;
+
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    if (parsed.action !== 'handoff' && parsed.action !== 'done') return null;
+    const action = parsed.action === 'done' ? 'done' as const : 'handoff' as const;
+    const targetAgent = typeof parsed.target_agent === 'string' ? parsed.target_agent : undefined;
+    const reason = typeof parsed.reason === 'string' ? parsed.reason : '';
+    const taskContext = typeof parsed.task_context === 'string' ? parsed.task_context : undefined;
+    return { action, targetAgent, reason, taskContext };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transcript for handoff context preservation
+// ---------------------------------------------------------------------------
+
+interface HandoffTurn {
+  speaker: string;
+  speakerMindId: string;
+  content: string;
+  hopNumber: number;
+}
+
+// ---------------------------------------------------------------------------
+// HandoffStrategy — agent-to-agent delegation with safety limits
+// ---------------------------------------------------------------------------
+
+export class HandoffStrategy implements OrchestrationStrategy {
+  readonly mode = 'handoff' as const;
+  private abortController: AbortController | null = null;
+  private currentUnsubs: (() => void)[] = [];
+  private readonly config: HandoffConfig;
+
+  constructor(config: HandoffConfig) {
+    this.config = config;
+  }
+
+  async execute(
+    userMessage: string,
+    participants: MindContext[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    if (participants.length === 0) return;
+
+    this.abortController = new AbortController();
+
+    const obs = new ObservabilityEmitter('handoff');
+    obs.start({ participantCount: participants.length, maxHops: this.config.maxHandoffHops });
+
+    // Resolve initial agent
+    let currentAgent = this.config.initialMindId
+      ? participants.find((p) => p.mindId === this.config.initialMindId) ?? participants[0]
+      : participants[0];
+
+    const visitedSequence: string[] = [];
+    const transcript: HandoffTurn[] = [];
+    let terminationReason: HandoffTerminationReason = 'MAX_HOPS';
+
+    const findAgent = (name: string): MindContext | undefined =>
+      participants.find((p) => p.identity.name.toLowerCase() === name.toLowerCase());
+
+    for (let hop = 0; hop < this.config.maxHandoffHops; hop++) {
+      if (this.abortController.signal.aborted) {
+        terminationReason = 'CANCELLED';
+        break;
+      }
+
+      // Loop detection: check if current agent already appears in recent sequence
+      if (this.detectLoop(visitedSequence, currentAgent.mindId)) {
+        terminationReason = 'LOOP_DETECTED';
+
+        context.emitEvent({
+          mindId: currentAgent.mindId,
+          mindName: currentAgent.identity.name,
+          messageId: '',
+          roundId,
+          event: {
+            type: 'orchestration:handoff-terminated',
+            data: { reason: 'LOOP_DETECTED', hop, visitedSequence: [...visitedSequence] },
+          },
+        });
+
+        obs.terminationReason('LOOP_DETECTED', { hop, visitedSequence });
+        break;
+      }
+
+      visitedSequence.push(currentAgent.mindId);
+
+      // Emit turn-start
+      context.emitEvent({
+        mindId: currentAgent.mindId,
+        mindName: currentAgent.identity.name,
+        messageId: '',
+        roundId,
+        event: {
+          type: 'orchestration:turn-start',
+          data: {
+            speaker: currentAgent.identity.name,
+            speakerMindId: currentAgent.mindId,
+            hop,
+          },
+        },
+      });
+
+      obs.agentStep(currentAgent.mindId, { hop });
+
+      // Build prompt with handoff context
+      const prompt = this.buildHandoffPrompt(
+        userMessage,
+        participants,
+        transcript,
+        context,
+        hop === 0,
+        currentAgent,
+      );
+
+      // Invoke agent
+      let response: ChatroomMessage | null = null;
+      let rawContent = '';
+      try {
+        ({ message: response, rawContent } = await sendToAgentWithRetry({
+          mind: currentAgent,
+          prompt,
+          roundId,
+          context,
+          abortSignal: this.abortController.signal,
+          unsubs: this.currentUnsubs,
+          orchestrationMode: 'handoff',
+          transformContent: (raw) => stripControlJson(raw, (a) => a === 'handoff' || a === 'done'),
+        }));
+      } catch (err) {
+        terminationReason = 'ERROR';
+        obs.failure(String(err), { hop, mindId: currentAgent.mindId });
+
+        context.emitEvent({
+          mindId: currentAgent.mindId,
+          mindName: currentAgent.identity.name,
+          messageId: '',
+          roundId,
+          event: {
+            type: 'orchestration:handoff-terminated',
+            data: { reason: 'ERROR', error: String(err), hop },
+          },
+        });
+        break;
+      }
+
+      if (!response) {
+        terminationReason = this.abortController.signal.aborted ? 'CANCELLED' : 'ERROR';
+        break;
+      }
+
+      // Record in transcript
+      transcript.push({
+        speaker: currentAgent.identity.name,
+        speakerMindId: currentAgent.mindId,
+        content: rawContent,
+        hopNumber: hop,
+      });
+
+      // Parse for handoff directive
+      const decision = parseHandoffResponse(rawContent);
+
+      if (!decision || decision.action === 'done') {
+        terminationReason = 'DONE';
+
+        context.emitEvent({
+          mindId: currentAgent.mindId,
+          mindName: currentAgent.identity.name,
+          messageId: '',
+          roundId,
+          event: {
+            type: 'orchestration:handoff-terminated',
+            data: {
+              reason: 'DONE',
+              hop,
+              finalAgent: currentAgent.identity.name,
+            },
+          },
+        });
+
+        obs.terminationReason('DONE', { hop });
+        break;
+      }
+
+      // Handoff to next agent
+      if (decision.targetAgent) {
+        const nextAgent = findAgent(decision.targetAgent);
+        if (nextAgent) {
+          context.emitEvent({
+            mindId: currentAgent.mindId,
+            mindName: currentAgent.identity.name,
+            messageId: '',
+            roundId,
+            event: {
+              type: 'orchestration:handoff',
+              data: {
+                from: currentAgent.identity.name,
+                fromMindId: currentAgent.mindId,
+                to: nextAgent.identity.name,
+                toMindId: nextAgent.mindId,
+                reason: decision.reason,
+                hop,
+              },
+            },
+          });
+
+          currentAgent = nextAgent;
+        } else {
+          // Target not found — treat as done
+          terminationReason = 'DONE';
+          obs.terminationReason('DONE', { hop, unknownTarget: decision.targetAgent });
+          break;
+        }
+      } else {
+        // No target specified — treat as done
+        terminationReason = 'DONE';
+        break;
+      }
+    }
+
+    // If we exhausted hops without terminating
+    if (terminationReason === 'MAX_HOPS') {
+      context.emitEvent({
+        mindId: currentAgent.mindId,
+        mindName: currentAgent.identity.name,
+        messageId: '',
+        roundId,
+        event: {
+          type: 'orchestration:handoff-terminated',
+          data: { reason: 'MAX_HOPS', maxHops: this.config.maxHandoffHops },
+        },
+      });
+
+      obs.terminationReason('MAX_HOPS', { maxHops: this.config.maxHandoffHops });
+    }
+
+    obs.end({ terminationReason, totalHops: visitedSequence.length });
+  }
+
+  stop(): void {
+    this.abortController?.abort();
+    for (const unsub of this.currentUnsubs) unsub();
+    this.currentUnsubs = [];
+  }
+
+  // -------------------------------------------------------------------------
+  // Loop detection — A→B→A or A→B→C→A patterns
+  // -------------------------------------------------------------------------
+
+  private detectLoop(visited: string[], candidate: string): boolean {
+    if (visited.length < 2) return false;
+    // Check if the candidate would create a cycle in the last 3 entries
+    const recent = visited.slice(-2);
+    return recent.includes(candidate);
+  }
+
+  // -------------------------------------------------------------------------
+  // Prompt building
+  // -------------------------------------------------------------------------
+
+  private buildHandoffPrompt(
+    userMessage: string,
+    participants: MindContext[],
+    transcript: HandoffTurn[],
+    context: OrchestrationContext,
+    isInitial: boolean,
+    forMind?: MindContext,
+  ): string {
+    const basePrompt = context.buildBasePrompt(userMessage, participants, forMind);
+    const participantNames = participants.map((p) => p.identity.name).join(', ');
+
+    let xml = '';
+
+    if (transcript.length > 0) {
+      xml += `<handoff-transcript>\n`;
+      for (const turn of transcript) {
+        xml += `  <turn speaker="${escapeXml(turn.speaker)}" hop="${turn.hopNumber}">${escapeXml(turn.content)}</turn>\n`;
+      }
+      xml += `</handoff-transcript>\n\n`;
+    }
+
+    xml += `<handoff-context participants="${escapeXml(participantNames)}" is-initial="${isInitial}">\n`;
+    xml += `  <user-question>${escapeXml(userMessage)}</user-question>\n`;
+    xml += `  <instruction>\n`;
+    xml += `    You are in a handoff orchestration. After answering, decide whether to:\n`;
+    xml += `    1. Complete the task (action: "done") — if you have fully addressed the question.\n`;
+    xml += `    2. Hand off to another agent (action: "handoff") — if another participant is better suited.\n\n`;
+    xml += `    Available participants: ${escapeXml(participantNames)}\n\n`;
+    xml += `    First provide your response to the user's question, then on a NEW LINE output EXACTLY this JSON:\n`;
+    xml += `    {"action": "done", "reason": "why task is complete"}\n`;
+    xml += `    OR\n`;
+    xml += `    {"action": "handoff", "target_agent": "exact agent name", "reason": "why handing off", "task_context": "summary for next agent"}\n`;
+    xml += `  </instruction>\n`;
+    xml += `</handoff-context>\n\n`;
+
+    return xml + basePrompt;
+  }
+}

--- a/src/main/services/chatroom/orchestration/MagenticStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/MagenticStrategy.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'test-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { MagenticStrategy } from './MagenticStrategy';
+import type { OrchestrationContext } from './types';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockSession() {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      const list = listeners.get(event);
+      if (!list) throw new Error('expected listener list');
+      list.push(cb);
+      const unsub = vi.fn(() => {
+        const cbs = listeners.get(event);
+        if (cbs) {
+          const idx = cbs.indexOf(cb);
+          if (idx >= 0) cbs.splice(idx, 1);
+        }
+      });
+      return unsub;
+    }),
+    _emit(event: string, data: unknown) {
+      for (const cb of listeners.get(event) ?? []) cb(data);
+    },
+    _listeners: listeners,
+  };
+}
+
+function autoIdleWith(session: ReturnType<typeof createMockSession>, content: string) {
+  session.send.mockImplementation(async () => {
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: 'sdk-msg-1', content },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+function autoIdleWithSequence(session: ReturnType<typeof createMockSession>, contents: string[]) {
+  let callIndex = 0;
+  session.send.mockImplementation(async () => {
+    const content = contents[callIndex] ?? contents[contents.length - 1];
+    callIndex++;
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: `sdk-msg-${callIndex}`, content },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+function makeMind(id: string, name: string): MindContext {
+  return {
+    mindId: id,
+    mindPath: `/minds/${id}`,
+    identity: { name, systemMessage: `I am ${name}` },
+    status: 'ready',
+  };
+}
+
+function createContext(
+  sessions: Map<string, ReturnType<typeof createMockSession>>,
+  overrides?: Partial<OrchestrationContext>,
+): OrchestrationContext {
+  const events: ChatroomStreamEvent[] = [];
+  const messages: ChatroomMessage[] = [];
+  return {
+    getOrCreateSession: vi.fn(async (mindId: string) => {
+      if (!sessions.has(mindId)) sessions.set(mindId, createMockSession());
+      return sessions.get(mindId)!;
+    }),
+    evictSession: vi.fn((mindId: string) => {
+      sessions.delete(mindId);
+    }),
+    buildBasePrompt: vi.fn(() => '<message sender="You">test</message>'),
+    emitEvent: vi.fn((event: ChatroomStreamEvent) => events.push(event)),
+    persistMessage: vi.fn((msg: ChatroomMessage) => messages.push(msg)),
+    getHistory: vi.fn(() => []),
+    orchestrationMode: 'magentic',
+    _events: events,
+    _messages: messages,
+    ...overrides,
+  } as OrchestrationContext & { _events: ChatroomStreamEvent[]; _messages: ChatroomMessage[] };
+}
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MagenticStrategy', () => {
+  let sessions: Map<string, ReturnType<typeof createMockSession>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+    sessions = new Map();
+  });
+
+  it('manager creates plan, assigns to worker, then completes', async () => {
+    const managerSess = createMockSession();
+    const workerSess = createMockSession();
+    sessions.set('manager', managerSess);
+    sessions.set('worker-a', workerSess);
+
+    // Manager: first call = plan, second call = assign, third call = complete
+    autoIdleWithSequence(managerSess, [
+      '{"action": "update-plan", "plan": [{"id": "1", "description": "research topic"}]}',
+      '{"action": "assign", "assignee": "Worker A", "task_id": "1", "task_description": "research topic"}',
+      '{"action": "complete", "summary": "All done"}',
+    ]);
+
+    autoIdleWith(workerSess, 'Here is my research on the topic.');
+
+    const strategy = new MagenticStrategy({
+      managerMindId: 'manager',
+      maxSteps: 10,
+    });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('manager', 'Manager'), makeMind('worker-a', 'Worker A')];
+
+    await strategy.execute('Research AI safety', minds, 'round-1', ctx);
+
+    // Manager called 2 times: plan + assign (loop exits when all tasks complete)
+    expect(managerSess.send).toHaveBeenCalledTimes(2);
+    // Worker should have been called once
+    expect(workerSess.send).toHaveBeenCalledTimes(1);
+
+    // All tasks completed — should have emitted ledger updates
+    const ledgerEvents = (ctx as unknown as { _events: ChatroomStreamEvent[] })._events.filter(
+      (e) => e.event.type === 'orchestration:task-ledger-update',
+    );
+    expect(ledgerEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('enforces step budget — no infinite loops', async () => {
+    const managerSess = createMockSession();
+    const workerSess = createMockSession();
+    sessions.set('manager', managerSess);
+    sessions.set('worker-a', workerSess);
+
+    // Manager always assigns — never completes
+    autoIdleWithSequence(managerSess, [
+      '{"action": "update-plan", "plan": [{"id": "1", "description": "infinite task"}]}',
+      '{"action": "assign", "assignee": "Worker A", "task_id": "1", "task_description": "do something"}',
+      '{"action": "assign", "assignee": "Worker A", "task_id": "1", "task_description": "do more"}',
+      '{"action": "assign", "assignee": "Worker A", "task_id": "1", "task_description": "even more"}',
+    ]);
+
+    autoIdleWith(workerSess, 'Done with this step');
+
+    const strategy = new MagenticStrategy({
+      managerMindId: 'manager',
+      maxSteps: 3,
+    });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('manager', 'Manager'), makeMind('worker-a', 'Worker A')];
+
+    await strategy.execute('Infinite task', minds, 'round-1', ctx);
+
+    // Manager: 1 plan call + 3 assign calls = 4 total max
+    // Worker: up to 3 times (one per step)
+    // The step budget should cap execution
+    expect(workerSess.send.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it('manager can only select agents from the allowlist', async () => {
+    const managerSess = createMockSession();
+    const allowedSess = createMockSession();
+    const deniedSess = createMockSession();
+    sessions.set('manager', managerSess);
+    sessions.set('allowed', allowedSess);
+    sessions.set('denied', deniedSess);
+
+    autoIdleWithSequence(managerSess, [
+      '{"action": "update-plan", "plan": [{"id": "1", "description": "task"}]}',
+      // Manager tries to assign to denied agent (not in allowlist)
+      '{"action": "assign", "assignee": "Denied Agent", "task_id": "1", "task_description": "do it"}',
+      // Then assigns to allowed agent
+      '{"action": "assign", "assignee": "Allowed Agent", "task_id": "1", "task_description": "do it"}',
+      '{"action": "complete", "summary": "done"}',
+    ]);
+
+    autoIdleWith(allowedSess, 'Done');
+
+    const strategy = new MagenticStrategy({
+      managerMindId: 'manager',
+      maxSteps: 10,
+      allowedMindIds: ['manager', 'allowed'],
+    });
+    const ctx = createContext(sessions);
+    const minds = [
+      makeMind('manager', 'Manager'),
+      makeMind('allowed', 'Allowed Agent'),
+      makeMind('denied', 'Denied Agent'),
+    ];
+
+    await strategy.execute('Test', minds, 'round-1', ctx);
+
+    // Denied agent should never have been called
+    expect(deniedSess.send).not.toHaveBeenCalled();
+    // Allowed agent should have been called
+    expect(allowedSess.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits task-ledger-update events', async () => {
+    const managerSess = createMockSession();
+    const workerSess = createMockSession();
+    sessions.set('manager', managerSess);
+    sessions.set('worker-a', workerSess);
+
+    autoIdleWithSequence(managerSess, [
+      '{"action": "update-plan", "plan": [{"id": "1", "description": "task one"}]}',
+      '{"action": "assign", "assignee": "Worker A", "task_id": "1", "task_description": "task one"}',
+      '{"action": "complete", "summary": "done"}',
+    ]);
+
+    autoIdleWith(workerSess, 'Completed');
+
+    const strategy = new MagenticStrategy({
+      managerMindId: 'manager',
+      maxSteps: 10,
+    });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('manager', 'Manager'), makeMind('worker-a', 'Worker A')];
+
+    await strategy.execute('Test', minds, 'round-1', ctx);
+
+    const ledgerEvents = (ctx as unknown as { _events: ChatroomStreamEvent[] })._events.filter(
+      (e) => e.event.type === 'orchestration:task-ledger-update',
+    );
+    // Should have at least 3 ledger updates: initial plan, task assigned, task completed
+    expect(ledgerEvents.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('handles missing manager gracefully', async () => {
+    const strategy = new MagenticStrategy({
+      managerMindId: 'nonexistent',
+      maxSteps: 10,
+    });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('worker-a', 'Worker A')];
+
+    // Should not throw
+    await strategy.execute('Test', minds, 'round-1', ctx);
+  });
+
+  it('handles no workers gracefully', async () => {
+    const managerSess = createMockSession();
+    sessions.set('manager', managerSess);
+
+    const strategy = new MagenticStrategy({
+      managerMindId: 'manager',
+      maxSteps: 10,
+    });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('manager', 'Manager')];
+
+    await strategy.execute('Test', minds, 'round-1', ctx);
+
+    // Manager should never be called as a worker
+    expect(managerSess.send).not.toHaveBeenCalled();
+  });
+
+  it('stop() aborts execution', async () => {
+    const managerSess = createMockSession();
+    sessions.set('manager', managerSess);
+
+    // Manager send resolves but never emits idle
+    managerSess.send.mockImplementation(async () => {
+      // Never emit idle
+    });
+
+    const strategy = new MagenticStrategy({
+      managerMindId: 'manager',
+      maxSteps: 10,
+    });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('manager', 'Manager'), makeMind('worker-a', 'Worker A')];
+
+    const executePromise = strategy.execute('Test', minds, 'round-1', ctx);
+
+    // Wait for send to be called, then stop
+    await vi.waitFor(() => expect(managerSess.send).toHaveBeenCalled());
+    strategy.stop();
+
+    await executePromise;
+
+    // Should not have persisted any messages from workers
+    expect(ctx.persistMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/chatroom/orchestration/MagenticStrategy.ts
+++ b/src/main/services/chatroom/orchestration/MagenticStrategy.ts
@@ -1,0 +1,440 @@
+import { randomUUID } from 'node:crypto';
+import type { MindContext } from '../../../../shared/types';
+import type {
+  MagenticConfig,
+  TaskLedgerItem,
+} from '../../../../shared/chatroom-types';
+import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import { ObservabilityEmitter } from './observability';
+import { escapeXml, textContent, extractJsonObject, stripControlJson } from './shared';
+import { sendToAgentWithRetry } from './stream-agent';
+
+// ---------------------------------------------------------------------------
+// Manager response parsing
+// ---------------------------------------------------------------------------
+
+interface ManagerDecision {
+  action: 'assign' | 'complete' | 'update-plan';
+  assignee?: string;
+  taskDescription?: string;
+  taskId?: string;
+  planUpdate?: Array<{ id: string; description: string }>;
+  summary?: string;
+}
+
+function parseManagerResponse(text: string): ManagerDecision | null {
+  const json = extractJsonObject(text);
+  if (!json) return null;
+
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    const action = (['assign', 'complete', 'update-plan'] as const).includes(
+      parsed.action as 'assign' | 'complete' | 'update-plan',
+    )
+      ? (parsed.action as 'assign' | 'complete' | 'update-plan')
+      : 'assign';
+    return {
+      action,
+      assignee: typeof parsed.assignee === 'string' ? parsed.assignee : undefined,
+      taskDescription: typeof parsed.task_description === 'string' ? parsed.task_description : undefined,
+      taskId: typeof parsed.task_id === 'string' ? parsed.task_id : undefined,
+      planUpdate: Array.isArray(parsed.plan)
+        ? (parsed.plan as Array<{ id: string; description: string }>)
+        : undefined,
+      summary: typeof parsed.summary === 'string' ? parsed.summary : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MagenticStrategy — manager-driven dynamic collaboration with task ledger
+// ---------------------------------------------------------------------------
+
+/**
+ * Closest equivalent to "Magentic-One" style orchestration:
+ * - A manager agent maintains a shared task ledger (plan with status)
+ * - Manager selects the next agent from a known allowlist
+ * - Step budget + termination criteria enforced
+ * - Each agent is a full Copilot SDK session with complete tool access
+ *   (file I/O, terminal, search, MCP) — more capable than Magentic-One's
+ *   narrow specialist tools (WebSurfer, FileSurfer, Coder)
+ *
+ * Current limitation:
+ * - Single-threaded execution (one worker per step, no parallel sub-tasks)
+ */
+export class MagenticStrategy implements OrchestrationStrategy {
+  readonly mode = 'magentic' as const;
+  private abortController: AbortController | null = null;
+  private currentUnsubs: (() => void)[] = [];
+  private readonly config: MagenticConfig;
+
+  constructor(config: MagenticConfig) {
+    this.config = config;
+  }
+
+  async execute(
+    userMessage: string,
+    participants: MindContext[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    if (participants.length === 0) return;
+
+    this.abortController = new AbortController();
+
+    const obs = new ObservabilityEmitter('magentic');
+    obs.start({ participantCount: participants.length, maxSteps: this.config.maxSteps });
+
+    // Resolve manager
+    const manager = participants.find((p) => p.mindId === this.config.managerMindId);
+    if (!manager) {
+      console.error('[Chatroom:Magentic] Manager mind not found among participants');
+      obs.failure('Manager mind not found');
+      obs.end({ terminationReason: 'ERROR' });
+      return;
+    }
+
+    // Build allowlist
+    const allowedIds = new Set(
+      this.config.allowedMindIds ?? participants.map((p) => p.mindId),
+    );
+    const workers = participants.filter(
+      (p) => p.mindId !== this.config.managerMindId && allowedIds.has(p.mindId),
+    );
+
+    if (workers.length === 0) {
+      obs.failure('No workers available');
+      obs.end({ terminationReason: 'ERROR' });
+      return;
+    }
+
+    // Task ledger
+    const ledger: TaskLedgerItem[] = [];
+    let step = 0;
+
+    // ── Phase 1: Manager creates initial plan ──
+
+    const planPrompt = this.buildPlanPrompt(userMessage, workers);
+
+    context.emitEvent({
+      mindId: manager.mindId,
+      mindName: manager.identity.name,
+      messageId: '',
+      roundId,
+      event: {
+        type: 'orchestration:manager-plan',
+        data: { phase: 'initial-planning' },
+      },
+    });
+
+    let planRawContent: string;
+    try {
+      ({ rawContent: planRawContent } = await sendToAgentWithRetry({
+        mind: manager,
+        prompt: planPrompt,
+        roundId,
+        context,
+        abortSignal: this.abortController.signal,
+        unsubs: this.currentUnsubs,
+        orchestrationMode: 'magentic',
+        transformContent: (raw) => stripControlJson(raw, (a) => ['assign', 'complete', 'update-plan'].includes(a as string)),
+      }));
+    } catch (err) {
+      obs.failure(`Planning failed: ${err instanceof Error ? err.message : String(err)}`);
+      obs.end({ terminationReason: 'ERROR' });
+      return;
+    }
+    const planDecision = parseManagerResponse(planRawContent);
+
+    // Populate ledger from plan
+    if (planDecision?.planUpdate) {
+      for (const item of planDecision.planUpdate) {
+        ledger.push({
+          id: item.id || randomUUID().slice(0, 8),
+          description: item.description,
+          status: 'pending',
+        });
+      }
+    } else {
+      // Fallback: single task
+      ledger.push({
+        id: randomUUID().slice(0, 8),
+        description: userMessage,
+        status: 'pending',
+      });
+    }
+
+    this.emitLedgerUpdate(manager, roundId, ledger, context);
+
+    // ── Phase 2: Manager-driven execution loop ──
+
+    for (step = 0; step < this.config.maxSteps; step++) {
+      if (this.abortController.signal.aborted) break;
+
+      // Check if all tasks are completed
+      const allDone = ledger.every(
+        (t) => t.status === 'completed' || t.status === 'failed',
+      );
+      if (allDone) {
+        obs.terminationReason('ALL_TASKS_COMPLETE', { step });
+        break;
+      }
+
+      // Ask manager to assign next task
+      const assignPrompt = this.buildAssignPrompt(userMessage, workers, ledger);
+
+      let assignRawContent: string;
+      try {
+        ({ rawContent: assignRawContent } = await sendToAgentWithRetry({
+          mind: manager,
+          prompt: assignPrompt,
+          roundId,
+          context,
+          abortSignal: this.abortController.signal,
+          unsubs: this.currentUnsubs,
+          orchestrationMode: 'magentic',
+          transformContent: (raw) => stripControlJson(raw, (a) => ['assign', 'complete', 'update-plan'].includes(a as string)),
+        }));
+      } catch (err) {
+        obs.failure(`Assignment failed: ${err instanceof Error ? err.message : String(err)}`, { step });
+        break;
+      }
+      const assignDecision = parseManagerResponse(assignRawContent);
+
+      if (!assignDecision) {
+        // Manager didn't produce a valid decision — treat as complete
+        obs.terminationReason('MANAGER_NO_DECISION', { step });
+        break;
+      }
+
+      if (assignDecision.action === 'complete') {
+        obs.terminationReason('MANAGER_COMPLETE', { step, summary: assignDecision.summary });
+
+        // Emit synthesis
+        context.emitEvent({
+          mindId: manager.mindId,
+          mindName: manager.identity.name,
+          messageId: '',
+          roundId,
+          event: {
+            type: 'orchestration:synthesis',
+            data: { synthesizer: manager.identity.name, summary: assignDecision.summary },
+          },
+        });
+        break;
+      }
+
+      if (assignDecision.action === 'assign' && assignDecision.assignee) {
+        // Validate assignee is in allowlist
+        const worker = workers.find(
+          (w) => w.identity.name.toLowerCase() === assignDecision.assignee!.toLowerCase(),
+        );
+        if (!worker) {
+          obs.failure(`Manager selected unknown agent: ${assignDecision.assignee}`, { step });
+          continue; // Skip this step, let manager try again
+        }
+
+        // Find or create the task in ledger
+        let task = assignDecision.taskId
+          ? ledger.find((t) => t.id === assignDecision.taskId)
+          : ledger.find((t) => t.status === 'pending');
+
+        if (!task) {
+          // Create new task if manager is adding work
+          task = {
+            id: assignDecision.taskId || randomUUID().slice(0, 8),
+            description: assignDecision.taskDescription || 'Task assigned by manager',
+            status: 'pending',
+          };
+          ledger.push(task);
+        }
+
+        task.status = 'in-progress';
+        task.assignee = worker.mindId;
+        this.emitLedgerUpdate(manager, roundId, ledger, context);
+
+        // Emit turn-start for worker
+        context.emitEvent({
+          mindId: worker.mindId,
+          mindName: worker.identity.name,
+          messageId: '',
+          roundId,
+          event: {
+            type: 'orchestration:turn-start',
+            data: { speaker: worker.identity.name, speakerMindId: worker.mindId, step },
+          },
+        });
+
+        obs.agentStep(worker.mindId, { step, taskId: task.id });
+
+        // Build worker prompt
+        const workerPrompt = this.buildWorkerPrompt(
+          userMessage,
+          participants,
+          task,
+          ledger,
+          context,
+          worker,
+        );
+
+        try {
+          const { message: workerResponse } = await sendToAgentWithRetry({
+            mind: worker,
+            prompt: workerPrompt,
+            roundId,
+            context,
+            abortSignal: this.abortController.signal,
+            unsubs: this.currentUnsubs,
+            orchestrationMode: 'magentic',
+          });
+          const workerText = workerResponse ? textContent(workerResponse) : '';
+
+          task.status = 'completed';
+          task.result = workerText.slice(0, 500); // Safe summary only
+          this.emitLedgerUpdate(manager, roundId, ledger, context);
+        } catch (err) {
+          task.status = 'failed';
+          task.result = String(err);
+          this.emitLedgerUpdate(manager, roundId, ledger, context);
+          obs.failure(String(err), { step, mindId: worker.mindId, taskId: task.id });
+        }
+      }
+    }
+
+    // Step budget exhausted
+    if (step >= this.config.maxSteps) {
+      obs.terminationReason('STEP_BUDGET_EXHAUSTED', { maxSteps: this.config.maxSteps });
+
+      context.emitEvent({
+        mindId: manager.mindId,
+        mindName: manager.identity.name,
+        messageId: '',
+        roundId,
+        event: {
+          type: 'orchestration:magentic-terminated',
+          data: { reason: 'STEP_BUDGET_EXHAUSTED', maxSteps: this.config.maxSteps },
+        },
+      });
+    }
+
+    obs.end({ totalSteps: step, ledgerSize: ledger.length });
+  }
+
+  stop(): void {
+    this.abortController?.abort();
+    for (const unsub of this.currentUnsubs) unsub();
+    this.currentUnsubs = [];
+  }
+
+  // -------------------------------------------------------------------------
+  // Task ledger emission (non-sensitive)
+  // -------------------------------------------------------------------------
+
+  private emitLedgerUpdate(
+    manager: MindContext,
+    roundId: string,
+    ledger: TaskLedgerItem[],
+    context: OrchestrationContext,
+  ): void {
+    // Persist a safe view of the ledger — no chain-of-thought, only metadata
+    const safeLedger = ledger.map((t) => ({
+      id: t.id,
+      description: t.description.slice(0, 100),
+      status: t.status,
+      assignee: t.assignee,
+    }));
+
+    context.emitEvent({
+      mindId: manager.mindId,
+      mindName: manager.identity.name,
+      messageId: '',
+      roundId,
+      event: {
+        type: 'orchestration:task-ledger-update',
+        data: { ledger: safeLedger },
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Prompt building
+  // -------------------------------------------------------------------------
+
+  private buildPlanPrompt(userMessage: string, workers: MindContext[]): string {
+    const workerList = workers.map((w) => `  - ${w.identity.name}`).join('\n');
+
+    let xml = `<magentic-planning>\n`;
+    xml += `  <user-question>${escapeXml(userMessage)}</user-question>\n`;
+    xml += `  <available-agents>\n${workerList}\n  </available-agents>\n`;
+    xml += `  <instruction>\n`;
+    xml += `    YOU ARE THE MANAGER. Break down the user's question into a plan.\n`;
+    xml += `    Create a list of tasks that can be assigned to the available agents.\n`;
+    xml += `    Each agent has different expertise — match tasks to the best agent.\n\n`;
+    xml += `    RESPOND WITH EXACTLY THIS JSON FORMAT AND NOTHING ELSE:\n`;
+    xml += `    {"action": "update-plan", "plan": [{"id": "1", "description": "task description"}, ...]}\n`;
+    xml += `  </instruction>\n`;
+    xml += `</magentic-planning>`;
+
+    return xml;
+  }
+
+  private buildAssignPrompt(
+    userMessage: string,
+    workers: MindContext[],
+    ledger: TaskLedgerItem[],
+  ): string {
+    const workerList = workers.map((w) => `  - ${w.identity.name}`).join('\n');
+    const ledgerXml = ledger
+      .map(
+        (t) =>
+          `    <task id="${escapeXml(t.id)}" status="${t.status}" assignee="${escapeXml(t.assignee ?? 'unassigned')}">${escapeXml(t.description)}${t.result ? ` [result: ${escapeXml(t.result.slice(0, 100))}]` : ''}</task>`,
+      )
+      .join('\n');
+
+    let xml = `<magentic-assign>\n`;
+    xml += `  <user-question>${escapeXml(userMessage)}</user-question>\n`;
+    xml += `  <available-agents>\n${workerList}\n  </available-agents>\n`;
+    xml += `  <task-ledger>\n${ledgerXml}\n  </task-ledger>\n`;
+    xml += `  <instruction>\n`;
+    xml += `    Review the task ledger. Decide the next action:\n`;
+    xml += `    1. ASSIGN a pending task to an agent:\n`;
+    xml += `       {"action": "assign", "assignee": "agent name", "task_id": "task id", "task_description": "what to do"}\n`;
+    xml += `    2. COMPLETE — all tasks done, provide summary:\n`;
+    xml += `       {"action": "complete", "summary": "final summary"}\n\n`;
+    xml += `    Only assign to agents listed above. RESPOND WITH JSON ONLY.\n`;
+    xml += `  </instruction>\n`;
+    xml += `</magentic-assign>`;
+
+    return xml;
+  }
+
+  private buildWorkerPrompt(
+    userMessage: string,
+    participants: MindContext[],
+    task: TaskLedgerItem,
+    ledger: TaskLedgerItem[],
+    context: OrchestrationContext,
+    forMind?: MindContext,
+  ): string {
+    const basePrompt = context.buildBasePrompt(userMessage, participants, forMind);
+
+    // Show completed tasks for context
+    const completedTasks = ledger.filter((t) => t.status === 'completed' && t.result);
+    let xml = '';
+
+    if (completedTasks.length > 0) {
+      xml += `<completed-tasks>\n`;
+      for (const t of completedTasks) {
+        xml += `  <task id="${escapeXml(t.id)}">${escapeXml(t.description)}: ${escapeXml(t.result!.slice(0, 200))}</task>\n`;
+      }
+      xml += `</completed-tasks>\n\n`;
+    }
+
+    xml += `<assigned-task id="${escapeXml(task.id)}">${escapeXml(task.description)}</assigned-task>\n`;
+    xml += `Complete the assigned task above. Provide a thorough response.\n\n`;
+
+    return xml + basePrompt;
+  }
+}

--- a/src/main/services/chatroom/orchestration/MagenticStrategy.ts
+++ b/src/main/services/chatroom/orchestration/MagenticStrategy.ts
@@ -4,7 +4,8 @@ import type {
   MagenticConfig,
   TaskLedgerItem,
 } from '../../../../shared/chatroom-types';
-import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import type { OrchestrationContext } from './types';
+import { BaseStrategy } from './types';
 import { ObservabilityEmitter } from './observability';
 import { escapeXml, textContent, extractJsonObject, stripControlJson } from './shared';
 import { sendToAgentWithRetry } from './stream-agent';
@@ -64,13 +65,12 @@ function parseManagerResponse(text: string): ManagerDecision | null {
  * Current limitation:
  * - Single-threaded execution (one worker per step, no parallel sub-tasks)
  */
-export class MagenticStrategy implements OrchestrationStrategy {
+export class MagenticStrategy extends BaseStrategy {
   readonly mode = 'magentic' as const;
-  private abortController: AbortController | null = null;
-  private currentUnsubs: (() => void)[] = [];
   private readonly config: MagenticConfig;
 
   constructor(config: MagenticConfig) {
+    super();
     this.config = config;
   }
 
@@ -82,7 +82,7 @@ export class MagenticStrategy implements OrchestrationStrategy {
   ): Promise<void> {
     if (participants.length === 0) return;
 
-    this.abortController = new AbortController();
+    this.begin();
 
     const obs = new ObservabilityEmitter('magentic');
     obs.start({ participantCount: participants.length, maxSteps: this.config.maxSteps });
@@ -136,7 +136,7 @@ export class MagenticStrategy implements OrchestrationStrategy {
         prompt: planPrompt,
         roundId,
         context,
-        abortSignal: this.abortController.signal,
+        abortSignal: this.abortController!.signal,
         unsubs: this.currentUnsubs,
         orchestrationMode: 'magentic',
         transformContent: (raw) => stripControlJson(raw, (a) => ['assign', 'complete', 'update-plan'].includes(a as string)),
@@ -171,7 +171,7 @@ export class MagenticStrategy implements OrchestrationStrategy {
     // ── Phase 2: Manager-driven execution loop ──
 
     for (step = 0; step < this.config.maxSteps; step++) {
-      if (this.abortController.signal.aborted) break;
+      if (this.isAborted) break;
 
       // Check if all tasks are completed
       const allDone = ledger.every(
@@ -192,7 +192,7 @@ export class MagenticStrategy implements OrchestrationStrategy {
           prompt: assignPrompt,
           roundId,
           context,
-          abortSignal: this.abortController.signal,
+          abortSignal: this.abortController!.signal,
           unsubs: this.currentUnsubs,
           orchestrationMode: 'magentic',
           transformContent: (raw) => stripControlJson(raw, (a) => ['assign', 'complete', 'update-plan'].includes(a as string)),
@@ -285,7 +285,7 @@ export class MagenticStrategy implements OrchestrationStrategy {
             prompt: workerPrompt,
             roundId,
             context,
-            abortSignal: this.abortController.signal,
+            abortSignal: this.abortController!.signal,
             unsubs: this.currentUnsubs,
             orchestrationMode: 'magentic',
           });
@@ -320,12 +320,6 @@ export class MagenticStrategy implements OrchestrationStrategy {
     }
 
     obs.end({ totalSteps: step, ledgerSize: ledger.length });
-  }
-
-  stop(): void {
-    this.abortController?.abort();
-    for (const unsub of this.currentUnsubs) unsub();
-    this.currentUnsubs = [];
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/services/chatroom/orchestration/SequentialStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/SequentialStrategy.test.ts
@@ -76,7 +76,7 @@ function createContext(
     evictSession: vi.fn((mindId: string) => {
       sessions.delete(mindId);
     }),
-    buildBasePrompt: vi.fn((_msg: string, _parts: MindContext[]) => '<message sender="You">test</message>'),
+    buildBasePrompt: vi.fn(() => '<message sender="You">test</message>'),
     emitEvent: vi.fn((event: ChatroomStreamEvent) => events.push(event)),
     persistMessage: vi.fn((msg: ChatroomMessage) => messages.push(msg)),
     getHistory: vi.fn(() => []),

--- a/src/main/services/chatroom/orchestration/SequentialStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/SequentialStrategy.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'test-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { SequentialStrategy } from './SequentialStrategy';
+import type { OrchestrationContext } from './types';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockSession() {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      const list = listeners.get(event);
+      if (!list) throw new Error('expected listener list');
+      list.push(cb);
+      const unsub = vi.fn(() => {
+        const cbs = listeners.get(event);
+        if (cbs) {
+          const idx = cbs.indexOf(cb);
+          if (idx >= 0) cbs.splice(idx, 1);
+        }
+      });
+      return unsub;
+    }),
+    _emit(event: string, data: unknown) {
+      for (const cb of listeners.get(event) ?? []) cb(data);
+    },
+    _listeners: listeners,
+  };
+}
+
+function autoIdleWith(session: ReturnType<typeof createMockSession>, content: string) {
+  session.send.mockImplementation(async () => {
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: 'sdk-msg-1', content },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+function makeMind(id: string, name: string): MindContext {
+  return {
+    mindId: id,
+    mindPath: `/minds/${id}`,
+    identity: { name, systemMessage: `I am ${name}` },
+    status: 'ready',
+  };
+}
+
+function createContext(
+  sessions: Map<string, ReturnType<typeof createMockSession>>,
+  overrides?: Partial<OrchestrationContext>,
+): OrchestrationContext {
+  const events: ChatroomStreamEvent[] = [];
+  const messages: ChatroomMessage[] = [];
+  return {
+    getOrCreateSession: vi.fn(async (mindId: string) => {
+      if (!sessions.has(mindId)) sessions.set(mindId, createMockSession());
+      return sessions.get(mindId)!;
+    }),
+    evictSession: vi.fn((mindId: string) => {
+      sessions.delete(mindId);
+    }),
+    buildBasePrompt: vi.fn((_msg: string, _parts: MindContext[]) => '<message sender="You">test</message>'),
+    emitEvent: vi.fn((event: ChatroomStreamEvent) => events.push(event)),
+    persistMessage: vi.fn((msg: ChatroomMessage) => messages.push(msg)),
+    getHistory: vi.fn(() => []),
+    orchestrationMode: 'sequential',
+    ...overrides,
+  };
+}
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SequentialStrategy', () => {
+  let sessions: Map<string, ReturnType<typeof createMockSession>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+    sessions = new Map();
+  });
+
+  it('calls agents sequentially, not in parallel', async () => {
+    const dudeSess = createMockSession();
+    const jarvisSess = createMockSession();
+    sessions.set('dude', dudeSess);
+    sessions.set('jarvis', jarvisSess);
+
+    const callOrder: string[] = [];
+    dudeSess.send.mockImplementation(async () => {
+      callOrder.push('dude');
+      setTimeout(() => {
+        dudeSess._emit('assistant.message', {
+          data: { messageId: 'sdk-1', content: 'Dude response' },
+        });
+        dudeSess._emit('session.idle', {});
+      }, 0);
+    });
+    jarvisSess.send.mockImplementation(async () => {
+      callOrder.push('jarvis');
+      setTimeout(() => {
+        jarvisSess._emit('assistant.message', {
+          data: { messageId: 'sdk-2', content: 'Jarvis response' },
+        });
+        jarvisSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const strategy = new SequentialStrategy();
+    const ctx = createContext(sessions);
+    const minds = [makeMind('dude', 'The Dude'), makeMind('jarvis', 'Jarvis')];
+
+    await strategy.execute('Hello', minds, 'round-1', ctx);
+
+    expect(callOrder).toEqual(['dude', 'jarvis']);
+    expect(dudeSess.send).toHaveBeenCalledTimes(1);
+    expect(jarvisSess.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("agent B's prompt contains agent A's response from same round", async () => {
+    const dudeSess = createMockSession();
+    const jarvisSess = createMockSession();
+    sessions.set('dude', dudeSess);
+    sessions.set('jarvis', jarvisSess);
+
+    autoIdleWith(dudeSess, 'Dude says hello');
+
+    // Capture Jarvis prompt
+    let jarvisPrompt = '';
+    jarvisSess.send.mockImplementation(async (opts: { prompt: string }) => {
+      jarvisPrompt = opts.prompt;
+      setTimeout(() => {
+        jarvisSess._emit('assistant.message', {
+          data: { messageId: 'sdk-2', content: 'Jarvis responds' },
+        });
+        jarvisSess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const strategy = new SequentialStrategy();
+    const ctx = createContext(sessions);
+    const minds = [makeMind('dude', 'The Dude'), makeMind('jarvis', 'Jarvis')];
+
+    await strategy.execute('Question?', minds, 'round-1', ctx);
+
+    expect(jarvisPrompt).toContain('<sequential-round>');
+    expect(jarvisPrompt).toContain('Dude says hello');
+    expect(jarvisPrompt).toContain('The Dude');
+  });
+
+  it('agent failure does not prevent subsequent agents', async () => {
+    const dudeSess = createMockSession();
+    const jarvisSess = createMockSession();
+    sessions.set('dude', dudeSess);
+    sessions.set('jarvis', jarvisSess);
+
+    dudeSess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        dudeSess._emit('session.error', { data: { message: 'dude broke' } });
+      }, 0);
+    });
+    autoIdleWith(jarvisSess, 'Jarvis is fine');
+
+    const strategy = new SequentialStrategy();
+    const ctx = createContext(sessions);
+    const minds = [makeMind('dude', 'The Dude'), makeMind('jarvis', 'Jarvis')];
+
+    await strategy.execute('Hello', minds, 'round-1', ctx);
+
+    expect(jarvisSess.send).toHaveBeenCalled();
+    expect(ctx.persistMessage).toHaveBeenCalled();
+  });
+
+  it('stop cancels current in-flight agent', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('assistant.message_delta', {
+          data: { messageId: 'sdk-1', deltaContent: 'partial...' },
+        });
+      }, 0);
+    });
+
+    const strategy = new SequentialStrategy();
+    const ctx = createContext(sessions);
+
+    const promise = strategy.execute('Hello', [makeMind('dude', 'The Dude')], 'round-1', ctx);
+
+    await vi.waitFor(() => expect(sess.send).toHaveBeenCalled());
+    strategy.stop();
+
+    await promise;
+  });
+
+  it('emits orchestration:turn-start for each agent', async () => {
+    const dudeSess = createMockSession();
+    const jarvisSess = createMockSession();
+    sessions.set('dude', dudeSess);
+    sessions.set('jarvis', jarvisSess);
+    autoIdleWith(dudeSess, 'hi');
+    autoIdleWith(jarvisSess, 'hi');
+
+    const strategy = new SequentialStrategy();
+    const ctx = createContext(sessions);
+    const minds = [makeMind('dude', 'The Dude'), makeMind('jarvis', 'Jarvis')];
+
+    await strategy.execute('Hello', minds, 'round-1', ctx);
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const turnStarts = events.filter((e) => e.event.type === 'orchestration:turn-start');
+    expect(turnStarts).toHaveLength(2);
+    expect(turnStarts[0].mindId).toBe('dude');
+    expect(turnStarts[1].mindId).toBe('jarvis');
+  });
+
+  it('does nothing with 0 participants', async () => {
+    const strategy = new SequentialStrategy();
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Hello', [], 'round-1', ctx);
+
+    expect(ctx.getOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('persists messages with sequential orchestrationMode', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    autoIdleWith(sess, 'reply');
+
+    const strategy = new SequentialStrategy();
+    const ctx = createContext(sessions);
+
+    await strategy.execute('Hello', [makeMind('dude', 'The Dude')], 'round-1', ctx);
+
+    const msg = (ctx.persistMessage as ReturnType<typeof vi.fn>).mock.calls[0][0] as ChatroomMessage;
+    expect(msg.orchestrationMode).toBe('sequential');
+  });
+
+  it('mode property is sequential', () => {
+    const strategy = new SequentialStrategy();
+    expect(strategy.mode).toBe('sequential');
+  });
+});

--- a/src/main/services/chatroom/orchestration/SequentialStrategy.ts
+++ b/src/main/services/chatroom/orchestration/SequentialStrategy.ts
@@ -1,6 +1,7 @@
 import type { MindContext } from '../../../../shared/types';
 import type { ChatroomMessage } from '../../../../shared/chatroom-types';
-import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import type { OrchestrationContext } from './types';
+import { BaseStrategy } from './types';
 import { sendToAgentWithRetry } from './stream-agent';
 import { escapeXml, textContent } from './shared';
 
@@ -8,10 +9,8 @@ import { escapeXml, textContent } from './shared';
 // SequentialStrategy — round-robin, each agent speaks in order
 // ---------------------------------------------------------------------------
 
-export class SequentialStrategy implements OrchestrationStrategy {
+export class SequentialStrategy extends BaseStrategy {
   readonly mode = 'sequential' as const;
-  private abortController: AbortController | null = null;
-  private currentUnsubs: (() => void)[] = [];
 
   async execute(
     userMessage: string,
@@ -21,11 +20,11 @@ export class SequentialStrategy implements OrchestrationStrategy {
   ): Promise<void> {
     if (participants.length === 0) return;
 
-    this.abortController = new AbortController();
+    this.begin();
     const roundResponses: ChatroomMessage[] = [];
 
     for (const mind of participants) {
-      if (this.abortController.signal.aborted) break;
+      if (this.isAborted) break;
 
       // Build prompt that includes responses from earlier agents in this round
       const prompt = this.buildSequentialPrompt(
@@ -53,7 +52,7 @@ export class SequentialStrategy implements OrchestrationStrategy {
         this.currentUnsubs = unsubs;
         const { message } = await sendToAgentWithRetry({
           mind, prompt, roundId, context,
-          abortSignal: this.abortController.signal,
+          abortSignal: this.abortController!.signal,
           unsubs,
           orchestrationMode: 'sequential',
         });
@@ -65,12 +64,6 @@ export class SequentialStrategy implements OrchestrationStrategy {
         // Continue to next agent — don't break the chain
       }
     }
-  }
-
-  stop(): void {
-    this.abortController?.abort();
-    for (const unsub of this.currentUnsubs) unsub();
-    this.currentUnsubs = [];
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/services/chatroom/orchestration/SequentialStrategy.ts
+++ b/src/main/services/chatroom/orchestration/SequentialStrategy.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from 'node:crypto';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+import type { OrchestrationStrategy, OrchestrationContext } from './types';
+import { isStaleSessionError } from '../../../../shared/sessionErrors';
+import type { CopilotSession } from '../../mind';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const XML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+function escapeXml(text: string): string {
+  return text.replace(/[&<>"']/g, (ch) => XML_ESCAPE_MAP[ch]);
+}
+
+function textContent(msg: ChatroomMessage): string {
+  return msg.blocks
+    .filter((b) => b.type === 'text')
+    .map((b) => (b as { content: string }).content)
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// SequentialStrategy — round-robin, each agent speaks in order
+// ---------------------------------------------------------------------------
+
+export class SequentialStrategy implements OrchestrationStrategy {
+  readonly mode = 'sequential' as const;
+  private abortController: AbortController | null = null;
+  private currentUnsubs: (() => void)[] = [];
+
+  async execute(
+    userMessage: string,
+    participants: MindContext[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void> {
+    if (participants.length === 0) return;
+
+    this.abortController = new AbortController();
+    const roundResponses: ChatroomMessage[] = [];
+
+    for (const mind of participants) {
+      if (this.abortController.signal.aborted) break;
+
+      // Build prompt that includes responses from earlier agents in this round
+      const prompt = this.buildSequentialPrompt(
+        userMessage,
+        participants,
+        roundResponses,
+        context,
+      );
+
+      // Emit turn-start orchestration event
+      context.emitEvent({
+        mindId: mind.mindId,
+        mindName: mind.identity.name,
+        messageId: '',
+        roundId,
+        event: {
+          type: 'orchestration:turn-start',
+          data: { speaker: mind.identity.name, speakerMindId: mind.mindId },
+        },
+      });
+
+      try {
+        const response = await this.sendToAgent(mind, prompt, roundId, context);
+        if (response) {
+          roundResponses.push(response);
+        }
+      } catch (err) {
+        console.error(`[Sequential] Agent ${mind.mindId} failed:`, err);
+        // Continue to next agent — don't break the chain
+      }
+    }
+  }
+
+  stop(): void {
+    this.abortController?.abort();
+    for (const unsub of this.currentUnsubs) unsub();
+    this.currentUnsubs = [];
+  }
+
+  // -------------------------------------------------------------------------
+  // Prompt building — includes prior agents' responses from this round
+  // -------------------------------------------------------------------------
+
+  private buildSequentialPrompt(
+    userMessage: string,
+    participants: MindContext[],
+    roundResponses: ChatroomMessage[],
+    context: OrchestrationContext,
+  ): string {
+    const basePrompt = context.buildBasePrompt(userMessage, participants);
+
+    if (roundResponses.length === 0) {
+      return basePrompt;
+    }
+
+    // Inject current-round responses before the user message
+    let xml = `<sequential-round>\n`;
+    for (const msg of roundResponses) {
+      xml += `  <response speaker="${escapeXml(msg.sender.name)}">${escapeXml(textContent(msg))}</response>\n`;
+    }
+    xml += `</sequential-round>\n`;
+    xml += `The above are responses from other agents in this round. Build on or respond to their points.\n\n`;
+
+    return xml + basePrompt;
+  }
+
+  // -------------------------------------------------------------------------
+  // Agent communication
+  // -------------------------------------------------------------------------
+
+  private async sendToAgent(
+    mind: MindContext,
+    prompt: string,
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<ChatroomMessage | null> {
+    const session = await context.getOrCreateSession(mind.mindId);
+    try {
+      return await this.streamToAgent(session, mind, prompt, roundId, context);
+    } catch (err) {
+      if (!isStaleSessionError(err)) throw err;
+      context.evictSession(mind.mindId);
+      const freshSession = await context.getOrCreateSession(mind.mindId);
+      return await this.streamToAgent(freshSession, mind, prompt, roundId, context);
+    }
+  }
+
+  private async streamToAgent(
+    session: CopilotSession,
+    mind: MindContext,
+    prompt: string,
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<ChatroomMessage | null> {
+    const messageId = randomUUID();
+    const unsubs: (() => void)[] = [];
+    this.currentUnsubs = unsubs;
+
+    const emitEvent = (event: ChatroomStreamEvent['event']) => {
+      if (!this.abortController?.signal.aborted) {
+        context.emitEvent({
+          mindId: mind.mindId,
+          mindName: mind.identity.name,
+          messageId,
+          roundId,
+          event,
+        } satisfies ChatroomStreamEvent);
+      }
+    };
+
+    let finalContent = '';
+
+    try {
+      unsubs.push(
+        session.on('assistant.message_delta', (e) => {
+          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.message', (e) => {
+          if (e.data.content) {
+            finalContent = e.data.content;
+            emitEvent({
+              type: 'message_final',
+              sdkMessageId: e.data.messageId,
+              content: e.data.content,
+            });
+          }
+        }),
+      );
+
+      unsubs.push(
+        session.on('assistant.reasoning_delta', (e) => {
+          emitEvent({
+            type: 'reasoning',
+            reasoningId: e.data.reasoningId,
+            content: e.data.deltaContent,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_start', (e) => {
+          emitEvent({
+            type: 'tool_start',
+            toolCallId: e.data.toolCallId,
+            toolName: e.data.toolName,
+            args: e.data.arguments,
+            parentToolCallId: e.data.parentToolCallId,
+          });
+        }),
+      );
+
+      unsubs.push(
+        session.on('tool.execution_complete', (e) => {
+          emitEvent({
+            type: 'tool_done',
+            toolCallId: e.data.toolCallId,
+            success: e.data.success,
+            result: e.data.result?.content,
+            error: e.data.error?.message,
+          });
+        }),
+      );
+
+      await session.send({ prompt });
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(resolve, 300_000);
+
+        const unsubIdle = session.on('session.idle', () => {
+          clearTimeout(timeout);
+          unsubIdle();
+          resolve();
+        });
+        unsubs.push(unsubIdle);
+
+        const unsubError = session.on('session.error', (e) => {
+          clearTimeout(timeout);
+          unsubError();
+          reject(new Error(e.data.message));
+        });
+        unsubs.push(unsubError);
+
+        if (this.abortController) {
+          this.abortController.signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+            { once: true },
+          );
+        }
+      });
+
+      if (this.abortController?.signal.aborted) return null;
+
+      if (finalContent) {
+        const agentMsg: ChatroomMessage = {
+          id: messageId,
+          role: 'assistant',
+          blocks: [{ type: 'text', content: finalContent }],
+          timestamp: Date.now(),
+          sender: { mindId: mind.mindId, name: mind.identity.name },
+          roundId,
+          orchestrationMode: 'sequential',
+        };
+        context.persistMessage(agentMsg);
+        emitEvent({ type: 'done' });
+        return agentMsg;
+      }
+
+      emitEvent({ type: 'done' });
+      return null;
+    } catch (err) {
+      if (!this.abortController?.signal.aborted) {
+        if (isStaleSessionError(err)) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        emitEvent({ type: 'error', message });
+      }
+      return null;
+    } finally {
+      for (const unsub of unsubs) unsub();
+      this.currentUnsubs = [];
+    }
+  }
+}

--- a/src/main/services/chatroom/orchestration/SequentialStrategy.ts
+++ b/src/main/services/chatroom/orchestration/SequentialStrategy.ts
@@ -1,32 +1,8 @@
-import { randomUUID } from 'node:crypto';
 import type { MindContext } from '../../../../shared/types';
-import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+import type { ChatroomMessage } from '../../../../shared/chatroom-types';
 import type { OrchestrationStrategy, OrchestrationContext } from './types';
-import { isStaleSessionError } from '../../../../shared/sessionErrors';
-import type { CopilotSession } from '../../mind';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const XML_ESCAPE_MAP: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&apos;',
-};
-
-function escapeXml(text: string): string {
-  return text.replace(/[&<>"']/g, (ch) => XML_ESCAPE_MAP[ch]);
-}
-
-function textContent(msg: ChatroomMessage): string {
-  return msg.blocks
-    .filter((b) => b.type === 'text')
-    .map((b) => (b as { content: string }).content)
-    .join('');
-}
+import { sendToAgentWithRetry } from './stream-agent';
+import { escapeXml, textContent } from './shared';
 
 // ---------------------------------------------------------------------------
 // SequentialStrategy — round-robin, each agent speaks in order
@@ -57,6 +33,7 @@ export class SequentialStrategy implements OrchestrationStrategy {
         participants,
         roundResponses,
         context,
+        mind,
       );
 
       // Emit turn-start orchestration event
@@ -72,12 +49,19 @@ export class SequentialStrategy implements OrchestrationStrategy {
       });
 
       try {
-        const response = await this.sendToAgent(mind, prompt, roundId, context);
-        if (response) {
-          roundResponses.push(response);
+        const unsubs: (() => void)[] = [];
+        this.currentUnsubs = unsubs;
+        const { message } = await sendToAgentWithRetry({
+          mind, prompt, roundId, context,
+          abortSignal: this.abortController.signal,
+          unsubs,
+          orchestrationMode: 'sequential',
+        });
+        if (message) {
+          roundResponses.push(message);
         }
       } catch (err) {
-        console.error(`[Sequential] Agent ${mind.mindId} failed:`, err);
+        console.error(`[Chatroom:Sequential] Agent ${mind.mindId} failed:`, err);
         // Continue to next agent — don't break the chain
       }
     }
@@ -98,8 +82,9 @@ export class SequentialStrategy implements OrchestrationStrategy {
     participants: MindContext[],
     roundResponses: ChatroomMessage[],
     context: OrchestrationContext,
+    forMind?: MindContext,
   ): string {
-    const basePrompt = context.buildBasePrompt(userMessage, participants);
+    const basePrompt = context.buildBasePrompt(userMessage, participants, forMind);
 
     if (roundResponses.length === 0) {
       return basePrompt;
@@ -114,168 +99,5 @@ export class SequentialStrategy implements OrchestrationStrategy {
     xml += `The above are responses from other agents in this round. Build on or respond to their points.\n\n`;
 
     return xml + basePrompt;
-  }
-
-  // -------------------------------------------------------------------------
-  // Agent communication
-  // -------------------------------------------------------------------------
-
-  private async sendToAgent(
-    mind: MindContext,
-    prompt: string,
-    roundId: string,
-    context: OrchestrationContext,
-  ): Promise<ChatroomMessage | null> {
-    const session = await context.getOrCreateSession(mind.mindId);
-    try {
-      return await this.streamToAgent(session, mind, prompt, roundId, context);
-    } catch (err) {
-      if (!isStaleSessionError(err)) throw err;
-      context.evictSession(mind.mindId);
-      const freshSession = await context.getOrCreateSession(mind.mindId);
-      return await this.streamToAgent(freshSession, mind, prompt, roundId, context);
-    }
-  }
-
-  private async streamToAgent(
-    session: CopilotSession,
-    mind: MindContext,
-    prompt: string,
-    roundId: string,
-    context: OrchestrationContext,
-  ): Promise<ChatroomMessage | null> {
-    const messageId = randomUUID();
-    const unsubs: (() => void)[] = [];
-    this.currentUnsubs = unsubs;
-
-    const emitEvent = (event: ChatroomStreamEvent['event']) => {
-      if (!this.abortController?.signal.aborted) {
-        context.emitEvent({
-          mindId: mind.mindId,
-          mindName: mind.identity.name,
-          messageId,
-          roundId,
-          event,
-        } satisfies ChatroomStreamEvent);
-      }
-    };
-
-    let finalContent = '';
-
-    try {
-      unsubs.push(
-        session.on('assistant.message_delta', (e) => {
-          emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.message', (e) => {
-          if (e.data.content) {
-            finalContent = e.data.content;
-            emitEvent({
-              type: 'message_final',
-              sdkMessageId: e.data.messageId,
-              content: e.data.content,
-            });
-          }
-        }),
-      );
-
-      unsubs.push(
-        session.on('assistant.reasoning_delta', (e) => {
-          emitEvent({
-            type: 'reasoning',
-            reasoningId: e.data.reasoningId,
-            content: e.data.deltaContent,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_start', (e) => {
-          emitEvent({
-            type: 'tool_start',
-            toolCallId: e.data.toolCallId,
-            toolName: e.data.toolName,
-            args: e.data.arguments,
-            parentToolCallId: e.data.parentToolCallId,
-          });
-        }),
-      );
-
-      unsubs.push(
-        session.on('tool.execution_complete', (e) => {
-          emitEvent({
-            type: 'tool_done',
-            toolCallId: e.data.toolCallId,
-            success: e.data.success,
-            result: e.data.result?.content,
-            error: e.data.error?.message,
-          });
-        }),
-      );
-
-      await session.send({ prompt });
-
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(resolve, 300_000);
-
-        const unsubIdle = session.on('session.idle', () => {
-          clearTimeout(timeout);
-          unsubIdle();
-          resolve();
-        });
-        unsubs.push(unsubIdle);
-
-        const unsubError = session.on('session.error', (e) => {
-          clearTimeout(timeout);
-          unsubError();
-          reject(new Error(e.data.message));
-        });
-        unsubs.push(unsubError);
-
-        if (this.abortController) {
-          this.abortController.signal.addEventListener(
-            'abort',
-            () => {
-              clearTimeout(timeout);
-              resolve();
-            },
-            { once: true },
-          );
-        }
-      });
-
-      if (this.abortController?.signal.aborted) return null;
-
-      if (finalContent) {
-        const agentMsg: ChatroomMessage = {
-          id: messageId,
-          role: 'assistant',
-          blocks: [{ type: 'text', content: finalContent }],
-          timestamp: Date.now(),
-          sender: { mindId: mind.mindId, name: mind.identity.name },
-          roundId,
-          orchestrationMode: 'sequential',
-        };
-        context.persistMessage(agentMsg);
-        emitEvent({ type: 'done' });
-        return agentMsg;
-      }
-
-      emitEvent({ type: 'done' });
-      return null;
-    } catch (err) {
-      if (!this.abortController?.signal.aborted) {
-        if (isStaleSessionError(err)) throw err;
-        const message = err instanceof Error ? err.message : String(err);
-        emitEvent({ type: 'error', message });
-      }
-      return null;
-    } finally {
-      for (const unsub of unsubs) unsub();
-      this.currentUnsubs = [];
-    }
   }
 }

--- a/src/main/services/chatroom/orchestration/approval-gate.test.ts
+++ b/src/main/services/chatroom/orchestration/approval-gate.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'approval-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { ApprovalGate } from './approval-gate';
+import type { ApprovalRequest, ApprovalDecision } from '../../../../shared/chatroom-types';
+import { ObservabilityEmitter } from './observability';
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `approval-${++uuidCounter}`);
+}
+
+describe('ApprovalGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+  });
+
+  // -------------------------------------------------------------------------
+  // Classification
+  // -------------------------------------------------------------------------
+
+  it('identifies side-effect tools as requiring approval', () => {
+    const gate = new ApprovalGate();
+
+    expect(gate.requiresApproval('send_email')).toBe(true);
+    expect(gate.requiresApproval('teams_post')).toBe(true);
+    expect(gate.requiresApproval('calendar_create')).toBe(true);
+    expect(gate.requiresApproval('delete_resource')).toBe(true);
+    expect(gate.requiresApproval('webhook_trigger')).toBe(true);
+  });
+
+  it('does not require approval for safe tools', () => {
+    const gate = new ApprovalGate();
+
+    expect(gate.requiresApproval('grep')).toBe(false);
+    expect(gate.requiresApproval('read_file')).toBe(false);
+    expect(gate.requiresApproval('list_agents')).toBe(false);
+    expect(gate.requiresApproval('search')).toBe(false);
+  });
+
+  it('respects allowedTools override', () => {
+    const gate = new ApprovalGate({
+      allowedTools: new Set(['send_email']),
+    });
+
+    // send_email is normally a side-effect but is in the allowlist
+    expect(gate.requiresApproval('send_email')).toBe(false);
+    // teams_post is still a side-effect
+    expect(gate.requiresApproval('teams_post')).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Default deny
+  // -------------------------------------------------------------------------
+
+  it('default-denies when no approval handler is registered', async () => {
+    const gate = new ApprovalGate();
+
+    const result = await gate.gate('agent-1', 'send_email', { to: 'user@example.com' }, 'sending report');
+
+    expect(result.approved).toBe(false);
+    expect(result.correlationId).toBe('approval-1');
+  });
+
+  // -------------------------------------------------------------------------
+  // Approval flow
+  // -------------------------------------------------------------------------
+
+  it('calls approval handler and respects approval', async () => {
+    const gate = new ApprovalGate();
+    const handler = vi.fn(async (req: ApprovalRequest): Promise<ApprovalDecision> => ({
+      correlationId: req.correlationId,
+      approved: true,
+      decidedBy: 'admin',
+      timestamp: Date.now(),
+    }));
+    gate.setApprovalHandler(handler);
+
+    const result = await gate.gate('agent-1', 'send_email', { to: 'user@example.com' }, 'sending report');
+
+    expect(result.approved).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'agent-1',
+        toolName: 'send_email',
+        riskLevel: 'high', // email = high risk
+      }),
+    );
+  });
+
+  it('calls approval handler and respects denial', async () => {
+    const gate = new ApprovalGate();
+    gate.setApprovalHandler(async (req) => ({
+      correlationId: req.correlationId,
+      approved: false,
+      decidedBy: 'admin',
+      timestamp: Date.now(),
+      reason: 'Denied by policy',
+    }));
+
+    const result = await gate.gate('agent-1', 'delete_resource', {}, 'cleanup');
+
+    expect(result.approved).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Parameter redaction
+  // -------------------------------------------------------------------------
+
+  it('redacts sensitive parameters in approval request', async () => {
+    const gate = new ApprovalGate();
+    let capturedRequest: ApprovalRequest | null = null;
+    gate.setApprovalHandler(async (req) => {
+      capturedRequest = req;
+      return {
+        correlationId: req.correlationId,
+        approved: true,
+        decidedBy: 'admin',
+        timestamp: Date.now(),
+      };
+    });
+
+    await gate.gate('agent-1', 'send_email', {
+      to: 'user@example.com',
+      password: 'secret123',
+      token: 'abc',
+      subject: 'Hello',
+    }, 'test');
+
+    expect(capturedRequest).not.toBeNull();
+    expect(capturedRequest!.parameters.password).toBe('[REDACTED]');
+    expect(capturedRequest!.parameters.token).toBe('[REDACTED]');
+    expect(capturedRequest!.parameters.to).toBe('user@example.com'); // not sensitive
+  });
+
+  // -------------------------------------------------------------------------
+  // Demo mode
+  // -------------------------------------------------------------------------
+
+  it('auto-approves in demo mode but still emits events', async () => {
+    const gate = new ApprovalGate({ demoMode: true });
+
+    const result = await gate.gate('agent-1', 'send_email', { to: 'test' }, 'demo');
+
+    expect(result.approved).toBe(true);
+
+    // Verify audit log contains demo-mode decision
+    const log = gate.getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].decision.decidedBy).toBe('demo-mode');
+  });
+
+  // -------------------------------------------------------------------------
+  // Audit log
+  // -------------------------------------------------------------------------
+
+  it('maintains audit log of all decisions', async () => {
+    const gate = new ApprovalGate({ demoMode: true });
+
+    await gate.gate('agent-1', 'send_email', {}, 'first');
+    await gate.gate('agent-2', 'delete_resource', {}, 'second');
+
+    const log = gate.getAuditLog();
+    expect(log).toHaveLength(2);
+    expect(log[0].request.actorId).toBe('agent-1');
+    expect(log[1].request.actorId).toBe('agent-2');
+  });
+
+  // -------------------------------------------------------------------------
+  // Skips gate for non-side-effect tools
+  // -------------------------------------------------------------------------
+
+  it('passes through non-side-effect tools without gating', async () => {
+    const gate = new ApprovalGate();
+    const handler = vi.fn();
+    gate.setApprovalHandler(handler);
+
+    const result = await gate.gate('agent-1', 'grep', { pattern: 'test' }, 'searching');
+
+    expect(result.approved).toBe(true);
+    expect(result.correlationId).toBe(''); // No correlation — not gated
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Observability integration
+  // -------------------------------------------------------------------------
+
+  it('emits observability events when approval is requested', async () => {
+    const obs = new ObservabilityEmitter('handoff');
+    const events: unknown[] = [];
+    obs.on((e) => events.push(e));
+
+    const gate = new ApprovalGate({ observability: obs, demoMode: true });
+
+    await gate.gate('agent-1', 'send_email', {}, 'test');
+
+    const kinds = events.map((e) => (e as { kind: string }).kind);
+    expect(kinds).toContain('approval_requested');
+    expect(kinds).toContain('approval_approved');
+  });
+
+  // -------------------------------------------------------------------------
+  // Risk classification
+  // -------------------------------------------------------------------------
+
+  it('classifies risk levels correctly', async () => {
+    const gate = new ApprovalGate({ demoMode: true });
+
+    await gate.gate('a', 'delete_resource', {}, '');
+    await gate.gate('a', 'send_email', {}, '');
+    await gate.gate('a', 'write_file', {}, '');
+    await gate.gate('a', 'update_config', {}, '');
+
+    const log = gate.getAuditLog();
+    expect(log[0].request.riskLevel).toBe('critical'); // delete
+    expect(log[1].request.riskLevel).toBe('high');     // send/email
+    expect(log[2].request.riskLevel).toBe('medium');   // write
+    expect(log[3].request.riskLevel).toBe('medium');   // update
+  });
+
+  // -------------------------------------------------------------------------
+  // Must-never rules
+  // -------------------------------------------------------------------------
+
+  it('never logs raw chain-of-thought in audit log', async () => {
+    const gate = new ApprovalGate({ demoMode: true });
+
+    await gate.gate('agent-1', 'send_email', {
+      body: 'This is a long email body with chain of thought reasoning that should be redacted',
+      content: 'Internal thoughts about the task',
+    }, 'test');
+
+    const log = gate.getAuditLog();
+    expect(log[0].request.parameters.body).toBe('[REDACTED]');
+    expect(log[0].request.parameters.content).toBe('[REDACTED]');
+  });
+});

--- a/src/main/services/chatroom/orchestration/approval-gate.ts
+++ b/src/main/services/chatroom/orchestration/approval-gate.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  ApprovalRequest,
+  ApprovalDecision,
+  RiskLevel,
+} from '../../../../shared/chatroom-types';
+import { redactParameters } from './observability';
+import type { ObservabilityEmitter } from './observability';
+
+// ---------------------------------------------------------------------------
+// Side-effect tool classification
+// ---------------------------------------------------------------------------
+
+/** Default set of tool name patterns considered side-effects */
+const DEFAULT_SIDE_EFFECT_PATTERNS: readonly string[] = [
+  'email', 'mail', 'calendar', 'teams', 'slack', 'post', 'send',
+  'write', 'delete', 'update', 'create', 'deploy', 'publish',
+  'notify', 'webhook', 'http_request', 'fetch_external',
+];
+
+// ---------------------------------------------------------------------------
+// ApprovalGate — intercepts side-effect tool calls
+// ---------------------------------------------------------------------------
+
+export interface ApprovalGateConfig {
+  /** Tool names/patterns requiring approval */
+  sideEffectPatterns?: readonly string[];
+  /** Known-safe tools that never need approval */
+  allowedTools?: ReadonlySet<string>;
+  /** Demo mode: still gated, but auto-approves after emitting the event */
+  demoMode?: boolean;
+  /** Observability emitter for structured events */
+  observability?: ObservabilityEmitter;
+}
+
+export type ApprovalHandler = (request: ApprovalRequest) => Promise<ApprovalDecision>;
+
+export class ApprovalGate {
+  private readonly sideEffectPatterns: readonly string[];
+  private readonly allowedTools: ReadonlySet<string>;
+  private readonly demoMode: boolean;
+  private readonly observability?: ObservabilityEmitter;
+  private approvalHandler: ApprovalHandler | null = null;
+  private readonly log: ApprovalLogEntry[] = [];
+
+  constructor(config: ApprovalGateConfig = {}) {
+    this.sideEffectPatterns = config.sideEffectPatterns ?? DEFAULT_SIDE_EFFECT_PATTERNS;
+    this.allowedTools = config.allowedTools ?? new Set();
+    this.demoMode = config.demoMode ?? false;
+    this.observability = config.observability;
+  }
+
+  /** Register the handler that surfaces approval requests to the user/system */
+  setApprovalHandler(handler: ApprovalHandler): void {
+    this.approvalHandler = handler;
+  }
+
+  /**
+   * Check whether a tool call requires approval.
+   * Returns true if the tool is classified as a side-effect.
+   */
+  requiresApproval(toolName: string): boolean {
+    if (this.allowedTools.has(toolName)) return false;
+    const lower = toolName.toLowerCase();
+    return this.sideEffectPatterns.some((p) => lower.includes(p));
+  }
+
+  /**
+   * Gate a tool invocation. If the tool is a side-effect:
+   * 1. Emit approval_requested event
+   * 2. Wait for approve/deny
+   * 3. Log decision
+   * 4. Return whether to proceed
+   *
+   * Default-deny for unknown tools with no handler.
+   */
+  async gate(
+    actorId: string,
+    toolName: string,
+    parameters: Record<string, unknown>,
+    reason: string = '',
+  ): Promise<{ approved: boolean; correlationId: string }> {
+    if (!this.requiresApproval(toolName)) {
+      return { approved: true, correlationId: '' };
+    }
+
+    const correlationId = randomUUID();
+    const riskLevel = this.classifyRisk(toolName);
+
+    const request: ApprovalRequest = {
+      correlationId,
+      actorId,
+      toolName,
+      parameters: redactParameters(parameters),
+      reason,
+      riskLevel,
+      timestamp: Date.now(),
+    };
+
+    // Emit observability event
+    this.observability?.emit('approval_requested', {
+      correlationId,
+      actorId,
+      toolName,
+      riskLevel,
+    });
+
+    let decision: ApprovalDecision;
+
+    if (this.demoMode) {
+      // Demo mode: auto-approve but still emit the event for visibility
+      decision = {
+        correlationId,
+        approved: true,
+        decidedBy: 'demo-mode',
+        timestamp: Date.now(),
+        reason: 'Auto-approved in demo mode',
+      };
+    } else if (this.approvalHandler) {
+      decision = await this.approvalHandler(request);
+    } else {
+      // Default deny: no handler registered
+      decision = {
+        correlationId,
+        approved: false,
+        decidedBy: 'system',
+        timestamp: Date.now(),
+        reason: 'No approval handler registered — default deny',
+      };
+    }
+
+    // Log decision
+    this.log.push({
+      request,
+      decision,
+    });
+
+    // Emit observability event
+    this.observability?.emit(
+      decision.approved ? 'approval_approved' : 'approval_denied',
+      {
+        correlationId,
+        actorId,
+        toolName,
+        decidedBy: decision.decidedBy,
+      },
+    );
+
+    return { approved: decision.approved, correlationId };
+  }
+
+  /** Get the audit log (non-sensitive, redacted parameters) */
+  getAuditLog(): readonly ApprovalLogEntry[] {
+    return [...this.log];
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private classifyRisk(toolName: string): RiskLevel {
+    const lower = toolName.toLowerCase();
+    if (lower.includes('delete') || lower.includes('deploy')) return 'critical';
+    if (lower.includes('email') || lower.includes('teams') || lower.includes('send')) return 'high';
+    if (lower.includes('write') || lower.includes('update') || lower.includes('create')) return 'medium';
+    return 'low';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Audit log entry
+// ---------------------------------------------------------------------------
+
+export interface ApprovalLogEntry {
+  request: ApprovalRequest;
+  decision: ApprovalDecision;
+}

--- a/src/main/services/chatroom/orchestration/index.ts
+++ b/src/main/services/chatroom/orchestration/index.ts
@@ -7,6 +7,7 @@ import { HandoffStrategy } from './HandoffStrategy';
 import { MagenticStrategy } from './MagenticStrategy';
 
 export type { OrchestrationStrategy, OrchestrationContext } from './types';
+export { BaseStrategy } from './types';
 export { ConcurrentStrategy } from './ConcurrentStrategy';
 export { SequentialStrategy } from './SequentialStrategy';
 export { GroupChatStrategy } from './GroupChatStrategy';

--- a/src/main/services/chatroom/orchestration/index.ts
+++ b/src/main/services/chatroom/orchestration/index.ts
@@ -1,0 +1,33 @@
+import type { OrchestrationMode, GroupChatConfig } from '../../../../shared/chatroom-types';
+import type { OrchestrationStrategy } from './types';
+import { ConcurrentStrategy } from './ConcurrentStrategy';
+import { SequentialStrategy } from './SequentialStrategy';
+import { GroupChatStrategy } from './GroupChatStrategy';
+
+export type { OrchestrationStrategy, OrchestrationContext } from './types';
+export { ConcurrentStrategy } from './ConcurrentStrategy';
+export { SequentialStrategy } from './SequentialStrategy';
+export { GroupChatStrategy } from './GroupChatStrategy';
+
+export function createStrategy(
+  mode: OrchestrationMode,
+  groupChatConfig?: GroupChatConfig,
+): OrchestrationStrategy {
+  switch (mode) {
+    case 'concurrent':
+      return new ConcurrentStrategy();
+    case 'sequential':
+      return new SequentialStrategy();
+    case 'group-chat': {
+      if (!groupChatConfig) {
+        throw new Error('GroupChatConfig is required for group-chat orchestration');
+      }
+      return new GroupChatStrategy(groupChatConfig);
+    }
+    case 'handoff':
+    case 'magentic':
+      throw new Error(`Orchestration mode "${mode}" is not yet implemented`);
+    default:
+      return new ConcurrentStrategy();
+  }
+}

--- a/src/main/services/chatroom/orchestration/index.ts
+++ b/src/main/services/chatroom/orchestration/index.ts
@@ -1,17 +1,26 @@
-import type { OrchestrationMode, GroupChatConfig } from '../../../../shared/chatroom-types';
+import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig } from '../../../../shared/chatroom-types';
 import type { OrchestrationStrategy } from './types';
 import { ConcurrentStrategy } from './ConcurrentStrategy';
 import { SequentialStrategy } from './SequentialStrategy';
 import { GroupChatStrategy } from './GroupChatStrategy';
+import { HandoffStrategy } from './HandoffStrategy';
+import { MagenticStrategy } from './MagenticStrategy';
 
 export type { OrchestrationStrategy, OrchestrationContext } from './types';
 export { ConcurrentStrategy } from './ConcurrentStrategy';
 export { SequentialStrategy } from './SequentialStrategy';
 export { GroupChatStrategy } from './GroupChatStrategy';
+export { HandoffStrategy } from './HandoffStrategy';
+export { MagenticStrategy } from './MagenticStrategy';
+export { ObservabilityEmitter, redactParameters } from './observability';
+export { ApprovalGate } from './approval-gate';
+export type { ApprovalGateConfig, ApprovalHandler, ApprovalLogEntry } from './approval-gate';
 
 export function createStrategy(
   mode: OrchestrationMode,
   groupChatConfig?: GroupChatConfig,
+  handoffConfig?: HandoffConfig,
+  magneticConfig?: MagenticConfig,
 ): OrchestrationStrategy {
   switch (mode) {
     case 'concurrent':
@@ -24,10 +33,18 @@ export function createStrategy(
       }
       return new GroupChatStrategy(groupChatConfig);
     }
-    case 'handoff':
-    case 'magentic':
-      throw new Error(`Orchestration mode "${mode}" is not yet implemented`);
-    default:
-      return new ConcurrentStrategy();
+    case 'handoff': {
+      return new HandoffStrategy(handoffConfig ?? { maxHandoffHops: 5 });
+    }
+    case 'magentic': {
+      if (!magneticConfig) {
+        throw new Error('MagenticConfig is required for magentic orchestration');
+      }
+      return new MagenticStrategy(magneticConfig);
+    }
+    default: {
+      const _exhaustive: never = mode;
+      throw new Error(`Unknown orchestration mode: ${_exhaustive}`);
+    }
   }
 }

--- a/src/main/services/chatroom/orchestration/observability.test.ts
+++ b/src/main/services/chatroom/orchestration/observability.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:crypto
+const mockRandomUUID = vi.fn(() => 'obs-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { ObservabilityEmitter, redactParameters } from './observability';
+import type { ObservabilityEvent } from './observability';
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `obs-${++uuidCounter}`);
+}
+
+describe('ObservabilityEmitter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+  });
+
+  it('emits structured events with correlationId', () => {
+    const emitter = new ObservabilityEmitter('handoff');
+    const events: ObservabilityEvent[] = [];
+    emitter.on((e) => events.push(e));
+
+    emitter.start({ participantCount: 3 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('orchestration_start');
+    expect(events[0].correlationId).toBe('obs-1');
+    expect(events[0].orchestrationMode).toBe('handoff');
+    expect(events[0].data.participantCount).toBe(3);
+  });
+
+  it('emits start and end events', () => {
+    const emitter = new ObservabilityEmitter('sequential');
+    const events: ObservabilityEvent[] = [];
+    emitter.on((e) => events.push(e));
+
+    emitter.start();
+    emitter.end({ terminationReason: 'DONE' });
+
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual(['orchestration_start', 'orchestration_end']);
+  });
+
+  it('emits agent step events', () => {
+    const emitter = new ObservabilityEmitter('magentic');
+    const events: ObservabilityEvent[] = [];
+    emitter.on((e) => events.push(e));
+
+    emitter.agentStep('mind-1', { hop: 0 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('per_agent_step');
+    expect(events[0].data.mindId).toBe('mind-1');
+  });
+
+  it('emits tool call events with redacted parameters', () => {
+    const emitter = new ObservabilityEmitter('handoff');
+    const events: ObservabilityEvent[] = [];
+    emitter.on((e) => events.push(e));
+
+    emitter.toolCallAttempted('mind-1', 'send_email', {
+      to: 'user@example.com',
+      password: 'secret',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('tool_call_attempted');
+    const params = events[0].data.parameters as Record<string, unknown>;
+    expect(params.to).toBe('user@example.com');
+    expect(params.password).toBe('[REDACTED]');
+  });
+
+  it('supports listener removal', () => {
+    const emitter = new ObservabilityEmitter('concurrent');
+    const events: ObservabilityEvent[] = [];
+    const unsub = emitter.on((e) => events.push(e));
+
+    emitter.start();
+    unsub();
+    emitter.end();
+
+    expect(events).toHaveLength(1); // Only start, not end
+  });
+
+  it('listener errors do not break emission', () => {
+    const emitter = new ObservabilityEmitter('concurrent');
+    const events: ObservabilityEvent[] = [];
+
+    emitter.on(() => {
+      throw new Error('listener exploded');
+    });
+    emitter.on((e) => events.push(e));
+
+    emitter.start();
+
+    // Second listener should still receive the event
+    expect(events).toHaveLength(1);
+  });
+
+  it('uses provided correlationId', () => {
+    const emitter = new ObservabilityEmitter('handoff', 'custom-id');
+    const events: ObservabilityEvent[] = [];
+    emitter.on((e) => events.push(e));
+
+    emitter.start();
+
+    expect(events[0].correlationId).toBe('custom-id');
+  });
+});
+
+describe('redactParameters', () => {
+  it('redacts sensitive keys', () => {
+    const result = redactParameters({
+      password: 'secret',
+      token: 'abc',
+      apiKey: 'key',
+      authorization: 'Bearer xxx',
+      safe: 'value',
+    });
+
+    expect(result.password).toBe('[REDACTED]');
+    expect(result.token).toBe('[REDACTED]');
+    expect(result.apiKey).toBe('[REDACTED]');
+    expect(result.authorization).toBe('[REDACTED]');
+    expect(result.safe).toBe('value');
+  });
+
+  it('truncates long string values', () => {
+    const longString = 'x'.repeat(300);
+    const result = redactParameters({ description: longString });
+
+    expect((result.description as string).length).toBeLessThan(300);
+    expect((result.description as string)).toContain('…[truncated]');
+  });
+
+  it('preserves non-sensitive short values', () => {
+    const result = redactParameters({ name: 'Agent A', count: 5 });
+    expect(result.name).toBe('Agent A');
+    expect(result.count).toBe(5);
+  });
+});

--- a/src/main/services/chatroom/orchestration/observability.ts
+++ b/src/main/services/chatroom/orchestration/observability.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from 'node:crypto';
+import type { OrchestrationMode } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Structured observability events — safe metadata only, no chain-of-thought
+// ---------------------------------------------------------------------------
+
+/** Redaction keys — values for these parameter keys are replaced with '[REDACTED]' */
+const REDACTED_KEYS = new Set([
+  'password', 'secret', 'token', 'apikey', 'api_key', 'authorization',
+  'cookie', 'credential', 'body', 'content', 'message',
+]);
+
+export function redactParameters(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (REDACTED_KEYS.has(key.toLowerCase())) {
+      redacted[key] = '[REDACTED]';
+    } else if (typeof value === 'string' && value.length > 200) {
+      redacted[key] = value.slice(0, 200) + '…[truncated]';
+    } else {
+      redacted[key] = value;
+    }
+  }
+  return redacted;
+}
+
+// ---------------------------------------------------------------------------
+// Event schema
+// ---------------------------------------------------------------------------
+
+export type ObservabilityEventKind =
+  | 'orchestration_start'
+  | 'orchestration_end'
+  | 'per_agent_step'
+  | 'tool_call_attempted'
+  | 'approval_requested'
+  | 'approval_approved'
+  | 'approval_denied'
+  | 'failure'
+  | 'timeout'
+  | 'termination_reason';
+
+export interface ObservabilityEvent {
+  kind: ObservabilityEventKind;
+  correlationId: string;
+  timestamp: number;
+  orchestrationMode: OrchestrationMode;
+  data: Record<string, unknown>;
+}
+
+export type ObservabilityListener = (event: ObservabilityEvent) => void;
+
+// ---------------------------------------------------------------------------
+// ObservabilityEmitter — thin wrapper for structured event emission
+// ---------------------------------------------------------------------------
+
+export class ObservabilityEmitter {
+  private listeners: ObservabilityListener[] = [];
+  readonly correlationId: string;
+  readonly orchestrationMode: OrchestrationMode;
+
+  constructor(orchestrationMode: OrchestrationMode, correlationId?: string) {
+    this.orchestrationMode = orchestrationMode;
+    this.correlationId = correlationId ?? randomUUID();
+  }
+
+  on(listener: ObservabilityListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+
+  emit(kind: ObservabilityEventKind, data: Record<string, unknown> = {}): void {
+    const event: ObservabilityEvent = {
+      kind,
+      correlationId: this.correlationId,
+      timestamp: Date.now(),
+      orchestrationMode: this.orchestrationMode,
+      data,
+    };
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // Observability must never break orchestration
+      }
+    }
+  }
+
+  start(data: Record<string, unknown> = {}): void {
+    this.emit('orchestration_start', data);
+  }
+
+  end(data: Record<string, unknown> = {}): void {
+    this.emit('orchestration_end', data);
+  }
+
+  agentStep(mindId: string, extra: Record<string, unknown> = {}): void {
+    this.emit('per_agent_step', { mindId, ...extra });
+  }
+
+  toolCallAttempted(
+    mindId: string,
+    toolName: string,
+    params: Record<string, unknown>,
+  ): void {
+    this.emit('tool_call_attempted', {
+      mindId,
+      toolName,
+      parameters: redactParameters(params),
+    });
+  }
+
+  failure(error: string, extra: Record<string, unknown> = {}): void {
+    this.emit('failure', { error, ...extra });
+  }
+
+  terminationReason(reason: string, extra: Record<string, unknown> = {}): void {
+    this.emit('termination_reason', { reason, ...extra });
+  }
+}

--- a/src/main/services/chatroom/orchestration/shared.test.ts
+++ b/src/main/services/chatroom/orchestration/shared.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+
+import { escapeXml, textContent, extractJsonObject, stripControlJson } from './shared';
+import type { ChatroomMessage } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helper to build a minimal ChatroomMessage with typed blocks
+// ---------------------------------------------------------------------------
+
+function msg(blocks: ChatroomMessage['blocks']): ChatroomMessage {
+  return {
+    id: 'test-msg',
+    role: 'assistant',
+    blocks,
+    timestamp: Date.now(),
+    sender: { mindId: 'test', name: 'Test' },
+    roundId: 'r1',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// escapeXml
+// ---------------------------------------------------------------------------
+
+describe('escapeXml', () => {
+  it('escapes ampersand', () => {
+    expect(escapeXml('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes less-than', () => {
+    expect(escapeXml('a<b')).toBe('a&lt;b');
+  });
+
+  it('escapes greater-than', () => {
+    expect(escapeXml('a>b')).toBe('a&gt;b');
+  });
+
+  it('escapes double quote', () => {
+    expect(escapeXml('a"b')).toBe('a&quot;b');
+  });
+
+  it('escapes single quote', () => {
+    expect(escapeXml("a'b")).toBe('a&apos;b');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(escapeXml('')).toBe('');
+  });
+
+  it('passes through strings with no special characters', () => {
+    expect(escapeXml('hello world')).toBe('hello world');
+  });
+
+  it('escapes multiple occurrences of the same character', () => {
+    expect(escapeXml('a&b&c&d')).toBe('a&amp;b&amp;c&amp;d');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// textContent
+// ---------------------------------------------------------------------------
+
+describe('textContent', () => {
+  it('extracts content from a single text block', () => {
+    const m = msg([{ type: 'text', content: 'hello' }]);
+    expect(textContent(m)).toBe('hello');
+  });
+
+  it('joins content from multiple text blocks', () => {
+    const m = msg([
+      { type: 'text', content: 'hello ' },
+      { type: 'text', content: 'world' },
+    ]);
+    expect(textContent(m)).toBe('hello world');
+  });
+
+  it('extracts only text blocks from mixed block types', () => {
+    const m = msg([
+      { type: 'text', content: 'before ' },
+      { type: 'tool_call', toolCallId: 'tc1', toolName: 'grep', status: 'done' },
+      { type: 'text', content: 'after' },
+    ]);
+    expect(textContent(m)).toBe('before after');
+  });
+
+  it('returns empty string when there are no text blocks', () => {
+    const m = msg([
+      { type: 'tool_call', toolCallId: 'tc1', toolName: 'grep', status: 'done' },
+      { type: 'reasoning', reasoningId: 'r1', content: 'thinking...' },
+    ]);
+    expect(textContent(m)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractJsonObject
+// ---------------------------------------------------------------------------
+
+describe('extractJsonObject', () => {
+  it('extracts a simple JSON object', () => {
+    expect(extractJsonObject('{"action":"stop"}')).toBe('{"action":"stop"}');
+  });
+
+  it('extracts nested JSON objects', () => {
+    const input = '{"a":{"b":{"c":1}}}';
+    expect(extractJsonObject(input)).toBe(input);
+  });
+
+  it('returns null when there is no JSON', () => {
+    expect(extractJsonObject('just plain text')).toBeNull();
+  });
+
+  it('extracts JSON preceded by text', () => {
+    expect(extractJsonObject('some preamble {"action":"go"}')).toBe('{"action":"go"}');
+  });
+
+  it('handles braces inside string values', () => {
+    const input = '{"content":"use { braces }"}';
+    expect(extractJsonObject(input)).toBe(input);
+  });
+
+  it('returns null for an unclosed object', () => {
+    expect(extractJsonObject('{"action":"stop"')).toBeNull();
+  });
+
+  it('handles escaped quotes inside strings', () => {
+    const input = '{"msg":"she said \\"hi\\""}';
+    expect(extractJsonObject(input)).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripControlJson
+// ---------------------------------------------------------------------------
+
+describe('stripControlJson', () => {
+  const isStop = (action: unknown) => action === 'stop';
+
+  it('strips matching control action', () => {
+    const text = 'prefix {"action":"stop"} suffix';
+    expect(stripControlJson(text, isStop)).toBe('prefix  suffix');
+  });
+
+  it('leaves text when action does not match predicate', () => {
+    const text = '{"action":"continue"}';
+    expect(stripControlJson(text, isStop)).toBe('{"action":"continue"}');
+  });
+
+  it('leaves text when no JSON is present', () => {
+    expect(stripControlJson('no json here', isStop)).toBe('no json here');
+  });
+
+  it('handles invalid JSON gracefully', () => {
+    const text = '{not valid json}';
+    expect(stripControlJson(text, isStop)).toBe('{not valid json}');
+  });
+
+  it('trims whitespace after stripping', () => {
+    const text = '   {"action":"stop"}   ';
+    expect(stripControlJson(text, isStop)).toBe('');
+  });
+});

--- a/src/main/services/chatroom/orchestration/shared.ts
+++ b/src/main/services/chatroom/orchestration/shared.ts
@@ -1,0 +1,67 @@
+import type { ChatroomMessage } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// XML helpers — used by strategies that build XML-structured prompts
+// ---------------------------------------------------------------------------
+
+const XML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+export function escapeXml(text: string): string {
+  return text.replace(/[&<>"']/g, (ch) => XML_ESCAPE_MAP[ch]);
+}
+
+export function textContent(msg: ChatroomMessage): string {
+  return msg.blocks
+    .filter((b) => b.type === 'text')
+    .map((b) => (b as { content: string }).content)
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// JSON extraction — used by strategies that parse control directives
+// ---------------------------------------------------------------------------
+
+/** Extract the outermost JSON object from text using bracket counting (string-aware) */
+export function extractJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) { escape = false; continue; }
+    if (ch === '\\' && inString) { escape = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === '{') depth++;
+    if (ch === '}') depth--;
+    if (depth === 0) return text.substring(start, i + 1);
+  }
+  return null;
+}
+
+/**
+ * Strip a control JSON directive from displayed content.
+ * `isControlAction` determines whether a parsed object is a control directive.
+ */
+export function stripControlJson(
+  text: string,
+  isControlAction: (action: unknown) => boolean,
+): string {
+  const json = extractJsonObject(text);
+  if (!json) return text;
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    if (isControlAction(parsed.action)) {
+      return text.replace(json, '').trim();
+    }
+  } catch { /* not valid JSON, leave as-is */ }
+  return text;
+}

--- a/src/main/services/chatroom/orchestration/stream-agent.test.ts
+++ b/src/main/services/chatroom/orchestration/stream-agent.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock node:crypto for UUID generation
+const mockRandomUUID = vi.fn(() => 'test-uuid');
+vi.mock('node:crypto', () => ({
+  randomUUID: (...args: unknown[]) => mockRandomUUID(...args),
+}));
+
+import { streamAgentTurn, sendToAgentWithRetry } from './stream-agent';
+import type { StreamAgentOptions, SendToAgentOptions } from './stream-agent';
+import type { OrchestrationContext } from './types';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockSession() {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      const list = listeners.get(event);
+      if (!list) throw new Error('expected listener list');
+      list.push(cb);
+      const unsub = vi.fn(() => {
+        const cbs = listeners.get(event);
+        if (cbs) {
+          const idx = cbs.indexOf(cb);
+          if (idx >= 0) cbs.splice(idx, 1);
+        }
+      });
+      return unsub;
+    }),
+    _emit(event: string, data: unknown) {
+      for (const cb of listeners.get(event) ?? []) cb(data);
+    },
+    _listeners: listeners,
+  };
+}
+
+type MockSession = ReturnType<typeof createMockSession>;
+
+function makeMind(id: string, name: string): MindContext {
+  return {
+    mindId: id,
+    mindPath: `/minds/${id}`,
+    identity: { name, systemMessage: `I am ${name}` },
+    status: 'ready',
+  };
+}
+
+function createContext(
+  sessions: Map<string, MockSession>,
+  overrides?: Partial<OrchestrationContext>,
+): OrchestrationContext {
+  const events: ChatroomStreamEvent[] = [];
+  const messages: ChatroomMessage[] = [];
+  return {
+    getOrCreateSession: vi.fn(async (mindId: string) => {
+      if (!sessions.has(mindId)) sessions.set(mindId, createMockSession());
+      return sessions.get(mindId)!;
+    }),
+    evictSession: vi.fn((mindId: string) => {
+      sessions.delete(mindId);
+    }),
+    buildBasePrompt: vi.fn(() => 'test prompt'),
+    emitEvent: vi.fn((event: ChatroomStreamEvent) => events.push(event)),
+    persistMessage: vi.fn((msg: ChatroomMessage) => messages.push(msg)),
+    getHistory: vi.fn(() => []),
+    orchestrationMode: 'concurrent',
+    ...overrides,
+  };
+}
+
+function autoIdle(session: MockSession) {
+  session.send.mockImplementation(async () => {
+    setTimeout(() => {
+      session._emit('assistant.message', {
+        data: { messageId: 'sdk-msg-1', content: 'Hello from agent' },
+      });
+      session._emit('session.idle', {});
+    }, 0);
+  });
+}
+
+const mind = makeMind('dude', 'The Dude');
+
+let uuidCounter = 0;
+function resetUUIDs() {
+  uuidCounter = 0;
+  mockRandomUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
+}
+
+function makeStreamOpts(
+  session: MockSession,
+  overrides?: Partial<StreamAgentOptions>,
+): StreamAgentOptions {
+  return {
+    session: session as unknown as StreamAgentOptions['session'],
+    mind,
+    prompt: 'Hello',
+    roundId: 'round-1',
+    context: createContext(new Map()),
+    abortSignal: new AbortController().signal,
+    unsubs: [],
+    orchestrationMode: 'concurrent',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// streamAgentTurn
+// ---------------------------------------------------------------------------
+
+describe('streamAgentTurn', () => {
+  let sessions: Map<string, MockSession>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+    sessions = new Map();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits chunk events on assistant.message_delta', async () => {
+    const sess = createMockSession();
+    const ctx = createContext(sessions);
+    const unsubs: (() => void)[] = [];
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('assistant.message_delta', {
+          data: { messageId: 'sdk-1', deltaContent: 'partial' },
+        });
+        sess._emit('session.idle', {});
+      }, 0);
+    });
+
+    await streamAgentTurn(makeStreamOpts(sess, { context: ctx, unsubs }));
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const chunks = events.filter((e) => e.event.type === 'chunk');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].event).toMatchObject({ type: 'chunk', content: 'partial', sdkMessageId: 'sdk-1' });
+  });
+
+  it('emits message_final on assistant.message and captures finalContent', async () => {
+    const sess = createMockSession();
+    const ctx = createContext(sessions);
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('assistant.message', {
+          data: { messageId: 'sdk-2', content: 'Final answer' },
+        });
+        sess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const result = await streamAgentTurn(makeStreamOpts(sess, { context: ctx }));
+
+    expect(result.finalContent).toBe('Final answer');
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const finals = events.filter((e) => e.event.type === 'message_final');
+    expect(finals).toHaveLength(1);
+    expect(finals[0].event).toMatchObject({ type: 'message_final', content: 'Final answer' });
+  });
+
+  it('emits tool events (tool_start, tool_progress, tool_output, tool_done)', async () => {
+    const sess = createMockSession();
+    const ctx = createContext(sessions);
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('tool.execution_start', {
+          data: { toolCallId: 'tc-1', toolName: 'grep', arguments: '{}', parentToolCallId: undefined },
+        });
+        sess._emit('tool.execution_progress', {
+          data: { toolCallId: 'tc-1', progressMessage: 'searching...' },
+        });
+        sess._emit('tool.execution_partial_result', {
+          data: { toolCallId: 'tc-1', partialOutput: 'found it' },
+        });
+        sess._emit('tool.execution_complete', {
+          data: { toolCallId: 'tc-1', success: true, result: { content: 'done' }, error: undefined },
+        });
+        sess._emit('session.idle', {});
+      }, 0);
+    });
+
+    await streamAgentTurn(makeStreamOpts(sess, { context: ctx }));
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const types = events.map((e) => e.event.type);
+    expect(types).toContain('tool_start');
+    expect(types).toContain('tool_progress');
+    expect(types).toContain('tool_output');
+    expect(types).toContain('tool_done');
+  });
+
+  it('emits reasoning events', async () => {
+    const sess = createMockSession();
+    const ctx = createContext(sessions);
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('assistant.reasoning_delta', {
+          data: { reasoningId: 'r-1', deltaContent: 'thinking...' },
+        });
+        sess._emit('session.idle', {});
+      }, 0);
+    });
+
+    await streamAgentTurn(makeStreamOpts(sess, { context: ctx }));
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    const reasoning = events.filter((e) => e.event.type === 'reasoning');
+    expect(reasoning).toHaveLength(1);
+    expect(reasoning[0].event).toMatchObject({ type: 'reasoning', reasoningId: 'r-1', content: 'thinking...' });
+  });
+
+  it('returns finalContent and messageId', async () => {
+    const sess = createMockSession();
+    autoIdle(sess);
+
+    const result = await streamAgentTurn(makeStreamOpts(sess));
+
+    expect(result.finalContent).toBe('Hello from agent');
+    expect(result.messageId).toBe('uuid-1');
+  });
+
+  it('does NOT emit events when abortSignal is aborted', async () => {
+    const sess = createMockSession();
+    const ctx = createContext(sessions);
+    const ac = new AbortController();
+    ac.abort();
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('assistant.message_delta', {
+          data: { messageId: 'sdk-1', deltaContent: 'should not appear' },
+        });
+        sess._emit('session.idle', {});
+      }, 0);
+    });
+
+    await streamAgentTurn(makeStreamOpts(sess, { context: ctx, abortSignal: ac.signal }));
+
+    expect(ctx.emitEvent).not.toHaveBeenCalled();
+  });
+
+  it('resolves on session.idle', async () => {
+    const sess = createMockSession();
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => sess._emit('session.idle', {}), 0);
+    });
+
+    const result = await streamAgentTurn(makeStreamOpts(sess));
+    expect(result.finalContent).toBe('');
+  });
+
+  it('rejects on session.error', async () => {
+    const sess = createMockSession();
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('session.error', { data: { message: 'boom' } });
+      }, 0);
+    });
+
+    await expect(streamAgentTurn(makeStreamOpts(sess))).rejects.toThrow('boom');
+  });
+
+  it('pushes unsub functions into the unsubs array', async () => {
+    const sess = createMockSession();
+    const unsubs: (() => void)[] = [];
+    autoIdle(sess);
+
+    await streamAgentTurn(makeStreamOpts(sess, { unsubs }));
+
+    // 7 event listeners + 2 (idle + error) = 9 unsubs
+    expect(unsubs.length).toBeGreaterThanOrEqual(9);
+    for (const u of unsubs) expect(typeof u).toBe('function');
+  });
+
+  it('send timeout: rejects with "Session not found" if session.send hangs for 30s', async () => {
+    vi.useFakeTimers();
+    const sess = createMockSession();
+    // send never resolves
+    sess.send.mockReturnValue(new Promise(() => {}));
+
+    // Suppress the PromiseRejectionHandledWarning that vitest's fake timer
+    // implementation triggers: the timer fires reject() in a setImmediate
+    // macrotask before the Promise.race microtask handler can catch it.
+    const swallow = () => {};
+    process.on('unhandledRejection', swallow);
+
+    const promise = streamAgentTurn(makeStreamOpts(sess));
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(promise).rejects.toThrow('Session not found');
+
+    // Drain the orphaned turnDone 300 000 ms timeout so it doesn't leak
+    await vi.runAllTimersAsync();
+    process.removeListener('unhandledRejection', swallow);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendToAgentWithRetry
+// ---------------------------------------------------------------------------
+
+describe('sendToAgentWithRetry', () => {
+  let sessions: Map<string, MockSession>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUUIDs();
+    sessions = new Map();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeSendOpts(
+    ctx: OrchestrationContext,
+    overrides?: Partial<SendToAgentOptions>,
+  ): SendToAgentOptions {
+    return {
+      mind,
+      prompt: 'Hello',
+      roundId: 'round-1',
+      context: ctx,
+      abortSignal: new AbortController().signal,
+      unsubs: [],
+      orchestrationMode: 'concurrent',
+      ...overrides,
+    };
+  }
+
+  it('happy path: creates session, streams, persists message, emits done', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    autoIdle(sess);
+    const ctx = createContext(sessions);
+
+    const result = await sendToAgentWithRetry(makeSendOpts(ctx));
+
+    expect(ctx.getOrCreateSession).toHaveBeenCalledWith('dude');
+    expect(sess.send).toHaveBeenCalledTimes(1);
+    expect(ctx.persistMessage).toHaveBeenCalledTimes(1);
+    expect(result.message).not.toBeNull();
+    expect(result.message!.role).toBe('assistant');
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    expect(events.some((e) => e.event.type === 'done')).toBe(true);
+  });
+
+  it('returns rawContent (before transform) and message (after transform)', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    autoIdle(sess);
+    const ctx = createContext(sessions);
+
+    const result = await sendToAgentWithRetry(
+      makeSendOpts(ctx, {
+        transformContent: (raw) => raw.toUpperCase(),
+      }),
+    );
+
+    expect(result.rawContent).toBe('Hello from agent');
+    expect(result.message!.blocks[0]).toMatchObject({ type: 'text', content: 'HELLO FROM AGENT' });
+  });
+
+  it('applies transformContent to display content', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    autoIdle(sess);
+    const ctx = createContext(sessions);
+
+    const result = await sendToAgentWithRetry(
+      makeSendOpts(ctx, { transformContent: () => 'transformed' }),
+    );
+
+    expect(result.message!.blocks[0]).toMatchObject({ type: 'text', content: 'transformed' });
+  });
+
+  it('returns null message when finalContent is empty', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    // Idle with no content
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => sess._emit('session.idle', {}), 0);
+    });
+    const ctx = createContext(sessions);
+
+    const result = await sendToAgentWithRetry(makeSendOpts(ctx));
+
+    expect(result.message).toBeNull();
+    expect(result.rawContent).toBe('');
+  });
+
+  it('returns null message when aborted', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    const ac = new AbortController();
+    ac.abort();
+    const ctx = createContext(sessions);
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('assistant.message', {
+          data: { messageId: 'sdk-1', content: 'content' },
+        });
+        sess._emit('session.idle', {});
+      }, 0);
+    });
+
+    const result = await sendToAgentWithRetry(makeSendOpts(ctx, { abortSignal: ac.signal }));
+
+    expect(result.message).toBeNull();
+  });
+
+  it('retries once on stale session error (evicts + creates fresh session)', async () => {
+    const staleSess = createMockSession();
+    sessions.set('dude', staleSess);
+    staleSess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        staleSess._emit('session.error', {
+          data: { message: 'Session not found: abc-123' },
+        });
+      }, 0);
+    });
+
+    const ctx = createContext(sessions);
+
+    // After eviction, getOrCreateSession will create a fresh session via the Map
+    // We need the fresh session to succeed
+    const freshSess = createMockSession();
+    autoIdle(freshSess);
+
+    let callCount = 0;
+    (ctx.getOrCreateSession as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return staleSess;
+      return freshSess;
+    });
+
+    const result = await sendToAgentWithRetry(makeSendOpts(ctx));
+
+    expect(ctx.evictSession).toHaveBeenCalledWith('dude');
+    expect(ctx.getOrCreateSession).toHaveBeenCalledTimes(2);
+    expect(result.message).not.toBeNull();
+  });
+
+  it('throws on non-stale errors (does NOT retry)', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('session.error', { data: { message: 'Something else broke' } });
+      }, 0);
+    });
+    const ctx = createContext(sessions);
+
+    await expect(sendToAgentWithRetry(makeSendOpts(ctx))).rejects.toThrow('Something else broke');
+    expect(ctx.evictSession).not.toHaveBeenCalled();
+    expect(ctx.getOrCreateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up unsubs in finally block', async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    autoIdle(sess);
+    const ctx = createContext(sessions);
+    const unsubs: (() => void)[] = [];
+
+    await sendToAgentWithRetry(makeSendOpts(ctx, { unsubs }));
+
+    // unsubs are called and array cleared in the finally block
+    expect(unsubs).toHaveLength(0);
+  });
+
+  it("caller's unsubs array receives listeners for mid-turn stop", async () => {
+    const sess = createMockSession();
+    sessions.set('dude', sess);
+    const ctx = createContext(sessions);
+    const callerUnsubs: (() => void)[] = [];
+
+    // Send hangs so we can inspect unsubs mid-flight
+    let resolveSend: () => void;
+    sess.send.mockImplementation(
+      () => new Promise<void>((r) => { resolveSend = r; }),
+    );
+
+    const promise = sendToAgentWithRetry(makeSendOpts(ctx, { unsubs: callerUnsubs }));
+
+    // Wait for send to be called
+    await vi.waitFor(() => expect(sess.send).toHaveBeenCalled());
+
+    // Mid-turn: unsubs should have been populated by streamAgentTurn
+    expect(callerUnsubs.length).toBeGreaterThan(0);
+
+    // Now let it finish
+    resolveSend!();
+    setTimeout(() => sess._emit('session.idle', {}), 0);
+    await promise;
+  });
+});

--- a/src/main/services/chatroom/orchestration/stream-agent.test.ts
+++ b/src/main/services/chatroom/orchestration/stream-agent.test.ts
@@ -316,8 +316,10 @@ describe('streamAgentTurn', () => {
 
     await expect(promise).rejects.toThrow('Session not found');
 
-    // Drain the orphaned turnDone 300 000 ms timeout so it doesn't leak
-    await vi.runAllTimersAsync();
+    // The 300s turnDone timer must have been cleared when the 30s send
+    // timeout fired. If it leaked, getTimerCount() would be 1.
+    expect(vi.getTimerCount()).toBe(0);
+
     process.removeListener('unhandledRejection', swallow);
   });
 });

--- a/src/main/services/chatroom/orchestration/stream-agent.ts
+++ b/src/main/services/chatroom/orchestration/stream-agent.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from 'node:crypto';
+import type { MindContext } from '../../../../shared/types';
+import type { ChatroomStreamEvent, OrchestrationMode, ChatroomMessage } from '../../../../shared/chatroom-types';
+import type { OrchestrationContext } from './types';
+import type { CopilotSession } from '../../mind';
+import { isStaleSessionError } from '../../../../shared/sessionErrors';
+
+// ---------------------------------------------------------------------------
+// streamAgentTurn — shared SDK event wiring for all orchestration strategies
+// ---------------------------------------------------------------------------
+
+export interface StreamAgentOptions {
+  session: CopilotSession;
+  mind: MindContext;
+  prompt: string;
+  roundId: string;
+  context: OrchestrationContext;
+  abortSignal: AbortSignal;
+  unsubs: (() => void)[];
+  orchestrationMode: OrchestrationMode;
+}
+
+export interface StreamAgentResult {
+  /** Raw final content from the assistant (empty string if no content) */
+  finalContent: string;
+  /** The message ID used for this turn */
+  messageId: string;
+}
+
+/**
+ * Wire all SDK event listeners, send the prompt, and wait for idle.
+ * Returns the raw final content — callers handle message creation and persistence.
+ */
+export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamAgentResult> {
+  const { session, mind, prompt, roundId, context, abortSignal, unsubs } = opts;
+  const messageId = randomUUID();
+
+  const emitEvent = (event: ChatroomStreamEvent['event']) => {
+    if (!abortSignal.aborted) {
+      context.emitEvent({
+        mindId: mind.mindId,
+        mindName: mind.identity.name,
+        messageId,
+        roundId,
+        event,
+      } satisfies ChatroomStreamEvent);
+    }
+  };
+
+  let finalContent = '';
+
+  unsubs.push(
+    session.on('assistant.message_delta', (e) => {
+      emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
+    }),
+  );
+
+  unsubs.push(
+    session.on('assistant.message', (e) => {
+      if (e.data.content) {
+        finalContent = e.data.content;
+        emitEvent({
+          type: 'message_final',
+          sdkMessageId: e.data.messageId,
+          content: e.data.content,
+        });
+      }
+    }),
+  );
+
+  unsubs.push(
+    session.on('assistant.reasoning_delta', (e) => {
+      emitEvent({
+        type: 'reasoning',
+        reasoningId: e.data.reasoningId,
+        content: e.data.deltaContent,
+      });
+    }),
+  );
+
+  unsubs.push(
+    session.on('tool.execution_start', (e) => {
+      emitEvent({
+        type: 'tool_start',
+        toolCallId: e.data.toolCallId,
+        toolName: e.data.toolName,
+        args: e.data.arguments,
+        parentToolCallId: e.data.parentToolCallId,
+      });
+    }),
+  );
+
+  unsubs.push(
+    session.on('tool.execution_progress', (e) => {
+      emitEvent({
+        type: 'tool_progress',
+        toolCallId: e.data.toolCallId,
+        message: e.data.progressMessage,
+      });
+    }),
+  );
+
+  unsubs.push(
+    session.on('tool.execution_partial_result', (e) => {
+      emitEvent({
+        type: 'tool_output',
+        toolCallId: e.data.toolCallId,
+        output: e.data.partialOutput,
+      });
+    }),
+  );
+
+  unsubs.push(
+    session.on('tool.execution_complete', (e) => {
+      emitEvent({
+        type: 'tool_done',
+        toolCallId: e.data.toolCallId,
+        success: e.data.success,
+        result: e.data.result?.content,
+        error: e.data.error?.message,
+      });
+    }),
+  );
+
+  // Set up idle/error listeners BEFORE send to avoid missing events
+  const turnDone = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, 300_000);
+
+    const unsubIdle = session.on('session.idle', () => {
+      clearTimeout(timeout);
+      unsubIdle();
+      resolve();
+    });
+    unsubs.push(unsubIdle);
+
+    const unsubError = session.on('session.error', (e) => {
+      clearTimeout(timeout);
+      unsubError();
+      reject(new Error(e.data.message));
+    });
+    unsubs.push(unsubError);
+
+    abortSignal.addEventListener('abort', () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+  });
+
+  let sendTimerId: ReturnType<typeof setTimeout> | undefined;
+  const sendTimeout = new Promise<never>((_, reject) => {
+    sendTimerId = setTimeout(() => reject(new Error('Session not found')), 30_000);
+  });
+  try {
+    await Promise.race([session.send({ prompt }), sendTimeout]);
+  } finally {
+    clearTimeout(sendTimerId);
+  }
+
+  await turnDone;
+
+  return { finalContent, messageId };
+}
+
+// ---------------------------------------------------------------------------
+// sendToAgentWithRetry — stale session retry wrapper
+// ---------------------------------------------------------------------------
+
+export interface SendToAgentOptions {
+  mind: MindContext;
+  prompt: string;
+  roundId: string;
+  context: OrchestrationContext;
+  abortSignal: AbortSignal;
+  unsubs: (() => void)[];
+  orchestrationMode: OrchestrationMode;
+  /** Optional content transform (e.g. stripControlJson) applied to display content */
+  transformContent?: (raw: string) => string;
+}
+
+export interface SendToAgentResult {
+  /** The persisted ChatroomMessage, or null if aborted/empty */
+  message: ChatroomMessage | null;
+  /** Raw final content (before transform) — useful for parsing control directives */
+  rawContent: string;
+}
+
+/**
+ * Get-or-create a session, stream a turn, persist the result.
+ * Retries once on stale session errors.
+ */
+export async function sendToAgentWithRetry(opts: SendToAgentOptions): Promise<SendToAgentResult> {
+  const { mind, prompt, roundId, context, abortSignal, orchestrationMode, transformContent } = opts;
+
+  const run = async (session: CopilotSession): Promise<SendToAgentResult> => {
+    try {
+      const { finalContent, messageId } = await streamAgentTurn({
+        session, mind, prompt, roundId, context,
+        abortSignal, unsubs: opts.unsubs, orchestrationMode,
+      });
+
+      if (abortSignal.aborted) return { message: null, rawContent: finalContent };
+
+      if (finalContent) {
+        const displayContent = transformContent ? transformContent(finalContent) : finalContent;
+        const msg: ChatroomMessage = {
+          id: messageId,
+          role: 'assistant',
+          blocks: [{ type: 'text', content: displayContent || finalContent }],
+          timestamp: Date.now(),
+          sender: { mindId: mind.mindId, name: mind.identity.name },
+          roundId,
+          orchestrationMode,
+        };
+        context.persistMessage(msg);
+
+        const emitDone = () => {
+          if (!abortSignal.aborted) {
+            context.emitEvent({
+              mindId: mind.mindId,
+              mindName: mind.identity.name,
+              messageId,
+              roundId,
+              event: { type: 'done' },
+            });
+          }
+        };
+        emitDone();
+
+        return {
+          message: msg,
+          rawContent: finalContent,
+        };
+      }
+
+      return { message: null, rawContent: '' };
+    } finally {
+      for (const unsub of opts.unsubs) unsub();
+      opts.unsubs.length = 0;
+    }
+  };
+
+  const session = await context.getOrCreateSession(mind.mindId);
+  try {
+    return await run(session);
+  } catch (err) {
+    if (!isStaleSessionError(err)) throw err;
+    context.evictSession(mind.mindId);
+    const freshSession = await context.getOrCreateSession(mind.mindId);
+    return await run(freshSession);
+  }
+}

--- a/src/main/services/chatroom/orchestration/stream-agent.ts
+++ b/src/main/services/chatroom/orchestration/stream-agent.ts
@@ -122,26 +122,29 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
     }),
   );
 
-  // Set up idle/error listeners BEFORE send to avoid missing events
+  // Set up idle/error listeners BEFORE send to avoid missing events.
+  // The turnDone timeout ID is hoisted so it can be cleared on any exit path
+  // (send timeout, abort, or normal completion) to prevent 5-minute timer leaks.
+  let turnDoneTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const turnDone = new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(resolve, 300_000);
+    turnDoneTimeoutId = setTimeout(resolve, 300_000);
 
     const unsubIdle = session.on('session.idle', () => {
-      clearTimeout(timeout);
+      clearTimeout(turnDoneTimeoutId);
       unsubIdle();
       resolve();
     });
     unsubs.push(unsubIdle);
 
     const unsubError = session.on('session.error', (e) => {
-      clearTimeout(timeout);
+      clearTimeout(turnDoneTimeoutId);
       unsubError();
       reject(new Error(e.data.message));
     });
     unsubs.push(unsubError);
 
     abortSignal.addEventListener('abort', () => {
-      clearTimeout(timeout);
+      clearTimeout(turnDoneTimeoutId);
       resolve();
     }, { once: true });
   });
@@ -152,6 +155,10 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
   });
   try {
     await Promise.race([session.send({ prompt }), sendTimeout]);
+  } catch (err) {
+    // Send failed (e.g. 30s timeout) — clear the turnDone timer to prevent leak
+    clearTimeout(turnDoneTimeoutId);
+    throw err;
   } finally {
     clearTimeout(sendTimerId);
   }

--- a/src/main/services/chatroom/orchestration/types.ts
+++ b/src/main/services/chatroom/orchestration/types.ts
@@ -1,0 +1,34 @@
+import type { OrchestrationMode, ChatroomStreamEvent, ChatroomMessage } from '../../../../shared/chatroom-types';
+import type { MindContext } from '../../../../shared/types';
+import type { CopilotSession } from '../../mind';
+
+// ---------------------------------------------------------------------------
+// OrchestrationStrategy — implemented by each orchestration mode
+// ---------------------------------------------------------------------------
+
+export interface OrchestrationStrategy {
+  readonly mode: OrchestrationMode;
+
+  execute(
+    userMessage: string,
+    participants: MindContext[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void>;
+
+  stop(): void;
+}
+
+// ---------------------------------------------------------------------------
+// OrchestrationContext — adapter provided by ChatroomService to strategies
+// ---------------------------------------------------------------------------
+
+export interface OrchestrationContext {
+  getOrCreateSession(mindId: string): Promise<CopilotSession>;
+  evictSession(mindId: string): void;
+  buildBasePrompt(userMessage: string, participants: MindContext[]): string;
+  emitEvent(event: ChatroomStreamEvent): void;
+  persistMessage(message: ChatroomMessage): void;
+  getHistory(): ChatroomMessage[];
+  readonly orchestrationMode: OrchestrationMode;
+}

--- a/src/main/services/chatroom/orchestration/types.ts
+++ b/src/main/services/chatroom/orchestration/types.ts
@@ -20,6 +20,46 @@ export interface OrchestrationStrategy {
 }
 
 // ---------------------------------------------------------------------------
+// BaseStrategy — shared lifecycle for strategies that use abort + unsubs
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstract base that owns the `abortController` / `unsubs` lifecycle
+ * shared by Sequential, GroupChat, Handoff, and Magentic strategies.
+ * ConcurrentStrategy manages per-agent controllers so it does NOT extend this.
+ */
+export abstract class BaseStrategy implements OrchestrationStrategy {
+  abstract readonly mode: OrchestrationMode;
+
+  protected abortController: AbortController | null = null;
+  protected currentUnsubs: (() => void)[] = [];
+
+  abstract execute(
+    userMessage: string,
+    participants: MindContext[],
+    roundId: string,
+    context: OrchestrationContext,
+  ): Promise<void>;
+
+  /** Start a new round — call at the top of execute() */
+  protected begin(): AbortController {
+    this.abortController = new AbortController();
+    return this.abortController;
+  }
+
+  /** Whether the current round has been cancelled */
+  protected get isAborted(): boolean {
+    return this.abortController?.signal.aborted ?? false;
+  }
+
+  stop(): void {
+    this.abortController?.abort();
+    for (const unsub of this.currentUnsubs) unsub();
+    this.currentUnsubs = [];
+  }
+}
+
+// ---------------------------------------------------------------------------
 // OrchestrationContext — adapter provided by ChatroomService to strategies
 // ---------------------------------------------------------------------------
 

--- a/src/main/services/chatroom/orchestration/types.ts
+++ b/src/main/services/chatroom/orchestration/types.ts
@@ -26,7 +26,7 @@ export interface OrchestrationStrategy {
 export interface OrchestrationContext {
   getOrCreateSession(mindId: string): Promise<CopilotSession>;
   evictSession(mindId: string): void;
-  buildBasePrompt(userMessage: string, participants: MindContext[]): string;
+  buildBasePrompt(userMessage: string, participants: MindContext[], forMind?: MindContext): string;
   emitEvent(event: ChatroomStreamEvent): void;
   persistMessage(message: ChatroomMessage): void;
   getHistory(): ChatroomMessage[];

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -58,6 +58,8 @@ const electronAPI: ElectronAPI = {
     history: () => ipcRenderer.invoke('chatroom:history'),
     clear: () => ipcRenderer.invoke('chatroom:clear'),
     stop: () => ipcRenderer.invoke('chatroom:stop'),
+    setOrchestration: (mode: string, config?: unknown) => ipcRenderer.invoke('chatroom:set-orchestration', mode, config),
+    getOrchestration: () => ipcRenderer.invoke('chatroom:get-orchestration'),
     onEvent: (callback) => createIpcListener(ipcRenderer, 'chatroom:event', callback),
   },
   a2a: {

--- a/src/renderer/components/chatroom/ChatroomPanel.test.tsx
+++ b/src/renderer/components/chatroom/ChatroomPanel.test.tsx
@@ -151,7 +151,13 @@ describe('ChatroomPanel', () => {
     expect(api.chatroom.onEvent).toHaveBeenCalled();
   });
 
-  // 10. Stop button calls chatroom.stop()
+  // 10. OrchestrationPicker renders
+  it('renders the orchestration picker', () => {
+    renderPanel({ minds: [MIND_A] }, api);
+    expect(screen.getByTestId('orchestration-picker')).toBeTruthy();
+  });
+
+  // 12. Stop button calls chatroom.stop()
   it('calls chatroom.stop() when stop is clicked during streaming', async () => {
     const streamingMsg = makeChatroomMessage({
       id: 's1',
@@ -169,9 +175,14 @@ describe('ChatroomPanel', () => {
       api,
     );
 
-    const button = screen.getByRole('button');
+    // The stop button is the one inside ChatInput (not the orchestration buttons)
+    const buttons = screen.getAllByRole('button');
+    const stopButton = buttons.find(
+      (b) => b.querySelector('svg rect') !== null,
+    );
+    expect(stopButton).toBeTruthy();
     await act(async () => {
-      fireEvent.click(button);
+      fireEvent.click(stopButton!);
     });
     expect(api.chatroom.stop).toHaveBeenCalled();
   });

--- a/src/renderer/components/chatroom/ChatroomPanel.tsx
+++ b/src/renderer/components/chatroom/ChatroomPanel.tsx
@@ -2,9 +2,10 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { useAppState, useAppDispatch, getPlainContent } from '../../lib/store';
 import { ChatInput } from '../chat/ChatInput';
 import { StreamingMessage } from '../chat/StreamingMessage';
+import { OrchestrationPicker } from './OrchestrationPicker';
 import { cn, formatTime } from '../../lib/utils';
 import type { MindContext } from '../../../shared/types';
-import type { ChatroomMessage } from '../../../shared/chatroom-types';
+import type { ChatroomMessage, OrchestrationEvent } from '../../../shared/chatroom-types';
 
 // ---------------------------------------------------------------------------
 // Colour palette for agent badges
@@ -15,6 +16,38 @@ const AGENT_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#e
 function agentColor(minds: MindContext[], mindId: string): string {
   const idx = minds.findIndex(m => m.mindId === mindId);
   return AGENT_COLORS[(idx >= 0 ? idx : 0) % AGENT_COLORS.length];
+}
+
+// ---------------------------------------------------------------------------
+// Moderator message detection & parsing
+// ---------------------------------------------------------------------------
+
+interface ModeratorDecision {
+  nextSpeaker: string;
+  direction: string;
+  action: string;
+}
+
+function parseModeratorJson(text: string): ModeratorDecision | null {
+  const match = text.match(/\{[\s\S]*?"next_speaker"[\s\S]*?\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]) as Record<string, unknown>;
+    return {
+      nextSpeaker: typeof parsed.next_speaker === 'string' ? parsed.next_speaker : '',
+      direction: typeof parsed.direction === 'string' ? parsed.direction : '',
+      action: typeof parsed.action === 'string' ? parsed.action : 'direct',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isModeratorMessage(message: ChatroomMessage, moderatorMindId?: string): boolean {
+  if (message.role !== 'assistant') return false;
+  if (moderatorMindId && message.sender?.mindId !== moderatorMindId) return false;
+  const text = getPlainContent(message);
+  return parseModeratorJson(text) !== null;
 }
 
 // ---------------------------------------------------------------------------
@@ -43,10 +76,89 @@ function ParticipantBar({ minds, streamingByMind }: { minds: MindContext[]; stre
 }
 
 // ---------------------------------------------------------------------------
+// ModeratorDecisionBubble — compact system message for moderator routing
+// ---------------------------------------------------------------------------
+
+function ModeratorDecisionBubble({ message, minds }: { message: ChatroomMessage; minds: MindContext[] }) {
+  const text = getPlainContent(message);
+  const decision = parseModeratorJson(text);
+  if (!decision) return null;
+
+  const color = agentColor(minds, message.sender?.mindId ?? '');
+  const moderatorName = message.sender?.name ?? 'Moderator';
+
+  if (decision.action === 'close') {
+    return (
+      <div className="flex justify-center py-2">
+        <span className="text-xs text-muted-foreground bg-secondary/50 rounded-full px-3 py-1 inline-flex items-center gap-1.5">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+          <span style={{ color }}>{moderatorName}</span> closed the discussion
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-center py-2">
+      <span className="text-xs text-muted-foreground bg-secondary/50 rounded-full px-3 py-1 inline-flex items-center gap-1.5 max-w-lg">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+        <span style={{ color }}>{moderatorName}</span>
+        <span className="text-muted-foreground">→</span>
+        <span className="font-medium text-foreground">{decision.nextSpeaker}</span>
+        {decision.direction && (
+          <span className="text-muted-foreground truncate">— {decision.direction}</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TypingIndicator — shows who is currently speaking/thinking
+// ---------------------------------------------------------------------------
+
+function TypingIndicator({ speaker, minds }: {
+  speaker: { mindId: string; mindName: string; phase: 'speaking' | 'moderating' | 'synthesizing' };
+  minds: MindContext[];
+}) {
+  const color = agentColor(minds, speaker.mindId);
+  const phaseText = speaker.phase === 'moderating'
+    ? 'is deciding who speaks next…'
+    : speaker.phase === 'synthesizing'
+      ? 'is synthesizing the discussion…'
+      : 'is speaking…';
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2">
+      <div className="max-w-3xl mx-auto flex items-center gap-2">
+        <div className="flex gap-1">
+          <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '0ms' }} />
+          <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '150ms' }} />
+          <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '300ms' }} />
+        </div>
+        <span className="text-xs text-muted-foreground">
+          <span className="font-medium" style={{ color }}>{speaker.mindName}</span> {phaseText}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ChatroomMessageList
 // ---------------------------------------------------------------------------
 
-function ChatroomMessageList({ messages, minds }: { messages: ChatroomMessage[]; minds: MindContext[] }) {
+function ChatroomMessageList({
+  messages,
+  minds,
+  moderatorMindId,
+  activeSpeaker,
+}: {
+  messages: ChatroomMessage[];
+  minds: MindContext[];
+  moderatorMindId?: string;
+  activeSpeaker: { mindId: string; mindName: string; phase: 'speaking' | 'moderating' | 'synthesizing' } | null;
+}) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isAutoScrolling = useRef(true);
 
@@ -54,7 +166,7 @@ function ChatroomMessageList({ messages, minds }: { messages: ChatroomMessage[];
     if (isAutoScrolling.current && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [messages]);
+  }, [messages, activeSpeaker]);
 
   const handleScroll = () => {
     if (!scrollRef.current) return;
@@ -66,6 +178,11 @@ function ChatroomMessageList({ messages, minds }: { messages: ChatroomMessage[];
     <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-4 py-4">
       <div className="max-w-3xl mx-auto space-y-6">
         {messages.map((message) => {
+          // Moderator routing messages → compact system bubble
+          if (moderatorMindId && isModeratorMessage(message, moderatorMindId)) {
+            return <ModeratorDecisionBubble key={message.id} message={message} minds={minds} />;
+          }
+
           const isUser = message.role === 'user';
           const senderName = message.sender?.name ?? 'Unknown';
           const color = isUser ? undefined : agentColor(minds, message.sender?.mindId ?? '');
@@ -108,6 +225,11 @@ function ChatroomMessageList({ messages, minds }: { messages: ChatroomMessage[];
             </div>
           );
         })}
+
+        {/* Typing indicator */}
+        {activeSpeaker && (
+          <TypingIndicator speaker={activeSpeaker} minds={minds} />
+        )}
       </div>
     </div>
   );
@@ -134,7 +256,16 @@ function ChatroomEmptyState({ connected }: { connected: boolean }) {
 // ---------------------------------------------------------------------------
 
 export function ChatroomPanel() {
-  const { chatroomMessages, minds, chatroomStreamingByMind, availableModels, selectedModel } = useAppState();
+  const {
+    chatroomMessages,
+    minds,
+    chatroomStreamingByMind,
+    availableModels,
+    selectedModel,
+    chatroomOrchestration,
+    chatroomGroupChatConfig,
+    chatroomActiveSpeaker,
+  } = useAppState();
   const dispatch = useAppDispatch();
   const isStreaming = Object.values(chatroomStreamingByMind).some(Boolean);
   const connected = minds.length > 0;
@@ -178,10 +309,30 @@ export function ChatroomPanel() {
     <div className="flex-1 flex flex-col min-h-0">
       <ParticipantBar minds={minds} streamingByMind={chatroomStreamingByMind} />
 
+      <OrchestrationPicker
+        mode={chatroomOrchestration}
+        groupChatConfig={chatroomGroupChatConfig}
+        minds={minds}
+        disabled={isStreaming}
+        onModeChange={(mode) => {
+          dispatch({ type: 'SET_ORCHESTRATION', payload: mode });
+          window.electronAPI.chatroom.setOrchestration(mode, chatroomGroupChatConfig ?? undefined);
+        }}
+        onGroupChatConfigChange={(config) => {
+          dispatch({ type: 'SET_GROUP_CHAT_CONFIG', payload: config });
+          window.electronAPI.chatroom.setOrchestration(chatroomOrchestration, config);
+        }}
+      />
+
       {chatroomMessages.length === 0 ? (
         <ChatroomEmptyState connected={connected} />
       ) : (
-        <ChatroomMessageList messages={chatroomMessages} minds={minds} />
+        <ChatroomMessageList
+          messages={chatroomMessages}
+          minds={minds}
+          moderatorMindId={chatroomOrchestration === 'group-chat' ? chatroomGroupChatConfig?.moderatorMindId : undefined}
+          activeSpeaker={chatroomActiveSpeaker}
+        />
       )}
 
       <ChatInput

--- a/src/renderer/components/chatroom/ChatroomPanel.tsx
+++ b/src/renderer/components/chatroom/ChatroomPanel.tsx
@@ -5,7 +5,7 @@ import { StreamingMessage } from '../chat/StreamingMessage';
 import { OrchestrationPicker } from './OrchestrationPicker';
 import { cn, formatTime } from '../../lib/utils';
 import type { MindContext } from '../../../shared/types';
-import type { ChatroomMessage, OrchestrationEvent } from '../../../shared/chatroom-types';
+import type { ChatroomMessage } from '../../../shared/chatroom-types';
 
 // ---------------------------------------------------------------------------
 // Colour palette for agent badges
@@ -129,14 +129,16 @@ function TypingIndicator({ speaker, minds }: {
       : 'is speaking…';
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2">
-      <div className="max-w-3xl mx-auto flex items-center gap-2">
+    <div className="flex gap-3">
+      {/* Spacer matching avatar width */}
+      <div className="w-7 shrink-0" />
+      <div className="flex items-center gap-1.5 text-muted-foreground">
         <div className="flex gap-1">
-          <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '0ms' }} />
-          <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '150ms' }} />
-          <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '300ms' }} />
+          <span className="h-1.5 w-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '0ms' }} />
+          <span className="h-1.5 w-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '150ms' }} />
+          <span className="h-1.5 w-1.5 rounded-full animate-bounce" style={{ backgroundColor: color, animationDelay: '300ms' }} />
         </div>
-        <span className="text-xs text-muted-foreground">
+        <span className="text-xs">
           <span className="font-medium" style={{ color }}>{speaker.mindName}</span> {phaseText}
         </span>
       </div>
@@ -264,6 +266,8 @@ export function ChatroomPanel() {
     selectedModel,
     chatroomOrchestration,
     chatroomGroupChatConfig,
+    chatroomHandoffConfig,
+    chatroomMagenticConfig,
     chatroomActiveSpeaker,
   } = useAppState();
   const dispatch = useAppDispatch();
@@ -312,15 +316,29 @@ export function ChatroomPanel() {
       <OrchestrationPicker
         mode={chatroomOrchestration}
         groupChatConfig={chatroomGroupChatConfig}
+        handoffConfig={chatroomHandoffConfig}
+        magneticConfig={chatroomMagenticConfig}
         minds={minds}
         disabled={isStreaming}
         onModeChange={(mode) => {
           dispatch({ type: 'SET_ORCHESTRATION', payload: mode });
-          window.electronAPI.chatroom.setOrchestration(mode, chatroomGroupChatConfig ?? undefined);
+          const config = mode === 'group-chat' ? chatroomGroupChatConfig
+            : mode === 'handoff' ? chatroomHandoffConfig
+            : mode === 'magentic' ? chatroomMagenticConfig
+            : undefined;
+          window.electronAPI.chatroom.setOrchestration(mode, config ?? undefined);
         }}
         onGroupChatConfigChange={(config) => {
           dispatch({ type: 'SET_GROUP_CHAT_CONFIG', payload: config });
-          window.electronAPI.chatroom.setOrchestration(chatroomOrchestration, config);
+          window.electronAPI.chatroom.setOrchestration('group-chat', config);
+        }}
+        onHandoffConfigChange={(config) => {
+          dispatch({ type: 'SET_HANDOFF_CONFIG', payload: config });
+          window.electronAPI.chatroom.setOrchestration('handoff', config);
+        }}
+        onMagneticConfigChange={(config) => {
+          dispatch({ type: 'SET_MAGENTIC_CONFIG', payload: config });
+          window.electronAPI.chatroom.setOrchestration('magentic', config);
         }}
       />
 

--- a/src/renderer/components/chatroom/OrchestrationPicker.test.tsx
+++ b/src/renderer/components/chatroom/OrchestrationPicker.test.tsx
@@ -1,12 +1,12 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { OrchestrationPicker } from './OrchestrationPicker';
 import type { MindContext } from '../../../shared/types';
-import type { OrchestrationMode, GroupChatConfig } from '../../../shared/chatroom-types';
+import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig } from '../../../shared/chatroom-types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -29,18 +29,26 @@ const MIND_B: MindContext = {
 function renderPicker(overrides?: {
   mode?: OrchestrationMode;
   groupChatConfig?: GroupChatConfig | null;
+  handoffConfig?: HandoffConfig | null;
+  magneticConfig?: MagenticConfig | null;
   minds?: MindContext[];
   disabled?: boolean;
   onModeChange?: (mode: OrchestrationMode) => void;
   onGroupChatConfigChange?: (config: GroupChatConfig) => void;
+  onHandoffConfigChange?: (config: HandoffConfig) => void;
+  onMagneticConfigChange?: (config: MagenticConfig) => void;
 }) {
   const props = {
     mode: overrides?.mode ?? 'concurrent',
     groupChatConfig: overrides?.groupChatConfig ?? null,
+    handoffConfig: overrides?.handoffConfig ?? null,
+    magneticConfig: overrides?.magneticConfig ?? null,
     minds: overrides?.minds ?? [MIND_A, MIND_B],
     disabled: overrides?.disabled ?? false,
     onModeChange: overrides?.onModeChange ?? vi.fn(),
     onGroupChatConfigChange: overrides?.onGroupChatConfigChange ?? vi.fn(),
+    onHandoffConfigChange: overrides?.onHandoffConfigChange ?? vi.fn(),
+    onMagneticConfigChange: overrides?.onMagneticConfigChange ?? vi.fn(),
   };
   return render(<OrchestrationPicker {...props} />);
 }
@@ -59,12 +67,18 @@ describe('OrchestrationPicker', () => {
     expect(screen.getByText('Magentic')).toBeTruthy();
   });
 
-  it('disables Handoff and Magentic buttons', () => {
-    renderPicker();
+  it('Handoff and Magentic buttons are enabled and clickable', () => {
+    const onModeChange = vi.fn();
+    renderPicker({ onModeChange });
     const handoff = screen.getByText('Handoff');
     const magentic = screen.getByText('Magentic');
-    expect(handoff.closest('button')?.disabled).toBe(true);
-    expect(magentic.closest('button')?.disabled).toBe(true);
+    expect(handoff.closest('button')?.disabled).toBe(false);
+    expect(magentic.closest('button')?.disabled).toBe(false);
+
+    fireEvent.click(handoff);
+    expect(onModeChange).toHaveBeenCalledWith('handoff');
+    fireEvent.click(magentic);
+    expect(onModeChange).toHaveBeenCalledWith('magentic');
   });
 
   it('calls onModeChange when a mode is selected', () => {
@@ -149,5 +163,83 @@ describe('OrchestrationPicker', () => {
   it('has data-testid orchestration-picker', () => {
     renderPicker();
     expect(screen.getByTestId('orchestration-picker')).toBeTruthy();
+  });
+
+  // -------------------------------------------------------------------------
+  // Handoff config
+  // -------------------------------------------------------------------------
+
+  it('shows initial agent selector when handoff mode is selected', () => {
+    renderPicker({ mode: 'handoff' });
+    expect(screen.getByText('Start with:')).toBeTruthy();
+  });
+
+  it('auto-creates default handoff config when switching to handoff', () => {
+    const onModeChange = vi.fn();
+    const onHandoffConfigChange = vi.fn();
+    renderPicker({ onModeChange, onHandoffConfigChange });
+
+    fireEvent.click(screen.getByText('Handoff'));
+    expect(onModeChange).toHaveBeenCalledWith('handoff');
+    expect(onHandoffConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialMindId: 'mind-a',
+        maxHandoffHops: 5,
+      }),
+    );
+  });
+
+  it('calls onHandoffConfigChange when initial agent is changed', () => {
+    const onHandoffConfigChange = vi.fn();
+    renderPicker({
+      mode: 'handoff',
+      handoffConfig: { initialMindId: 'mind-a', maxHandoffHops: 5 },
+      onHandoffConfigChange,
+    });
+
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'mind-b' } });
+    expect(onHandoffConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ initialMindId: 'mind-b' }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Magentic config
+  // -------------------------------------------------------------------------
+
+  it('shows manager selector when magentic mode is selected', () => {
+    renderPicker({ mode: 'magentic' });
+    expect(screen.getByText('Manager:')).toBeTruthy();
+  });
+
+  it('auto-creates default magentic config when switching to magentic', () => {
+    const onModeChange = vi.fn();
+    const onMagneticConfigChange = vi.fn();
+    renderPicker({ onModeChange, onMagneticConfigChange });
+
+    fireEvent.click(screen.getByText('Magentic'));
+    expect(onModeChange).toHaveBeenCalledWith('magentic');
+    expect(onMagneticConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        managerMindId: 'mind-a',
+        maxSteps: 10,
+      }),
+    );
+  });
+
+  it('calls onMagneticConfigChange when manager is changed', () => {
+    const onMagneticConfigChange = vi.fn();
+    renderPicker({
+      mode: 'magentic',
+      magneticConfig: { managerMindId: 'mind-a', maxSteps: 10 },
+      onMagneticConfigChange,
+    });
+
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'mind-b' } });
+    expect(onMagneticConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ managerMindId: 'mind-b' }),
+    );
   });
 });

--- a/src/renderer/components/chatroom/OrchestrationPicker.test.tsx
+++ b/src/renderer/components/chatroom/OrchestrationPicker.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { OrchestrationPicker } from './OrchestrationPicker';
+import type { MindContext } from '../../../shared/types';
+import type { OrchestrationMode, GroupChatConfig } from '../../../shared/chatroom-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MIND_A: MindContext = {
+  mindId: 'mind-a',
+  mindPath: 'C:\\agents\\a',
+  identity: { name: 'The Dude', systemMessage: '' },
+  status: 'ready',
+};
+
+const MIND_B: MindContext = {
+  mindId: 'mind-b',
+  mindPath: 'C:\\agents\\b',
+  identity: { name: 'Jarvis', systemMessage: '' },
+  status: 'ready',
+};
+
+function renderPicker(overrides?: {
+  mode?: OrchestrationMode;
+  groupChatConfig?: GroupChatConfig | null;
+  minds?: MindContext[];
+  disabled?: boolean;
+  onModeChange?: (mode: OrchestrationMode) => void;
+  onGroupChatConfigChange?: (config: GroupChatConfig) => void;
+}) {
+  const props = {
+    mode: overrides?.mode ?? 'concurrent',
+    groupChatConfig: overrides?.groupChatConfig ?? null,
+    minds: overrides?.minds ?? [MIND_A, MIND_B],
+    disabled: overrides?.disabled ?? false,
+    onModeChange: overrides?.onModeChange ?? vi.fn(),
+    onGroupChatConfigChange: overrides?.onGroupChatConfigChange ?? vi.fn(),
+  };
+  return render(<OrchestrationPicker {...props} />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OrchestrationPicker', () => {
+  it('renders all mode buttons', () => {
+    renderPicker();
+    expect(screen.getByText('Concurrent')).toBeTruthy();
+    expect(screen.getByText('Sequential')).toBeTruthy();
+    expect(screen.getByText('Group Chat')).toBeTruthy();
+    expect(screen.getByText('Handoff')).toBeTruthy();
+    expect(screen.getByText('Magentic')).toBeTruthy();
+  });
+
+  it('disables Handoff and Magentic buttons', () => {
+    renderPicker();
+    const handoff = screen.getByText('Handoff');
+    const magentic = screen.getByText('Magentic');
+    expect(handoff.closest('button')?.disabled).toBe(true);
+    expect(magentic.closest('button')?.disabled).toBe(true);
+  });
+
+  it('calls onModeChange when a mode is selected', () => {
+    const onModeChange = vi.fn();
+    renderPicker({ onModeChange });
+
+    fireEvent.click(screen.getByText('Sequential'));
+    expect(onModeChange).toHaveBeenCalledWith('sequential');
+  });
+
+  it('does not call onModeChange when disabled', () => {
+    const onModeChange = vi.fn();
+    renderPicker({ onModeChange, disabled: true });
+
+    fireEvent.click(screen.getByText('Sequential'));
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it('shows moderator selector when group-chat mode is selected', () => {
+    renderPicker({ mode: 'group-chat' });
+    expect(screen.getByText('Moderator:')).toBeTruthy();
+  });
+
+  it('does not show moderator selector for non-group-chat modes', () => {
+    renderPicker({ mode: 'concurrent' });
+    expect(screen.queryByText('Moderator:')).toBeNull();
+  });
+
+  it('auto-creates default group chat config when switching to group-chat', () => {
+    const onModeChange = vi.fn();
+    const onGroupChatConfigChange = vi.fn();
+    renderPicker({ onModeChange, onGroupChatConfigChange });
+
+    fireEvent.click(screen.getByText('Group Chat'));
+    expect(onModeChange).toHaveBeenCalledWith('group-chat');
+    expect(onGroupChatConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        moderatorMindId: 'mind-a', // First ready mind
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      }),
+    );
+  });
+
+  it('moderator dropdown lists all ready minds', () => {
+    renderPicker({
+      mode: 'group-chat',
+      groupChatConfig: {
+        moderatorMindId: 'mind-a',
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      },
+    });
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toBe('The Dude');
+    expect(options[1].textContent).toBe('Jarvis');
+  });
+
+  it('calls onGroupChatConfigChange when moderator is changed', () => {
+    const onGroupChatConfigChange = vi.fn();
+    renderPicker({
+      mode: 'group-chat',
+      groupChatConfig: {
+        moderatorMindId: 'mind-a',
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      },
+      onGroupChatConfigChange,
+    });
+
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'mind-b' } });
+    expect(onGroupChatConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ moderatorMindId: 'mind-b' }),
+    );
+  });
+
+  it('has data-testid orchestration-picker', () => {
+    renderPicker();
+    expect(screen.getByTestId('orchestration-picker')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/chatroom/OrchestrationPicker.tsx
+++ b/src/renderer/components/chatroom/OrchestrationPicker.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cn } from '../../lib/utils';
-import type { OrchestrationMode, GroupChatConfig } from '../../../shared/chatroom-types';
+import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig } from '../../../shared/chatroom-types';
 import type { MindContext } from '../../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -17,8 +17,8 @@ const MODES: ModeOption[] = [
   { value: 'concurrent', label: 'Concurrent', enabled: true },
   { value: 'sequential', label: 'Sequential', enabled: true },
   { value: 'group-chat', label: 'Group Chat', enabled: true },
-  { value: 'handoff', label: 'Handoff', enabled: false },
-  { value: 'magentic', label: 'Magentic', enabled: false },
+  { value: 'handoff', label: 'Handoff', enabled: true },
+  { value: 'magentic', label: 'Magentic', enabled: true },
 ];
 
 // ---------------------------------------------------------------------------
@@ -28,10 +28,14 @@ const MODES: ModeOption[] = [
 interface OrchestrationPickerProps {
   mode: OrchestrationMode;
   groupChatConfig: GroupChatConfig | null;
+  handoffConfig: HandoffConfig | null;
+  magneticConfig: MagenticConfig | null;
   minds: MindContext[];
   disabled?: boolean;
   onModeChange: (mode: OrchestrationMode) => void;
   onGroupChatConfigChange: (config: GroupChatConfig) => void;
+  onHandoffConfigChange: (config: HandoffConfig) => void;
+  onMagneticConfigChange: (config: MagenticConfig) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -41,10 +45,14 @@ interface OrchestrationPickerProps {
 export function OrchestrationPicker({
   mode,
   groupChatConfig,
+  handoffConfig,
+  magneticConfig,
   minds,
   disabled = false,
   onModeChange,
   onGroupChatConfigChange,
+  onHandoffConfigChange,
+  onMagneticConfigChange,
 }: OrchestrationPickerProps) {
   const readyMinds = minds.filter((m) => m.status === 'ready');
 
@@ -59,6 +67,22 @@ export function OrchestrationPicker({
         maxTurns: 10,
         minRounds: 1,
         maxSpeakerRepeats: 3,
+      });
+    }
+
+    // Auto-create default handoff config
+    if (newMode === 'handoff' && !handoffConfig) {
+      onHandoffConfigChange({
+        initialMindId: readyMinds[0]?.mindId,
+        maxHandoffHops: 5,
+      });
+    }
+
+    // Auto-create default magentic config
+    if (newMode === 'magentic' && !magneticConfig && readyMinds.length > 0) {
+      onMagneticConfigChange({
+        managerMindId: readyMinds[0].mindId,
+        maxSteps: 10,
       });
     }
   };
@@ -101,6 +125,54 @@ export function OrchestrationPicker({
                 maxTurns: groupChatConfig?.maxTurns ?? 10,
                 minRounds: groupChatConfig?.minRounds ?? 1,
                 maxSpeakerRepeats: groupChatConfig?.maxSpeakerRepeats ?? 3,
+              });
+            }}
+            className="bg-secondary text-secondary-foreground rounded px-2 py-0.5 text-xs border border-border"
+          >
+            {readyMinds.map((mind) => (
+              <option key={mind.mindId} value={mind.mindId}>
+                {mind.identity.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Handoff config: initial agent selector */}
+      {mode === 'handoff' && readyMinds.length > 0 && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Start with:</span>
+          <select
+            disabled={disabled}
+            value={handoffConfig?.initialMindId ?? readyMinds[0].mindId}
+            onChange={(e) => {
+              onHandoffConfigChange({
+                initialMindId: e.target.value,
+                maxHandoffHops: handoffConfig?.maxHandoffHops ?? 5,
+              });
+            }}
+            className="bg-secondary text-secondary-foreground rounded px-2 py-0.5 text-xs border border-border"
+          >
+            {readyMinds.map((mind) => (
+              <option key={mind.mindId} value={mind.mindId}>
+                {mind.identity.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Magentic config: manager selector */}
+      {mode === 'magentic' && readyMinds.length > 0 && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Manager:</span>
+          <select
+            disabled={disabled}
+            value={magneticConfig?.managerMindId ?? readyMinds[0].mindId}
+            onChange={(e) => {
+              onMagneticConfigChange({
+                managerMindId: e.target.value,
+                maxSteps: magneticConfig?.maxSteps ?? 10,
               });
             }}
             className="bg-secondary text-secondary-foreground rounded px-2 py-0.5 text-xs border border-border"

--- a/src/renderer/components/chatroom/OrchestrationPicker.tsx
+++ b/src/renderer/components/chatroom/OrchestrationPicker.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+import type { OrchestrationMode, GroupChatConfig } from '../../../shared/chatroom-types';
+import type { MindContext } from '../../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Mode metadata
+// ---------------------------------------------------------------------------
+
+interface ModeOption {
+  value: OrchestrationMode;
+  label: string;
+  enabled: boolean;
+}
+
+const MODES: ModeOption[] = [
+  { value: 'concurrent', label: 'Concurrent', enabled: true },
+  { value: 'sequential', label: 'Sequential', enabled: true },
+  { value: 'group-chat', label: 'Group Chat', enabled: true },
+  { value: 'handoff', label: 'Handoff', enabled: false },
+  { value: 'magentic', label: 'Magentic', enabled: false },
+];
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface OrchestrationPickerProps {
+  mode: OrchestrationMode;
+  groupChatConfig: GroupChatConfig | null;
+  minds: MindContext[];
+  disabled?: boolean;
+  onModeChange: (mode: OrchestrationMode) => void;
+  onGroupChatConfigChange: (config: GroupChatConfig) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function OrchestrationPicker({
+  mode,
+  groupChatConfig,
+  minds,
+  disabled = false,
+  onModeChange,
+  onGroupChatConfigChange,
+}: OrchestrationPickerProps) {
+  const readyMinds = minds.filter((m) => m.status === 'ready');
+
+  const handleModeChange = (newMode: OrchestrationMode) => {
+    if (disabled) return;
+    onModeChange(newMode);
+
+    // Auto-create default group chat config when switching to group-chat
+    if (newMode === 'group-chat' && !groupChatConfig && readyMinds.length > 0) {
+      onGroupChatConfigChange({
+        moderatorMindId: readyMinds[0].mindId,
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-2 border-b border-border" data-testid="orchestration-picker">
+      {/* Mode selector */}
+      <div className="flex items-center gap-1">
+        {MODES.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            disabled={disabled || !opt.enabled}
+            onClick={() => handleModeChange(opt.value)}
+            className={cn(
+              'text-xs px-2.5 py-1 rounded-full font-medium transition-colors',
+              opt.value === mode
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+              (!opt.enabled || disabled) && 'opacity-50 cursor-not-allowed',
+            )}
+            aria-pressed={opt.value === mode}
+            title={!opt.enabled ? `${opt.label} — coming soon` : opt.label}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Group Chat config: moderator selector */}
+      {mode === 'group-chat' && readyMinds.length > 0 && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Moderator:</span>
+          <select
+            disabled={disabled}
+            value={groupChatConfig?.moderatorMindId ?? readyMinds[0].mindId}
+            onChange={(e) => {
+              onGroupChatConfigChange({
+                moderatorMindId: e.target.value,
+                maxTurns: groupChatConfig?.maxTurns ?? 10,
+                minRounds: groupChatConfig?.minRounds ?? 1,
+                maxSpeakerRepeats: groupChatConfig?.maxSpeakerRepeats ?? 3,
+              });
+            }}
+            className="bg-secondary text-secondary-foreground rounded px-2 py-0.5 text-xs border border-border"
+          >
+            {readyMinds.map((mind) => (
+              <option key={mind.mindId} value={mind.mindId}>
+                {mind.identity.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/layout/MindSidebar.tsx
+++ b/src/renderer/components/layout/MindSidebar.tsx
@@ -156,6 +156,7 @@ export function MindSidebar() {
           onClick={async () => {
             if (activeMindId) {
               await window.electronAPI.chat.newConversation(activeMindId);
+              await window.electronAPI.chatroom.clear();
               dispatch({ type: 'NEW_CONVERSATION' });
               dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
             }

--- a/src/renderer/lib/store/reducer.test.ts
+++ b/src/renderer/lib/store/reducer.test.ts
@@ -728,4 +728,130 @@ describe('appReducer — chatroom actions', () => {
     expect(state.chatroomMessages).toEqual([]);
     expect(state.chatroomStreamingByMind).toEqual({});
   });
+
+  // -------------------------------------------------------------------------
+  // Orchestration events — set chatroomActiveSpeaker
+  // -------------------------------------------------------------------------
+
+  it('orchestration:turn-start sets active speaker with phase speaking', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:turn-start', data: { speaker: 'Agent A', speakerMindId: 'mind-1' } },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toEqual({ mindId: 'mind-1', mindName: 'Agent A', phase: 'speaking' });
+  });
+
+  it('orchestration:moderator-decision sets phase moderating', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mod-1', mindName: 'Moderator', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:moderator-decision', data: {} },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toEqual({ mindId: 'mod-1', mindName: 'Moderator', phase: 'moderating' });
+  });
+
+  it('orchestration:synthesis sets phase synthesizing', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mod-1', mindName: 'Moderator', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:synthesis', data: {} },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toEqual({ mindId: 'mod-1', mindName: 'Moderator', phase: 'synthesizing' });
+  });
+
+  it('orchestration:convergence clears active speaker', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomActiveSpeaker: { mindId: 'mind-1', mindName: 'Agent A', phase: 'speaking' },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:convergence', data: {} },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toBeNull();
+  });
+
+  it('orchestration:handoff-terminated clears active speaker', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomActiveSpeaker: { mindId: 'mind-1', mindName: 'Agent A', phase: 'speaking' },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:handoff-terminated', data: { reason: 'DONE' } },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toBeNull();
+  });
+
+  it('orchestration:magentic-terminated clears active speaker', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomActiveSpeaker: { mindId: 'mgr-1', mindName: 'Manager', phase: 'moderating' },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mgr-1', mindName: 'Manager', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:magentic-terminated', data: { reason: 'STEP_BUDGET_EXHAUSTED' } },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toBeNull();
+  });
+
+  it('orchestration:handoff sets active speaker to handoff target', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:handoff', data: { from: 'Agent A', fromMindId: 'mind-1', to: 'Agent B', toMindId: 'mind-2' } },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toEqual({ mindId: 'mind-2', mindName: 'Agent B', phase: 'speaking' });
+  });
+
+  it('orchestration:manager-plan sets phase moderating', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mgr-1', mindName: 'Manager', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:manager-plan', data: { phase: 'initial-planning' } },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toEqual({ mindId: 'mgr-1', mindName: 'Manager', phase: 'moderating' });
+  });
+
+  it('orchestration:task-ledger-update sets phase moderating', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mgr-1', mindName: 'Manager', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:task-ledger-update', data: { ledger: [] } },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toEqual({ mindId: 'mgr-1', mindName: 'Manager', phase: 'moderating' });
+  });
+
+  it('unknown orchestration event is a no-op', () => {
+    const state = appReducer(initialState, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:unknown-future-event', data: {} },
+      },
+    });
+    expect(state.chatroomActiveSpeaker).toBeNull();
+  });
 });

--- a/src/renderer/lib/store/reducer.test.ts
+++ b/src/renderer/lib/store/reducer.test.ts
@@ -849,9 +849,42 @@ describe('appReducer — chatroom actions', () => {
       type: 'CHATROOM_EVENT',
       payload: {
         mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
-        event: { type: 'orchestration:unknown-future-event', data: {} },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- forward-compat: simulates a future event type
+        event: { type: 'orchestration:unknown-future-event', data: {} } as any,
       },
     });
     expect(state.chatroomActiveSpeaker).toBeNull();
+  });
+
+  it('orchestration:approval-requested is a no-op', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomActiveSpeaker: { mindId: 'mind-1', mindName: 'Agent A', phase: 'speaking' },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:approval-requested', data: { correlationId: 'c1' } },
+      },
+    });
+    // State unchanged — approval events don't modify active speaker
+    expect(state).toBe(base);
+  });
+
+  it('orchestration:approval-decided is a no-op', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomActiveSpeaker: { mindId: 'mind-1', mindName: 'Agent A', phase: 'speaking' },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: {
+        mindId: 'mind-1', mindName: 'Agent A', messageId: '', roundId: 'r1',
+        event: { type: 'orchestration:approval-decided', data: { correlationId: 'c1' } },
+      },
+    });
+    // State unchanged
+    expect(state).toBe(base);
   });
 });

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -401,8 +401,29 @@ export function appReducer(state: AppState, action: AppAction): AppState {
             },
           };
         }
-        if (orchType === 'orchestration:convergence') {
+        if (orchType === 'orchestration:convergence' || orchType === 'orchestration:handoff-terminated' || orchType === 'orchestration:magentic-terminated') {
           return { ...state, chatroomActiveSpeaker: null };
+        }
+        if (orchType === 'orchestration:handoff') {
+          const data = (event as { data: Record<string, unknown> }).data;
+          return {
+            ...state,
+            chatroomActiveSpeaker: {
+              mindId: (data.toMindId as string) ?? mindId,
+              mindName: (data.to as string) ?? mindName,
+              phase: 'speaking',
+            },
+          };
+        }
+        if (orchType === 'orchestration:manager-plan' || orchType === 'orchestration:task-ledger-update') {
+          return {
+            ...state,
+            chatroomActiveSpeaker: {
+              mindId,
+              mindName,
+              phase: 'moderating',
+            },
+          };
         }
         return state;
       }
@@ -450,6 +471,12 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case 'SET_GROUP_CHAT_CONFIG':
       return { ...state, chatroomGroupChatConfig: action.payload };
+
+    case 'SET_HANDOFF_CONFIG':
+      return { ...state, chatroomHandoffConfig: action.payload };
+
+    case 'SET_MAGENTIC_CONFIG':
+      return { ...state, chatroomMagenticConfig: action.payload };
 
     case 'CHATROOM_ACTIVE_SPEAKER':
       return { ...state, chatroomActiveSpeaker: action.payload };

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -1,6 +1,7 @@
 import type { ChatMessage, ChatEvent, ContentBlock } from '../../../shared/types';
 import type { Task, TaskState } from '../../../shared/a2a-types';
 import type { ChatroomMessage } from '../../../shared/chatroom-types';
+import { isOrchestrationEvent } from '../../../shared/chatroom-types';
 import type { AppState, AppAction } from './state';
 
 /** Extract plain text from content blocks (for search, accessibility, etc.) */
@@ -368,64 +369,69 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const { mindId, mindName, messageId, roundId, event } = action.payload;
 
       // Orchestration events update the active speaker indicator
-      if ('type' in event && (event.type as string).startsWith('orchestration:')) {
-        const orchType = event.type as string;
-        if (orchType === 'orchestration:turn-start') {
-          const data = (event as { data: Record<string, unknown> }).data;
-          return {
-            ...state,
-            chatroomActiveSpeaker: {
-              mindId: (data.speakerMindId as string) ?? mindId,
-              mindName: (data.speaker as string) ?? mindName,
-              phase: 'speaking',
-            },
-          };
+      if (isOrchestrationEvent(event)) {
+        switch (event.type) {
+          case 'orchestration:turn-start':
+            return {
+              ...state,
+              chatroomActiveSpeaker: {
+                mindId: event.data.speakerMindId ?? mindId,
+                mindName: event.data.speaker ?? mindName,
+                phase: 'speaking',
+              },
+            };
+
+          case 'orchestration:moderator-decision':
+            return {
+              ...state,
+              chatroomActiveSpeaker: {
+                mindId,
+                mindName,
+                phase: 'moderating',
+              },
+            };
+
+          case 'orchestration:synthesis':
+            return {
+              ...state,
+              chatroomActiveSpeaker: {
+                mindId,
+                mindName,
+                phase: 'synthesizing',
+              },
+            };
+
+          case 'orchestration:convergence':
+          case 'orchestration:handoff-terminated':
+          case 'orchestration:magentic-terminated':
+            return { ...state, chatroomActiveSpeaker: null };
+
+          case 'orchestration:handoff':
+            return {
+              ...state,
+              chatroomActiveSpeaker: {
+                mindId: event.data.toMindId ?? mindId,
+                mindName: event.data.to ?? mindName,
+                phase: 'speaking',
+              },
+            };
+
+          case 'orchestration:manager-plan':
+          case 'orchestration:task-ledger-update':
+            return {
+              ...state,
+              chatroomActiveSpeaker: {
+                mindId,
+                mindName,
+                phase: 'moderating',
+              },
+            };
+
+          case 'orchestration:approval-requested':
+          case 'orchestration:approval-decided':
+          default:
+            return state;
         }
-        if (orchType === 'orchestration:moderator-decision') {
-          return {
-            ...state,
-            chatroomActiveSpeaker: {
-              mindId,
-              mindName,
-              phase: 'moderating',
-            },
-          };
-        }
-        if (orchType === 'orchestration:synthesis') {
-          return {
-            ...state,
-            chatroomActiveSpeaker: {
-              mindId,
-              mindName,
-              phase: 'synthesizing',
-            },
-          };
-        }
-        if (orchType === 'orchestration:convergence' || orchType === 'orchestration:handoff-terminated' || orchType === 'orchestration:magentic-terminated') {
-          return { ...state, chatroomActiveSpeaker: null };
-        }
-        if (orchType === 'orchestration:handoff') {
-          const data = (event as { data: Record<string, unknown> }).data;
-          return {
-            ...state,
-            chatroomActiveSpeaker: {
-              mindId: (data.toMindId as string) ?? mindId,
-              mindName: (data.to as string) ?? mindName,
-              phase: 'speaking',
-            },
-          };
-        }
-        if (orchType === 'orchestration:manager-plan' || orchType === 'orchestration:task-ledger-update') {
-          return {
-            ...state,
-            chatroomActiveSpeaker: {
-              mindId,
-              mindName,
-              phase: 'moderating',
-            },
-          };
-        }
-        return state;
       }
 
       // At this point, event is a ChatEvent (not an OrchestrationEvent)

--- a/src/renderer/lib/store/reducer.ts
+++ b/src/renderer/lib/store/reducer.ts
@@ -262,6 +262,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         streamingByMind: state.activeMindId
           ? { ...state.streamingByMind, [state.activeMindId]: false }
           : state.streamingByMind,
+        chatroomMessages: [],
+        chatroomStreamingByMind: {},
+        chatroomActiveSpeaker: null,
       };
 
     case 'A2A_INCOMING': {
@@ -363,6 +366,50 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case 'CHATROOM_EVENT': {
       const { mindId, mindName, messageId, roundId, event } = action.payload;
+
+      // Orchestration events update the active speaker indicator
+      if ('type' in event && (event.type as string).startsWith('orchestration:')) {
+        const orchType = event.type as string;
+        if (orchType === 'orchestration:turn-start') {
+          const data = (event as { data: Record<string, unknown> }).data;
+          return {
+            ...state,
+            chatroomActiveSpeaker: {
+              mindId: (data.speakerMindId as string) ?? mindId,
+              mindName: (data.speaker as string) ?? mindName,
+              phase: 'speaking',
+            },
+          };
+        }
+        if (orchType === 'orchestration:moderator-decision') {
+          return {
+            ...state,
+            chatroomActiveSpeaker: {
+              mindId,
+              mindName,
+              phase: 'moderating',
+            },
+          };
+        }
+        if (orchType === 'orchestration:synthesis') {
+          return {
+            ...state,
+            chatroomActiveSpeaker: {
+              mindId,
+              mindName,
+              phase: 'synthesizing',
+            },
+          };
+        }
+        if (orchType === 'orchestration:convergence') {
+          return { ...state, chatroomActiveSpeaker: null };
+        }
+        return state;
+      }
+
+      // At this point, event is a ChatEvent (not an OrchestrationEvent)
+      const chatEvent = event as ChatEvent;
+
       let messages = state.chatroomMessages;
 
       // Auto-create placeholder if this is the first event for an unknown message
@@ -380,19 +427,32 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         messages = [...messages, placeholder];
       }
 
-      const newMessages = handleChatEvent(messages, messageId, event);
-      const isDone = event.type === 'done' || event.type === 'error';
+      const newMessages = handleChatEvent(messages, messageId, chatEvent);
+      const isDone = chatEvent.type === 'done' || chatEvent.type === 'error';
       return {
         ...state,
         chatroomMessages: newMessages as ChatroomMessage[],
         chatroomStreamingByMind: isDone
           ? { ...state.chatroomStreamingByMind, [mindId]: false }
           : { ...state.chatroomStreamingByMind, [mindId]: true },
+        // Clear active speaker when all streaming stops
+        ...(isDone && !Object.entries(state.chatroomStreamingByMind).some(
+          ([id, s]) => s && id !== mindId,
+        ) ? { chatroomActiveSpeaker: null } : {}),
       };
     }
 
     case 'CHATROOM_CLEAR':
-      return { ...state, chatroomMessages: [], chatroomStreamingByMind: {} };
+      return { ...state, chatroomMessages: [], chatroomStreamingByMind: {}, chatroomActiveSpeaker: null };
+
+    case 'SET_ORCHESTRATION':
+      return { ...state, chatroomOrchestration: action.payload };
+
+    case 'SET_GROUP_CHAT_CONFIG':
+      return { ...state, chatroomGroupChatConfig: action.payload };
+
+    case 'CHATROOM_ACTIVE_SPEAKER':
+      return { ...state, chatroomActiveSpeaker: action.payload };
 
     default:
       return state;

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, ChatEvent, ModelInfo, LensViewManifest, MindContext } from '../../../shared/types';
 import type { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '../../../shared/a2a-types';
-import type { ChatroomMessage, ChatroomStreamEvent } from '../../../shared/chatroom-types';
+import type { ChatroomMessage, ChatroomStreamEvent, OrchestrationMode, GroupChatConfig } from '../../../shared/chatroom-types';
 
 export type LensView = 'chat' | string;
 
@@ -21,6 +21,10 @@ export interface AppState {
   tasksByMind: Record<string, Task[]>;
   chatroomMessages: ChatroomMessage[];
   chatroomStreamingByMind: Record<string, boolean>;
+  chatroomOrchestration: OrchestrationMode;
+  chatroomGroupChatConfig: GroupChatConfig | null;
+  /** Who is currently speaking / being selected — shown as typing indicator */
+  chatroomActiveSpeaker: { mindId: string; mindName: string; phase: 'speaking' | 'moderating' | 'synthesizing' } | null;
 }
 
 export type AppAction =
@@ -50,7 +54,10 @@ export type AppAction =
   | { type: 'CHATROOM_USER_MESSAGE'; payload: ChatroomMessage }
   | { type: 'CHATROOM_AGENT_MESSAGE'; payload: { messageId: string; mindId: string; mindName: string; roundId: string; timestamp: number } }
   | { type: 'CHATROOM_EVENT'; payload: ChatroomStreamEvent }
-  | { type: 'CHATROOM_CLEAR' };
+  | { type: 'CHATROOM_CLEAR' }
+  | { type: 'SET_ORCHESTRATION'; payload: OrchestrationMode }
+  | { type: 'SET_GROUP_CHAT_CONFIG'; payload: GroupChatConfig | null }
+  | { type: 'CHATROOM_ACTIVE_SPEAKER'; payload: { mindId: string; mindName: string; phase: 'speaking' | 'moderating' | 'synthesizing' } | null };
 
 export const initialState: AppState = {
   minds: [],
@@ -69,4 +76,7 @@ export const initialState: AppState = {
   tasksByMind: {},
   chatroomMessages: [],
   chatroomStreamingByMind: {},
+  chatroomOrchestration: 'concurrent',
+  chatroomGroupChatConfig: null,
+  chatroomActiveSpeaker: null,
 };

--- a/src/renderer/lib/store/state.ts
+++ b/src/renderer/lib/store/state.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, ChatEvent, ModelInfo, LensViewManifest, MindContext } from '../../../shared/types';
 import type { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '../../../shared/a2a-types';
-import type { ChatroomMessage, ChatroomStreamEvent, OrchestrationMode, GroupChatConfig } from '../../../shared/chatroom-types';
+import type { ChatroomMessage, ChatroomStreamEvent, OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig } from '../../../shared/chatroom-types';
 
 export type LensView = 'chat' | string;
 
@@ -23,6 +23,8 @@ export interface AppState {
   chatroomStreamingByMind: Record<string, boolean>;
   chatroomOrchestration: OrchestrationMode;
   chatroomGroupChatConfig: GroupChatConfig | null;
+  chatroomHandoffConfig: HandoffConfig | null;
+  chatroomMagenticConfig: MagenticConfig | null;
   /** Who is currently speaking / being selected — shown as typing indicator */
   chatroomActiveSpeaker: { mindId: string; mindName: string; phase: 'speaking' | 'moderating' | 'synthesizing' } | null;
 }
@@ -57,6 +59,8 @@ export type AppAction =
   | { type: 'CHATROOM_CLEAR' }
   | { type: 'SET_ORCHESTRATION'; payload: OrchestrationMode }
   | { type: 'SET_GROUP_CHAT_CONFIG'; payload: GroupChatConfig | null }
+  | { type: 'SET_HANDOFF_CONFIG'; payload: HandoffConfig | null }
+  | { type: 'SET_MAGENTIC_CONFIG'; payload: MagenticConfig | null }
   | { type: 'CHATROOM_ACTIVE_SPEAKER'; payload: { mindId: string; mindName: string; phase: 'speaking' | 'moderating' | 'synthesizing' } | null };
 
 export const initialState: AppState = {
@@ -78,5 +82,7 @@ export const initialState: AppState = {
   chatroomStreamingByMind: {},
   chatroomOrchestration: 'concurrent',
   chatroomGroupChatConfig: null,
+  chatroomHandoffConfig: null,
+  chatroomMagenticConfig: null,
   chatroomActiveSpeaker: null,
 };

--- a/src/shared/chatroom-types.test.ts
+++ b/src/shared/chatroom-types.test.ts
@@ -1,12 +1,25 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import type { ChatroomMessage, ChatroomTranscript, ChatroomStreamEvent, ChatroomAPI } from './chatroom-types';
-import type { ChatMessage } from './types';
+import type {
+  ChatroomMessage,
+  ChatroomTranscript,
+  ChatroomStreamEvent,
+  ChatroomAPI,
+  OrchestrationMode,
+  GroupChatConfig,
+  OrchestrationEvent,
+  OrchestrationEventType,
+} from './chatroom-types';
+import type { ChatMessage, ChatEvent } from './types';
 
 describe('chatroom-types', () => {
   it('ChatroomMessage extends ChatMessage with required sender and roundId', () => {
     expectTypeOf<ChatroomMessage>().toMatchTypeOf<ChatMessage>();
     expectTypeOf<ChatroomMessage['sender']>().toEqualTypeOf<{ mindId: string; name: string }>();
     expectTypeOf<ChatroomMessage['roundId']>().toEqualTypeOf<string>();
+  });
+
+  it('ChatroomMessage has optional orchestrationMode', () => {
+    expectTypeOf<ChatroomMessage['orchestrationMode']>().toEqualTypeOf<OrchestrationMode | undefined>();
   });
 
   it('ChatroomTranscript has versioned shape', () => {
@@ -21,11 +34,38 @@ describe('chatroom-types', () => {
     expectTypeOf<ChatroomStreamEvent['roundId']>().toBeString();
   });
 
+  it('ChatroomStreamEvent.event accepts ChatEvent or OrchestrationEvent', () => {
+    expectTypeOf<ChatEvent>().toMatchTypeOf<ChatroomStreamEvent['event']>();
+    expectTypeOf<OrchestrationEvent>().toMatchTypeOf<ChatroomStreamEvent['event']>();
+  });
+
   it('ChatroomAPI defines the full IPC surface', () => {
     expectTypeOf<ChatroomAPI['send']>().toBeFunction();
     expectTypeOf<ChatroomAPI['history']>().toBeFunction();
     expectTypeOf<ChatroomAPI['clear']>().toBeFunction();
     expectTypeOf<ChatroomAPI['stop']>().toBeFunction();
+    expectTypeOf<ChatroomAPI['setOrchestration']>().toBeFunction();
+    expectTypeOf<ChatroomAPI['getOrchestration']>().toBeFunction();
     expectTypeOf<ChatroomAPI['onEvent']>().toBeFunction();
+  });
+
+  it('OrchestrationMode is a string union of five modes', () => {
+    expectTypeOf<'concurrent'>().toMatchTypeOf<OrchestrationMode>();
+    expectTypeOf<'sequential'>().toMatchTypeOf<OrchestrationMode>();
+    expectTypeOf<'handoff'>().toMatchTypeOf<OrchestrationMode>();
+    expectTypeOf<'group-chat'>().toMatchTypeOf<OrchestrationMode>();
+    expectTypeOf<'magentic'>().toMatchTypeOf<OrchestrationMode>();
+  });
+
+  it('GroupChatConfig has required fields', () => {
+    expectTypeOf<GroupChatConfig['moderatorMindId']>().toBeString();
+    expectTypeOf<GroupChatConfig['maxTurns']>().toBeNumber();
+    expectTypeOf<GroupChatConfig['minRounds']>().toBeNumber();
+    expectTypeOf<GroupChatConfig['maxSpeakerRepeats']>().toBeNumber();
+  });
+
+  it('OrchestrationEvent has type and data', () => {
+    expectTypeOf<OrchestrationEvent['type']>().toEqualTypeOf<OrchestrationEventType>();
+    expectTypeOf<OrchestrationEvent['data']>().toEqualTypeOf<Record<string, unknown>>();
   });
 });

--- a/src/shared/chatroom-types.test.ts
+++ b/src/shared/chatroom-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expectTypeOf } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import type {
   ChatroomMessage,
   ChatroomTranscript,
@@ -9,6 +9,7 @@ import type {
   OrchestrationEvent,
   OrchestrationEventType,
 } from './chatroom-types';
+import { isOrchestrationEvent } from './chatroom-types';
 import type { ChatMessage, ChatEvent } from './types';
 
 describe('chatroom-types', () => {
@@ -66,6 +67,51 @@ describe('chatroom-types', () => {
 
   it('OrchestrationEvent has type and data', () => {
     expectTypeOf<OrchestrationEvent['type']>().toEqualTypeOf<OrchestrationEventType>();
-    expectTypeOf<OrchestrationEvent['data']>().toEqualTypeOf<Record<string, unknown>>();
+    expectTypeOf<OrchestrationEvent['data']>().toMatchTypeOf<Record<string, unknown>>();
+  });
+
+  // -------------------------------------------------------------------------
+  // isOrchestrationEvent — runtime type guard tests
+  // -------------------------------------------------------------------------
+
+  it('isOrchestrationEvent returns true for orchestration:turn-start', () => {
+    const event: OrchestrationEvent = { type: 'orchestration:turn-start', data: { speaker: 'A', speakerMindId: 'a1' } };
+    expect(isOrchestrationEvent(event)).toBe(true);
+  });
+
+  it('isOrchestrationEvent returns true for all orchestration event types', () => {
+    const types: OrchestrationEventType[] = [
+      'orchestration:turn-start',
+      'orchestration:moderator-decision',
+      'orchestration:convergence',
+      'orchestration:synthesis',
+      'orchestration:handoff',
+      'orchestration:handoff-terminated',
+      'orchestration:magentic-terminated',
+      'orchestration:task-ledger-update',
+      'orchestration:manager-plan',
+      'orchestration:approval-requested',
+      'orchestration:approval-decided',
+    ];
+    for (const type of types) {
+      // Use `as any` because not all data shapes match the discriminated members
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(isOrchestrationEvent({ type, data: {} } as any)).toBe(true);
+    }
+  });
+
+  it('isOrchestrationEvent returns false for ChatEvent types', () => {
+    const chatEvents: ChatEvent[] = [
+      { type: 'chunk', content: 'hello' },
+      { type: 'done' },
+      { type: 'error', message: 'fail' },
+      { type: 'reconnecting' },
+      { type: 'tool_start', toolCallId: 't1', toolName: 'read' },
+      { type: 'reasoning', reasoningId: 'r1', content: 'thinking' },
+      { type: 'message_final', sdkMessageId: 's1', content: 'final' },
+    ];
+    for (const event of chatEvents) {
+      expect(isOrchestrationEvent(event)).toBe(false);
+    }
   });
 });

--- a/src/shared/chatroom-types.ts
+++ b/src/shared/chatroom-types.ts
@@ -3,12 +3,47 @@
 import type { ChatMessage, ChatEvent } from './types';
 
 // ---------------------------------------------------------------------------
+// Orchestration patterns — ordered by complexity
+// ---------------------------------------------------------------------------
+
+export type OrchestrationMode =
+  | 'concurrent'    // Today's broadcast (all agents respond in parallel)
+  | 'sequential'    // Round-robin (agents take turns in order)
+  | 'handoff'       // One agent delegates to the next (stub)
+  | 'group-chat'    // Moderated — a moderator mind picks next speaker
+  | 'magentic';     // Autonomous multi-agent (stub)
+
+/** Configuration for group-chat orchestration */
+export interface GroupChatConfig {
+  moderatorMindId: string;      // Which mind acts as moderator
+  maxTurns: number;             // Safety cap on total individual turns (default 10)
+  minRounds: number;            // Minimum complete rounds where every participant speaks (default 1)
+  maxSpeakerRepeats: number;    // Max times one speaker can go consecutively (default 3)
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration events — emitted alongside normal ChatroomStreamEvents
+// ---------------------------------------------------------------------------
+
+export type OrchestrationEventType =
+  | 'orchestration:turn-start'
+  | 'orchestration:moderator-decision'
+  | 'orchestration:convergence'
+  | 'orchestration:synthesis';
+
+export interface OrchestrationEvent {
+  type: OrchestrationEventType;
+  data: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
 // Chatroom message — ChatMessage with required sender attribution
 // ---------------------------------------------------------------------------
 
 export interface ChatroomMessage extends ChatMessage {
   sender: { mindId: string; name: string };
   roundId: string;
+  orchestrationMode?: OrchestrationMode;
 }
 
 // ---------------------------------------------------------------------------
@@ -30,7 +65,7 @@ export interface ChatroomStreamEvent {
   mindName: string;
   messageId: string;
   roundId: string;
-  event: ChatEvent;
+  event: ChatEvent | OrchestrationEvent;
 }
 
 // ---------------------------------------------------------------------------
@@ -42,5 +77,7 @@ export interface ChatroomAPI {
   history: () => Promise<ChatroomMessage[]>;
   clear: () => Promise<void>;
   stop: () => Promise<void>;
+  setOrchestration: (mode: OrchestrationMode, config?: GroupChatConfig) => Promise<void>;
+  getOrchestration: () => Promise<{ mode: OrchestrationMode; config: GroupChatConfig | null }>;
   onEvent: (callback: (event: ChatroomStreamEvent) => void) => () => void;
 }

--- a/src/shared/chatroom-types.ts
+++ b/src/shared/chatroom-types.ts
@@ -21,6 +21,63 @@ export interface GroupChatConfig {
   maxSpeakerRepeats: number;    // Max times one speaker can go consecutively (default 3)
 }
 
+/** Configuration for handoff orchestration */
+export interface HandoffConfig {
+  initialMindId?: string;       // Which mind starts (defaults to first participant)
+  maxHandoffHops: number;       // Safety cap on total handoffs (default 5)
+}
+
+/** Reason a handoff orchestration terminated */
+export type HandoffTerminationReason =
+  | 'DONE'           // Agent signalled task complete
+  | 'MAX_HOPS'       // Hit maxHandoffHops limit
+  | 'LOOP_DETECTED'  // Cycle detected (A→B→A)
+  | 'ERROR'          // Unrecoverable error
+  | 'CANCELLED';     // User/system abort
+
+/** Configuration for magentic (manager-driven) orchestration */
+export interface MagenticConfig {
+  managerMindId: string;        // Which mind acts as the manager
+  maxSteps: number;             // Safety cap on total steps (default 10)
+  allowedMindIds?: string[];    // Allowlist of agent mindIds (defaults to all participants)
+}
+
+/** A single task item in the magentic task ledger */
+export interface TaskLedgerItem {
+  id: string;
+  description: string;
+  assignee?: string;            // mindId of assigned agent
+  status: 'pending' | 'in-progress' | 'completed' | 'failed';
+  result?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Approval gate — governance for side-effect tools
+// ---------------------------------------------------------------------------
+
+/** Risk level for side-effect tool invocation */
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+/** Payload emitted when a side-effect tool requires approval */
+export interface ApprovalRequest {
+  correlationId: string;
+  actorId: string;
+  toolName: string;
+  parameters: Record<string, unknown>;  // Redacted
+  reason: string;
+  riskLevel: RiskLevel;
+  timestamp: number;
+}
+
+/** Decision from an approver */
+export interface ApprovalDecision {
+  correlationId: string;
+  approved: boolean;
+  decidedBy: string;
+  timestamp: number;
+  reason?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Orchestration events — emitted alongside normal ChatroomStreamEvents
 // ---------------------------------------------------------------------------
@@ -29,7 +86,14 @@ export type OrchestrationEventType =
   | 'orchestration:turn-start'
   | 'orchestration:moderator-decision'
   | 'orchestration:convergence'
-  | 'orchestration:synthesis';
+  | 'orchestration:synthesis'
+  | 'orchestration:handoff'
+  | 'orchestration:handoff-terminated'
+  | 'orchestration:magentic-terminated'
+  | 'orchestration:task-ledger-update'
+  | 'orchestration:manager-plan'
+  | 'orchestration:approval-requested'
+  | 'orchestration:approval-decided';
 
 export interface OrchestrationEvent {
   type: OrchestrationEventType;
@@ -77,7 +141,7 @@ export interface ChatroomAPI {
   history: () => Promise<ChatroomMessage[]>;
   clear: () => Promise<void>;
   stop: () => Promise<void>;
-  setOrchestration: (mode: OrchestrationMode, config?: GroupChatConfig) => Promise<void>;
-  getOrchestration: () => Promise<{ mode: OrchestrationMode; config: GroupChatConfig | null }>;
+  setOrchestration: (mode: OrchestrationMode, config?: GroupChatConfig | HandoffConfig | MagenticConfig) => Promise<void>;
+  getOrchestration: () => Promise<{ mode: OrchestrationMode; config: GroupChatConfig | HandoffConfig | MagenticConfig | null }>;
   onEvent: (callback: (event: ChatroomStreamEvent) => void) => () => void;
 }

--- a/src/shared/chatroom-types.ts
+++ b/src/shared/chatroom-types.ts
@@ -95,9 +95,25 @@ export type OrchestrationEventType =
   | 'orchestration:approval-requested'
   | 'orchestration:approval-decided';
 
-export interface OrchestrationEvent {
-  type: OrchestrationEventType;
-  data: Record<string, unknown>;
+/** Discriminated union of orchestration events — enables type-safe switch in reducers */
+export type OrchestrationEvent =
+  | { type: 'orchestration:turn-start'; data: { speaker: string; speakerMindId: string } & Record<string, unknown> }
+  | { type: 'orchestration:moderator-decision'; data: Record<string, unknown> }
+  | { type: 'orchestration:convergence'; data: Record<string, unknown> }
+  | { type: 'orchestration:synthesis'; data: Record<string, unknown> }
+  | { type: 'orchestration:handoff'; data: { from: string; fromMindId: string; to: string; toMindId: string; reason: string } & Record<string, unknown> }
+  | { type: 'orchestration:handoff-terminated'; data: Record<string, unknown> }
+  | { type: 'orchestration:magentic-terminated'; data: Record<string, unknown> }
+  | { type: 'orchestration:task-ledger-update'; data: Record<string, unknown> }
+  | { type: 'orchestration:manager-plan'; data: Record<string, unknown> }
+  | { type: 'orchestration:approval-requested'; data: Record<string, unknown> }
+  | { type: 'orchestration:approval-decided'; data: Record<string, unknown> };
+
+/** Type guard: narrows ChatEvent | OrchestrationEvent to OrchestrationEvent */
+export function isOrchestrationEvent(
+  event: ChatEvent | OrchestrationEvent,
+): event is OrchestrationEvent {
+  return event.type.startsWith('orchestration:');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -10,7 +10,14 @@ import type {
   LensViewManifest,
   ElectronAPI,
 } from '../shared/types';
-import type { ChatroomMessage, ChatroomStreamEvent } from '../shared/chatroom-types';
+import type {
+  ChatroomMessage,
+  ChatroomStreamEvent,
+  OrchestrationMode,
+  GroupChatConfig,
+  OrchestrationEvent,
+  OrchestrationEventType,
+} from '../shared/chatroom-types';
 
 // ---------------------------------------------------------------------------
 // ContentBlock factories
@@ -144,6 +151,8 @@ export function mockElectronAPI(): ElectronAPI {
       history: vi.fn().mockResolvedValue([]),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
+      setOrchestration: vi.fn().mockResolvedValue(undefined),
+      getOrchestration: vi.fn().mockResolvedValue({ mode: 'concurrent', config: null }),
       onEvent: vi.fn().mockReturnValue(vi.fn()),
     },
     a2a: {
@@ -198,4 +207,27 @@ export function installElectronAPI(api?: ElectronAPI): ElectronAPI {
   const mock = api ?? mockElectronAPI();
   Object.defineProperty(window, 'electronAPI', { value: mock, writable: true, configurable: true });
   return mock;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration factories
+// ---------------------------------------------------------------------------
+
+export function makeOrchestrationEvent(
+  type: OrchestrationEventType = 'orchestration:turn-start',
+  data: Record<string, unknown> = { speaker: 'Agent One' },
+): OrchestrationEvent {
+  return { type, data };
+}
+
+export function makeGroupChatConfig(
+  overrides?: Partial<GroupChatConfig>,
+): GroupChatConfig {
+  return {
+    moderatorMindId: 'moderator-1',
+    maxTurns: 10,
+    minRounds: 1,
+    maxSpeakerRepeats: 3,
+    ...overrides,
+  };
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -13,8 +13,9 @@ import type {
 import type {
   ChatroomMessage,
   ChatroomStreamEvent,
-  OrchestrationMode,
   GroupChatConfig,
+  HandoffConfig,
+  MagenticConfig,
   OrchestrationEvent,
   OrchestrationEventType,
 } from '../shared/chatroom-types';
@@ -228,6 +229,25 @@ export function makeGroupChatConfig(
     maxTurns: 10,
     minRounds: 1,
     maxSpeakerRepeats: 3,
+    ...overrides,
+  };
+}
+
+export function makeHandoffConfig(
+  overrides?: Partial<HandoffConfig>,
+): HandoffConfig {
+  return {
+    maxHandoffHops: 5,
+    ...overrides,
+  };
+}
+
+export function makeMagenticConfig(
+  overrides?: Partial<MagenticConfig>,
+): MagenticConfig {
+  return {
+    managerMindId: 'manager-1',
+    maxSteps: 10,
     ...overrides,
   };
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -216,9 +216,9 @@ export function installElectronAPI(api?: ElectronAPI): ElectronAPI {
 
 export function makeOrchestrationEvent(
   type: OrchestrationEventType = 'orchestration:turn-start',
-  data: Record<string, unknown> = { speaker: 'Agent One' },
+  data: Record<string, unknown> = { speaker: 'Agent One', speakerMindId: 'agent-1' },
 ): OrchestrationEvent {
-  return { type, data };
+  return { type, data } as OrchestrationEvent;
 }
 
 export function makeGroupChatConfig(


### PR DESCRIPTION
## Summary

Adds 5 pluggable orchestration strategies for multi-agent chatroom collaboration. Each implements `OrchestrationStrategy` and plugs into `ChatroomService` via factory — zero changes to existing chat/mind infrastructure.

## Orchestration Modes

- **Concurrent** — all agents respond in parallel with per-agent abort tracking
- **Sequential** — round-robin; each agent sees prior responses via XML context
- **GroupChat** — moderator picks speakers, directs focus, enforces convergence, synthesizes
- **Handoff** — agents embed JSON directives to delegate tasks with transcript preservation
- **Magentic** — manager creates plan, assigns tasks via shared ledger, tracks status

All agents are full Copilot SDK sessions with complete tool access (file I/O, terminal, search, MCP).

## Shared Infrastructure

- `BaseStrategy` — abstract class owning abort/unsubs/stop() lifecycle; Sequential, Handoff, GroupChat, Magentic extend it
- `stream-agent.ts` — SDK event wiring, idle/error listeners, stale session retry, 30s send timeout
- `shared.ts` — escapeXml, textContent, extractJsonObject (string-aware), stripControlJson
- `observability.ts` — structured events with parameter redaction
- `approval-gate.ts` — tool execution review with risk classification

## Bug Fixes

- **Session idle race** — idle/error listeners now register BEFORE `session.send()`, preventing 5-minute hangs from missed events
- **Send timeout** — 30s guard on `session.send()` with proper cleanup; hangs trigger stale session retry

## Refactors

- **BaseStrategy extraction** — eliminated ~30 lines of duplicated abort/unsubs/stop() code across 4 strategies
- **Discriminated union events** — `OrchestrationEvent` is now a typed union with `isOrchestrationEvent()` guard; reducer uses `switch(event.type)` with compiler-enforced narrowing instead of stringly-typed `as string` casts

## UI

- `OrchestrationPicker` — mode selector with per-mode config dialogs
- `ChatroomPanel` — left-aligned typing indicator, participant-aware phase text
- Reducer handles all 11 orchestration event types via type-safe switch

## Quality

- **Lint**: 0 errors
- **Tests**: 745 passed / 68 files (71 new tests covering strategies, shared modules, BaseStrategy lifecycle, type guard, orchestration events)
- **Build**: `npm run package` succeeds

42 files changed, +6,995 / -278