### PR TITLE
feat(main): add native right-click context menu (closes #94)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { ChatroomService } from './main/services/chatroom';
 import { CanvasService } from './main/services/canvas';
 import { CronService } from './main/services/cron';
 import { createAppTray, loadAppIcon } from './main/tray/Tray';
+import { installContextMenu } from './main/contextMenu/ContextMenu';
 
 // IPC adapters
 import { setupChatIPC } from './main/ipc/chat';
@@ -138,6 +139,8 @@ const createWindow = () => {
       sandbox: false,
     },
   });
+
+  installContextMenu(mainWindow.webContents);
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);

--- a/src/main/contextMenu/ContextMenu.test.ts
+++ b/src/main/contextMenu/ContextMenu.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ContextMenuParams, WebContents } from 'electron';
+
+const { mockBuildFromTemplate, mockPopup, mockFromWebContents } = vi.hoisted(() => ({
+  mockBuildFromTemplate: vi.fn(),
+  mockPopup: vi.fn(),
+  mockFromWebContents: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  Menu: { buildFromTemplate: mockBuildFromTemplate },
+  BrowserWindow: { fromWebContents: mockFromWebContents },
+}));
+
+import { buildContextMenuTemplate, installContextMenu } from './ContextMenu';
+
+function makeParams(overrides: {
+  isEditable?: boolean;
+  selectionText?: string;
+  editFlags?: Partial<ContextMenuParams['editFlags']>;
+} = {}): ContextMenuParams {
+  const { editFlags: editFlagsOverride, ...rest } = overrides;
+  return {
+    isEditable: false,
+    selectionText: '',
+    ...rest,
+    editFlags: {
+      canCut: false,
+      canCopy: false,
+      canPaste: false,
+      canSelectAll: false,
+      canDelete: false,
+      canUndo: false,
+      canRedo: false,
+      ...editFlagsOverride,
+    },
+  } as ContextMenuParams;
+}
+
+describe('buildContextMenuTemplate', () => {
+  it('returns Cut/Copy/Paste/separator/SelectAll for editable input with no selection and canPaste', () => {
+    const params = makeParams({
+      isEditable: true,
+      editFlags: { canCut: false, canCopy: false, canPaste: true, canSelectAll: true },
+    });
+
+    const result = buildContextMenuTemplate(params);
+
+    expect(result).toHaveLength(5);
+    expect(result[0]).toEqual({ role: 'cut', label: 'Cut', enabled: false });
+    expect(result[1]).toEqual({ role: 'copy', label: 'Copy', enabled: false });
+    expect(result[2]).toEqual({ role: 'paste', label: 'Paste', enabled: true });
+    expect(result[3]).toEqual({ type: 'separator' });
+    expect(result[4]).toEqual({ role: 'selectAll', label: 'Select All', enabled: true });
+  });
+
+  it('returns all items enabled when editable with selection and all editFlags set', () => {
+    const params = makeParams({
+      isEditable: true,
+      selectionText: 'hello',
+      editFlags: { canCut: true, canCopy: true, canPaste: true, canSelectAll: true },
+    });
+
+    const result = buildContextMenuTemplate(params);
+
+    expect(result).toHaveLength(5);
+    expect(result[0]).toEqual({ role: 'cut', label: 'Cut', enabled: true });
+    expect(result[1]).toEqual({ role: 'copy', label: 'Copy', enabled: true });
+    expect(result[2]).toEqual({ role: 'paste', label: 'Paste', enabled: true });
+    expect(result[3]).toEqual({ type: 'separator' });
+    expect(result[4]).toEqual({ role: 'selectAll', label: 'Select All', enabled: true });
+  });
+
+  it('shows Paste disabled when clipboard is empty', () => {
+    const params = makeParams({
+      isEditable: true,
+      editFlags: { canCut: false, canCopy: false, canPaste: false, canSelectAll: true },
+    });
+
+    const result = buildContextMenuTemplate(params);
+
+    expect(result).toHaveLength(5);
+    expect(result[2]).toEqual({ role: 'paste', label: 'Paste', enabled: false });
+    expect(result[3]).toEqual({ type: 'separator' });
+  });
+
+  it('returns only Copy/separator/SelectAll for readonly text with selection', () => {
+    const params = makeParams({
+      isEditable: false,
+      selectionText: 'selected text',
+      editFlags: { canCopy: true, canSelectAll: true },
+    });
+
+    const result = buildContextMenuTemplate(params);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ role: 'copy', label: 'Copy', enabled: true });
+    expect(result[1]).toEqual({ type: 'separator' });
+    expect(result[2]).toEqual({ role: 'selectAll', label: 'Select All', enabled: true });
+    // No Cut or Paste
+    expect(result.find((item) => 'role' in item && item.role === 'cut')).toBeUndefined();
+    expect(result.find((item) => 'role' in item && item.role === 'paste')).toBeUndefined();
+  });
+
+  it('returns empty array for readonly text with no selection', () => {
+    const params = makeParams({ isEditable: false, selectionText: '' });
+
+    const result = buildContextMenuTemplate(params);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('installContextMenu', () => {
+  const listeners = new Map<string, (...args: unknown[]) => void>();
+  const webContents = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      listeners.set(event, handler);
+      return webContents;
+    }),
+  } as unknown as WebContents;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listeners.clear();
+  });
+
+  it('registers exactly one context-menu listener', () => {
+    installContextMenu(webContents);
+
+    expect(webContents.on).toHaveBeenCalledOnce();
+    expect(webContents.on).toHaveBeenCalledWith('context-menu', expect.any(Function));
+  });
+
+  it('skips Menu.buildFromTemplate and popup when template is empty', () => {
+    installContextMenu(webContents);
+    const handler = listeners.get('context-menu')!;
+    const params = makeParams({ isEditable: false, selectionText: '' });
+
+    handler({} /* event */, params);
+
+    expect(mockBuildFromTemplate).not.toHaveBeenCalled();
+    expect(mockPopup).not.toHaveBeenCalled();
+  });
+
+  it('calls popup with the window when BrowserWindow.fromWebContents returns a window', () => {
+    const fakeWindow = { id: 1 };
+    mockFromWebContents.mockReturnValue(fakeWindow);
+    mockBuildFromTemplate.mockReturnValue({ popup: mockPopup });
+
+    installContextMenu(webContents);
+    const handler = listeners.get('context-menu')!;
+    const params = makeParams({
+      isEditable: true,
+      editFlags: { canPaste: true, canSelectAll: true },
+    });
+
+    handler({} /* event */, params);
+
+    expect(mockBuildFromTemplate).toHaveBeenCalledOnce();
+    expect(mockPopup).toHaveBeenCalledOnce();
+    expect(mockPopup).toHaveBeenCalledWith({ window: fakeWindow });
+  });
+
+  it('calls popup with undefined when BrowserWindow.fromWebContents returns null', () => {
+    mockFromWebContents.mockReturnValue(null);
+    mockBuildFromTemplate.mockReturnValue({ popup: mockPopup });
+
+    installContextMenu(webContents);
+    const handler = listeners.get('context-menu')!;
+    const params = makeParams({
+      isEditable: true,
+      editFlags: { canPaste: true, canSelectAll: true },
+    });
+
+    handler({} /* event */, params);
+
+    expect(mockPopup).toHaveBeenCalledOnce();
+    expect(mockPopup).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/main/contextMenu/ContextMenu.ts
+++ b/src/main/contextMenu/ContextMenu.ts
@@ -1,0 +1,47 @@
+import { BrowserWindow, Menu } from 'electron';
+import type { ContextMenuParams, MenuItemConstructorOptions, WebContents } from 'electron';
+
+export function buildContextMenuTemplate(
+  params: ContextMenuParams,
+): MenuItemConstructorOptions[] {
+  const { isEditable, selectionText, editFlags } = params;
+  const hasSelection = selectionText.length > 0;
+  const items: MenuItemConstructorOptions[] = [];
+
+  if (isEditable) {
+    items.push({ role: 'cut', label: 'Cut', enabled: editFlags.canCut });
+  }
+
+  if (isEditable || hasSelection) {
+    items.push({ role: 'copy', label: 'Copy', enabled: editFlags.canCopy });
+  }
+
+  if (isEditable) {
+    items.push({ role: 'paste', label: 'Paste', enabled: editFlags.canPaste });
+  }
+
+  const showSelectAll = isEditable || hasSelection;
+
+  if (showSelectAll) {
+    items.push({ type: 'separator' });
+  }
+
+  if (showSelectAll) {
+    items.push({ role: 'selectAll', label: 'Select All', enabled: editFlags.canSelectAll });
+  }
+
+  return items;
+}
+
+// Must be called once per webContents. Multiple calls stack listeners,
+// which would open duplicate menus on every right-click.
+export function installContextMenu(webContents: WebContents): void {
+  webContents.on('context-menu', (_event, params) => {
+    const template = buildContextMenuTemplate(params);
+    if (template.length === 0) return;
+
+    const menu = Menu.buildFromTemplate(template);
+    const win = BrowserWindow.fromWebContents(webContents);
+    menu.popup(win ? { window: win } : undefined);
+  });
+}


### PR DESCRIPTION
## What

Wires a native Electron context menu to the main `BrowserWindow` so right-clicking anywhere in the app produces the correct OS-native clipboard menu — no custom renderer code, no new dependencies.

## Behavior

| Context | Menu items shown |
|---|---|
| Editable field (input, textarea) | Cut · Copy · Paste · — · Select All |
| Editable field, nothing selected, clipboard empty | Cut · Copy · Paste (disabled) · — · Select All |
| Read-only text with a selection | Copy · — · Select All |
| Read-only area, nothing selected | *(no menu)* |

All items use Electron's built-in `role` strings (`cut`, `copy`, `paste`, `selectAll`), so the OS handles the actual clipboard operations. No custom `click` handlers.

## How

**`src/main/contextMenu/ContextMenu.ts`** — two exports:

- `buildContextMenuTemplate(params)` — pure function. Takes the `ContextMenuParams` from Electron's `context-menu` event and returns a `MenuItemConstructorOptions[]` based on `params.isEditable`, `params.selectionText`, and `params.editFlags`. No side effects, no Electron API calls.
- `installContextMenu(webContents)` — subscribes once to the `context-menu` event, calls the builder, skips entirely if the template is empty, otherwise calls `Menu.buildFromTemplate` and `popup`. Follows the same module pattern as `src/main/tray/Tray.ts`.

**`src/main/contextMenu/ContextMenu.test.ts`** — 9 unit tests covering every branch of both functions. Electron is mocked at the module level via `vi.hoisted` + `vi.mock`. `buildContextMenuTemplate` tests exercise the pure logic directly; `installContextMenu` tests cover event wiring, the early-exit path, popup-with-window, and popup-with-null-window.

**`src/main.ts`** — one new import, one call to `installContextMenu(mainWindow.webContents)` immediately after `new BrowserWindow(...)` is constructed.

## Out of scope

"Copy Link Address", "Copy Image", spell-check, "Inspect Element", and right-click inside `CanvasService`-rendered `BrowserView`s (those frames don't propagate the main-window `context-menu` event — tracked separately).

## Testing

```bash
npm run typecheck       # zero errors
vitest run src/main     # 497/497 pass (all main-process tests, tray unaffected)
npm run lint            # tsc + eslint clean