### PR TITLE
feat: restore built-in canvas service (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.27.0 (2026-04-23)
+
+### Built-in canvas
+
+- **CanvasService** — Chamber now ships canvas as a first-class main-process service instead of a per-mind `.github/extensions/canvas` adapter.
+- **Shared localhost canvas server** — one built-in HTTP server serves canvases for all loaded minds with mind-scoped URLs and server-sent-event live reload.
+- **Per-mind canvas content** — rendered files now live in `<mindPath>/.chamber/canvas/` instead of under `.github/extensions/canvas/data/content/`.
+- **Canvas tools restored** — minds once again get `canvas_show`, `canvas_update`, `canvas_close`, and `canvas_list`.
+- **Default browser launch** — canvas pages now open via Electron in the user's default browser instead of hardcoding Microsoft Edge.
+
+### Runtime architecture
+
+- **CanvasServer** — pure Node HTTP server with bridge-script injection, SSE reload, and browser action POST back-channel.
+- **ChamberToolProvider reuse** — canvas now plugs into the same provider seam used by cron and A2A instead of reviving the deleted extension loader.
+
 ## v0.26.0 (2026-04-23)
 
 ### Built-in cron

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Chamber is where that happens. Your agent wakes up, finds its voice, and prepare
 - **Prompt-driven views** — click Refresh, the agent gathers data and populates the view. Edit the prompt to change what it shows.
 - **Write-back** — type instructions in the action bar on any view. The agent modifies the data.
 - **Self-extending** — the agent has a Lens skill. Ask it to "create a view for my cron jobs" and it builds one.
+- **Built-in canvas** — render HTML dashboards, reports, and forms in the browser with live reload and a simple action back-channel.
 - **Built-in cron** — schedule prompt, process, webhook, and notification jobs per mind without installing per-mind extensions.
 - **Activity bar** — VS Code-style icon strip. Icons appear as views are discovered.
 - **Streaming chat** — real-time responses with markdown, tool calls, and reasoning blocks.
@@ -50,6 +51,7 @@ Select a mind directory from the sidebar. The agent connects, views appear, and 
 ```
 Electron Main Process
 ├── CopilotClientFactory — per-mind CopilotClient lifecycle
+├── CanvasService       — browser-rendered HTML canvases with live reload
 ├── CronService         — built-in scheduled jobs and durable run history
 ├── ChatService         — streaming sessions, background prompts
 ├── ChatroomService     — multi-agent broadcast, orchestration strategy dispatch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { ChatService } from './main/services/chat/ChatService';
 import { TurnQueue } from './main/services/chat/TurnQueue';
 import { A2aToolProvider, AgentCardRegistry, MessageRouter, TaskManager } from './main/services/a2a';
 import { ChatroomService } from './main/services/chatroom';
+import { CanvasService } from './main/services/canvas';
 import { CronService } from './main/services/cron';
 import { createAppTray, loadAppIcon } from './main/tray/Tray';
 
@@ -65,6 +66,7 @@ const taskManager = new TaskManager(mindManager, agentCardRegistry);
 const chatService: ChatService = new ChatService(mindManager, turnQueue);
 const messageRouter: MessageRouter = new MessageRouter(chatService, agentCardRegistry, a2aEventBus);
 const chatroomService = new ChatroomService(mindManager);
+const canvasService = new CanvasService();
 const cronService = new CronService({
   getTaskManager: () => taskManager,
   showMind: (mindId) => {
@@ -74,7 +76,7 @@ const cronService = new CronService({
 });
 const a2aToolProvider = new A2aToolProvider(messageRouter, agentCardRegistry, taskManager);
 
-mindManager.setProviders([cronService, a2aToolProvider]);
+mindManager.setProviders([cronService, canvasService, a2aToolProvider]);
 
 wireLifecycleEvents({ mindManager, agentCardRegistry, taskManager, a2aEventBus });
 

--- a/src/main/services/canvas/CanvasServer.test.ts
+++ b/src/main/services/canvas/CanvasServer.test.ts
@@ -1,0 +1,132 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CanvasServer } from './CanvasServer';
+
+const tempDirs: string[] = [];
+
+function makeMindDir(name = 'mind-1'): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-canvas-server-'));
+  const mindDir = path.join(root, name);
+  fs.mkdirSync(mindDir, { recursive: true });
+  tempDirs.push(root);
+  return mindDir;
+}
+
+async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<{ done: boolean; text: string }> {
+  const { done, value } = await reader.read();
+  return {
+    done,
+    text: value ? new TextDecoder().decode(value) : '',
+  };
+}
+
+describe('CanvasServer', () => {
+  let server: CanvasServer;
+  const mindDirs = new Map<string, string>();
+  const onAction = vi.fn();
+
+  beforeEach(() => {
+    mindDirs.clear();
+    onAction.mockReset();
+    server = new CanvasServer({
+      resolveContentDir: (mindId) => mindDirs.get(mindId) ?? null,
+      onAction,
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir && fs.existsSync(dir)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('serves html with the bridge script injected', async () => {
+    const mindDir = makeMindDir();
+    mindDirs.set('mind-1', mindDir);
+    fs.writeFileSync(
+      path.join(mindDir, 'report.html'),
+      '<!DOCTYPE html><html><body><h1>Hello</h1></body></html>',
+      'utf8',
+    );
+
+    const port = await server.start();
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/report.html`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("new EventSource('_sse?canvas=' + encodeURIComponent(canvasFile))");
+    expect(html).toContain("fetch('_action?canvas=' + encodeURIComponent(canvasFile)");
+  });
+
+  it('supports targeted reload and close events over SSE', async () => {
+    const mindDir = makeMindDir();
+    mindDirs.set('mind-1', mindDir);
+    fs.writeFileSync(path.join(mindDir, 'report.html'), '<html><body>Hi</body></html>', 'utf8');
+
+    const port = await server.start();
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/_sse?canvas=report.html`);
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Expected SSE response body');
+    }
+
+    const first = await readChunk(reader);
+    expect(first.text).toContain('connected');
+
+    server.reload('mind-1', 'report.html');
+    const second = await readChunk(reader);
+    expect(second.text).toContain('reload');
+
+    server.closeClients('mind-1', 'report.html');
+    const third = await readChunk(reader);
+    expect(third.text).toContain('close');
+
+    const fourth = await readChunk(reader);
+    expect(fourth.done).toBe(true);
+  });
+
+  it('routes browser actions back to the callback', async () => {
+    const mindDir = makeMindDir();
+    mindDirs.set('mind-1', mindDir);
+
+    const port = await server.start();
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/_action?canvas=report.html`, {
+      body: JSON.stringify({
+        action: 'button-clicked',
+        data: { id: 'approve' },
+        timestamp: 123,
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"ok":true}');
+    expect(onAction).toHaveBeenCalledWith({
+      action: 'button-clicked',
+      canvas: 'report.html',
+      data: { id: 'approve' },
+      mindId: 'mind-1',
+      timestamp: 123,
+    });
+  });
+
+  it('rejects path traversal outside the mind content directory', async () => {
+    const mindDir = makeMindDir();
+    mindDirs.set('mind-1', mindDir);
+
+    const port = await server.start();
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/..%2Fsecret.txt`);
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('Forbidden');
+  });
+});

--- a/src/main/services/canvas/CanvasServer.ts
+++ b/src/main/services/canvas/CanvasServer.ts
@@ -1,0 +1,333 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { URL } from 'node:url';
+import type { CanvasAction, CanvasServerLike } from './types';
+
+const MIME_TYPES: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpg': 'image/jpeg',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+};
+
+interface CanvasServerOptions {
+  resolveContentDir: (mindId: string) => string | null;
+  onAction: (action: CanvasAction) => void;
+}
+
+type CanvasClient = ServerResponse<IncomingMessage>;
+
+function buildBridgeScript(filename: string): string {
+  return `
+<script>
+(function() {
+  var canvasFile = ${JSON.stringify(filename)};
+  var es = new EventSource('_sse?canvas=' + encodeURIComponent(canvasFile));
+  es.onmessage = function(e) {
+    if (e.data === 'reload') { location.reload(); }
+    if (e.data === 'close') { window.close(); }
+  };
+
+  window.canvas = {
+    sendAction: function(name, data) {
+      return fetch('_action?canvas=' + encodeURIComponent(canvasFile), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: name, data: data || {}, timestamp: Date.now() })
+      });
+    }
+  };
+})();
+</script>`;
+}
+
+function injectBridge(html: string, filename: string): string {
+  const bridgeScript = buildBridgeScript(filename);
+  if (html.includes('</body>')) {
+    return html.replace('</body>', `${bridgeScript}\n</body>`);
+  }
+  if (html.includes('</html>')) {
+    return html.replace('</html>', `${bridgeScript}\n</html>`);
+  }
+  return `${html}${bridgeScript}`;
+}
+
+function normalizePath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const normalizedParent = normalizePath(parent);
+  const normalizedChild = normalizePath(child);
+  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}${path.sep}`);
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+export class CanvasServer implements CanvasServerLike {
+  private server: Server | null = null;
+  private port: number | null = null;
+  private readonly sseClients = new Map<string, Set<CanvasClient>>();
+
+  constructor(private readonly options: CanvasServerOptions) {}
+
+  async start(): Promise<number> {
+    if (this.server) {
+      if (this.port === null) {
+        throw new Error('Canvas server is running without a bound port');
+      }
+      return this.port;
+    }
+
+    return new Promise<number>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        void this.handleRequest(req, res);
+      });
+
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          reject(new Error('Canvas server failed to bind to a TCP port'));
+          return;
+        }
+
+        this.server = server;
+        this.port = address.port;
+        resolve(address.port);
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    const server = this.server;
+    this.closeClients();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    this.server = null;
+    this.port = null;
+    this.sseClients.clear();
+  }
+
+  reload(mindId?: string, filename?: string): void {
+    this.broadcast('reload', mindId, filename);
+  }
+
+  closeClients(mindId?: string, filename?: string): void {
+    const entries = this.matchingClientEntries(mindId, filename);
+    for (const [key, clients] of entries) {
+      for (const client of clients) {
+        try {
+          client.write('data: close\n\n');
+          client.end();
+        } catch {
+          // Ignore client disconnect races during close.
+        }
+      }
+      this.sseClients.delete(key);
+    }
+  }
+
+  getPort(): number | null {
+    return this.port;
+  }
+
+  isRunning(): boolean {
+    return this.server !== null;
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const segments = requestUrl.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+
+    if (segments.length === 0) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+
+    const [mindId, ...rest] = segments;
+    if (!mindId) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+
+    if (rest.length === 1 && rest[0] === '_sse') {
+      this.handleSse(req, res, mindId, requestUrl.searchParams.get('canvas'));
+      return;
+    }
+
+    if (rest.length === 1 && rest[0] === '_action') {
+      await this.handleAction(req, res, mindId, requestUrl.searchParams.get('canvas'));
+      return;
+    }
+
+    this.handleStaticFile(res, mindId, rest);
+  }
+
+  private handleSse(req: IncomingMessage, res: ServerResponse, mindId: string, filename: string | null): void {
+    if (!filename) {
+      res.writeHead(400);
+      res.end('Missing canvas query parameter');
+      return;
+    }
+
+    res.writeHead(200, {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Content-Type': 'text/event-stream',
+    });
+    res.write('data: connected\n\n');
+
+    this.addClient(mindId, filename, res);
+    req.on('close', () => {
+      this.removeClient(mindId, filename, res);
+    });
+  }
+
+  private async handleAction(req: IncomingMessage, res: ServerResponse, mindId: string, filename: string | null): Promise<void> {
+    if (!filename) {
+      res.writeHead(400);
+      res.end('{"error":"missing canvas"}');
+      return;
+    }
+
+    try {
+      const body = await readRequestBody(req);
+      const parsed = JSON.parse(body) as Record<string, unknown>;
+      this.options.onAction({
+        mindId,
+        canvas: filename,
+        action: typeof parsed.action === 'string' ? parsed.action : 'unknown',
+        data: parsed.data,
+        timestamp: typeof parsed.timestamp === 'number' ? parsed.timestamp : Date.now(),
+      });
+      res.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      });
+      res.end('{"ok":true}');
+    } catch {
+      res.writeHead(400);
+      res.end('{"error":"invalid json"}');
+    }
+  }
+
+  private handleStaticFile(res: ServerResponse, mindId: string, segments: string[]): void {
+    const contentDir = this.options.resolveContentDir(mindId);
+    if (!contentDir) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+
+    const relativePath = segments.length === 0 ? 'index.html' : path.join(...segments);
+    const fullPath = path.resolve(contentDir, relativePath);
+    if (!isPathInside(contentDir, fullPath)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+
+    if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isFile()) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+
+    try {
+      let content: Buffer | string = fs.readFileSync(fullPath);
+      const extension = path.extname(fullPath).toLowerCase();
+      const mimeType = MIME_TYPES[extension] ?? 'application/octet-stream';
+
+      if (extension === '.html') {
+        content = injectBridge(content.toString('utf8'), relativePath.replace(/\\/g, '/'));
+      }
+
+      res.writeHead(200, {
+        'Cache-Control': 'no-store',
+        'Content-Type': mimeType,
+      });
+      res.end(content);
+    } catch {
+      res.writeHead(500);
+      res.end('Server error');
+    }
+  }
+
+  private broadcast(message: 'reload' | 'close', mindId?: string, filename?: string): void {
+    const entries = this.matchingClientEntries(mindId, filename);
+    for (const [, clients] of entries) {
+      for (const client of clients) {
+        try {
+          client.write(`data: ${message}\n\n`);
+        } catch {
+          // Ignore client disconnect races during broadcast.
+        }
+      }
+    }
+  }
+
+  private addClient(mindId: string, filename: string, client: CanvasClient): void {
+    const key = this.clientKey(mindId, filename);
+    const clients = this.sseClients.get(key) ?? new Set<CanvasClient>();
+    clients.add(client);
+    this.sseClients.set(key, clients);
+  }
+
+  private removeClient(mindId: string, filename: string, client: CanvasClient): void {
+    const key = this.clientKey(mindId, filename);
+    const clients = this.sseClients.get(key);
+    if (!clients) {
+      return;
+    }
+
+    clients.delete(client);
+    if (clients.size === 0) {
+      this.sseClients.delete(key);
+    }
+  }
+
+  private matchingClientEntries(mindId?: string, filename?: string): Array<[string, Set<CanvasClient>]> {
+    if (mindId && filename) {
+      const clients = this.sseClients.get(this.clientKey(mindId, filename));
+      return clients ? [[this.clientKey(mindId, filename), clients]] : [];
+    }
+
+    if (mindId) {
+      const prefix = `${mindId}:`;
+      return [...this.sseClients.entries()].filter(([key]) => key.startsWith(prefix));
+    }
+
+    return [...this.sseClients.entries()];
+  }
+
+  private clientKey(mindId: string, filename: string): string {
+    return `${mindId}:${filename}`;
+  }
+}

--- a/src/main/services/canvas/CanvasService.test.ts
+++ b/src/main/services/canvas/CanvasService.test.ts
@@ -1,0 +1,194 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CanvasService } from './CanvasService';
+import type { CanvasServerLike } from './types';
+
+const tempDirs: string[] = [];
+
+function makeMindPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-canvas-service-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+class MockCanvasServer implements CanvasServerLike {
+  private port: number | null = null;
+
+  readonly start = vi.fn(async () => {
+    if (this.port === null) {
+      this.port = 4312;
+    }
+    return this.port;
+  });
+
+  readonly stop = vi.fn(async () => {
+    this.port = null;
+  });
+
+  readonly reload = vi.fn();
+  readonly closeClients = vi.fn();
+
+  readonly getPort = vi.fn(() => this.port);
+  readonly isRunning = vi.fn(() => this.port !== null);
+}
+
+describe('CanvasService', () => {
+  let server: MockCanvasServer;
+  let openExternal: (url: string) => Promise<void>;
+  let openExternalMock: ReturnType<typeof vi.fn>;
+  let service: CanvasService;
+
+  beforeEach(() => {
+    server = new MockCanvasServer();
+    openExternalMock = vi.fn(async () => {});
+    openExternal = openExternalMock as unknown as (url: string) => Promise<void>;
+    service = new CanvasService({
+      openExternal,
+      server,
+    });
+  });
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir && fs.existsSync(dir)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('activateMind creates the .chamber\\canvas directory', async () => {
+    const mindPath = makeMindPath();
+
+    await service.activateMind('mind-1', mindPath);
+
+    expect(fs.existsSync(path.join(mindPath, '.chamber', 'canvas'))).toBe(true);
+  });
+
+  it('shows a wrapped canvas, starts the server, and opens the browser by default', async () => {
+    const mindPath = makeMindPath();
+
+    const result = await service.showCanvas('mind-1', mindPath, {
+      html: '<h1>Plan</h1>',
+      name: 'daily-plan',
+    });
+
+    const contentPath = path.join(mindPath, '.chamber', 'canvas', 'daily-plan.html');
+    const content = fs.readFileSync(contentPath, 'utf8');
+
+    expect(server.start).toHaveBeenCalledOnce();
+    expect(openExternalMock).toHaveBeenCalledWith('http://127.0.0.1:4312/mind-1/daily-plan.html');
+    expect(content).toContain('<!DOCTYPE html>');
+    expect(content).toContain('<h1>Plan</h1>');
+    expect(result).toContain('opened in browser');
+    expect(service.listCanvases('mind-1', mindPath)).toContain('daily-plan');
+  });
+
+  it('can copy an existing html file without opening the browser', async () => {
+    const mindPath = makeMindPath();
+    const sourceFile = path.join(mindPath, 'source.html');
+    fs.writeFileSync(sourceFile, '<html><body>From file</body></html>', 'utf8');
+
+    const result = await service.showCanvas('mind-1', mindPath, {
+      file: sourceFile,
+      name: 'copied',
+      open_browser: false,
+    });
+
+    const copied = fs.readFileSync(path.join(mindPath, '.chamber', 'canvas', 'copied.html'), 'utf8');
+    expect(copied).toBe('<html><body>From file</body></html>');
+    expect(openExternalMock).not.toHaveBeenCalled();
+    expect(result).toContain('http://127.0.0.1:4312/mind-1/copied.html');
+  });
+
+  it('updates an existing canvas and triggers targeted reload', async () => {
+    const mindPath = makeMindPath();
+    await service.showCanvas('mind-1', mindPath, {
+      html: '<h1>Before</h1>',
+      name: 'report',
+      open_browser: false,
+    });
+
+    const result = service.updateCanvas('mind-1', mindPath, {
+      html: '<h1>After</h1>',
+      name: 'report',
+    });
+
+    const content = fs.readFileSync(path.join(mindPath, '.chamber', 'canvas', 'report.html'), 'utf8');
+    expect(content).toContain('<h1>After</h1>');
+    expect(server.reload).toHaveBeenCalledWith('mind-1', 'report.html');
+    expect(result).toContain('updated');
+  });
+
+  it('closes a single canvas, removes its file, and stops the server when it was the last one', async () => {
+    const mindPath = makeMindPath();
+    await service.showCanvas('mind-1', mindPath, {
+      html: '<h1>Report</h1>',
+      name: 'report',
+      open_browser: false,
+    });
+
+    const result = await service.closeCanvas('mind-1', mindPath, {
+      name: 'report',
+    });
+
+    expect(server.closeClients).toHaveBeenCalledWith('mind-1', 'report.html');
+    expect(server.stop).toHaveBeenCalledOnce();
+    expect(fs.existsSync(path.join(mindPath, '.chamber', 'canvas', 'report.html'))).toBe(false);
+    expect(result).toContain('Server stopped');
+  });
+
+  it('close all only affects the current mind and keeps the server running if others remain', async () => {
+    const mindPathA = makeMindPath();
+    const mindPathB = makeMindPath();
+
+    await service.showCanvas('mind-a', mindPathA, {
+      html: '<h1>A</h1>',
+      name: 'alpha',
+      open_browser: false,
+    });
+    await service.showCanvas('mind-b', mindPathB, {
+      html: '<h1>B</h1>',
+      name: 'beta',
+      open_browser: false,
+    });
+
+    const result = await service.closeCanvas('mind-a', mindPathA, {
+      name: 'all',
+    });
+
+    expect(server.closeClients).toHaveBeenCalledWith('mind-a');
+    expect(server.stop).not.toHaveBeenCalled();
+    expect(result).toContain('1 canvas(es) still active');
+    expect(service.listCanvases('mind-b', mindPathB)).toContain('beta');
+  });
+
+  it('releaseMind closes that mind clients and stops the server when no canvases remain', async () => {
+    const mindPath = makeMindPath();
+    await service.showCanvas('mind-1', mindPath, {
+      html: '<h1>Report</h1>',
+      name: 'report',
+      open_browser: false,
+    });
+
+    await service.releaseMind('mind-1');
+
+    expect(server.closeClients).toHaveBeenCalledWith('mind-1');
+    expect(server.stop).toHaveBeenCalledOnce();
+  });
+
+  it('rejects invalid names and missing content', async () => {
+    const mindPath = makeMindPath();
+
+    await expect(service.showCanvas('mind-1', mindPath, {
+      html: '<h1>Bad</h1>',
+      name: '../bad',
+    })).rejects.toThrow('Invalid canvas name');
+
+    await expect(service.showCanvas('mind-1', mindPath, {
+      name: 'empty',
+    })).rejects.toThrow('canvas_show requires either "html" or "file"');
+  });
+});

--- a/src/main/services/canvas/CanvasService.ts
+++ b/src/main/services/canvas/CanvasService.ts
@@ -1,0 +1,262 @@
+import { shell } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ChamberToolProvider } from '../chamberTools';
+import type { Tool } from '../mind/types';
+import { CanvasServer } from './CanvasServer';
+import { buildCanvasTools } from './tools';
+import type {
+  CanvasAction,
+  CanvasCloseInput,
+  CanvasEntry,
+  CanvasServerLike,
+  CanvasShowInput,
+  CanvasUpdateInput,
+} from './types';
+
+const CANVAS_DIR = path.join('.chamber', 'canvas');
+const VALID_CANVAS_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export interface CanvasServiceOptions {
+  onAction?: (action: CanvasAction) => void;
+  openExternal?: (url: string) => Promise<void> | void;
+  server?: CanvasServerLike;
+}
+
+function validateCanvasName(name: string): void {
+  if (name === 'all') {
+    throw new Error('"all" is reserved for canvas_close and cannot be used as a canvas name');
+  }
+
+  if (!VALID_CANVAS_NAME.test(name)) {
+    throw new Error(`Invalid canvas name "${name}". Use letters, numbers, dots, underscores, or hyphens.`);
+  }
+}
+
+function wrapHtml(name: string, html: string, title?: string): string {
+  const lowerCaseHtml = html.toLowerCase();
+  if (!lowerCaseHtml.includes('<!doctype') && !lowerCaseHtml.includes('<html')) {
+    const pageTitle = title ?? name;
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${pageTitle}</title>
+</head>
+<body>
+${html}
+</body>
+</html>`;
+  }
+
+  if (title && !lowerCaseHtml.includes('<title>')) {
+    return html.replace('</head>', `  <title>${title}</title>\n</head>`);
+  }
+
+  return html;
+}
+
+export class CanvasService implements ChamberToolProvider {
+  private readonly mindPaths = new Map<string, string>();
+  private readonly canvases = new Map<string, Map<string, CanvasEntry>>();
+  private readonly server: CanvasServerLike;
+  private readonly openExternal: (url: string) => Promise<void> | void;
+
+  constructor(options: CanvasServiceOptions = {}) {
+    const onAction = options.onAction ?? ((action: CanvasAction) => {
+      console.log('[canvas] Action received:', action);
+    });
+
+    this.server = options.server ?? new CanvasServer({
+      resolveContentDir: (mindId) => this.getContentDirForMind(mindId),
+      onAction,
+    });
+    this.openExternal = options.openExternal ?? ((url: string) => shell.openExternal(url));
+  }
+
+  getToolsForMind(mindId: string, mindPath: string): Tool[] {
+    return buildCanvasTools(mindId, mindPath, this) as Tool[];
+  }
+
+  async activateMind(mindId: string, mindPath: string): Promise<void> {
+    this.ensureMind(mindId, mindPath);
+  }
+
+  async releaseMind(mindId: string): Promise<void> {
+    this.server.closeClients(mindId);
+    this.canvases.delete(mindId);
+    this.mindPaths.delete(mindId);
+    await this.stopServerIfIdle();
+  }
+
+  async showCanvas(mindId: string, mindPath: string, input: CanvasShowInput): Promise<string> {
+    validateCanvasName(input.name);
+    if (!input.html && !input.file) {
+      throw new Error('canvas_show requires either "html" or "file"');
+    }
+
+    const contentDir = this.ensureMind(mindId, mindPath);
+    const filename = `${input.name}.html`;
+    const targetPath = path.join(contentDir, filename);
+
+    if (input.file) {
+      if (!path.isAbsolute(input.file)) {
+        throw new Error('canvas_show file must be an absolute path');
+      }
+      if (!fs.existsSync(input.file)) {
+        throw new Error(`Canvas source file not found: ${input.file}`);
+      }
+      fs.copyFileSync(input.file, targetPath);
+    } else {
+      fs.writeFileSync(targetPath, wrapHtml(input.name, input.html ?? '', input.title), 'utf8');
+    }
+
+    const port = await this.server.start();
+    const url = this.buildCanvasUrl(mindId, filename, port);
+    this.upsertCanvas(mindId, {
+      filename,
+      name: input.name,
+      url,
+    });
+
+    if (input.open_browser !== false) {
+      await this.openExternal(url);
+      return `Canvas **${input.name}** is live at ${url} (opened in browser)`;
+    }
+
+    return `Canvas **${input.name}** is live at ${url}`;
+  }
+
+  updateCanvas(mindId: string, mindPath: string, input: CanvasUpdateInput): string {
+    validateCanvasName(input.name);
+    const contentDir = this.ensureMind(mindId, mindPath);
+    const existing = this.requireCanvas(mindId, input.name);
+    fs.writeFileSync(
+      path.join(contentDir, existing.filename),
+      wrapHtml(input.name, input.html, input.title),
+      'utf8',
+    );
+    this.server.reload(mindId, existing.filename);
+    return `Canvas **${input.name}** updated. Browser will auto-reload.`;
+  }
+
+  async closeCanvas(mindId: string, mindPath: string, input: CanvasCloseInput): Promise<string> {
+    this.ensureMind(mindId, mindPath);
+    if (input.name === 'all') {
+      return this.closeAllCanvases(mindId);
+    }
+
+    validateCanvasName(input.name);
+    const existing = this.requireCanvas(mindId, input.name);
+    this.server.closeClients(mindId, existing.filename);
+
+    const canvases = this.canvases.get(mindId);
+    canvases?.delete(input.name);
+    if (canvases && canvases.size === 0) {
+      this.canvases.delete(mindId);
+    }
+
+    this.deleteCanvasFile(mindId, existing.filename);
+    const remaining = this.totalCanvasCount();
+    if (remaining === 0) {
+      await this.server.stop();
+      return `Canvas **${input.name}** closed. Server stopped (no remaining canvases).`;
+    }
+
+    return `Canvas **${input.name}** closed. ${remaining} canvas(es) still active.`;
+  }
+
+  listCanvases(mindId: string, mindPath: string): string {
+    this.ensureMind(mindId, mindPath);
+    const canvases = this.canvases.get(mindId);
+    if (!canvases || canvases.size === 0) {
+      return 'No canvases are open.';
+    }
+
+    const lines = [...canvases.values()]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map((entry) => `- **${entry.name}** - ${entry.url}`);
+
+    const status = this.server.isRunning()
+      ? `Server running on port ${this.server.getPort()}`
+      : 'Server not running';
+
+    return `${lines.join('\n')}\n\n${status}`;
+  }
+
+  private async closeAllCanvases(mindId: string): Promise<string> {
+    const canvases = this.canvases.get(mindId);
+    if (!canvases || canvases.size === 0) {
+      return 'No canvases are open.';
+    }
+
+    this.server.closeClients(mindId);
+    const count = canvases.size;
+    for (const entry of canvases.values()) {
+      this.deleteCanvasFile(mindId, entry.filename);
+    }
+    this.canvases.delete(mindId);
+
+    const remaining = this.totalCanvasCount();
+    if (remaining === 0) {
+      await this.server.stop();
+      return `Closed ${count} canvas(es) and stopped the server.`;
+    }
+
+    return `Closed ${count} canvas(es). ${remaining} canvas(es) still active.`;
+  }
+
+  private ensureMind(mindId: string, mindPath: string): string {
+    this.mindPaths.set(mindId, mindPath);
+    const contentDir = path.join(mindPath, CANVAS_DIR);
+    fs.mkdirSync(contentDir, { recursive: true });
+    return contentDir;
+  }
+
+  private requireCanvas(mindId: string, name: string): CanvasEntry {
+    const existing = this.canvases.get(mindId)?.get(name);
+    if (!existing) {
+      throw new Error(`Canvas "${name}" not found. Use canvas_show to create it first.`);
+    }
+    return existing;
+  }
+
+  private getContentDirForMind(mindId: string): string | null {
+    const mindPath = this.mindPaths.get(mindId);
+    return mindPath ? path.join(mindPath, CANVAS_DIR) : null;
+  }
+
+  private upsertCanvas(mindId: string, entry: CanvasEntry): void {
+    const canvases = this.canvases.get(mindId) ?? new Map<string, CanvasEntry>();
+    canvases.set(entry.name, entry);
+    this.canvases.set(mindId, canvases);
+  }
+
+  private buildCanvasUrl(mindId: string, filename: string, port: number): string {
+    return `http://127.0.0.1:${port}/${encodeURIComponent(mindId)}/${encodeURIComponent(filename)}`;
+  }
+
+  private deleteCanvasFile(mindId: string, filename: string): void {
+    const contentDir = this.getContentDirForMind(mindId);
+    if (!contentDir) {
+      return;
+    }
+
+    fs.rmSync(path.join(contentDir, filename), { force: true });
+  }
+
+  private totalCanvasCount(): number {
+    let count = 0;
+    for (const canvases of this.canvases.values()) {
+      count += canvases.size;
+    }
+    return count;
+  }
+
+  private async stopServerIfIdle(): Promise<void> {
+    if (this.totalCanvasCount() === 0 && this.server.isRunning()) {
+      await this.server.stop();
+    }
+  }
+}

--- a/src/main/services/canvas/index.ts
+++ b/src/main/services/canvas/index.ts
@@ -1,0 +1,11 @@
+export { CanvasServer } from './CanvasServer';
+export { CanvasService } from './CanvasService';
+export { buildCanvasTools } from './tools';
+export type {
+  CanvasAction,
+  CanvasCloseInput,
+  CanvasEntry,
+  CanvasServerLike,
+  CanvasShowInput,
+  CanvasUpdateInput,
+} from './types';

--- a/src/main/services/canvas/tools.test.ts
+++ b/src/main/services/canvas/tools.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasService } from './CanvasService';
+import { buildCanvasTools } from './tools';
+
+const mockService = {
+  closeCanvas: vi.fn(),
+  listCanvases: vi.fn(),
+  showCanvas: vi.fn(),
+  updateCanvas: vi.fn(),
+};
+
+describe('buildCanvasTools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 4 tools with the expected names', () => {
+    const tools = buildCanvasTools('mind-1', 'C:\\minds\\one', mockService as unknown as CanvasService);
+
+    expect(tools).toHaveLength(4);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'canvas_show',
+      'canvas_update',
+      'canvas_close',
+      'canvas_list',
+    ]);
+  });
+
+  it('canvas_show dispatches to CanvasService.showCanvas', async () => {
+    const tools = buildCanvasTools('mind-1', 'C:\\minds\\one', mockService as unknown as CanvasService);
+    const show = tools.find((tool) => tool.name === 'canvas_show');
+    if (!show) {
+      throw new Error('Expected canvas_show tool');
+    }
+
+    const input = { html: '<h1>Plan</h1>', name: 'plan' };
+    await show.handler(input);
+
+    expect(mockService.showCanvas).toHaveBeenCalledWith('mind-1', 'C:\\minds\\one', input);
+  });
+
+  it('canvas_update dispatches to CanvasService.updateCanvas', async () => {
+    const tools = buildCanvasTools('mind-1', 'C:\\minds\\one', mockService as unknown as CanvasService);
+    const update = tools.find((tool) => tool.name === 'canvas_update');
+    if (!update) {
+      throw new Error('Expected canvas_update tool');
+    }
+
+    const input = { html: '<h1>Updated</h1>', name: 'plan' };
+    await update.handler(input);
+
+    expect(mockService.updateCanvas).toHaveBeenCalledWith('mind-1', 'C:\\minds\\one', input);
+  });
+
+  it('canvas_close dispatches to CanvasService.closeCanvas', async () => {
+    const tools = buildCanvasTools('mind-1', 'C:\\minds\\one', mockService as unknown as CanvasService);
+    const close = tools.find((tool) => tool.name === 'canvas_close');
+    if (!close) {
+      throw new Error('Expected canvas_close tool');
+    }
+
+    await close.handler({ name: 'plan' });
+
+    expect(mockService.closeCanvas).toHaveBeenCalledWith('mind-1', 'C:\\minds\\one', { name: 'plan' });
+  });
+
+  it('canvas_list dispatches to CanvasService.listCanvases', async () => {
+    const tools = buildCanvasTools('mind-1', 'C:\\minds\\one', mockService as unknown as CanvasService);
+    const list = tools.find((tool) => tool.name === 'canvas_list');
+    if (!list) {
+      throw new Error('Expected canvas_list tool');
+    }
+
+    await list.handler({});
+
+    expect(mockService.listCanvases).toHaveBeenCalledWith('mind-1', 'C:\\minds\\one');
+  });
+});

--- a/src/main/services/canvas/tools.ts
+++ b/src/main/services/canvas/tools.ts
@@ -1,0 +1,91 @@
+import type { SessionTool } from '../a2a/tools';
+import type { CanvasService } from './CanvasService';
+import type { CanvasCloseInput, CanvasShowInput, CanvasUpdateInput } from './types';
+
+export function buildCanvasTools(
+  mindId: string,
+  mindPath: string,
+  canvasService: CanvasService,
+): SessionTool[] {
+  return [
+    {
+      name: 'canvas_show',
+      description:
+        'Display HTML content in the browser. Creates a local canvas page and opens it in the default browser. Use this for dashboards, reports, forms, or any rich visual output.',
+      parameters: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Canvas identifier. Use letters, numbers, dots, underscores, or hyphens.',
+          },
+          html: {
+            type: 'string',
+            description: 'HTML content to display. Can be a complete page or fragment.',
+          },
+          file: {
+            type: 'string',
+            description: 'Absolute path to an existing HTML file to copy into the canvas content directory.',
+          },
+          title: {
+            type: 'string',
+            description: 'Optional page title if html does not already include one.',
+          },
+          open_browser: {
+            type: 'boolean',
+            description: 'Whether to open the browser. Defaults to true.',
+          },
+        },
+        required: ['name'],
+      },
+      handler: async (args) => canvasService.showCanvas(mindId, mindPath, args as unknown as CanvasShowInput),
+    },
+    {
+      name: 'canvas_update',
+      description: 'Update an existing canvas. The browser auto-reloads via server-sent events.',
+      parameters: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Canvas name to update.',
+          },
+          html: {
+            type: 'string',
+            description: 'New HTML content to display.',
+          },
+          title: {
+            type: 'string',
+            description: 'Optional updated page title.',
+          },
+        },
+        required: ['name', 'html'],
+      },
+      handler: async (args) => canvasService.updateCanvas(mindId, mindPath, args as unknown as CanvasUpdateInput),
+    },
+    {
+      name: 'canvas_close',
+      description: 'Close a canvas. Use "all" to close every canvas for this mind.',
+      parameters: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Canvas name to close, or "all" to close every canvas for this mind.',
+          },
+        },
+        required: ['name'],
+      },
+      handler: async (args) => canvasService.closeCanvas(mindId, mindPath, args as unknown as CanvasCloseInput),
+    },
+    {
+      name: 'canvas_list',
+      description: 'List the currently open canvases for this mind.',
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+      handler: async () => canvasService.listCanvases(mindId, mindPath),
+    },
+  ];
+}

--- a/src/main/services/canvas/types.ts
+++ b/src/main/services/canvas/types.ts
@@ -1,0 +1,40 @@
+export interface CanvasAction {
+  mindId: string;
+  canvas: string;
+  action: string;
+  data: unknown;
+  timestamp: number;
+}
+
+export interface CanvasEntry {
+  name: string;
+  filename: string;
+  url: string;
+}
+
+export interface CanvasShowInput {
+  name: string;
+  html?: string;
+  file?: string;
+  title?: string;
+  open_browser?: boolean;
+}
+
+export interface CanvasUpdateInput {
+  name: string;
+  html: string;
+  title?: string;
+}
+
+export interface CanvasCloseInput {
+  name: string;
+}
+
+export interface CanvasServerLike {
+  start(): Promise<number>;
+  stop(): Promise<void>;
+  reload(mindId?: string, filename?: string): void;
+  closeClients(mindId?: string, filename?: string): void;
+  getPort(): number | null;
+  isRunning(): boolean;
+}


### PR DESCRIPTION
## Summary

Closes #110.

Re-internalize canvas as a Chamber-native service on the ChamberToolProvider seam.

### What changed

- Added a built-in CanvasService in src/main/services/canvas/
- Added a shared localhost CanvasServer with:
  - mind-scoped routes: /{mindId}/{filename}
  - SSE live reload
  - HTML bridge-script injection
  - action POST back-channel
- Restored canvas_show, canvas_update, canvas_close, and canvas_list
- Store rendered canvas content in <mindPath>/.chamber/canvas/
- Wire canvas into main.ts alongside cron and A2A providers
- Open canvases in the default browser via Electron shell.openExternal() instead of hardcoding Edge
- Bumped version to 