### PR TITLE
feat: add Windows Sandbox installer-test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,14 @@ React Renderer
 npm start          # Launch with hot reload
 npm run lint       # TypeScript + ESLint
 npm run make       # Build distributable
+npm run make:sandbox  # Build + launch Windows Sandbox to test the installer
+npm run sandbox       # Launch sandbox using existing out/make artifacts
 ```
+
+`make:sandbox` rebuilds chamber, then opens a fresh Windows Sandbox with
+`out/make` mapped read-only to `C:\installer`. Explorer auto-opens to the
+Squirrel installer so you can simulate a clean first-run install. Requires
+Windows Pro/Enterprise/Education with the Windows Sandbox feature enabled.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start": "electron-forge start",
     "package": "node scripts/prepare-node-runtime.js && electron-forge package",
     "make": "node scripts/prepare-node-runtime.js && electron-forge make",
+    "make:sandbox": "npm run make && node scripts/sandbox-test.js",
+    "sandbox": "node scripts/sandbox-test.js",
     "publish": "node scripts/prepare-node-runtime.js && electron-forge publish",
     "lint": "tsc --noEmit && eslint .",
     "typecheck": "tsc --noEmit",

--- a/scripts/sandbox-test.js
+++ b/scripts/sandbox-test.js
@@ -15,6 +15,15 @@ const { spawn } = require('child_process');
 const repoRoot = path.resolve(__dirname, '..');
 const makeDir = path.join(repoRoot, 'out', 'make');
 
+function escapeXml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
 if (process.platform !== 'win32') {
   console.error('Windows Sandbox is Windows-only.');
   process.exit(1);
@@ -34,13 +43,13 @@ const wsbXml = `<Configuration>
   <Networking>Enable</Networking>
   <MappedFolders>
     <MappedFolder>
-      <HostFolder>${makeDir}</HostFolder>
+      <HostFolder>${escapeXml(makeDir)}</HostFolder>
       <SandboxFolder>C:\\installer</SandboxFolder>
       <ReadOnly>true</ReadOnly>
     </MappedFolder>
   </MappedFolders>
   <LogonCommand>
-    <Command>explorer.exe ${sandboxOpenTarget}</Command>
+    <Command>explorer.exe ${escapeXml(sandboxOpenTarget)}</Command>
   </LogonCommand>
 </Configuration>
 `;

--- a/scripts/sandbox-test.js
+++ b/scripts/sandbox-test.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+/**
+ * Launch a Windows Sandbox that maps the latest `out/make` build into the
+ * sandbox and opens Explorer at the Squirrel installer folder. Use to
+ * exercise the zero-deps first-run install experience on a clean machine.
+ *
+ * Usage: npm run make:sandbox  (which runs `npm run make` first)
+ *        npm run sandbox       (skip rebuild, use existing artifacts)
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const makeDir = path.join(repoRoot, 'out', 'make');
+
+if (process.platform !== 'win32') {
+  console.error('Windows Sandbox is Windows-only.');
+  process.exit(1);
+}
+
+if (!fs.existsSync(makeDir)) {
+  console.error(`No build output found at ${makeDir}. Run \`npm run make\` first.`);
+  process.exit(1);
+}
+
+const squirrelDir = path.join(makeDir, 'squirrel.windows', 'x64');
+const sandboxOpenTarget = fs.existsSync(squirrelDir)
+  ? 'C:\\installer\\squirrel.windows\\x64'
+  : 'C:\\installer';
+
+const wsbXml = `<Configuration>
+  <Networking>Enable</Networking>
+  <MappedFolders>
+    <MappedFolder>
+      <HostFolder>${makeDir}</HostFolder>
+      <SandboxFolder>C:\\installer</SandboxFolder>
+      <ReadOnly>true</ReadOnly>
+    </MappedFolder>
+  </MappedFolders>
+  <LogonCommand>
+    <Command>explorer.exe ${sandboxOpenTarget}</Command>
+  </LogonCommand>
+</Configuration>
+`;
+
+const wsbPath = path.join(os.tmpdir(), `chamber-sandbox-${process.pid}.wsb`);
+fs.writeFileSync(wsbPath, wsbXml, 'utf8');
+
+console.log(`Mapping ${makeDir} -> C:\\installer (read-only)`);
+console.log(`Launching Windows Sandbox via ${wsbPath}`);
+
+const child = spawn('cmd.exe', ['/c', 'start', '""', wsbPath], {
+  detached: true,
+  stdio: 'ignore',
+});
+child.unref();


### PR DESCRIPTION
Adds an 
pm run make:sandbox (and 
pm run sandbox) flow that builds chamber and launches a fresh Windows Sandbox with out/make mapped read-only at C:\installer. Explorer auto-opens to the Squirrel installer folder so you can simulate a zero-deps first-run install on a clean OS, then dispose the VM.

## Changes
- scripts/sandbox-test.js -- generates a temp .wsb with the absolute path to out/make and launches it
- package.json -- make:sandbox (build + launch) and sandbox (launch only)
- README.md -- documents the new scripts under Development

## How to test
``n
npm run make:sandbox
``n
Requires Windows Pro/Enterprise/Education with the Windows Sandbox optional feature enabled.