### PR TITLE
feat(chatroom): orchestration "best for" guidance, running-task indicator, and approval-gate hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,6 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -304,6 +303,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -352,6 +352,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -798,6 +799,7 @@
       "integrity": "sha512-38ho27/mtUV/LpsZ1LCDJUomKBBSUZDk/qBH4FNNtoN5fmnkmWDcIp5pm1Kv3InqhRjKZKs7Jzx+wWZNMArHrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "electron-fuses": "dist/bin.js"
       },
@@ -1106,29 +1108,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1697,6 +1676,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -1967,6 +1947,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -4544,8 +4525,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
@@ -4722,6 +4702,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4732,6 +4713,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4805,6 +4787,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -4993,6 +4976,7 @@
       "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.59.0",
@@ -5323,6 +5307,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -5642,6 +5627,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5989,6 +5975,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6671,8 +6658,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7246,6 +7232,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7362,6 +7349,7 @@
       "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@package-json/types": "^0.0.12",
         "@typescript-eslint/types": "^8.56.0",
@@ -8902,8 +8890,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.0.2",
@@ -8911,6 +8898,7 @@
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",
@@ -9620,7 +9608,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11460,7 +11447,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11476,7 +11462,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11694,6 +11679,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11703,6 +11689,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11715,8 +11702,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -12336,6 +12322,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12863,7 +12850,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -13100,6 +13088,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13312,6 +13301,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13673,6 +13663,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13764,6 +13755,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -303,7 +304,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -352,7 +352,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -799,7 +798,6 @@
       "integrity": "sha512-38ho27/mtUV/LpsZ1LCDJUomKBBSUZDk/qBH4FNNtoN5fmnkmWDcIp5pm1Kv3InqhRjKZKs7Jzx+wWZNMArHrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "electron-fuses": "dist/bin.js"
       },
@@ -1108,6 +1106,29 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1676,7 +1697,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -1947,7 +1967,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -4525,7 +4544,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
@@ -4702,7 +4722,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4713,7 +4732,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4787,7 +4805,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -4976,7 +4993,6 @@
       "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.59.0",
@@ -5307,7 +5323,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -5627,7 +5642,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5975,7 +5989,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6658,7 +6671,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7232,7 +7246,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7349,7 +7362,6 @@
       "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@package-json/types": "^0.0.12",
         "@typescript-eslint/types": "^8.56.0",
@@ -8890,7 +8902,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "29.0.2",
@@ -8898,7 +8911,6 @@
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",
@@ -9608,6 +9620,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11447,6 +11460,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11462,6 +11476,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11679,7 +11694,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11689,7 +11703,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11702,7 +11715,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -12322,7 +12336,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12850,8 +12863,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -13088,7 +13100,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13301,7 +13312,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13663,7 +13673,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13755,7 +13764,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,7 +136,7 @@ const createWindow = () => {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false,
+      sandbox: false, // Required: copilot-sdk IPC uses Node.js APIs via preload; mitigated by contextIsolation:true + nodeIntegration:false
     },
   });
 

--- a/src/main/services/chatroom/orchestration/MagenticStrategy.test.ts
+++ b/src/main/services/chatroom/orchestration/MagenticStrategy.test.ts
@@ -560,4 +560,70 @@ describe('MagenticStrategy', () => {
     expect(capturedPrompt).toContain('Respond concisely and directly');
     expect(capturedPrompt).toContain('Limit tool usage');
   });
+
+  // -------------------------------------------------------------------------
+  // formatManagerResponse: synthetic message formatting
+  // -------------------------------------------------------------------------
+
+  it('formats assign action into human-readable assignment message', async () => {
+    const managerSess = createMockSession();
+    const workerSess = createMockSession();
+    sessions.set('manager', managerSess);
+    sessions.set('worker-a', workerSess);
+
+    autoIdleWithSequence(managerSess, [
+      '{"action": "update-plan", "plan": [{"id": "1", "description": "write tests"}]}',
+      '{"action": "assign", "assignee": "Worker A", "task_id": "1", "task_description": "write tests"}',
+      '{"action": "complete", "summary": "done"}',
+    ]);
+    autoIdleWith(workerSess, 'Tests written');
+
+    const strategy = new MagenticStrategy({ managerMindId: 'manager', maxSteps: 10 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('manager', 'Manager'), makeMind('worker-a', 'Worker A')];
+
+    await strategy.execute('Write tests', minds, 'round-1', ctx);
+
+    const persisted = (ctx as unknown as { _messages: ChatroomMessage[] })._messages;
+    const assignMsg = persisted.find((m) =>
+      m.blocks.some((b) => b.type === 'text' && b.content.includes('**Assigning tasks:**')),
+    );
+    expect(assignMsg).toBeDefined();
+    expect(assignMsg!.blocks[0]).toMatchObject({
+      type: 'text',
+      content: expect.stringContaining('Worker A'),
+    });
+    expect(assignMsg!.blocks[0]).toMatchObject({
+      type: 'text',
+      content: expect.stringContaining('write tests'),
+    });
+  });
+
+  it('does not emit a synthetic message when manager responds with plain text', async () => {
+    const managerSess = createMockSession();
+    const workerSess = createMockSession();
+    sessions.set('manager', managerSess);
+    sessions.set('worker-a', workerSess);
+
+    // Plain-text plan response — no JSON, so formatManagerResponse returns it unchanged
+    // and the guard (planSummary !== planRawContent) prevents synthetic emission
+    autoIdleWithSequence(managerSess, [
+      'I will plan this task carefully.',
+      '{"action": "assign", "assignee": "Worker A", "task_id": "1", "task_description": "do work"}',
+      '{"action": "complete", "summary": "done"}',
+    ]);
+    autoIdleWith(workerSess, 'Done');
+
+    const strategy = new MagenticStrategy({ managerMindId: 'manager', maxSteps: 10 });
+    const ctx = createContext(sessions);
+    const minds = [makeMind('manager', 'Manager'), makeMind('worker-a', 'Worker A')];
+
+    await strategy.execute('Do work', minds, 'round-1', ctx);
+
+    const persisted = (ctx as unknown as { _messages: ChatroomMessage[] })._messages;
+    const planningMsg = persisted.find((m) =>
+      m.blocks.some((b) => b.type === 'text' && b.content.includes('**Planning:**')),
+    );
+    expect(planningMsg).toBeUndefined();
+  });
 });

--- a/src/main/services/chatroom/orchestration/approval-gate.test.ts
+++ b/src/main/services/chatroom/orchestration/approval-gate.test.ts
@@ -34,6 +34,7 @@ describe('ApprovalGate', () => {
     expect(gate.requiresApproval('calendar_create')).toBe(true);
     expect(gate.requiresApproval('delete_resource')).toBe(true);
     expect(gate.requiresApproval('webhook_trigger')).toBe(true);
+    expect(gate.requiresApproval('copilot_chat')).toBe(true);
   });
 
   it('does not require approval for safe tools', () => {

--- a/src/main/services/chatroom/orchestration/approval-gate.ts
+++ b/src/main/services/chatroom/orchestration/approval-gate.ts
@@ -16,6 +16,9 @@ const DEFAULT_SIDE_EFFECT_PATTERNS: readonly string[] = [
   'email', 'mail', 'calendar', 'teams', 'slack', 'post', 'send',
   'write', 'delete', 'update', 'create', 'deploy', 'publish',
   'notify', 'webhook', 'http_request', 'fetch_external',
+  // M365 Copilot can take actions on the user's behalf via its own tool set,
+  // so gate any chat call into it.
+  'copilot_chat',
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/components/chatroom/OrchestrationPicker.test.tsx
+++ b/src/renderer/components/chatroom/OrchestrationPicker.test.tsx
@@ -242,4 +242,44 @@ describe('OrchestrationPicker', () => {
       expect.objectContaining({ managerMindId: 'mind-b' }),
     );
   });
+
+  // -------------------------------------------------------------------------
+  // "Best for" guidance — caption + tooltip
+  // -------------------------------------------------------------------------
+
+  it('renders an inline description for the active mode', () => {
+    renderPicker({ mode: 'concurrent' });
+    // Caption begins with "Concurrent:" and includes the "Best for:" hint.
+    expect(screen.getByText(/Concurrent:/)).toBeTruthy();
+    expect(screen.getByText(/Best for:/)).toBeTruthy();
+  });
+
+  it('updates the inline description when the mode changes', () => {
+    const { rerender } = renderPicker({ mode: 'concurrent' });
+    expect(screen.queryByText(/Sequential:/)).toBeNull();
+
+    rerender(
+      <OrchestrationPicker
+        mode="sequential"
+        groupChatConfig={null}
+        handoffConfig={null}
+        magneticConfig={null}
+        minds={[MIND_A, MIND_B]}
+        disabled={false}
+        onModeChange={vi.fn()}
+        onGroupChatConfigChange={vi.fn()}
+        onHandoffConfigChange={vi.fn()}
+        onMagneticConfigChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Sequential:/)).toBeTruthy();
+  });
+
+  it('exposes "Best for:" in each mode button title for hover tooltips', () => {
+    renderPicker();
+    for (const label of ['Concurrent', 'Sequential', 'Group Chat', 'Handoff', 'Magentic']) {
+      const btn = screen.getByText(label).closest('button');
+      expect(btn?.getAttribute('title')).toMatch(/Best for:/);
+    }
+  });
 });

--- a/src/renderer/components/chatroom/OrchestrationPicker.tsx
+++ b/src/renderer/components/chatroom/OrchestrationPicker.tsx
@@ -11,14 +11,46 @@ interface ModeOption {
   value: OrchestrationMode;
   label: string;
   enabled: boolean;
+  description: string;
+  bestFor: string;
 }
 
 const MODES: ModeOption[] = [
-  { value: 'concurrent', label: 'Concurrent', enabled: true },
-  { value: 'sequential', label: 'Sequential', enabled: true },
-  { value: 'group-chat', label: 'Group Chat', enabled: true },
-  { value: 'handoff', label: 'Handoff', enabled: true },
-  { value: 'magentic', label: 'Magentic', enabled: true },
+  {
+    value: 'concurrent',
+    label: 'Concurrent',
+    enabled: true,
+    description: 'All agents respond to every message simultaneously, independently.',
+    bestFor: 'Getting multiple perspectives at once, brainstorming, parallel research, comparing approaches across agents.',
+  },
+  {
+    value: 'sequential',
+    label: 'Sequential',
+    enabled: true,
+    description: 'Agents respond in turn, each seeing the previous agent\'s full response.',
+    bestFor: 'Progressive refinement, pipelines where each agent builds on the last (e.g. research → draft → review).',
+  },
+  {
+    value: 'group-chat',
+    label: 'Group Chat',
+    enabled: true,
+    description: 'A designated moderator agent decides who speaks next and steers the discussion.',
+    bestFor: 'Structured debate, role-play, panel discussions, when you need controlled turn-taking with a clear chair.',
+  },
+  {
+    value: 'handoff',
+    label: 'Handoff',
+    enabled: true,
+    description: 'One agent handles the task until it decides to pass control to a more suitable agent.',
+    bestFor: 'Specialised pipelines across distinct domains (e.g. diagnose → fix → document a customer issue).',
+  },
+  {
+    value: 'magentic',
+    label: 'Magentic',
+    enabled: true,
+    description: 'A manager agent decomposes the goal into a task ledger and delegates subtasks to workers.',
+    bestFor: 'Complex multi-step projects, long-running workflows, anything that benefits from explicit task planning and parallel delegation.',
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -105,12 +137,25 @@ export function OrchestrationPicker({
               (!opt.enabled || disabled) && 'opacity-50 cursor-not-allowed',
             )}
             aria-pressed={opt.value === mode}
-            title={!opt.enabled ? `${opt.label} — coming soon` : opt.label}
+            title={!opt.enabled ? `${opt.label} — coming soon` : `${opt.description}\n\nBest for: ${opt.bestFor}`}
           >
             {opt.label}
           </button>
         ))}
       </div>
+
+      {/* Active mode description */}
+      {(() => {
+        const active = MODES.find((m) => m.value === mode);
+        if (!active) return null;
+        return (
+          <p className="text-[11px] text-muted-foreground leading-snug">
+            <span className="font-medium text-foreground/70">{active.label}:</span>{' '}
+            {active.description}{' '}
+            <span className="text-muted-foreground/60">Best for: {active.bestFor}</span>
+          </p>
+        );
+      })()}
 
       {/* Group Chat config: moderator selector */}
       {mode === 'group-chat' && readyMinds.length > 0 && (

--- a/src/renderer/components/layout/ActivityBar.test.tsx
+++ b/src/renderer/components/layout/ActivityBar.test.tsx
@@ -6,12 +6,13 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ActivityBar } from './ActivityBar';
 import { AppStateProvider } from '../../lib/store';
+import type { AppState } from '../../lib/store/state';
 import { TooltipProvider } from '../ui/tooltip';
 import { installElectronAPI } from '../../../test/helpers';
 
-function renderActivityBar() {
+function renderActivityBar(testInitialState?: Partial<AppState>) {
   return render(
-    <AppStateProvider>
+    <AppStateProvider testInitialState={testInitialState}>
       <TooltipProvider>
         <ActivityBar />
       </TooltipProvider>
@@ -40,4 +41,28 @@ describe('ActivityBar', () => {
     expect(screen.getByLabelText('Chat')).toBeTruthy();
     expect(screen.getByLabelText('Chatroom')).toBeTruthy();
   });
+
+  // -------------------------------------------------------------------------
+  // Running indicator — yellow dot when any chatroom mind is streaming
+  // -------------------------------------------------------------------------
+
+  it('does not render the running indicator when no chatroom minds are streaming', () => {
+    renderActivityBar({ chatroomStreamingByMind: {} });
+    const chatroomBtn = screen.getByLabelText('Chatroom');
+    // The pulse dot is the only span with .animate-pulse inside the chatroom button.
+    expect(chatroomBtn.querySelector('.animate-pulse')).toBeNull();
+  });
+
+  it('renders the running indicator when at least one chatroom mind is streaming', () => {
+    renderActivityBar({ chatroomStreamingByMind: { 'mind-1': true } });
+    const chatroomBtn = screen.getByLabelText('Chatroom');
+    expect(chatroomBtn.querySelector('.animate-pulse')).not.toBeNull();
+  });
+
+  it('does not render the running indicator when all streams are flagged false', () => {
+    renderActivityBar({ chatroomStreamingByMind: { 'mind-1': false, 'mind-2': false } });
+    const chatroomBtn = screen.getByLabelText('Chatroom');
+    expect(chatroomBtn.querySelector('.animate-pulse')).toBeNull();
+  });
 });
+

--- a/src/renderer/components/layout/ActivityBar.tsx
+++ b/src/renderer/components/layout/ActivityBar.tsx
@@ -22,8 +22,9 @@ function getIcon(iconName: string, size = 20): React.ReactNode {
 }
 
 export function ActivityBar() {
-  const { activeView, discoveredViews } = useAppState();
+  const { activeView, discoveredViews, chatroomStreamingByMind } = useAppState();
   const dispatch = useAppDispatch();
+  const isChatroomRunning = Object.values(chatroomStreamingByMind).some(Boolean);
 
   return (
     <div className="w-12 bg-card border border-border rounded-xl flex flex-col items-center py-2 shrink-0">
@@ -54,16 +55,21 @@ export function ActivityBar() {
               aria-label="Chatroom"
               onClick={() => dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chatroom' })}
               className={cn(
-                'w-10 h-10 rounded-lg flex items-center justify-center transition-colors',
+                'relative w-10 h-10 rounded-lg flex items-center justify-center transition-colors',
                 activeView === 'chatroom'
                   ? 'bg-accent text-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
               )}
             >
               <Users size={20} />
+              {isChatroomRunning && (
+                <span className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
+              )}
             </button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={8}>Chatroom</TooltipContent>
+          <TooltipContent side="right" sideOffset={8}>
+            {isChatroomRunning ? 'Chatroom — agents running…' : 'Chatroom'}
+          </TooltipContent>
         </Tooltip>
 
         {discoveredViews.length > 0 && <Separator className="my-1 w-8" />}


### PR DESCRIPTION
## Summary

Bundle of v0.28-feedback fixes plus one Magentic v2 follow-up.

User feedback this addresses (verbatim):

> "Can we add the 'best for' examples as a comment when you hover over each one?"
>
> "Is there a key for when and how to use each of the orchestration patterns?
>  I don't really understand the difference and based on convo above this is
>  a major difference."
>
> "I have found myself over the last week saying 'Hey MM, are you done? are you
>  still working? do you need anything from me?' Some sort of 'processing'
>  indicator, or a page where I can see 'running tasks' would be fab."

## What changed

### 1. Orchestration mode picker — descriptions + "best for" guidance
Each of the five modes (Concurrent, Sequential, Group Chat, Handoff, Magentic)
now carries a one-line description and a "Best for:" example. Both surface in:
- the **button `title`** (hover tooltip)
- an **always-visible caption** under the picker

Single source of truth: the `MODES` array in `OrchestrationPicker.tsx`.

### 2. Activity bar — running indicator
Yellow pulsing dot on the chatroom icon whenever any mind in
`chatroomStreamingByMind` is `true`, plus tooltip flips to
"Chatroom — agents running…".

This is the lightweight half of the request. A dedicated running-tasks panel
is intentionally deferred — happy to spec one in a follow-up issue.

### 3. Approval gate — `copilot_chat` is now side-effecting
M365 Copilot can take user-visible actions via its own tool set
(send mail, post Teams, modify calendar). Added `copilot_chat` to
`DEFAULT_SIDE_EFFECT_PATTERNS`.

### 4. Magentic v2 — formatter test coverage
Two pinning tests for `formatManagerResponse`:
- `assign` action produces a human-readable "Assigning tasks:" message
- plain-text manager responses do NOT emit a synthetic "Planning:" message

### 5. Doc-only: `sandbox: false` rationale
Added an inline comment to `main.ts` explaining why `sandbox: false` stays
(copilot-sdk IPC needs Node.js APIs via preload, mitigated by
`contextIsolation: true` + `nodeIntegration: false`). No behaviour change.

## Out of scope (filed separately)
- v0.28 filesystem regression report ("was working with v0.25") — unable to
  repro from the report alone; tracking issue with repro template incoming.
- Full "running tasks" panel — needs a design pass.

## Validation
- `npm run lint` ✅ (`tsc --noEmit && eslint .`)
- `npm test` — **830 / 838** pass (+6 over the master baseline of 824).
  The 7 failures in `CopilotClientFactory.test.ts` are pre-existing on
  `origin/master` (`HEAD = 58a06a8`) and unrelated to this branch.
- New tests added:
  - `OrchestrationPicker.test.tsx`: +3 (caption renders, updates on
    rerender, every button title contains `Best for:`)
  - `ActivityBar.test.tsx`: +3 (no dot empty, dot when streaming,
    no dot when all `false`)
  - `MagenticStrategy.test.ts`: +2 (assign formatter, plain-text plan
    suppression)
  - `approval-gate.test.ts`: +1 (`copilot_chat` requires approval)

## Screenshots
Orchestration Descriptions and 'Best for..' inline info (works on hover, as well)
<img width="1285" height="180" alt="image" src="https://github.com/user-attachments/assets/71c246cf-c519-4b45-bb62-d1eac76dc5e1" />

Activity Bar (Chatroom glows when running) 
<img width="1903" height="1051" alt="image" src="https://github.com/user-attachments/assets/659abd40-debd-451d-aa96-6d7691aa9b4d" />

## Commits
- `feat(orchestration): add "best for" guidance to mode picker`
- `feat(activity-bar): show running indicator when chatroom agents are working`
- `fix(approval-gate): require approval for copilot_chat tool calls`
- `test(magentic): cover formatManagerResponse synthetic-message paths`