### PR TITLE
feat: add governance artifacts for agent runtime safety

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -1,0 +1,152 @@
+name: Governance Check
+
+on:
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: governance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check governance artifacts exist
+        run: |
+          echo "=== Checking governance artifacts ==="
+          MISSING=0
+
+          for file in AGENTS.md policy.yaml mcp-allowlist.yaml; do
+            if [ ! -f "$file" ]; then
+              echo "::error::Missing required governance artifact: $file"
+              MISSING=1
+            else
+              echo "Found: $file"
+            fi
+          done
+
+          if [ $MISSING -eq 1 ]; then
+            exit 1
+          fi
+          echo "All governance artifacts present."
+
+      - name: Validate policy.yaml schema
+        run: |
+          echo "=== Validating policy.yaml ==="
+          python3 -c "
+          import yaml, sys
+          with open('policy.yaml', 'r') as f:
+              policy = yaml.safe_load(f)
+          required = ['version', 'name', 'rules']
+          for field in required:
+              if field not in policy:
+                  print(f'::error::policy.yaml missing required field: {field}')
+                  sys.exit(1)
+          for rule in policy.get('rules', []):
+              if 'id' not in rule or 'severity' not in rule:
+                  print(f'::error::Rule missing id or severity: {rule}')
+                  sys.exit(1)
+          print(f'Policy validated: {len(policy[\"rules\"])} rules defined')
+          "
+
+      - name: Validate mcp-allowlist.yaml schema
+        run: |
+          echo "=== Validating mcp-allowlist.yaml ==="
+          python3 -c "
+          import yaml, sys
+          with open('mcp-allowlist.yaml', 'r') as f:
+              allowlist = yaml.safe_load(f)
+          required = ['version', 'default_action']
+          for field in required:
+              if field not in allowlist:
+                  print(f'::error::mcp-allowlist.yaml missing required field: {field}')
+                  sys.exit(1)
+          servers = allowlist.get('servers', [])
+          tools = allowlist.get('tools', [])
+          print(f'Allowlist validated: {len(servers)} servers, {len(tools)} tools defined')
+          print(f'Default action: {allowlist[\"default_action\"]}')
+          "
+
+      - name: Scan for secrets in mind directories
+        run: |
+          echo "=== Scanning for secrets ==="
+          FOUND=0
+          PATTERNS=(
+            'PRIVATE KEY'
+            'sk-[a-zA-Z0-9]'
+            'ghp_[a-zA-Z0-9]'
+            'github_pat_'
+            'Bearer [a-zA-Z0-9]'
+            'password\s*[:=]'
+          )
+          for pattern in "${PATTERNS[@]}"; do
+            if grep -rn --include="*.md" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.ts" --include="*.js" -E "$pattern" . --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null; then
+              echo "::warning::Potential secret pattern found: $pattern"
+              FOUND=1
+            fi
+          done
+          if [ $FOUND -eq 1 ]; then
+            echo "::warning::Review flagged patterns above for actual secrets"
+          else
+            echo "No secret patterns detected."
+          fi
+
+      - name: Check .working-memory not modified
+        run: |
+          echo "=== Checking .working-memory protection ==="
+          CHANGED=$(git diff --name-only origin/master...HEAD -- .working-memory/ 2>/dev/null || true)
+          if [ -n "$CHANGED" ]; then
+            echo "::warning::PR modifies .working-memory/ files (agent-managed):"
+            echo "$CHANGED"
+          else
+            echo ".working-memory/ not modified in this PR."
+          fi
+
+      - name: Validate Lens view.json files
+        run: |
+          echo "=== Validating Lens view.json files ==="
+          python3 -c "
+          import json, glob, sys
+          views = glob.glob('.github/lens/**/view.json', recursive=True)
+          if not views:
+              print('No Lens view.json files found (OK)')
+              sys.exit(0)
+          errors = 0
+          VALID_TYPES = ['form', 'table', 'briefing', 'detail', 'status-board', 'timeline', 'editor']
+          for path in views:
+              with open(path) as f:
+                  try:
+                      view = json.load(f)
+                  except json.JSONDecodeError as e:
+                      print(f'::error::Invalid JSON in {path}: {e}')
+                      errors += 1
+                      continue
+              if 'type' in view and view['type'] not in VALID_TYPES:
+                  print(f'::error::Invalid view type in {path}: {view[\"type\"]}')
+                  errors += 1
+          if errors:
+              sys.exit(1)
+          print(f'Validated {len(views)} Lens view(s)')
+          "
+
+      - name: npm audit
+        run: |
+          echo "=== Running npm audit ==="
+          npm audit --omit=dev 2>&1 || echo "::warning::npm audit found vulnerabilities"
+
+  governance-status:
+    needs: [governance]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance gate
+        run: |
+          if [ "${{ needs.governance.result }}" != "success" ]; then
+            echo "::error::Governance checks failed. Please fix issues above."
+            exit 1
+          fi
+          echo "All governance checks passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md - Chamber Agent Governance
+
+## Overview
+
+Chamber is a desktop application where AI agents ("minds") operate as a Chief of Staff. Agents connect via the GitHub Copilot SDK and can extend the UI, execute tool calls, modify data, and run scheduled jobs.
+
+## Agent Capabilities
+
+### Minds
+- **Identity**: Each mind has a name, personality, and persistent memory
+- **Tool access**: Minds invoke tools via the Copilot SDK (model-driven tool calls)
+- **Lens views**: Minds can create `view.json` files in `.github/lens/` to extend the UI with 7 view types (form, table, briefing, detail, status-board, timeline, editor)
+- **Write-back**: Minds can modify data through the action bar on any Lens view
+- **Canvas**: Minds can render HTML dashboards, reports, and forms in a browser with live reload
+- **Cron**: Minds can schedule prompt, process, webhook, and notification jobs
+
+### Chatroom (Multi-Agent)
+- **Concurrent**: All agents respond in parallel
+- **Sequential**: Round-robin turns
+- **GroupChat**: Moderator-directed conversation
+- **Handoff**: Agent-to-agent delegation
+- **Magentic**: Manager-driven task ledger
+
+## Security Boundaries
+
+### Credential Storage
+- Credentials stored via `keytar` (OS-native keychain)
+- Never store credentials in mind directories or `.working-memory/`
+
+### Tool Execution
+- All tool calls flow through the Copilot SDK
+- Approval gate (`approval-gate.ts`) provides tool execution review
+- Observability layer (`observability.ts`) emits structured events with redaction
+
+### Desktop Considerations
+- Close-to-tray means agents may run unattended
+- Squirrel auto-updates verify Azure Trusted Signing signatures
+- Mind directories are user-local; do not share across untrusted users
+
+## Coding Agent Instructions
+
+When contributing to Chamber:
+- Do not commit secrets, tokens, or credentials
+- Do not modify `.working-memory/` files in PRs (agent-managed)
+- Validate all `view.json` files against the Lens schema before rendering
+- Canvas HTML rendering must be sandboxed (no access to Electron main process APIs)
+- Cron job definitions must not allow arbitrary shell execution
+- Tool call responses must be sanitized before display in chat UI
+- Multi-agent chatroom changes require review of orchestration safety (delegation limits, approval gates)

--- a/mcp-allowlist.yaml
+++ b/mcp-allowlist.yaml
@@ -1,0 +1,42 @@
+# MCP Allowlist for Chamber
+# Controls which MCP servers and tools minds are permitted to invoke
+# Unlisted servers are blocked by default
+
+version: "1.0"
+default_action: block
+
+servers:
+  # GitHub Copilot SDK (core runtime)
+  - name: github-copilot
+    url: "https://api.githubcopilot.com"
+    action: allow
+    description: Core Copilot SDK endpoint for agent interactions
+    trust_level: high
+
+  # GitHub API (repo operations)
+  - name: github-api
+    url: "https://api.github.com"
+    action: allow
+    description: GitHub REST and GraphQL API access
+    trust_level: high
+
+# Tool restrictions
+tools:
+  # File system access scoped to mind directories
+  - name: file-read
+    action: allow
+    scope: mind-directory-only
+
+  - name: file-write
+    action: allow
+    scope: mind-directory-only
+
+  # Network access requires explicit approval
+  - name: network-fetch
+    action: warn
+    description: External network calls require user approval via approval gate
+
+  # Shell execution blocked by default
+  - name: shell-execute
+    action: block
+    description: Direct shell execution is not permitted for minds

--- a/policy.yaml
+++ b/policy.yaml
@@ -1,0 +1,69 @@
+# Chamber Governance Policy
+# Enforced by governance-check workflow
+# Schema: https://github.com/microsoft/agent-governance-toolkit
+
+version: "1.0"
+name: chamber-governance
+description: Governance policy for Chamber desktop agent platform
+
+rules:
+  # Agent identity and boundaries
+  - id: agent-identity
+    description: Every mind must declare its name and capabilities
+    severity: error
+    check: mind-manifest-required
+
+  # Tool access control
+  - id: tool-allowlist
+    description: Minds may only invoke tools listed in the MCP allowlist
+    severity: error
+    check: mcp-allowlist-enforced
+
+  # Credential safety
+  - id: no-committed-secrets
+    description: No secrets, tokens, or credentials in committed files
+    severity: error
+    check: secret-scan
+
+  # Lens view safety
+  - id: lens-schema-validation
+    description: All view.json files must conform to the Lens schema
+    severity: error
+    check: lens-schema-valid
+
+  # Canvas sandboxing
+  - id: canvas-sandbox
+    description: Canvas HTML must not access Electron main process APIs
+    severity: error
+    check: canvas-isolation
+
+  # Cron safety
+  - id: cron-no-shell
+    description: Cron jobs must not allow arbitrary shell execution
+    severity: warning
+    check: cron-safe-execution
+
+  # Chatroom orchestration
+  - id: chatroom-delegation-limit
+    description: Agent-to-agent delegation depth must not exceed 3
+    severity: warning
+    check: delegation-depth-limit
+    parameters:
+      max_depth: 3
+
+  # Dependency hygiene
+  - id: dependency-audit
+    description: npm dependencies must pass security audit
+    severity: error
+    check: npm-audit-clean
+
+  # Working memory protection
+  - id: working-memory-readonly
+    description: PRs must not modify .working-memory/ files
+    severity: warning
+    check: working-memory-protected
+
+metadata:
+  framework: agent-governance-toolkit
+  applies_to: desktop-agent-platform
+  review_cadence: quarterly


### PR DESCRIPTION
## Summary

Adds governance artifacts to Chamber, addressing the gaps identified in #125.

## What's included

**AGENTS.md** - Documents all agent capabilities (minds, tool access, Lens views, write-back, canvas, cron, chatroom orchestration modes) and security boundaries (credential storage, tool execution, desktop considerations).

**policy.yaml** - AGT-compatible governance policy with 9 enforceable rules covering agent identity, tool allowlisting, secret scanning, Lens schema validation, canvas sandboxing, cron safety, chatroom delegation limits, dependency audit, and working-memory protection.

**mcp-allowlist.yaml** - Controls which MCP servers and tools minds are permitted to invoke. Default action is block. Explicitly allows GitHub Copilot SDK and GitHub API. Blocks direct shell execution for minds.

**governance-check.yml** - CI workflow (runs on PRs to master) that validates:
- Governance artifact presence
- policy.yaml and mcp-allowlist.yaml schema compliance
- Secret pattern scanning across source files
- .working-memory/ modification protection
- Lens view.json schema validation
- npm dependency audit

## Context

These artifacts follow the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) patterns. Chamber is a natural fit for AGT governance given it runs agents with tool-call capabilities, self-extending UI, multi-agent orchestration, and unattended desktop operation.

Closes #125