### PR TITLE
Prototype avatar popout local voice

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "@chamber/services": "file:../../packages/services",
-    "@chamber/shared": "file:../../packages/shared"
+    "@chamber/shared": "file:../../packages/shared",
+    "edge-tts-universal": "^1.4.0"
   }
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -51,6 +51,7 @@ import { setupAuthIPC } from './main/ipc/auth';
 import { setupA2AIPC } from './main/ipc/a2a';
 import { setupChatroomIPC } from './main/ipc/chatroom';
 import { setupUpdaterIPC } from './main/ipc/updater';
+import { setupVoiceIPC } from './main/ipc/voice';
 
 import { EventEmitter } from 'events';
 import { wireLifecycleEvents } from './main/wireLifecycleEvents';
@@ -455,6 +456,7 @@ app.on('ready', async () => {
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager);
   setupChatroomIPC(chatroomService);
   setupUpdaterIPC(updaterService);
+  setupVoiceIPC();
 
   // Window controls
   ipcMain.on('window:minimize', () => mainWindow?.minimize());

--- a/apps/desktop/src/main/ipc/mind.ts
+++ b/apps/desktop/src/main/ipc/mind.ts
@@ -66,10 +66,10 @@ export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): v
 
     // Create popout window
     const win = new BrowserWindow({
-      width: 900,
-      height: 700,
+      width: 860,
+      height: 900,
       minWidth: 500,
-      minHeight: 400,
+      minHeight: 520,
       title: `${mind.identity.name} — Chamber`,
       titleBarStyle: 'hiddenInset',
       titleBarOverlay: process.platform === 'win32' ? {
@@ -84,6 +84,7 @@ export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): v
         contextIsolation: true,
         nodeIntegration: false,
         sandbox: false,
+        backgroundThrottling: false,
       },
     });
 

--- a/apps/desktop/src/main/ipc/voice.ts
+++ b/apps/desktop/src/main/ipc/voice.ts
@@ -1,0 +1,214 @@
+import { ipcMain } from 'electron';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import type { VoiceRecognitionResult, VoiceSynthesisResult } from '@chamber/shared/types';
+
+const DEFAULT_RECOGNITION_LANGUAGE = 'en-US';
+const DEFAULT_RECOGNITION_TIMEOUT_MS = 30_000;
+const DEFAULT_VOICE_NAME = 'en-US-EmmaMultilingualNeural';
+
+let activeRecognitionProcess: ChildProcessWithoutNullStreams | null = null;
+
+export function setupVoiceIPC(): void {
+  ipcMain.handle('voice:recognizeOnce', async (_event, options?: {
+    language?: string;
+    timeoutMs?: number;
+  }): Promise<VoiceRecognitionResult> => {
+    return recognizeWithWindowsSpeech({
+      language: options?.language ?? DEFAULT_RECOGNITION_LANGUAGE,
+      timeoutMs: options?.timeoutMs ?? DEFAULT_RECOGNITION_TIMEOUT_MS,
+    });
+  });
+
+  ipcMain.handle('voice:stopRecognition', async (): Promise<void> => {
+    stopActiveRecognition();
+  });
+
+  ipcMain.handle('voice:synthesize', async (_event, text: string, options?: {
+    voice?: string;
+  }): Promise<VoiceSynthesisResult> => {
+    return synthesizeWithEdgeTts(text, options?.voice ?? firstEnv('CHAMBER_TTS_VOICE', 'SPEECH_VOICE') ?? DEFAULT_VOICE_NAME);
+  });
+}
+
+async function recognizeWithWindowsSpeech({
+  language,
+  timeoutMs,
+}: {
+  language: string;
+  timeoutMs: number;
+}): Promise<VoiceRecognitionResult> {
+  if (process.platform !== 'win32') {
+    return {
+      provider: 'windows-system-speech',
+      error: 'Local voice input currently uses Windows built-in speech recognition.',
+    };
+  }
+
+  stopActiveRecognition();
+
+  const script = createWindowsSpeechRecognitionScript(language, timeoutMs);
+  const encoded = Buffer.from(script, 'utf16le').toString('base64');
+
+  return new Promise((resolve) => {
+    const child = spawn('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-EncodedCommand',
+      encoded,
+    ], {
+      windowsHide: true,
+    });
+
+    activeRecognitionProcess = child;
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+
+    const timeout = setTimeout(() => {
+      if (activeRecognitionProcess === child) stopActiveRecognition();
+    }, timeoutMs + 5_000);
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timeout);
+      if (activeRecognitionProcess === child) activeRecognitionProcess = null;
+
+      if (signal) {
+        resolve({ provider: 'windows-system-speech', error: 'Voice input was stopped.' });
+        return;
+      }
+
+      if (code !== 0) {
+        resolve({
+          provider: 'windows-system-speech',
+          error: stderr.trim() || `Windows speech recognition exited with code ${code}.`,
+        });
+        return;
+      }
+
+      resolve(parseRecognitionOutput(stdout, stderr));
+    });
+
+    child.on('error', (error) => {
+      clearTimeout(timeout);
+      if (activeRecognitionProcess === child) activeRecognitionProcess = null;
+      resolve({
+        provider: 'windows-system-speech',
+        error: `Could not start Windows speech recognition: ${error.message}`,
+      });
+    });
+  });
+}
+
+function stopActiveRecognition() {
+  if (!activeRecognitionProcess) return;
+  activeRecognitionProcess.kill();
+  activeRecognitionProcess = null;
+}
+
+function parseRecognitionOutput(stdout: string, stderr: string): VoiceRecognitionResult {
+  const output = stdout.trim();
+  if (!output) {
+    return {
+      provider: 'windows-system-speech',
+      error: stderr.trim() || 'No speech recognized. Try again after the listening indicator appears.',
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(output) as { text?: string; confidence?: number; error?: string };
+    return {
+      provider: 'windows-system-speech',
+      text: parsed.text,
+      confidence: parsed.confidence,
+      error: parsed.error,
+    };
+  } catch {
+    return {
+      provider: 'windows-system-speech',
+      error: output,
+    };
+  }
+}
+
+function createWindowsSpeechRecognitionScript(language: string, timeoutMs: number): string {
+  const safeLanguage = JSON.stringify(language);
+  const safeTimeoutMs = Math.max(1_000, Math.min(timeoutMs, 60_000));
+
+  return `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Speech
+$recognizer = $null
+try {
+  $culture = [System.Globalization.CultureInfo]::GetCultureInfo(${safeLanguage})
+  try {
+    $recognizer = New-Object System.Speech.Recognition.SpeechRecognitionEngine($culture)
+  } catch {
+    $recognizer = New-Object System.Speech.Recognition.SpeechRecognitionEngine
+  }
+  $recognizer.LoadGrammar((New-Object System.Speech.Recognition.DictationGrammar))
+  $recognizer.InitialSilenceTimeout = [TimeSpan]::FromSeconds(8)
+  $recognizer.BabbleTimeout = [TimeSpan]::FromSeconds(8)
+  $recognizer.EndSilenceTimeout = [TimeSpan]::FromMilliseconds(900)
+  $recognizer.EndSilenceTimeoutAmbiguous = [TimeSpan]::FromMilliseconds(1200)
+  $recognizer.SetInputToDefaultAudioDevice()
+  $result = $recognizer.Recognize([TimeSpan]::FromMilliseconds(${safeTimeoutMs}))
+  if ($result -and $result.Text) {
+    [PSCustomObject]@{ text = $result.Text; confidence = $result.Confidence } | ConvertTo-Json -Compress
+  } else {
+    [PSCustomObject]@{ text = ''; error = 'No speech recognized. Try again after the listening indicator appears.' } | ConvertTo-Json -Compress
+  }
+} catch {
+  [PSCustomObject]@{ text = ''; error = $_.Exception.Message } | ConvertTo-Json -Compress
+} finally {
+  if ($recognizer) { $recognizer.Dispose() }
+}
+`;
+}
+
+async function synthesizeWithEdgeTts(text: string, voice: string): Promise<VoiceSynthesisResult> {
+  const cleanText = text.trim();
+  if (!cleanText) {
+    return { provider: 'edge-tts', error: 'No text provided for voice output.' };
+  }
+
+  try {
+    const { Communicate } = await import('edge-tts-universal');
+    const comm = new Communicate(cleanText, { voice });
+    const chunks: Buffer[] = [];
+
+    for await (const chunk of comm.stream()) {
+      if (chunk.type === 'audio' && chunk.data) {
+        chunks.push(Buffer.from(chunk.data));
+      }
+    }
+
+    if (chunks.length === 0) {
+      return { provider: 'edge-tts', error: 'No TTS audio was generated.' };
+    }
+
+    return {
+      provider: 'edge-tts',
+      audioBase64: Buffer.concat(chunks).toString('base64'),
+      mimeType: 'audio/mpeg',
+    };
+  } catch (error) {
+    return {
+      provider: 'edge-tts',
+      error: error instanceof Error ? error.message : 'Edge TTS failed.',
+    };
+  }
+}
+
+function firstEnv(...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -66,6 +66,11 @@ const electronAPI: ElectronAPI = {
     getOrchestration: () => ipcRenderer.invoke('chatroom:get-orchestration'),
     onEvent: (callback) => createIpcListener(ipcRenderer, 'chatroom:event', callback),
   },
+  voice: {
+    recognizeOnce: (options) => ipcRenderer.invoke('voice:recognizeOnce', options),
+    stopRecognition: () => ipcRenderer.invoke('voice:stopRecognition'),
+    synthesize: (text, options) => ipcRenderer.invoke('voice:synthesize', text, options),
+  },
   updater: {
     getState: () => ipcRenderer.invoke('updater:get-state'),
     check: () => ipcRenderer.invoke('updater:check'),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@chamber/client": "file:../../packages/client",
-    "@chamber/shared": "file:../../packages/shared"
+    "@chamber/shared": "file:../../packages/shared",
+    "@met4citizen/talkinghead": "^1.7.0"
   }
 }

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -228,6 +228,17 @@ export function installBrowserApi(): void {
       removeGenesisRegistry: async () => ({ success: false, error: 'Marketplace management is desktop-only in browser mode.' }),
     },
     chatroom: createBrowserChatroomApi(),
+    voice: {
+      recognizeOnce: async () => ({
+        provider: 'windows-system-speech',
+        error: 'Voice input is unavailable in browser mode.',
+      }),
+      stopRecognition: async () => undefined,
+      synthesize: async () => ({
+        provider: 'edge-tts',
+        error: 'Voice output is unavailable in browser mode.',
+      }),
+    },
     updater: {
       getState: async () => ({
         enabled: false,

--- a/apps/web/src/renderer/components/avatar/AgentAvatarPanel.logic.test.ts
+++ b/apps/web/src/renderer/components/avatar/AgentAvatarPanel.logic.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatMessage } from '@chamber/shared/types';
+import {
+  deriveAvatarState,
+  getSpeechBubbleText,
+  stripMarkdownForSpeech,
+  takeSpeakableText,
+} from './AgentAvatarPanel.logic';
+
+function message(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: overrides.id ?? 'm1',
+    role: overrides.role ?? 'assistant',
+    blocks: overrides.blocks ?? [],
+    timestamp: overrides.timestamp ?? 0,
+    isStreaming: overrides.isStreaming,
+  };
+}
+
+describe('AgentAvatarPanel logic', () => {
+  it('stays idle when chat is not streaming', () => {
+    const messages = [
+      message({
+        blocks: [{ type: 'text', content: 'Done.' }],
+        isStreaming: false,
+      }),
+    ];
+
+    expect(deriveAvatarState(messages, false)).toBe('idle');
+  });
+
+  it('shows listening when a user message is waiting for an assistant placeholder', () => {
+    const messages = [
+      message({
+        role: 'user',
+        blocks: [{ type: 'text', content: 'Hello' }],
+      }),
+    ];
+
+    expect(deriveAvatarState(messages, true)).toBe('listening');
+  });
+
+  it('shows thinking for an empty streaming assistant message', () => {
+    const messages = [message({ isStreaming: true })];
+
+    expect(deriveAvatarState(messages, true)).toBe('thinking');
+  });
+
+  it('shows speaking when assistant text is streaming', () => {
+    const messages = [
+      message({
+        isStreaming: true,
+        blocks: [{ type: 'text', content: 'Working on it.' }],
+      }),
+    ];
+
+    expect(deriveAvatarState(messages, true)).toBe('speaking');
+  });
+
+  it('clips speech bubble text to the latest assistant response tail', () => {
+    const messages = [
+      message({
+        blocks: [{ type: 'text', content: 'First response.' }],
+      }),
+      message({
+        id: 'm2',
+        blocks: [{ type: 'text', content: 'This is the latest response that should be visible in the speech bubble.' }],
+      }),
+    ];
+
+    expect(getSpeechBubbleText(messages, 38)).toBe('be visible in the speech bubble.');
+  });
+
+  it('extracts complete speakable sentences from streaming deltas', () => {
+    expect(takeSpeakableText('This is ready. This is not yet')?.text).toBe('This is ready.');
+    expect(takeSpeakableText('No sentence yet')).toBeNull();
+  });
+
+  it('strips markdown before silent lip-sync speech', () => {
+    expect(stripMarkdownForSpeech('## Hello [there](https://example.com), `friend`!')).toBe('Hello there, friend!');
+  });
+});

--- a/apps/web/src/renderer/components/avatar/AgentAvatarPanel.logic.ts
+++ b/apps/web/src/renderer/components/avatar/AgentAvatarPanel.logic.ts
@@ -1,0 +1,96 @@
+import type { ChatMessage, ContentBlock } from '@chamber/shared/types';
+
+export type AvatarPanelState = 'idle' | 'listening' | 'thinking' | 'speaking';
+
+export interface LatestAssistantText {
+  messageId: string;
+  text: string;
+  isStreaming: boolean;
+}
+
+export interface SpeakableText {
+  text: string;
+  consumed: number;
+}
+
+export function deriveAvatarState(messages: ChatMessage[], isStreaming: boolean): AvatarPanelState {
+  if (!isStreaming) return 'idle';
+
+  const lastMessage = messages[messages.length - 1];
+  if (lastMessage?.role === 'user') return 'listening';
+
+  const latestAssistant = getLatestAssistantText(messages);
+  if (!latestAssistant || latestAssistant.text.trim().length === 0) {
+    return 'thinking';
+  }
+
+  return 'speaking';
+}
+
+export function getLatestAssistantText(messages: ChatMessage[]): LatestAssistantText | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.role === 'assistant') {
+      return {
+        messageId: message.id,
+        text: getTextFromBlocks(message.blocks),
+        isStreaming: Boolean(message.isStreaming),
+      };
+    }
+  }
+
+  return null;
+}
+
+export function getSpeechBubbleText(messages: ChatMessage[], maxLength = 220): string | null {
+  const latestAssistant = getLatestAssistantText(messages);
+  const text = latestAssistant?.text.replace(/\s+/g, ' ').trim();
+  if (!text) return null;
+  if (text.length <= maxLength) return text;
+
+  const tail = text.slice(-maxLength);
+  const firstSpace = tail.indexOf(' ');
+  return firstSpace >= 0 ? tail.slice(firstSpace + 1) : tail;
+}
+
+export function takeSpeakableText(text: string, maxChunkLength = 180): SpeakableText | null {
+  const leadingWhitespace = text.length - text.trimStart().length;
+  const candidate = text.slice(leadingWhitespace);
+  if (candidate.length === 0) return null;
+
+  const sentenceMatch = candidate.match(/^([\s\S]*?[.!?])(?:\s|$)/);
+  if (sentenceMatch?.[1] && sentenceMatch[1].trim().length > 2) {
+    const sentence = sentenceMatch[1];
+    return {
+      text: sentence,
+      consumed: leadingWhitespace + sentence.length,
+    };
+  }
+
+  if (candidate.length < maxChunkLength) return null;
+
+  const chunk = candidate.slice(0, maxChunkLength);
+  const lastSpace = chunk.lastIndexOf(' ');
+  const end = lastSpace > 80 ? lastSpace : maxChunkLength;
+  return {
+    text: candidate.slice(0, end),
+    consumed: leadingWhitespace + end,
+  };
+}
+
+export function stripMarkdownForSpeech(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/g, ' code block ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#*_>~-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getTextFromBlocks(blocks: ContentBlock[]): string {
+  return blocks
+    .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+    .map(block => block.content)
+    .join('');
+}

--- a/apps/web/src/renderer/components/avatar/AgentAvatarPanel.tsx
+++ b/apps/web/src/renderer/components/avatar/AgentAvatarPanel.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { ChatMessage } from '@chamber/shared/types';
+import { cn } from '../../lib/utils';
+import {
+  deriveAvatarState,
+  getLatestAssistantText,
+  getSpeechBubbleText,
+  stripMarkdownForSpeech,
+  takeSpeakableText,
+  type AvatarPanelState,
+} from './AgentAvatarPanel.logic';
+import { createTalkingHeadAvatar, type TalkingHeadAvatarController } from './talkingHeadAvatar';
+
+interface Props {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  agentName: string;
+  connected: boolean;
+  captionsVisible?: boolean;
+  layout?: 'side' | 'stage';
+  stateOverride?: AvatarPanelState;
+}
+
+type LoadState = 'loading' | 'ready' | 'fallback';
+
+export function AgentAvatarPanel({
+  messages,
+  isStreaming,
+  agentName,
+  connected,
+  captionsVisible = true,
+  layout = 'side',
+  stateOverride,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const controllerRef = useRef<TalkingHeadAvatarController | null>(null);
+  const lastSpokenRef = useRef<{ messageId: string | null; length: number }>({ messageId: null, length: 0 });
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [loadProgress, setLoadProgress] = useState(0);
+  const avatarState = useMemo(
+    () => stateOverride ?? (connected ? deriveAvatarState(messages, isStreaming) : 'idle'),
+    [connected, isStreaming, messages, stateOverride],
+  );
+  const speechBubble = captionsVisible && avatarState === 'speaking' ? getSpeechBubbleText(messages) : null;
+
+  useEffect(() => {
+    let disposed = false;
+
+    async function initAvatar() {
+      if (!containerRef.current) return;
+
+      try {
+        const controller = await createTalkingHeadAvatar(containerRef.current, setLoadProgress);
+        if (disposed) {
+          controller.dispose();
+          return;
+        }
+        controllerRef.current = controller;
+        setLoadState('ready');
+      } catch (error) {
+        console.warn('[avatar] Falling back to local orb avatar:', error);
+        if (!disposed) setLoadState('fallback');
+      }
+    }
+
+    void initAvatar();
+
+    return () => {
+      disposed = true;
+      controllerRef.current?.dispose();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    controllerRef.current?.setState(avatarState);
+  }, [avatarState]);
+
+  useEffect(() => {
+    if (avatarState !== 'speaking' || !controllerRef.current) return;
+
+    const latestAssistant = getLatestAssistantText(messages);
+    if (!latestAssistant) return;
+
+    if (lastSpokenRef.current.messageId !== latestAssistant.messageId) {
+      lastSpokenRef.current = { messageId: latestAssistant.messageId, length: 0 };
+    }
+
+    const pendingText = latestAssistant.text.slice(lastSpokenRef.current.length);
+    const speakable = takeSpeakableText(pendingText);
+    if (!speakable) return;
+
+    lastSpokenRef.current.length += speakable.consumed;
+    const speechText = stripMarkdownForSpeech(speakable.text);
+    controllerRef.current.speakText(speechText);
+  }, [avatarState, messages]);
+
+  const avatarSurface = (
+    <div className="relative min-h-0 flex-1 overflow-hidden bg-[radial-gradient(circle_at_50%_18%,oklch(0.28_0.04_260),oklch(0.145_0.008_260)_58%)]">
+      <div
+        ref={containerRef}
+        className={cn(
+          'chamber-agent-avatar-canvas absolute inset-0',
+          loadState !== 'ready' && 'opacity-0',
+        )}
+      />
+
+      {loadState !== 'ready' && (
+        <FallbackAvatar
+          state={avatarState}
+          agentName={agentName}
+          loading={loadState === 'loading'}
+          progress={loadProgress}
+          large={layout === 'stage'}
+        />
+      )}
+
+      {speechBubble && (
+        <div className={cn(
+          'absolute inset-x-4 bottom-4 max-h-32 overflow-y-auto rounded-2xl border border-white/10 bg-black/60 px-4 py-3 text-sm leading-relaxed text-white shadow-2xl backdrop-blur',
+          layout === 'stage' && 'left-1/2 right-auto w-[min(620px,calc(100%-2rem))] -translate-x-1/2 text-base',
+        )}>
+          {speechBubble}
+        </div>
+      )}
+    </div>
+  );
+
+  if (layout === 'stage') {
+    return (
+      <section data-testid="agent-avatar-stage" className="flex h-full w-full flex-col overflow-hidden bg-background">
+        <div className="titlebar-drag flex items-center justify-between border-b border-border/70 px-6 py-4">
+          <div className="min-w-0">
+            <div className="truncate text-lg font-semibold">{agentName}</div>
+            <div className="text-sm text-muted-foreground">Avatar conversation</div>
+          </div>
+          <StateBadge state={avatarState} />
+        </div>
+        {avatarSurface}
+      </section>
+    );
+  }
+
+  return (
+    <aside className="hidden w-80 shrink-0 flex-col border-l border-border bg-card/60 lg:flex">
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium">{agentName}</div>
+          <div className="text-xs text-muted-foreground">Local avatar preview</div>
+        </div>
+        <StateBadge state={avatarState} />
+      </div>
+      {avatarSurface}
+    </aside>
+  );
+}
+
+function StateBadge({ state }: { state: AvatarPanelState }) {
+  const label = {
+    idle: 'Ready',
+    listening: 'Listening',
+    thinking: 'Thinking',
+    speaking: 'Speaking',
+  }[state];
+
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-border bg-background/60 px-2.5 py-1 text-xs text-muted-foreground">
+      <span
+        className={cn(
+          'h-2 w-2 rounded-full',
+          state === 'idle' && 'bg-emerald-400',
+          state === 'listening' && 'bg-sky-400',
+          state === 'thinking' && 'animate-pulse bg-amber-400',
+          state === 'speaking' && 'chamber-avatar-state-speaking bg-genesis',
+        )}
+      />
+      {label}
+    </div>
+  );
+}
+
+function FallbackAvatar({
+  state,
+  agentName,
+  loading,
+  progress,
+  large = false,
+}: {
+  state: AvatarPanelState;
+  agentName: string;
+  loading: boolean;
+  progress: number;
+  large?: boolean;
+}) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-5 px-6 text-center">
+      <div
+        data-testid="agent-avatar-fallback"
+        className={cn(
+          'chamber-avatar-orb flex items-center justify-center rounded-full font-semibold text-primary-foreground shadow-2xl',
+          large ? 'h-52 w-52 text-7xl' : 'h-28 w-28 text-4xl',
+          state,
+        )}
+      >
+        {agentName.charAt(0).toUpperCase()}
+      </div>
+      <div>
+        <div className="text-sm font-medium">
+          {loading ? `Loading avatar${progress > 0 ? ` ${progress}%` : ''}` : 'Avatar fallback active'}
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          {loading ? 'Fetching the local dev TalkingHead model.' : 'Using local orb animation.'}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/avatar/PopoutAvatarWindow.test.tsx
+++ b/apps/web/src/renderer/components/avatar/PopoutAvatarWindow.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PopoutAvatarWindow } from './PopoutAvatarWindow';
+import { AppStateProvider } from '../../lib/store';
+import { installElectronAPI } from '../../../test/helpers';
+import type { ElectronAPI, MindContext } from '@chamber/shared/types';
+
+vi.mock('./AgentAvatarPanel', () => ({
+  AgentAvatarPanel: ({ agentName }: { agentName: string }) => (
+    <div data-testid="agent-avatar-stage">{agentName}</div>
+  ),
+}));
+
+const mind: MindContext = {
+  mindId: 'alfred-1',
+  mindPath: 'C:\\agents\\alfred',
+  identity: { name: 'Alfred', systemMessage: '' },
+  status: 'ready',
+};
+
+function renderPopout() {
+  const electronAPI = installElectronAPI();
+
+  return {
+    electronAPI,
+    ...render(
+    <AppStateProvider
+      testInitialState={{
+        minds: [mind],
+        activeMindId: mind.mindId,
+        mindsChecked: true,
+        messagesByMind: {
+          [mind.mindId]: [
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              blocks: [{ type: 'text', content: 'Hello from Alfred.' }],
+              timestamp: 1,
+            },
+          ],
+        },
+      }}
+    >
+      <PopoutAvatarWindow popoutMindId={mind.mindId} />
+    </AppStateProvider>,
+    ),
+  };
+}
+
+describe('PopoutAvatarWindow', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts in avatar mode without starter prompt buttons', () => {
+    renderPopout();
+
+    expect(screen.getByTestId('agent-avatar-stage').textContent).toBe('Alfred');
+    expect(screen.getByLabelText('Show transcript')).toBeTruthy();
+    expect(screen.queryByText('Daily briefing')).toBeNull();
+  });
+
+  it('switches to transcript mode when the red exit button is clicked', () => {
+    renderPopout();
+
+    fireEvent.click(screen.getByLabelText('Show transcript'));
+
+    expect(screen.queryByTestId('agent-avatar-stage')).toBeNull();
+    expect(screen.getByText('Conversation transcript')).toBeTruthy();
+    expect(screen.getByText('Hello from Alfred.')).toBeTruthy();
+    expect(screen.queryByText('Daily briefing')).toBeNull();
+  });
+
+  it('keeps speech recognition errors visible when recognition ends immediately', async () => {
+    installMicrophoneAccess();
+    const { electronAPI } = renderPopout();
+    vi.mocked((electronAPI as ElectronAPI).voice.recognizeOnce).mockResolvedValue({
+      provider: 'windows-system-speech',
+      text: '',
+      error: 'No speech recognized. Try again after the listening indicator appears.',
+    });
+
+    fireEvent.click(screen.getByLabelText('Start voice input'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No speech recognized\. Try again/)).toBeTruthy();
+    });
+  });
+
+  it('submits final speech recognition transcript to the active mind', async () => {
+    installMicrophoneAccess();
+    const { electronAPI } = renderPopout();
+    vi.mocked((electronAPI as ElectronAPI).voice.recognizeOnce).mockResolvedValue({
+      provider: 'windows-system-speech',
+      text: 'what is on my calendar',
+    });
+
+    fireEvent.click(screen.getByLabelText('Start voice input'));
+
+    await waitFor(() => {
+      expect((electronAPI as ElectronAPI).chat.send).toHaveBeenCalledWith(
+        mind.mindId,
+        'what is on my calendar',
+        expect.any(String),
+        undefined,
+        undefined,
+      );
+    });
+  });
+});
+
+function installMicrophoneAccess() {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: {
+      getUserMedia: vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: vi.fn() }],
+      }),
+    },
+    configurable: true,
+  });
+}

--- a/apps/web/src/renderer/components/avatar/PopoutAvatarWindow.tsx
+++ b/apps/web/src/renderer/components/avatar/PopoutAvatarWindow.tsx
@@ -1,0 +1,494 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Captions, MessageSquare, Mic, X } from 'lucide-react';
+import { useAppDispatch, useAppState } from '../../lib/store';
+import { useChatStreaming } from '../../hooks/useChatStreaming';
+import { ChatInput } from '../chat/ChatInput';
+import { MessageList } from '../chat/MessageList';
+import { cn } from '../../lib/utils';
+import type { ChatMessage } from '@chamber/shared/types';
+import {
+  getLatestAssistantText,
+  stripMarkdownForSpeech,
+  takeSpeakableText,
+} from './AgentAvatarPanel.logic';
+import { AgentAvatarPanel } from './AgentAvatarPanel';
+
+interface Props {
+  popoutMindId: string | null;
+}
+
+export function PopoutAvatarWindow({ popoutMindId }: Props) {
+  const {
+    messagesByMind,
+    activeMindId,
+    minds,
+    availableModels,
+    selectedModel,
+  } = useAppState();
+  const dispatch = useAppDispatch();
+  const { sendMessage, stopStreaming, isStreaming } = useChatStreaming();
+  const [mode, setMode] = useState<'avatar' | 'transcript'>('avatar');
+  const [captionsVisible, setCaptionsVisible] = useState(true);
+
+  const mindId = popoutMindId ?? activeMindId;
+  const activeMind = minds.find(m => m.mindId === mindId);
+  const messages = mindId ? (messagesByMind[mindId] ?? []) : [];
+  const connected = Boolean(activeMind);
+  const agentName = activeMind?.identity.name ?? 'Agent';
+  const assistantVoice = useAssistantVoice({
+    messages,
+    enabled: mode === 'avatar',
+  });
+  const voiceInput = useVoiceInput({
+    disabled: !connected || mode !== 'avatar',
+    onBeforeStart: () => {
+      assistantVoice.interruptAndActivate();
+      if (isStreaming) void stopStreaming();
+    },
+    onSubmit: sendMessage,
+  });
+
+  useEffect(() => {
+    if (mode !== 'avatar' && typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      window.speechSynthesis.cancel();
+    }
+  }, [mode]);
+
+  if (mode === 'transcript') {
+    return (
+      <div className="flex h-full w-full flex-col bg-background text-foreground">
+        <div className="titlebar-drag flex items-center justify-between border-b border-border px-5 py-3">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold">{agentName}</div>
+            <div className="text-xs text-muted-foreground">Conversation transcript</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setMode('avatar')}
+            className="titlebar-no-drag inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <MessageSquare size={14} />
+            Avatar mode
+          </button>
+        </div>
+
+        {messages.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center px-6 text-sm text-muted-foreground">
+            No transcript yet. Return to avatar mode and use the microphone to start.
+          </div>
+        ) : (
+          <MessageList />
+        )}
+
+        <ChatInput
+          onSend={sendMessage}
+          onStop={stopStreaming}
+          isStreaming={isStreaming}
+          disabled={!connected}
+          availableModels={availableModels}
+          selectedModel={selectedModel}
+          onModelChange={(model) => dispatch({ type: 'SET_SELECTED_MODEL', payload: model })}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full overflow-hidden bg-background text-foreground">
+      <AgentAvatarPanel
+        layout="stage"
+        messages={messages}
+        isStreaming={isStreaming || voiceInput.isListening}
+        agentName={agentName}
+        connected={connected}
+        captionsVisible={captionsVisible}
+        stateOverride={voiceInput.isListening ? 'listening' : undefined}
+      />
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-8 flex flex-col items-center gap-4 px-4">
+        {(voiceInput.status || voiceInput.transcript) && (
+          <div className="max-w-2xl rounded-2xl border border-white/10 bg-black/45 px-4 py-2 text-center text-sm text-white/80 shadow-2xl backdrop-blur">
+            {voiceInput.transcript || voiceInput.status}
+            {assistantVoice.status && (
+              <div className="mt-1 text-xs text-white/55">{assistantVoice.status}</div>
+            )}
+          </div>
+        )}
+
+        <div className="pointer-events-auto flex items-center gap-3 rounded-full border border-border bg-card/95 px-5 py-3 shadow-2xl">
+          <button
+            type="button"
+            aria-label={captionsVisible ? 'Hide captions' : 'Show captions'}
+            onClick={() => setCaptionsVisible(v => !v)}
+            className={cn(
+              'flex h-10 w-10 items-center justify-center rounded-full transition-colors',
+              captionsVisible ? 'bg-secondary text-secondary-foreground' : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Captions size={20} />
+          </button>
+
+          <button
+            type="button"
+            aria-label={voiceInput.isListening ? 'Stop voice input' : 'Start voice input'}
+            onClick={voiceInput.toggle}
+            disabled={!connected}
+            className={cn(
+              'flex h-12 w-12 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+              voiceInput.isListening
+                ? 'bg-sky-500 text-white shadow-[0_0_30px_rgba(56,189,248,0.45)]'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+            )}
+          >
+            <Mic size={24} />
+          </button>
+
+          <button
+            type="button"
+            aria-label="Show transcript"
+            onClick={() => setMode('transcript')}
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-red-600 text-white shadow-[0_0_30px_rgba(220,38,38,0.35)] transition-colors hover:bg-red-500"
+          >
+            <X size={26} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function useAssistantVoice({ messages, enabled }: { messages: ChatMessage[]; enabled: boolean }) {
+  const spokenRef = useRef<{ messageId: string | null; length: number }>({ messageId: null, length: 0 });
+  const enabledRef = useRef(enabled);
+  const activatedRef = useRef(false);
+  const speakingRef = useRef(false);
+  const queueRef = useRef<string[]>([]);
+  const generationRef = useRef(0);
+  const currentAudioRef = useRef<HTMLAudioElement | null>(null);
+  const currentAudioUrlRef = useRef<string | null>(null);
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  const stopPlayback = useCallback(() => {
+    generationRef.current += 1;
+    queueRef.current = [];
+    speakingRef.current = false;
+    currentAudioRef.current?.pause();
+    currentAudioRef.current = null;
+    if (currentAudioUrlRef.current) {
+      URL.revokeObjectURL(currentAudioUrlRef.current);
+      currentAudioUrlRef.current = null;
+    }
+    if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      window.speechSynthesis.cancel();
+    }
+    setStatus('');
+  }, []);
+
+  const speakNext = useCallback(() => {
+    if (
+      speakingRef.current ||
+      queueRef.current.length === 0 ||
+      !enabledRef.current ||
+      !activatedRef.current ||
+      typeof window === 'undefined'
+    ) {
+      return;
+    }
+
+    const text = queueRef.current.shift();
+    if (!text) return;
+    const generation = generationRef.current;
+
+    speakingRef.current = true;
+    setStatus('Voice output speaking...');
+    void playAssistantSpeech(text, {
+      currentAudioRef,
+      currentAudioUrlRef,
+    }, () => generationRef.current === generation).catch((error: unknown) => {
+      if (generationRef.current !== generation) return;
+      console.warn('[avatar voice] Speech output failed:', error);
+      setStatus('Voice output stopped. Check system audio output, then try again.');
+    }).finally(() => {
+      if (generationRef.current !== generation) return;
+      speakingRef.current = false;
+      setStatus('');
+      speakNext();
+    });
+  }, []);
+
+  const interruptAndActivate = useCallback(() => {
+    stopPlayback();
+    activatedRef.current = true;
+    if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      window.speechSynthesis.resume();
+    }
+    speakNext();
+  }, [speakNext, stopPlayback]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const latestAssistant = getLatestAssistantText(messages);
+    if (!latestAssistant) return;
+
+    if (spokenRef.current.messageId !== latestAssistant.messageId) {
+      spokenRef.current = { messageId: latestAssistant.messageId, length: 0 };
+      stopPlayback();
+    }
+
+    const pendingText = latestAssistant.text.slice(spokenRef.current.length);
+    const speakable = takeSpeakableText(pendingText)
+      ?? (!latestAssistant.isStreaming && pendingText.trim().length > 2
+        ? { text: pendingText, consumed: pendingText.length }
+        : null);
+    if (!speakable) return;
+
+    spokenRef.current.length += speakable.consumed;
+    const text = stripMarkdownForSpeech(speakable.text);
+    if (!text) return;
+
+    queueRef.current.push(text);
+    speakNext();
+  }, [enabled, messages, speakNext, stopPlayback]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    if ('speechSynthesis' in window) {
+      window.speechSynthesis.onvoiceschanged = () => speakNext();
+    }
+
+    return () => {
+      if ('speechSynthesis' in window) {
+        window.speechSynthesis.onvoiceschanged = null;
+      }
+      stopPlayback();
+    };
+  }, [speakNext, stopPlayback]);
+
+  return { interruptAndActivate, status };
+}
+
+function useVoiceInput({
+  disabled,
+  onBeforeStart,
+  onSubmit,
+}: {
+  disabled: boolean;
+  onBeforeStart: () => void;
+  onSubmit: (message: string) => void;
+}) {
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const stopRequestedRef = useRef(false);
+  const startingRef = useRef(false);
+  const recognitionActiveRef = useRef(false);
+  const [isListening, setIsListening] = useState(false);
+  const [status, setStatus] = useState('Press the microphone and speak to your agent.');
+  const [transcript, setTranscript] = useState('');
+
+  const stop = useCallback(() => {
+    stopRequestedRef.current = true;
+    setStatus('Stopping voice input...');
+    if (recognitionActiveRef.current) {
+      void window.electronAPI.voice.stopRecognition();
+    }
+  }, []);
+
+  const start = useCallback(async () => {
+    if (disabled || startingRef.current) return;
+
+    startingRef.current = true;
+    stopRequestedRef.current = false;
+    onBeforeStart();
+    setTranscript('');
+    setStatus('Checking microphone access...');
+
+    let stream: MediaStream | null = null;
+    try {
+      stream = await requestMicrophoneAccess();
+    } catch (error) {
+      startingRef.current = false;
+      setIsListening(false);
+      setStatus(getMicrophoneErrorMessage(error));
+      return;
+    }
+
+    stopMediaStream(stream);
+    mediaStreamRef.current = null;
+    if (stopRequestedRef.current) {
+      startingRef.current = false;
+      setStatus('Stopped listening.');
+      return;
+    }
+
+    setIsListening(true);
+    setStatus('Listening with Windows speech... speak now.');
+    recognitionActiveRef.current = true;
+
+    try {
+      const result = await window.electronAPI.voice.recognizeOnce({
+        language: 'en-US',
+        timeoutMs: 30000,
+      });
+      recognitionActiveRef.current = false;
+      setIsListening(false);
+      startingRef.current = false;
+      setTranscript('');
+
+      if (stopRequestedRef.current) {
+        setStatus('Stopped listening.');
+        return;
+      }
+
+      const spokenText = result.text?.trim();
+      if (spokenText) {
+        setStatus('Sending...');
+        onSubmit(spokenText);
+        return;
+      }
+
+      setStatus(result.error ?? 'No speech recognized. Try again after the listening indicator appears.');
+    } catch (error) {
+      recognitionActiveRef.current = false;
+      startingRef.current = false;
+      setIsListening(false);
+      setTranscript('');
+      setStatus(error instanceof Error ? error.message : 'Could not start local voice input.');
+    }
+  }, [disabled, onBeforeStart, onSubmit]);
+
+  useEffect(() => () => {
+    if (recognitionActiveRef.current) void window.electronAPI.voice.stopRecognition();
+    stopMediaStream(mediaStreamRef.current);
+  }, []);
+
+  return {
+    isListening,
+    status,
+    transcript,
+    toggle: isListening ? stop : start,
+  };
+}
+
+async function requestMicrophoneAccess(): Promise<MediaStream | null> {
+  if (!navigator.mediaDevices?.getUserMedia) return null;
+
+  return navigator.mediaDevices.getUserMedia({
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+    },
+  });
+}
+
+function stopMediaStream(stream: MediaStream | null) {
+  stream?.getTracks().forEach(track => track.stop());
+}
+
+function getMicrophoneErrorMessage(error: unknown): string {
+  const name = error instanceof DOMException ? error.name : '';
+  if (name === 'NotAllowedError' || name === 'SecurityError') {
+    return 'Microphone permission was blocked. Allow microphone access for Chamber in Windows/privacy settings and try again.';
+  }
+  if (name === 'NotFoundError' || name === 'DevicesNotFoundError') {
+    return 'No microphone was found. Connect or select an input device, then try again.';
+  }
+  if (name === 'NotReadableError' || name === 'TrackStartError') {
+    return 'The microphone is busy or unavailable. Close other apps using it, then try again.';
+  }
+  return 'Could not access the microphone. Check your input device and try again.';
+}
+
+function chooseAssistantVoice(voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null {
+  return voices.find(voice => voice.lang === 'en-US' && /Jenny|Aria|Emma|Michelle|Samantha/i.test(voice.name))
+    ?? voices.find(voice => voice.lang === 'en-US')
+    ?? voices.find(voice => voice.lang.startsWith('en'))
+    ?? null;
+}
+
+async function playAssistantSpeech(
+  text: string,
+  refs: {
+    currentAudioRef: React.MutableRefObject<HTMLAudioElement | null>;
+    currentAudioUrlRef: React.MutableRefObject<string | null>;
+  },
+  shouldContinue: () => boolean,
+): Promise<void> {
+  try {
+    const result = await window.electronAPI.voice.synthesize(text);
+    if (result.audioBase64) {
+      const blob = base64AudioToBlob(result.audioBase64, result.mimeType ?? 'audio/mpeg');
+      if (!shouldContinue()) return;
+      await playAudioBlob(blob, refs, shouldContinue);
+      return;
+    }
+    if (result.error) {
+      console.warn('[avatar voice] Edge TTS failed, falling back to browser speech:', result.error);
+    }
+  } catch (error) {
+    console.warn('[avatar voice] Edge TTS failed, falling back to browser speech:', error);
+  }
+
+  if (!shouldContinue()) return;
+  await speakWithBrowserSpeech(text);
+}
+
+function base64AudioToBlob(audioBase64: string, mimeType: string): Blob {
+  const binary = window.atob(audioBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new Blob([bytes], { type: mimeType });
+}
+
+async function playAudioBlob(
+  blob: Blob,
+  refs: {
+    currentAudioRef: React.MutableRefObject<HTMLAudioElement | null>;
+    currentAudioUrlRef: React.MutableRefObject<string | null>;
+  },
+  shouldContinue: () => boolean,
+): Promise<void> {
+  if (!shouldContinue()) return;
+  const url = URL.createObjectURL(blob);
+  refs.currentAudioUrlRef.current = url;
+  const audio = new Audio(url);
+  refs.currentAudioRef.current = audio;
+  audio.volume = 1;
+
+  try {
+    await audio.play();
+    await new Promise<void>((resolve, reject) => {
+      audio.onended = () => resolve();
+      audio.onpause = () => resolve();
+      audio.onerror = () => reject(new Error('Audio playback failed.'));
+    });
+  } finally {
+    if (refs.currentAudioRef.current === audio) refs.currentAudioRef.current = null;
+    if (refs.currentAudioUrlRef.current === url) refs.currentAudioUrlRef.current = null;
+    URL.revokeObjectURL(url);
+  }
+}
+
+function speakWithBrowserSpeech(text: string): Promise<void> {
+  if (typeof window === 'undefined' || !('speechSynthesis' in window)) {
+    return Promise.reject(new Error('Browser speech synthesis is unavailable.'));
+  }
+
+  return new Promise((resolve, reject) => {
+    const utterance = new SpeechSynthesisUtterance(text);
+    const voice = chooseAssistantVoice(window.speechSynthesis.getVoices());
+    if (voice) utterance.voice = voice;
+    utterance.rate = 0.95;
+    utterance.pitch = 1.02;
+    utterance.onend = () => resolve();
+    utterance.onerror = () => reject(new Error('Browser speech synthesis failed.'));
+    window.speechSynthesis.resume();
+    window.speechSynthesis.speak(utterance);
+  });
+}

--- a/apps/web/src/renderer/components/avatar/talkingHeadAvatar.ts
+++ b/apps/web/src/renderer/components/avatar/talkingHeadAvatar.ts
@@ -1,0 +1,153 @@
+import type { AvatarPanelState } from './AgentAvatarPanel.logic';
+
+const AVATAR_MODEL_URL = 'https://cdn.jsdelivr.net/gh/met4citizen/TalkingHead@1.7/avatars/brunette.glb';
+
+interface TalkingHeadInstance {
+  showAvatar(
+    avatar: Record<string, unknown>,
+    onProgress?: (event: ProgressEvent) => void,
+  ): Promise<void>;
+  setMood(mood: string, weight?: number): void;
+  playGesture(name: string): void;
+  speakText(text: string, options?: { ttsEndpoint?: string | null }): Promise<void>;
+  stopSpeaking?: () => Promise<void> | void;
+  dispose?: () => Promise<void> | void;
+}
+
+interface TalkingHeadConstructor {
+  new(container: HTMLElement, options: Record<string, unknown>): TalkingHeadInstance;
+}
+
+export interface TalkingHeadAvatarController {
+  setState(state: AvatarPanelState): void;
+  speakText(text: string): void;
+  dispose(): void;
+}
+
+export async function createTalkingHeadAvatar(
+  container: HTMLElement,
+  onProgress: (percent: number) => void,
+): Promise<TalkingHeadAvatarController> {
+  const moduleRecord: unknown = await import('@met4citizen/talkinghead');
+  const TalkingHead = getTalkingHeadConstructor(moduleRecord);
+
+  if (!TalkingHead) {
+    throw new Error('TalkingHead module did not expose a TalkingHead constructor.');
+  }
+
+  const head = new TalkingHead(container, {
+    lipsyncModules: ['en'],
+    cameraView: 'mid',
+    cameraDistance: 0,
+    cameraRotateEnable: false,
+    cameraZoomEnable: false,
+    cameraPanEnable: false,
+    lightAmbientColor: 0xffffff,
+    lightAmbientIntensity: 2,
+    lightDirectColor: 0x8888aa,
+    lightDirectIntensity: 30,
+    lightDirectPhi: 0.1,
+    lightDirectTheta: 2,
+    avatarMood: 'neutral',
+    avatarIdleEyeContact: 0.4,
+    avatarIdleHeadMove: 0.45,
+    avatarSpeakingEyeContact: 0.7,
+    avatarSpeakingHeadMove: 0.6,
+    modelFPS: 30,
+  });
+
+  await head.showAvatar({
+    url: AVATAR_MODEL_URL,
+    body: 'F',
+    avatarMood: 'neutral',
+    lipsyncLang: 'en',
+  }, (event) => {
+    if (event.lengthComputable) {
+      onProgress(Math.round((event.loaded / event.total) * 100));
+    }
+  });
+
+  return createController(head);
+}
+
+function createController(head: TalkingHeadInstance): TalkingHeadAvatarController {
+  let requestedState: AvatarPanelState = 'idle';
+  let speechQueue: Promise<void> = Promise.resolve();
+  let disposed = false;
+
+  const applyState = (state: AvatarPanelState) => {
+    if (disposed) return;
+
+    switch (state) {
+      case 'thinking':
+        head.setMood('neutral');
+        head.playGesture('thinking');
+        break;
+      case 'listening':
+        head.setMood('happy', 0.3);
+        break;
+      case 'speaking':
+        head.setMood('neutral');
+        break;
+      case 'idle':
+      default:
+        head.setMood('neutral');
+        break;
+    }
+  };
+
+  return {
+    setState(state) {
+      if (disposed) return;
+      requestedState = state;
+      applyState(state);
+    },
+    speakText(text) {
+      if (disposed) return;
+
+      const cleanText = text.trim();
+      if (cleanText.length === 0) return;
+
+      speechQueue = speechQueue
+        .catch((error: unknown) => {
+          console.warn('[avatar] Previous speech item failed:', error);
+        })
+        .then(async () => {
+          if (disposed) return;
+          applyState('speaking');
+          try {
+            await head.speakText(cleanText, { ttsEndpoint: null });
+          } catch (error) {
+            console.warn('[avatar] Silent lip-sync failed:', error);
+          } finally {
+            applyState(requestedState);
+          }
+        });
+
+      void speechQueue;
+    },
+    dispose() {
+      disposed = true;
+      if (head.stopSpeaking) {
+        void Promise.resolve(head.stopSpeaking()).catch((error: unknown) => {
+          console.warn('[avatar] Failed to stop speaking:', error);
+        });
+      }
+      if (head.dispose) {
+        void Promise.resolve(head.dispose()).catch((error: unknown) => {
+          console.warn('[avatar] Failed to dispose TalkingHead:', error);
+        });
+      }
+    },
+  };
+}
+
+function getTalkingHeadConstructor(moduleRecord: unknown): TalkingHeadConstructor | null {
+  if (!isRecord(moduleRecord)) return null;
+  const candidate = moduleRecord.TalkingHead;
+  return typeof candidate === 'function' ? candidate as TalkingHeadConstructor : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/web/src/renderer/components/layout/AppShell.tsx
+++ b/apps/web/src/renderer/components/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { ActivityBar } from './ActivityBar';
 import { MacTitlebarDrag } from './MacTitlebarDrag';
 import { MindSidebar } from './MindSidebar';
 import { ViewRouter } from './ViewRouter';
+import { PopoutAvatarWindow } from '../avatar/PopoutAvatarWindow';
 
 function usePopoutParams() {
   const params = new URLSearchParams(window.location.search);
@@ -28,17 +29,23 @@ export function AppShell() {
     }
   }, [isPopout, popoutMindId, minds.length, dispatch]);
 
-  // Popout mode: just chat, no sidebar or activity bar
+  // Popout mode: avatar-first stage when running in Electron desktop;
+  // browser variant has no voice IPC, so fall back to the chat view there.
   if (isPopout) {
+    const hasVoice = typeof window !== 'undefined' && Boolean(window.electronAPI?.voice);
     return (
       <TooltipProvider>
         <MacTitlebarDrag />
         <div className="flex flex-col h-screen w-screen bg-background text-foreground">
-          <div className="flex flex-1 min-h-0">
-            <main className="flex-1 flex flex-col min-w-0">
-              <ViewRouter />
-            </main>
-          </div>
+          {hasVoice ? (
+            <PopoutAvatarWindow popoutMindId={popoutMindId} />
+          ) : (
+            <div className="flex flex-1 min-h-0">
+              <main className="flex-1 flex flex-col min-w-0">
+                <ViewRouter />
+              </main>
+            </div>
+          )}
         </div>
       </TooltipProvider>
     );

--- a/apps/web/src/renderer/index.css
+++ b/apps/web/src/renderer/index.css
@@ -98,3 +98,46 @@ body {
 .prose table {
   font-size: 0.875em;
 }
+
+.chamber-agent-avatar-canvas canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.chamber-avatar-orb {
+  background: linear-gradient(135deg, var(--color-genesis), oklch(0.62 0.18 255));
+  box-shadow: 0 0 48px color-mix(in oklch, var(--color-genesis) 55%, transparent);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.chamber-avatar-orb.listening {
+  box-shadow: 0 0 60px color-mix(in oklch, oklch(0.72 0.13 235) 65%, transparent);
+}
+
+.chamber-avatar-orb.thinking {
+  animation: chamber-avatar-thinking 1.8s ease-in-out infinite;
+}
+
+.chamber-avatar-orb.speaking,
+.chamber-avatar-state-speaking {
+  animation: chamber-avatar-speaking 520ms ease-in-out infinite alternate;
+}
+
+@keyframes chamber-avatar-thinking {
+  0%, 100% {
+    transform: translateY(0) rotate(0deg) scale(1);
+  }
+  50% {
+    transform: translateY(-5px) rotate(3deg) scale(0.97);
+  }
+}
+
+@keyframes chamber-avatar-speaking {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.14);
+  }
+}

--- a/apps/web/src/renderer/types/talkinghead.d.ts
+++ b/apps/web/src/renderer/types/talkinghead.d.ts
@@ -1,0 +1,16 @@
+declare module '@met4citizen/talkinghead' {
+  export class TalkingHead {
+    constructor(container: HTMLElement, options: Record<string, unknown>);
+
+    showAvatar(
+      avatar: Record<string, unknown>,
+      onProgress?: (event: ProgressEvent) => void,
+    ): Promise<void>;
+
+    setMood(mood: string, weight?: number): void;
+    playGesture(name: string): void;
+    speakText(text: string, options?: { ttsEndpoint?: string | null }): Promise<void>;
+    stopSpeaking?: () => Promise<void> | void;
+    dispose?: () => Promise<void> | void;
+  }
+}

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -207,6 +207,18 @@ export function mockElectronAPI(): ElectronAPI {
       getOrchestration: vi.fn().mockResolvedValue({ mode: 'concurrent', config: null }),
       onEvent: vi.fn().mockReturnValue(vi.fn()),
     },
+    voice: {
+      recognizeOnce: vi.fn().mockResolvedValue({
+        provider: 'windows-system-speech',
+        text: '',
+        error: 'No speech recognized. Try again after the listening indicator appears.',
+      }),
+      stopRecognition: vi.fn().mockResolvedValue(undefined),
+      synthesize: vi.fn().mockResolvedValue({
+        provider: 'edge-tts',
+        error: 'TTS is not configured for tests.',
+      }),
+    },
     updater: {
       getState: vi.fn((): Promise<DesktopUpdateState> => new Promise<DesktopUpdateState>(() => {})),
       check: vi.fn().mockResolvedValue({ success: false }),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'node:path';
 export default defineConfig({
   root: __dirname,
   plugins: [tailwindcss()],
+  optimizeDeps: {
+    exclude: ['@met4citizen/talkinghead'],
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,8 @@
       "version": "0.31.0",
       "dependencies": {
         "@chamber/services": "file:../../packages/services",
-        "@chamber/shared": "file:../../packages/shared"
+        "@chamber/shared": "file:../../packages/shared",
+        "edge-tts-universal": "^1.4.0"
       }
     },
     "apps/server": {
@@ -100,7 +101,8 @@
       "version": "0.31.0",
       "dependencies": {
         "@chamber/client": "file:../../packages/client",
-        "@chamber/shared": "file:../../packages/shared"
+        "@chamber/shared": "file:../../packages/shared",
+        "@met4citizen/talkinghead": "^1.7.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2220,6 +2222,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@met4citizen/talkinghead": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@met4citizen/talkinghead/-/talkinghead-1.7.0.tgz",
+      "integrity": "sha512-iBQhTjvwOO2lLht/YeWqAUmsH0jk4FGpxiPTPMMp3QYVjst/u2rDhn4up59BMJwfdeW3DyU7Im6y+TWmnNllZA==",
+      "license": "MIT",
+      "dependencies": {
+        "three": "^0.180.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -6103,7 +6114,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6648,7 +6658,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -6669,6 +6678,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/bail": {
@@ -6962,7 +6982,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7309,7 +7328,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -7416,6 +7434,15 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7649,7 +7676,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -7898,7 +7924,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7915,6 +7940,25 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/edge-tts-universal": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/edge-tts-universal/-/edge-tts-universal-1.4.0.tgz",
+      "integrity": "sha512-53Zk6UH3+3g844APjuhtHb2KTTdRLY6fZtEZsSIF3Kz3tYEpsjwQedCtaz8qTaxYdqFOMoFyCGNOHm2PxuX2Jw==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "axios": "^1.12.1",
+        "cross-fetch": "^4.1.0",
+        "https-proxy-agent": "^7.0.6",
+        "isomorphic-ws": "^5.0.0",
+        "uuid": "^11.1.0",
+        "ws": "^8.18.3",
+        "xml-escape": "^1.1.0"
+      },
+      "engines": {
+        "node": "^18.17 || ^20.9 || >=22",
+        "npm": ">=9"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -8541,7 +8585,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8551,7 +8594,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8568,7 +8610,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -8581,7 +8622,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9443,11 +9483,30 @@
         "node": ">= 12"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -9525,7 +9584,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9584,7 +9642,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -9651,7 +9708,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -9834,7 +9890,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9903,7 +9958,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9916,7 +9970,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9932,7 +9985,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -10113,7 +10165,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -10552,6 +10603,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -11524,7 +11584,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12445,7 +12504,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12455,7 +12513,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -12655,7 +12712,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -12676,21 +12732,18 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -13449,6 +13502,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pump": {
@@ -15171,6 +15233,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
@@ -15967,6 +16035,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -16536,6 +16617,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+      "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==",
+      "license": "MIT License"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -187,6 +187,20 @@ export interface DesktopUpdateActionResult {
   message?: string;
 }
 
+export interface VoiceRecognitionResult {
+  text?: string;
+  error?: string;
+  confidence?: number;
+  provider: 'windows-system-speech';
+}
+
+export interface VoiceSynthesisResult {
+  audioBase64?: string;
+  mimeType?: string;
+  error?: string;
+  provider: 'edge-tts';
+}
+
 export interface ElectronAPI {
   chat: {
     send: (mindId: string, message: string, messageId: string, model?: string, attachments?: ChatImageAttachment[]) => Promise<void>;
@@ -238,6 +252,11 @@ export interface ElectronAPI {
     removeGenesisRegistry: (id: string) => Promise<MarketplaceRegistryActionResult>;
   };
   chatroom: ChatroomAPI;
+  voice: {
+    recognizeOnce: (options?: { language?: string; timeoutMs?: number }) => Promise<VoiceRecognitionResult>;
+    stopRecognition: () => Promise<void>;
+    synthesize: (text: string, options?: { voice?: string }) => Promise<VoiceSynthesisResult>;
+  };
   updater: {
     getState: () => Promise<DesktopUpdateState>;
     check: () => Promise<DesktopUpdateActionResult>;


### PR DESCRIPTION
## Summary

Avatar-first popped-out agent window for the developer prototype.

- Routes popped-out agent windows to a dedicated avatar experience instead of the full chat UI (in Electron desktop only — browser mode falls back to the chat view).
- Adds a TalkingHead-based avatar stage with captions, microphone, and transcript exit controls.
- Keeps the main/default chat interface unchanged.
- Adds local developer voice support using Windows built-in speech recognition for STT and Edge TTS for speech output.

## Updated for monorepo restructure

This PR was originally opened before master's monorepo restructure into `apps/desktop`, `apps/web`, `apps/server`, `packages/services`, `packages/shared`. The full prototype has been rebased onto the new layout:

| Original (flat `src/`) | New location |
|---|---|
| `src/main/ipc/voice.ts` | `apps/desktop/src/main/ipc/voice.ts` |
| `src/main.ts` (wiring) | `apps/desktop/src/main.ts` (`+ setupVoiceIPC()`) |
| `src/preload.ts` (voice namespace) | `apps/desktop/src/preload.ts` |
| `src/main/ipc/mind.ts` (popout window tweaks) | `apps/desktop/src/main/ipc/mind.ts` (860×900 + `backgroundThrottling: false`) |
| `src/shared/types.ts` (voice types) | `packages/shared/src/types.ts` |
| `src/renderer/components/avatar/*` | `apps/web/src/renderer/components/avatar/*` |
| `src/renderer/types/talkinghead.d.ts` | `apps/web/src/renderer/types/talkinghead.d.ts` |
| `src/renderer/index.css` (avatar stage CSS) | `apps/web/src/renderer/index.css` |
| `src/renderer/components/layout/AppShell.tsx` | `apps/web/src/renderer/components/layout/AppShell.tsx` (with browser-vs-Electron guard via `window.electronAPI?.voice`) |
| `src/test/helpers.ts` (mockElectronAPI voice) | `apps/web/src/test/helpers.ts` |
| `vite.renderer.config.ts` (`optimizeDeps.exclude`) | `apps/web/vite.config.ts` |
| `src/main/services/sdk/sdkPaths.ts` (dev-mode fix) | **No longer needed** — master's `packages/services/src/sdk/sdkPaths.ts` already enforces repo-local SDK in dev mode (more strictly than the original PR fix). |

A new `apps/web/src/browserApi.ts` voice stub returns `"unavailable in browser mode"` errors so the browser variant doesn't crash if a developer opens the popout URL there. The avatar stage activates only when `window.electronAPI.voice` is present (Electron desktop).

## Validation

- `npm run lint` — typecheck + eslint + dependency-cruiser **clean** (315 modules, 593 deps, 0 violations)
- `npm test` — full vitest suite **clean (1050/1050 passing)**
- Focused tests passing at new locations:
  - `apps/web/src/renderer/components/avatar/PopoutAvatarWindow.test.tsx` (4)
  - `apps/web/src/renderer/components/avatar/AgentAvatarPanel.logic.test.ts` (7)
  - `packages/services/src/sdk/sdkPaths.test.ts` (4)
  - `packages/services/src/sdk/CopilotClientFactory.test.ts` (8)
- Manual local dev smoke (`npm start`): avatar visible, mic captures speech via Windows `System.Speech`, agent reply plays via Edge TTS, red ✕ returns to transcript, main chat unchanged.

## Dependencies added

- `@met4citizen/talkinghead@^1.7.0` (MIT) → `apps/web` — avatar rendering
- `edge-tts-universal@^1.4.0` (AGPL-3.0) → `apps/desktop` — local TTS output
  - Note: AGPL-3.0 is copyleft; flagged here for visibility. Used only at runtime in the desktop main process; not redistributed as source.

## Follow-ups (intentionally out of scope here)

- **Voice/avatar provider abstraction.** Current implementation has flat voice IPC and a single TalkingHead path. Formalizing this behind a `VoiceProvider` interface should happen alongside any second provider (e.g. Foundry).
- **Foundry / Azure Speech avatar integration** as a separate optional provider — being explored on a separate spike branch, not mixed into the local prototype.
- **Browser variant avatar/voice support** — the popout currently degrades to the chat view in `apps/web`. Adding a Web Speech API + browser TTS shim could enable a browser-only path.
