### PR TITLE
feat(chat-input): emoji picker popover + :shortcode autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.29.2",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,11 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "croner": "^10.0.1",
         "electron-squirrel-startup": "^1.0.1",
+        "emojibase-data": "^17.0.0",
+        "frimousse": "^0.3.0",
         "highlight.js": "^11.11.1",
         "keytar": "^7.9.0",
         "lucide-react": "^1.9.0",
@@ -6275,6 +6278,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7117,6 +7136,33 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojibase": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-17.0.0.tgz",
+      "integrity": "sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      }
+    },
+    "node_modules/emojibase-data": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/emojibase-data/-/emojibase-data-17.0.0.tgz",
+      "integrity": "sha512-Yvgb5AWoHViHV/gq1qr5ZAarcBip+B27/ZLRsUJkbgAEaLlZ/fof9g882LTpmEpyhBNEC0m2SEmItljHsTygjA==",
+      "license": "MIT",
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      },
+      "peerDependencies": {
+        "emojibase": "*"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -8013,6 +8059,25 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/frimousse": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/frimousse/-/frimousse-0.3.0.tgz",
+      "integrity": "sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site"
+      ],
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs-constants": {
@@ -13310,7 +13375,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,11 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "croner": "^10.0.1",
     "electron-squirrel-startup": "^1.0.1",
+    "emojibase-data": "^17.0.0",
+    "frimousse": "^0.3.0",
     "highlight.js": "^11.11.1",
     "keytar": "^7.9.0",
     "lucide-react": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/renderer/components/chat/ChatInput.test.tsx
+++ b/src/renderer/components/chat/ChatInput.test.tsx
@@ -3,9 +3,28 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ChatInput } from './ChatInput';
 import type { ModelInfo } from '../../../shared/types';
+
+// jsdom does not provide ResizeObserver; cmdk needs it.
+class MockResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
+  MockResizeObserver;
+// jsdom does not implement Element.scrollIntoView; cmdk calls it on focus.
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}
+
+// Stub the textarea-caret util — jsdom returns 0 for layout, so we provide
+// stable coordinates that the tests can assert against.
+vi.mock('../../lib/textarea-caret', () => ({
+  getTextareaCaretCoords: () => ({ top: 100, left: 50, height: 16 }),
+}));
 
 const defaultProps = {
   onSend: vi.fn(),
@@ -111,6 +130,167 @@ describe('ChatInput', () => {
       const evt = fireEvent.mouseDown(trigger);
       // preventDefault means default action of moving focus is suppressed
       expect(evt).toBe(false); // fireEvent returns false when preventDefault was called
+    });
+  });
+
+  describe(':shortcode autocomplete', () => {
+    function typeWithCaret(textarea: HTMLTextAreaElement, value: string) {
+      // Set caret at the end of the new value so detection sees the trailing token.
+      Object.defineProperty(textarea, 'selectionStart', { configurable: true, value: value.length });
+      Object.defineProperty(textarea, 'selectionEnd', { configurable: true, value: value.length });
+      fireEvent.change(textarea, { target: { value } });
+    }
+
+    async function expectShortcodeOpen() {
+      return await waitFor(() => screen.getByTestId('shortcode-popover'));
+    }
+
+    it('opens popover for ":sm" and shows suggestions', async () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':sm');
+      await expectShortcodeOpen();
+    });
+
+    it('does not open for ":" alone', () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':');
+      expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+    });
+
+    it('does not open for ":30" (no letter)', () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':30');
+      expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+    });
+
+    it('does not open for "12:30" (no boundary before colon)', () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, '12:30am');
+      expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+    });
+
+    it('does not open inside an image token span', () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      // Place caret just after the colon-y char inside a fake image token.
+      const value = '[📷 :sm';
+      typeWithCaret(ta, value);
+      // The token span continues without `]`, so detectShortcode treats the
+      // `:sm` as inside the (unclosed) image span. Closed-token case is
+      // covered explicitly below.
+      expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+    });
+
+    it('does not open inside a closed image token', () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      // Caret positioned within the `[📷 …]` span via selectionStart override.
+      const value = '[📷 :smile.png] after';
+      Object.defineProperty(ta, 'selectionStart', { configurable: true, value: 8 });
+      Object.defineProperty(ta, 'selectionEnd', { configurable: true, value: 8 });
+      fireEvent.change(ta, { target: { value } });
+      expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+    });
+
+    it('Escape closes popover without altering text', async () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':sm');
+      await expectShortcodeOpen();
+      fireEvent.keyDown(ta, { key: 'Escape' });
+      expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+      expect(ta.value).toBe(':sm');
+    });
+
+    it('Enter accepts active suggestion and replaces shortcode token', async () => {
+      const onSend = vi.fn();
+      render(<ChatInput {...defaultProps} onSend={onSend} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':smile');
+      await expectShortcodeOpen();
+      fireEvent.keyDown(ta, { key: 'Enter' });
+      // Should not have submitted the message.
+      expect(onSend).not.toHaveBeenCalled();
+      // The :smile token should be replaced with an emoji char (not start with ':').
+      await waitFor(() => {
+        expect(ta.value.startsWith(':')).toBe(false);
+        expect(ta.value.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('Tab also accepts active suggestion', async () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':smile');
+      await expectShortcodeOpen();
+      fireEvent.keyDown(ta, { key: 'Tab' });
+      await waitFor(() => {
+        expect(ta.value.startsWith(':')).toBe(false);
+      });
+    });
+
+    it('Enter while popover open AND streaming does not call onStop', async () => {
+      const onStop = vi.fn();
+      render(<ChatInput {...defaultProps} isStreaming={true} onStop={onStop} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':smile');
+      await expectShortcodeOpen();
+      fireEvent.keyDown(ta, { key: 'Enter' });
+      expect(onStop).not.toHaveBeenCalled();
+    });
+
+    it('Shift+Enter does not accept; closes/keeps popover and inserts newline-style behavior', async () => {
+      const onSend = vi.fn();
+      render(<ChatInput {...defaultProps} onSend={onSend} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':smile');
+      await expectShortcodeOpen();
+      fireEvent.keyDown(ta, { key: 'Enter', shiftKey: true });
+      // Did not submit, and the colon-token is still in the value (not replaced).
+      expect(onSend).not.toHaveBeenCalled();
+      expect(ta.value).toBe(':smile');
+    });
+
+    it('IME composition suppresses popover and Enter', async () => {
+      const onSend = vi.fn();
+      render(<ChatInput {...defaultProps} onSend={onSend} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      fireEvent.compositionStart(ta);
+      typeWithCaret(ta, ':smile');
+      expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+      fireEvent.keyDown(ta, { key: 'Enter', isComposing: true });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it('typing past the boundary closes the popover', async () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':smile');
+      await expectShortcodeOpen();
+      typeWithCaret(ta, ':smile ');
+      await waitFor(() => {
+        expect(screen.queryByTestId('shortcode-popover')).toBeNull();
+      });
+    });
+
+    it('clicking a suggestion replaces the token', async () => {
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':smile');
+      const popover = await expectShortcodeOpen();
+      const item = popover.querySelector('[data-slot="command-item"]') as HTMLElement;
+      expect(item).toBeTruthy();
+      // Use mousedown — the handler is on mousedown, not click.
+      act(() => {
+        fireEvent.mouseDown(item);
+      });
+      await waitFor(() => {
+        expect(ta.value.startsWith(':')).toBe(false);
+      });
     });
   });
 });

--- a/src/renderer/components/chat/ChatInput.test.tsx
+++ b/src/renderer/components/chat/ChatInput.test.tsx
@@ -60,13 +60,57 @@ describe('ChatInput', () => {
   it('streaming shows stop button, clicking calls onStop', () => {
     const onStop = vi.fn();
     render(<ChatInput {...defaultProps} isStreaming={true} onStop={onStop} />);
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
+    // The emoji trigger has aria-label "Insert emoji"; the stop button is the only other button.
+    const buttons = screen.getAllByRole('button');
+    const stop = buttons.find((b) => b.getAttribute('aria-label') !== 'Insert emoji');
+    expect(stop).toBeTruthy();
+    fireEvent.click(stop!);
     expect(onStop).toHaveBeenCalled();
   });
 
   it('shows Loading models when no models available and not disabled', () => {
     render(<ChatInput {...defaultProps} />);
     expect(screen.getByText('Loading models…')).toBeTruthy();
+  });
+
+  describe('emoji picker', () => {
+    it('renders an emoji trigger button with aria-label', () => {
+      render(<ChatInput {...defaultProps} />);
+      const trigger = screen.getByRole('button', { name: 'Insert emoji' });
+      expect(trigger).toBeTruthy();
+      expect(trigger.getAttribute('aria-haspopup')).toBe('dialog');
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('disables emoji trigger when disabled prop is true', () => {
+      render(<ChatInput {...defaultProps} disabled={true} />);
+      const trigger = screen.getByRole('button', { name: 'Insert emoji' });
+      expect((trigger as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('emoji trigger remains enabled while streaming', () => {
+      render(<ChatInput {...defaultProps} isStreaming={true} />);
+      const trigger = screen.getByRole('button', { name: 'Insert emoji' });
+      expect((trigger as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('emoji trigger toggles aria-expanded on click', () => {
+      render(<ChatInput {...defaultProps} />);
+      const trigger = screen.getByRole('button', { name: 'Insert emoji' });
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+      fireEvent.click(trigger);
+      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('preserves textarea selection when emoji trigger is mousedown', () => {
+      render(<ChatInput {...defaultProps} />);
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: 'hello world' } });
+      textarea.setSelectionRange(5, 5);
+      const trigger = screen.getByRole('button', { name: 'Insert emoji' });
+      const evt = fireEvent.mouseDown(trigger);
+      // preventDefault means default action of moving focus is suppressed
+      expect(evt).toBe(false); // fireEvent returns false when preventDefault was called
+    });
   });
 });

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useCallback, Suspense } from 'react';
+import React, { useState, useRef, useCallback, Suspense, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '../../lib/utils';
 import type { ModelInfo, ChatImageAttachment } from '../../../shared/types';
 import {
@@ -13,7 +14,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '../ui/popover';
+import {
+  Command,
+  CommandList,
+  CommandItem,
+} from '../ui/command';
 import { pushRecentEmoji } from '../../lib/emoji-recents';
+import { loadEmojiData, type EmojiRecord } from '../../lib/emoji-data';
+import { getTextareaCaretCoords } from '../../lib/textarea-caret';
 
 const EmojiPickerLazy = React.lazy(() =>
   import('../ui/emoji-picker').then((m) => ({ default: m.EmojiPicker })),
@@ -31,6 +39,39 @@ interface Props {
 }
 
 const IMAGE_TOKEN_RE = /\[📷 ([^\]]+)\]/g;
+
+// Boundary-aware shortcode detector. Matches a `:foo` token at the caret
+// where:
+//   - it sits at start-of-string or after whitespace / `(` / `[` / `{`
+//   - the body has at least one letter (so `:30` does not trigger)
+//   - the body is 2+ chars total
+const SHORTCODE_RE = /(^|[\s([{])(:(?=[a-z0-9_+-]*[a-z])[a-z0-9_+-]{2,})$/i;
+
+interface ShortcodeMatch {
+  /** Start index of the `:` in the input. */
+  start: number;
+  /** Query text minus the leading colon. */
+  query: string;
+}
+
+function detectShortcode(text: string, caret: number): ShortcodeMatch | null {
+  const upToCaret = text.slice(0, caret);
+  const m = SHORTCODE_RE.exec(upToCaret);
+  if (!m) return null;
+  const token = m[2];
+  const start = caret - token.length;
+
+  // Suppress if caret is inside an existing image token span.
+  IMAGE_TOKEN_RE.lastIndex = 0;
+  let img: RegExpExecArray | null;
+  while ((img = IMAGE_TOKEN_RE.exec(text)) !== null) {
+    const imgStart = img.index;
+    const imgEnd = imgStart + img[0].length;
+    if (start >= imgStart && start < imgEnd) return null;
+  }
+
+  return { start, query: token.slice(1).toLowerCase() };
+}
 
 function mimeToExt(mime: string): string {
   const map: Record<string, string> = {
@@ -64,6 +105,11 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<ChatImageAttachment[]>([]);
   const [emojiOpen, setEmojiOpen] = useState(false);
+  const [shortcodeMatch, setShortcodeMatch] = useState<ShortcodeMatch | null>(null);
+  const [shortcodeResults, setShortcodeResults] = useState<EmojiRecord[]>([]);
+  const [shortcodeIndex, setShortcodeIndex] = useState(0);
+  const [shortcodeAnchor, setShortcodeAnchor] = useState<{ top: number; left: number; height: number } | null>(null);
+  const isComposingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const pastedSeq = useRef(0);
   // Last known textarea selection — preserved across blur (e.g., when the
@@ -77,6 +123,13 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
       start: el.selectionStart ?? el.value.length,
       end: el.selectionEnd ?? el.value.length,
     };
+  }, []);
+
+  const closeShortcode = useCallback(() => {
+    setShortcodeMatch(null);
+    setShortcodeResults([]);
+    setShortcodeIndex(0);
+    setShortcodeAnchor(null);
   }, []);
 
   const getMaxHeight = useCallback((el: HTMLTextAreaElement) => {
@@ -162,10 +215,45 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     setInput('');
     setAttachments([]);
     setEmojiOpen(false);
+    closeShortcode();
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [input, attachments, isStreaming, disabled, onSend, onStop]);
+  }, [input, attachments, isStreaming, disabled, onSend, onStop, closeShortcode]);
+
+  const acceptShortcode = useCallback(
+    (record: EmojiRecord) => {
+      const match = shortcodeMatch;
+      if (!match) return;
+      const el = textareaRef.current;
+      if (!el) return;
+      const before = el.value.slice(0, match.start);
+      const afterStart = match.start + 1 + match.query.length; // include the `:`
+      const after = el.value.slice(afterStart);
+      const next = before + record.emoji + after;
+      setInput(next);
+      pushRecentEmoji(record.emoji);
+      const caret = before.length + record.emoji.length;
+      selectionRef.current = { start: caret, end: caret };
+      // Prune attachments whose tokens may have been removed.
+      setAttachments((prev) => {
+        const tokens = new Set<string>();
+        let m: RegExpExecArray | null;
+        IMAGE_TOKEN_RE.lastIndex = 0;
+        while ((m = IMAGE_TOKEN_RE.exec(next)) !== null) tokens.add(m[1]);
+        const pruned = prev.filter((a) => tokens.has(a.name));
+        return pruned.length === prev.length ? prev : pruned;
+      });
+      closeShortcode();
+      requestAnimationFrame(() => {
+        if (!textareaRef.current) return;
+        textareaRef.current.focus();
+        textareaRef.current.setSelectionRange(caret, caret);
+        resize(textareaRef.current);
+      });
+    },
+    [shortcodeMatch, closeShortcode, resize],
+  );
 
   const handleEmojiSelect = useCallback(
     (emoji: string) => {
@@ -179,7 +267,54 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     [insertAtCaret],
   );
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  // Load shortcode results when the query changes.
+  useEffect(() => {
+    if (!shortcodeMatch) return;
+    let cancelled = false;
+    loadEmojiData().then((ds) => {
+      if (cancelled) return;
+      const results = ds.search(shortcodeMatch.query, 10);
+      setShortcodeResults(results);
+      setShortcodeIndex(0);
+      if (results.length === 0) {
+        // Keep the match open so re-typing can re-trigger; just no results.
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [shortcodeMatch]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // 1) IME composition — let the IME own the key.
+    if (isComposingRef.current || (e.nativeEvent as KeyboardEvent).isComposing) {
+      return;
+    }
+    // 2) Shortcode popover open — intercept navigation / accept / dismiss.
+    if (shortcodeMatch && shortcodeResults.length > 0) {
+      if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
+        e.preventDefault();
+        const pick = shortcodeResults[shortcodeIndex] ?? shortcodeResults[0];
+        if (pick) acceptShortcode(pick);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeShortcode();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setShortcodeIndex((i) => Math.min(i + 1, shortcodeResults.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setShortcodeIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+    }
+    // 3) Default Enter submit / Shift+Enter newline.
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit();
@@ -199,6 +334,22 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
       const pruned = prev.filter((a) => tokens.has(a.name));
       return pruned.length === prev.length ? prev : pruned;
     });
+    // Shortcode detection — suppressed during IME composition.
+    if (isComposingRef.current) {
+      closeShortcode();
+      return;
+    }
+    const caret = e.target.selectionStart ?? next.length;
+    const match = detectShortcode(next, caret);
+    if (match) {
+      setShortcodeMatch(match);
+      setShortcodeIndex(0);
+      // Anchor at the caret in viewport coords.
+      const coords = getTextareaCaretCoords(e.target, caret);
+      setShortcodeAnchor(coords);
+    } else if (shortcodeMatch) {
+      closeShortcode();
+    }
   };
 
   const canSubmit = (input.trim().length > 0 || attachments.length > 0) && !disabled;
@@ -215,6 +366,13 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
             onPaste={handlePaste}
             onSelect={updateSelectionRef}
             onBlur={updateSelectionRef}
+            onCompositionStart={() => {
+              isComposingRef.current = true;
+              closeShortcode();
+            }}
+            onCompositionEnd={() => {
+              isComposingRef.current = false;
+            }}
             placeholder={disabled ? 'Select a mind directory to start…' : (placeholder ?? 'Message your agent… (paste an image to attach)')}
             disabled={disabled}
             rows={1}
@@ -311,6 +469,45 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
           AI agents can make mistakes. Verify important information.
         </p>
       </div>
+      {shortcodeMatch && shortcodeAnchor && shortcodeResults.length > 0 && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              role="listbox"
+              aria-label="Emoji shortcode suggestions"
+              data-testid="shortcode-popover"
+              style={{
+                position: 'fixed',
+                top: shortcodeAnchor.top + shortcodeAnchor.height + 4,
+                left: shortcodeAnchor.left,
+                zIndex: 60,
+              }}
+              className="min-w-[220px] rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
+            >
+              <Command shouldFilter={false}>
+                <CommandList>
+                  {shortcodeResults.map((rec, i) => (
+                    <CommandItem
+                      key={rec.hexcode}
+                      value={rec.shortcodes[0]}
+                      data-selected={i === shortcodeIndex || undefined}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        acceptShortcode(rec);
+                      }}
+                      onMouseEnter={() => setShortcodeIndex(i)}
+                    >
+                      <span className="text-base">{rec.emoji}</span>
+                      <span className="text-xs text-muted-foreground">
+                        :{rec.shortcodes[0]}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandList>
+              </Command>
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, Suspense } from 'react';
 import { cn } from '../../lib/utils';
 import type { ModelInfo, ChatImageAttachment } from '../../../shared/types';
 import {
@@ -8,6 +8,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '../ui/popover';
+import { pushRecentEmoji } from '../../lib/emoji-recents';
+
+const EmojiPickerLazy = React.lazy(() =>
+  import('../ui/emoji-picker').then((m) => ({ default: m.EmojiPicker })),
+);
 
 interface Props {
   onSend: (message: string, attachments?: ChatImageAttachment[]) => void;
@@ -53,8 +63,21 @@ function readAsBase64(file: Blob): Promise<string> {
 export function ChatInput({ onSend, onStop, isStreaming, disabled, availableModels, selectedModel, onModelChange, placeholder }: Props) {
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<ChatImageAttachment[]>([]);
+  const [emojiOpen, setEmojiOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const pastedSeq = useRef(0);
+  // Last known textarea selection — preserved across blur (e.g., when the
+  // emoji popover steals focus) so insertAtCaret can land in the right place.
+  const selectionRef = useRef<{ start: number; end: number } | null>(null);
+
+  const updateSelectionRef = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    selectionRef.current = {
+      start: el.selectionStart ?? el.value.length,
+      end: el.selectionEnd ?? el.value.length,
+    };
+  }, []);
 
   const getMaxHeight = useCallback((el: HTMLTextAreaElement) => {
     const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20;
@@ -78,14 +101,17 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
       setInput((v) => v + text);
       return;
     }
-    const start = el.selectionStart ?? el.value.length;
-    const end = el.selectionEnd ?? el.value.length;
+    const focused = document.activeElement === el;
+    const saved = selectionRef.current;
+    const start = focused ? (el.selectionStart ?? el.value.length) : (saved?.start ?? el.value.length);
+    const end = focused ? (el.selectionEnd ?? el.value.length) : (saved?.end ?? start);
     const next = el.value.slice(0, start) + text + el.value.slice(end);
     setInput(next);
+    const caret = start + text.length;
+    selectionRef.current = { start: caret, end: caret };
     // Restore caret after React commits
     requestAnimationFrame(() => {
       if (!textareaRef.current) return;
-      const caret = start + text.length;
       textareaRef.current.setSelectionRange(caret, caret);
       resize(textareaRef.current);
     });
@@ -135,10 +161,23 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     onSend(input, kept.length > 0 ? kept : undefined);
     setInput('');
     setAttachments([]);
+    setEmojiOpen(false);
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
   }, [input, attachments, isStreaming, disabled, onSend, onStop]);
+
+  const handleEmojiSelect = useCallback(
+    (emoji: string) => {
+      insertAtCaret(emoji);
+      pushRecentEmoji(emoji);
+      setEmojiOpen(false);
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
+    },
+    [insertAtCaret],
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -174,6 +213,8 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
             onChange={handleInput}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
+            onSelect={updateSelectionRef}
+            onBlur={updateSelectionRef}
             placeholder={disabled ? 'Select a mind directory to start…' : (placeholder ?? 'Message your agent… (paste an image to attach)')}
             disabled={disabled}
             rows={1}
@@ -181,28 +222,64 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
           />
 
           <div className="flex items-center justify-between">
-            {availableModels.length > 0 ? (
-              <Select
-                value={selectedModel ?? undefined}
-                onValueChange={onModelChange}
-                disabled={isStreaming}
-              >
-                <SelectTrigger className="h-6 w-auto gap-1.5 border-none bg-transparent px-0 text-xs text-muted-foreground shadow-none hover:text-foreground focus:ring-0">
-                  <SelectValue placeholder="Select model" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableModels.map((model) => (
-                    <SelectItem key={model.id} value={model.id} className="text-xs">
-                      {model.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            ) : (
-              <span className="text-xs text-muted-foreground">
-                {disabled ? '' : 'Loading models…'}
-              </span>
-            )}
+            <div className="flex items-center gap-1">
+              <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Insert emoji"
+                    aria-haspopup="dialog"
+                    aria-expanded={emojiOpen}
+                    disabled={disabled}
+                    onMouseDown={(e) => {
+                      // Preserve textarea selection across the focus shift.
+                      updateSelectionRef();
+                      e.preventDefault();
+                    }}
+                    onClick={() => setEmojiOpen((v) => !v)}
+                    className="h-6 w-6 shrink-0 rounded-md text-base text-muted-foreground hover:text-foreground hover:bg-accent disabled:opacity-50 disabled:hover:bg-transparent flex items-center justify-center"
+                  >
+                    😀
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  side="top"
+                  className="p-0"
+                  onCloseAutoFocus={(e) => {
+                    e.preventDefault();
+                    textareaRef.current?.focus();
+                  }}
+                >
+                  <Suspense fallback={<div className="h-[340px] w-[320px] flex items-center justify-center text-xs text-muted-foreground">Loading emoji…</div>}>
+                    <EmojiPickerLazy onSelect={handleEmojiSelect} />
+                  </Suspense>
+                </PopoverContent>
+              </Popover>
+
+              {availableModels.length > 0 ? (
+                <Select
+                  value={selectedModel ?? undefined}
+                  onValueChange={onModelChange}
+                  disabled={isStreaming}
+                >
+                  <SelectTrigger className="h-6 w-auto gap-1.5 border-none bg-transparent px-0 text-xs text-muted-foreground shadow-none hover:text-foreground focus:ring-0">
+                    <SelectValue placeholder="Select model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableModels.map((model) => (
+                      <SelectItem key={model.id} value={model.id} className="text-xs">
+                        {model.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <span className="text-xs text-muted-foreground">
+                  {disabled ? '' : 'Loading models…'}
+                </span>
+              )}
+            </div>
 
             <button
               onClick={handleSubmit}

--- a/src/renderer/components/ui/command.tsx
+++ b/src/renderer/components/ui/command.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+
+import { cn } from "@/renderer/lib/utils"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn("max-h-[240px] overflow-x-hidden overflow-y-auto", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className={cn("py-3 text-center text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn("overflow-hidden p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1 text-sm outline-none select-none",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Command, CommandList, CommandEmpty, CommandGroup, CommandItem }

--- a/src/renderer/components/ui/emoji-picker.tsx
+++ b/src/renderer/components/ui/emoji-picker.tsx
@@ -11,16 +11,16 @@ import {
   type EmojiSkinTone,
 } from '@/renderer/lib/emoji-skin-tone';
 
+// Install the offline data interceptor at module load (before the picker
+// renders) so frimousse's internal fetch sees our shim from the first call.
+installFrimousseDataInterceptor();
+
 export interface EmojiPickerProps {
   onSelect: (emoji: string, label: string) => void;
   className?: string;
 }
 
 export function EmojiPicker({ onSelect, className }: EmojiPickerProps) {
-  React.useEffect(() => {
-    installFrimousseDataInterceptor();
-  }, []);
-
   const [skinTone, setSkinToneState] = React.useState<EmojiSkinTone>(() =>
     getEmojiSkinTone(),
   );

--- a/src/renderer/components/ui/emoji-picker.tsx
+++ b/src/renderer/components/ui/emoji-picker.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { EmojiPicker as FrimousseEmojiPicker } from 'frimousse';
+import { cn } from '@/renderer/lib/utils';
+import {
+  FRIMOUSSE_OFFLINE_URL,
+  installFrimousseDataInterceptor,
+} from '@/renderer/lib/emoji-data';
+import {
+  getEmojiSkinTone,
+  setEmojiSkinTone,
+  type EmojiSkinTone,
+} from '@/renderer/lib/emoji-skin-tone';
+
+export interface EmojiPickerProps {
+  onSelect: (emoji: string, label: string) => void;
+  className?: string;
+}
+
+export function EmojiPicker({ onSelect, className }: EmojiPickerProps) {
+  React.useEffect(() => {
+    installFrimousseDataInterceptor();
+  }, []);
+
+  const [skinTone, setSkinToneState] = React.useState<EmojiSkinTone>(() =>
+    getEmojiSkinTone(),
+  );
+
+  return (
+    <FrimousseEmojiPicker.Root
+      data-slot="emoji-picker"
+      emojibaseUrl={FRIMOUSSE_OFFLINE_URL}
+      skinTone={skinTone}
+      onEmojiSelect={({ emoji, label }) => onSelect(emoji, label)}
+      className={cn(
+        'isolate flex h-[340px] w-[320px] flex-col bg-popover text-popover-foreground',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 border-b border-border px-2 py-2">
+        <FrimousseEmojiPicker.Search
+          placeholder="Search emoji…"
+          className="flex-1 rounded-md border border-input bg-transparent px-2 py-1 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+        />
+        <FrimousseEmojiPicker.SkinTone>
+          {({ skinTone: current, setSkinTone, skinToneVariations }) => {
+            const variation = skinToneVariations.find((v) => v.skinTone === current);
+            const next =
+              skinToneVariations[
+                (skinToneVariations.indexOf(variation ?? skinToneVariations[0]) + 1) %
+                  skinToneVariations.length
+              ];
+            return (
+              <button
+                type="button"
+                aria-label="Cycle emoji skin tone"
+                onClick={() => {
+                  setSkinTone(next.skinTone);
+                  setSkinToneState(next.skinTone);
+                  setEmojiSkinTone(next.skinTone);
+                }}
+                className="size-7 rounded-md text-base hover:bg-accent"
+              >
+                {variation?.emoji ?? '✋'}
+              </button>
+            );
+          }}
+        </FrimousseEmojiPicker.SkinTone>
+      </div>
+      <FrimousseEmojiPicker.Viewport className="relative flex-1 outline-none">
+        <FrimousseEmojiPicker.Loading className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+          Loading…
+        </FrimousseEmojiPicker.Loading>
+        <FrimousseEmojiPicker.Empty className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+          No emoji found
+        </FrimousseEmojiPicker.Empty>
+        <FrimousseEmojiPicker.List
+          className="select-none pb-1.5"
+          components={{
+            CategoryHeader: ({ category, ...props }) => (
+              <div
+                {...props}
+                className="bg-popover px-2 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+              >
+                {category.label}
+              </div>
+            ),
+            Row: ({ children, ...props }) => (
+              <div {...props} className="scroll-my-1.5 px-1.5">
+                {children}
+              </div>
+            ),
+            Emoji: ({ emoji, ...props }) => (
+              <button
+                {...props}
+                className="flex size-8 items-center justify-center rounded-md text-lg data-[active=true]:bg-accent"
+              >
+                {emoji.emoji}
+              </button>
+            ),
+          }}
+        />
+      </FrimousseEmojiPicker.Viewport>
+    </FrimousseEmojiPicker.Root>
+  );
+}

--- a/src/renderer/components/ui/popover.tsx
+++ b/src/renderer/components/ui/popover.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/renderer/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+          "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/src/renderer/lib/emoji-data.test.ts
+++ b/src/renderer/lib/emoji-data.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  loadEmojiData,
+  installFrimousseDataInterceptor,
+  FRIMOUSSE_OFFLINE_URL,
+  __emojiDataTestExports,
+} from './emoji-data';
+
+describe('loadEmojiData', () => {
+  beforeEach(() => {
+    __emojiDataTestExports.reset();
+  });
+
+  it('returns a dataset with records and byShortcode', async () => {
+    const ds = await loadEmojiData();
+    expect(ds.records.length).toBeGreaterThan(500);
+    expect(ds.byShortcode.size).toBeGreaterThan(500);
+  });
+
+  it('byShortcode resolves :smile to a smile emoji', async () => {
+    const ds = await loadEmojiData();
+    const rec = ds.byShortcode.get('smile');
+    expect(rec).toBeTruthy();
+    expect(rec?.emoji).toBeTruthy();
+    expect(rec?.shortcodes).toContain('smile');
+  });
+
+  it('search ranks exact shortcode hits first', async () => {
+    const ds = await loadEmojiData();
+    const results = ds.search('smile', 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].shortcodes.map((s) => s.toLowerCase())).toContain('smile');
+  });
+
+  it('search returns [] for empty query', async () => {
+    const ds = await loadEmojiData();
+    expect(ds.search('')).toEqual([]);
+  });
+
+  it('search respects limit', async () => {
+    const ds = await loadEmojiData();
+    expect(ds.search('a', 3).length).toBeLessThanOrEqual(3);
+  });
+
+  it('is idempotent (single load)', async () => {
+    const a = await loadEmojiData();
+    const b = await loadEmojiData();
+    expect(a).toBe(b);
+  });
+});
+
+describe('installFrimousseDataInterceptor', () => {
+  beforeEach(() => {
+    __emojiDataTestExports.reset();
+  });
+
+  it('serves data.json for the offline URL', async () => {
+    installFrimousseDataInterceptor();
+    const res = await fetch(`${FRIMOUSSE_OFFLINE_URL}/en/data.json`);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json)).toBe(true);
+    expect(json.length).toBeGreaterThan(500);
+  });
+
+  it('serves messages.json for the offline URL', async () => {
+    installFrimousseDataInterceptor();
+    const res = await fetch(`${FRIMOUSSE_OFFLINE_URL}/en/messages.json`);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveProperty('groups');
+  });
+
+  it('returns 200 for HEAD requests without a body', async () => {
+    installFrimousseDataInterceptor();
+    const res = await fetch(`${FRIMOUSSE_OFFLINE_URL}/en/data.json`, { method: 'HEAD' });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 404 for unsupported paths under the sentinel', async () => {
+    installFrimousseDataInterceptor();
+    const res = await fetch(`${FRIMOUSSE_OFFLINE_URL}/en/bogus.json`);
+    expect(res.status).toBe(404);
+  });
+
+  it('is idempotent', () => {
+    installFrimousseDataInterceptor();
+    const first = window.fetch;
+    installFrimousseDataInterceptor();
+    expect(window.fetch).toBe(first);
+  });
+});

--- a/src/renderer/lib/emoji-data.ts
+++ b/src/renderer/lib/emoji-data.ts
@@ -1,0 +1,184 @@
+/**
+ * Canonical app-owned emoji dataset.
+ *
+ * Backs the `:shortcode` inline autocomplete. Frimousse loads its own data
+ * via a fetch interceptor (see installFrimousseDataInterceptor). Both rely
+ * on the same `emojibase-data` package so they stay version-consistent.
+ */
+
+export interface EmojiRecord {
+  emoji: string;
+  label: string;
+  shortcodes: string[];
+  tags: string[];
+  hexcode: string;
+}
+
+export interface EmojiDataset {
+  records: EmojiRecord[];
+  byShortcode: Map<string, EmojiRecord>;
+  search(query: string, limit?: number): EmojiRecord[];
+}
+
+interface CompactEmoji {
+  hexcode: string;
+  unicode: string;
+  label: string;
+  tags?: string[];
+  skins?: CompactEmoji[];
+}
+
+let datasetPromise: Promise<EmojiDataset> | null = null;
+
+function buildDataset(
+  compact: CompactEmoji[],
+  shortcodeMap: Record<string, string | string[]>,
+): EmojiDataset {
+  const records: EmojiRecord[] = [];
+  const byShortcode = new Map<string, EmojiRecord>();
+
+  for (const c of compact) {
+    const sc = shortcodeMap[c.hexcode];
+    const shortcodes = sc ? (Array.isArray(sc) ? sc : [sc]) : [];
+    if (shortcodes.length === 0) continue;
+    const rec: EmojiRecord = {
+      emoji: c.unicode,
+      label: c.label,
+      shortcodes,
+      tags: c.tags ?? [],
+      hexcode: c.hexcode,
+    };
+    records.push(rec);
+    for (const code of shortcodes) {
+      const key = code.toLowerCase();
+      if (!byShortcode.has(key)) byShortcode.set(key, rec);
+    }
+  }
+
+  function search(rawQuery: string, limit = 25): EmojiRecord[] {
+    const q = rawQuery.trim().toLowerCase();
+    if (!q) return [];
+    const exact: EmojiRecord[] = [];
+    const prefix: EmojiRecord[] = [];
+    const tag: EmojiRecord[] = [];
+    const seen = new Set<string>();
+    for (const rec of records) {
+      if (seen.has(rec.hexcode)) continue;
+      const exactHit = rec.shortcodes.some((s) => s.toLowerCase() === q);
+      const prefixHit =
+        !exactHit &&
+        (rec.shortcodes.some((s) => s.toLowerCase().startsWith(q)) ||
+          rec.label.toLowerCase().startsWith(q));
+      const tagHit =
+        !exactHit &&
+        !prefixHit &&
+        (rec.tags.some((t) => t.toLowerCase().includes(q)) ||
+          rec.label.toLowerCase().includes(q));
+      if (exactHit) {
+        exact.push(rec);
+        seen.add(rec.hexcode);
+      } else if (prefixHit) {
+        prefix.push(rec);
+        seen.add(rec.hexcode);
+      } else if (tagHit) {
+        tag.push(rec);
+        seen.add(rec.hexcode);
+      }
+      if (exact.length + prefix.length + tag.length >= limit * 2) break;
+    }
+    return [...exact, ...prefix, ...tag].slice(0, limit);
+  }
+
+  return { records, byShortcode, search };
+}
+
+export function loadEmojiData(): Promise<EmojiDataset> {
+  if (datasetPromise) return datasetPromise;
+  datasetPromise = (async () => {
+    const [compactMod, shortcodeMod] = await Promise.all([
+      import('emojibase-data/en/compact.json'),
+      import('emojibase-data/en/shortcodes/iamcal.json'),
+    ]);
+    const compact = (compactMod as { default: CompactEmoji[] }).default ?? compactMod;
+    const shortcodes = (shortcodeMod as { default: Record<string, string | string[]> })
+      .default ?? shortcodeMod;
+    return buildDataset(compact as CompactEmoji[], shortcodes as Record<string, string | string[]>);
+  })();
+  return datasetPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Frimousse offline data interceptor.
+//
+// Frimousse fetches `${emojibaseUrl}/${locale}/data.json` and
+// `${emojibaseUrl}/${locale}/messages.json`. To keep the picker fully offline
+// in packaged Electron, we register a sentinel URL and shim `window.fetch` to
+// resolve those requests from the bundled `emojibase-data` package.
+// ---------------------------------------------------------------------------
+
+export const FRIMOUSSE_OFFLINE_URL = 'https://chamber.local/__emoji_cdn__';
+
+const cache = new Map<string, unknown>();
+
+async function loadFrimousseAsset(locale: string, file: string): Promise<unknown> {
+  const key = `${locale}/${file}`;
+  if (cache.has(key)) return cache.get(key);
+  let mod: { default: unknown };
+  if (file === 'data') {
+    mod = (await import(`emojibase-data/${locale}/data.json`)) as { default: unknown };
+  } else if (file === 'messages') {
+    mod = (await import(`emojibase-data/${locale}/messages.json`)) as { default: unknown };
+  } else {
+    throw new Error(`unsupported frimousse asset: ${file}`);
+  }
+  cache.set(key, mod.default ?? mod);
+  return cache.get(key);
+}
+
+let interceptorInstalled = false;
+
+export function installFrimousseDataInterceptor(): void {
+  if (interceptorInstalled) return;
+  if (typeof window === 'undefined') return;
+  const orig = window.fetch.bind(window);
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    if (url.startsWith(FRIMOUSSE_OFFLINE_URL)) {
+      const path = url.slice(FRIMOUSSE_OFFLINE_URL.length).replace(/^\//, '');
+      const match = /^([a-z-]+)\/(data|messages)\.json$/i.exec(path);
+      if (!match) {
+        return new Response('not found', { status: 404 });
+      }
+      const [, locale, file] = match;
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'HEAD') {
+        return new Response(null, { status: 200 });
+      }
+      try {
+        const data = await loadFrimousseAsset(locale, file);
+        return new Response(JSON.stringify(data), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      } catch (err) {
+        return new Response(String(err), { status: 500 });
+      }
+    }
+    return orig(input, init);
+  };
+  interceptorInstalled = true;
+}
+
+// Test-only resets.
+export const __emojiDataTestExports = {
+  reset(): void {
+    datasetPromise = null;
+    cache.clear();
+    interceptorInstalled = false;
+  },
+};

--- a/src/renderer/lib/emoji-data.ts
+++ b/src/renderer/lib/emoji-data.ts
@@ -123,11 +123,14 @@ const cache = new Map<string, unknown>();
 async function loadFrimousseAsset(locale: string, file: string): Promise<unknown> {
   const key = `${locale}/${file}`;
   if (cache.has(key)) return cache.get(key);
+  if (locale !== 'en') {
+    throw new Error(`unsupported locale: ${locale}`);
+  }
   let mod: { default: unknown };
   if (file === 'data') {
-    mod = (await import(`emojibase-data/${locale}/data.json`)) as { default: unknown };
+    mod = (await import('emojibase-data/en/data.json')) as { default: unknown };
   } else if (file === 'messages') {
-    mod = (await import(`emojibase-data/${locale}/messages.json`)) as { default: unknown };
+    mod = (await import('emojibase-data/en/messages.json')) as { default: unknown };
   } else {
     throw new Error(`unsupported frimousse asset: ${file}`);
   }
@@ -141,7 +144,10 @@ export function installFrimousseDataInterceptor(): void {
   if (interceptorInstalled) return;
   if (typeof window === 'undefined') return;
   const orig = window.fetch.bind(window);
-  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const shim = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
     const url =
       typeof input === 'string'
         ? input
@@ -171,6 +177,9 @@ export function installFrimousseDataInterceptor(): void {
     }
     return orig(input, init);
   };
+  window.fetch = shim;
+  // Frimousse may also reach for globalThis.fetch directly.
+  (globalThis as unknown as { fetch: typeof shim }).fetch = shim;
   interceptorInstalled = true;
 }
 

--- a/src/renderer/lib/emoji-recents.test.ts
+++ b/src/renderer/lib/emoji-recents.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getRecentEmojis,
+  pushRecentEmoji,
+  clearRecentEmojis,
+  __emojiRecentsTestExports,
+} from './emoji-recents';
+
+const KEY = __emojiRecentsTestExports.STORAGE_KEY;
+
+describe('emoji-recents', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns [] when storage is empty', () => {
+    expect(getRecentEmojis()).toEqual([]);
+  });
+
+  it('push stores and returns the emoji', () => {
+    const next = pushRecentEmoji('😀');
+    expect(next).toEqual(['😀']);
+    expect(getRecentEmojis()).toEqual(['😀']);
+  });
+
+  it('push dedupes and moves to front', () => {
+    pushRecentEmoji('😀');
+    pushRecentEmoji('🎉');
+    pushRecentEmoji('😀');
+    expect(getRecentEmojis()).toEqual(['😀', '🎉']);
+  });
+
+  it('caps at MAX_RECENTS', () => {
+    for (let i = 0; i < 25; i++) pushRecentEmoji(String.fromCodePoint(0x1f600 + i));
+    expect(getRecentEmojis().length).toBe(__emojiRecentsTestExports.MAX_RECENTS);
+  });
+
+  it('returns [] on malformed JSON', () => {
+    localStorage.setItem(KEY, '{not json');
+    expect(getRecentEmojis()).toEqual([]);
+  });
+
+  it('returns [] when stored value is not an array', () => {
+    localStorage.setItem(KEY, '"oops"');
+    expect(getRecentEmojis()).toEqual([]);
+  });
+
+  it('filters non-string entries defensively', () => {
+    localStorage.setItem(KEY, JSON.stringify(['😀', 42, null, '🎉']));
+    expect(getRecentEmojis()).toEqual(['😀', '🎉']);
+  });
+
+  it('push ignores empty string', () => {
+    pushRecentEmoji('');
+    expect(getRecentEmojis()).toEqual([]);
+  });
+
+  it('clear removes the entry', () => {
+    pushRecentEmoji('😀');
+    clearRecentEmojis();
+    expect(getRecentEmojis()).toEqual([]);
+  });
+
+  it('survives setItem throwing (quota exceeded)', () => {
+    const orig = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error('quota');
+    };
+    try {
+      const next = pushRecentEmoji('😀');
+      expect(next).toEqual(['😀']);
+    } finally {
+      Storage.prototype.setItem = orig;
+    }
+  });
+});

--- a/src/renderer/lib/emoji-recents.ts
+++ b/src/renderer/lib/emoji-recents.ts
@@ -1,0 +1,53 @@
+const STORAGE_KEY = 'chamber:emoji:recents:v1';
+const MAX_RECENTS = 16;
+
+function safeStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getRecentEmojis(): string[] {
+  const storage = safeStorage();
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === 'string').slice(0, MAX_RECENTS);
+  } catch {
+    return [];
+  }
+}
+
+export function pushRecentEmoji(emoji: string): string[] {
+  if (!emoji) return getRecentEmojis();
+  const current = getRecentEmojis();
+  const deduped = current.filter((e) => e !== emoji);
+  const next = [emoji, ...deduped].slice(0, MAX_RECENTS);
+  const storage = safeStorage();
+  if (storage) {
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // quota exceeded or other failure — ignore, in-memory next is still returned
+    }
+  }
+  return next;
+}
+
+export function clearRecentEmojis(): void {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export const __emojiRecentsTestExports = { STORAGE_KEY, MAX_RECENTS };

--- a/src/renderer/lib/emoji-skin-tone.test.ts
+++ b/src/renderer/lib/emoji-skin-tone.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getEmojiSkinTone,
+  setEmojiSkinTone,
+  __emojiSkinToneTestExports,
+} from './emoji-skin-tone';
+
+const KEY = __emojiSkinToneTestExports.STORAGE_KEY;
+
+describe('emoji-skin-tone', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns "none" by default', () => {
+    expect(getEmojiSkinTone()).toBe('none');
+  });
+
+  it('round-trips a valid value', () => {
+    setEmojiSkinTone('medium');
+    expect(getEmojiSkinTone()).toBe('medium');
+  });
+
+  it('ignores invalid stored values', () => {
+    localStorage.setItem(KEY, 'not-a-tone');
+    expect(getEmojiSkinTone()).toBe('none');
+  });
+
+  it('does not persist invalid values', () => {
+    // @ts-expect-error testing runtime guard
+    setEmojiSkinTone('purple');
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/src/renderer/lib/emoji-skin-tone.ts
+++ b/src/renderer/lib/emoji-skin-tone.ts
@@ -1,0 +1,51 @@
+export type EmojiSkinTone =
+  | 'none'
+  | 'light'
+  | 'medium-light'
+  | 'medium'
+  | 'medium-dark'
+  | 'dark';
+
+const STORAGE_KEY = 'chamber:emoji:skinTone:v1';
+const VALID: ReadonlySet<EmojiSkinTone> = new Set([
+  'none',
+  'light',
+  'medium-light',
+  'medium',
+  'medium-dark',
+  'dark',
+]);
+
+function safeStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getEmojiSkinTone(): EmojiSkinTone {
+  const storage = safeStorage();
+  if (!storage) return 'none';
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return 'none';
+    return VALID.has(raw as EmojiSkinTone) ? (raw as EmojiSkinTone) : 'none';
+  } catch {
+    return 'none';
+  }
+}
+
+export function setEmojiSkinTone(value: EmojiSkinTone): void {
+  const storage = safeStorage();
+  if (!storage) return;
+  if (!VALID.has(value)) return;
+  try {
+    storage.setItem(STORAGE_KEY, value);
+  } catch {
+    // ignore
+  }
+}
+
+export const __emojiSkinToneTestExports = { STORAGE_KEY };

--- a/src/renderer/lib/textarea-caret.test.ts
+++ b/src/renderer/lib/textarea-caret.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { getTextareaCaretCoords } from './textarea-caret';
+
+function makeTextarea(value: string): HTMLTextAreaElement {
+  const ta = document.createElement('textarea');
+  ta.value = value;
+  document.body.appendChild(ta);
+  return ta;
+}
+
+describe('getTextareaCaretCoords', () => {
+  it('returns numeric {top,left,height} shape', () => {
+    const ta = makeTextarea('hello world');
+    const coords = getTextareaCaretCoords(ta, 5);
+    expect(typeof coords.top).toBe('number');
+    expect(typeof coords.left).toBe('number');
+    expect(typeof coords.height).toBe('number');
+    expect(Number.isFinite(coords.top)).toBe(true);
+    expect(Number.isFinite(coords.left)).toBe(true);
+    document.body.removeChild(ta);
+  });
+
+  it('subtracts textarea scrollTop from the result', () => {
+    const ta = makeTextarea('a\n'.repeat(50));
+    Object.defineProperty(ta, 'scrollTop', { configurable: true, value: 0 });
+    const a = getTextareaCaretCoords(ta, 100);
+    Object.defineProperty(ta, 'scrollTop', { configurable: true, value: 200 });
+    const b = getTextareaCaretCoords(ta, 100);
+    expect(b.top).toBe(a.top - 200);
+    document.body.removeChild(ta);
+  });
+
+  it('subtracts textarea scrollLeft from the result', () => {
+    const ta = makeTextarea('hello world');
+    Object.defineProperty(ta, 'scrollLeft', { configurable: true, value: 0 });
+    const a = getTextareaCaretCoords(ta, 5);
+    Object.defineProperty(ta, 'scrollLeft', { configurable: true, value: 50 });
+    const b = getTextareaCaretCoords(ta, 5);
+    expect(b.left).toBe(a.left - 50);
+    document.body.removeChild(ta);
+  });
+
+  it('cleans up the mirror div', () => {
+    const ta = makeTextarea('hello');
+    const beforeChildCount = document.body.children.length;
+    getTextareaCaretCoords(ta, 3);
+    expect(document.body.children.length).toBe(beforeChildCount);
+    document.body.removeChild(ta);
+  });
+});

--- a/src/renderer/lib/textarea-caret.ts
+++ b/src/renderer/lib/textarea-caret.ts
@@ -1,0 +1,109 @@
+/**
+ * Compute viewport-relative coordinates of the caret (or any selection
+ * index) inside an HTMLTextAreaElement. Uses the standard "mirror div"
+ * technique: render an off-screen <div> that copies the textarea's text
+ * styling and content up to the caret, measure a marker span, then add
+ * the textarea's bounding rect minus its scroll offset.
+ *
+ * Returns { top, left, height } in viewport (client) coordinates.
+ */
+
+const COPIED_PROPS = [
+  'boxSizing',
+  'width',
+  'height',
+  'overflowX',
+  'overflowY',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'borderStyle',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'fontStyle',
+  'fontVariant',
+  'fontWeight',
+  'fontStretch',
+  'fontSize',
+  'fontSizeAdjust',
+  'lineHeight',
+  'fontFamily',
+  'textAlign',
+  'textTransform',
+  'textIndent',
+  'textDecoration',
+  'letterSpacing',
+  'wordSpacing',
+  'tabSize',
+  'whiteSpace',
+  'wordBreak',
+  'overflowWrap',
+] as const;
+
+export interface CaretCoords {
+  /** Viewport-relative top of the caret line. */
+  top: number;
+  /** Viewport-relative left of the caret. */
+  left: number;
+  /** Line height at the caret. */
+  height: number;
+}
+
+export function getTextareaCaretCoords(
+  textarea: HTMLTextAreaElement,
+  position: number,
+): CaretCoords {
+  const doc = textarea.ownerDocument;
+  if (!doc) return { top: 0, left: 0, height: 0 };
+
+  const div = doc.createElement('div');
+  doc.body.appendChild(div);
+
+  const style = div.style;
+  const computed = doc.defaultView?.getComputedStyle(textarea);
+
+  style.position = 'absolute';
+  style.top = '0';
+  style.left = '0';
+  style.visibility = 'hidden';
+  style.whiteSpace = 'pre-wrap';
+  style.wordWrap = 'break-word';
+  style.overflow = 'hidden';
+
+  if (computed) {
+    for (const prop of COPIED_PROPS) {
+      (style as unknown as Record<string, string>)[prop] = (computed as unknown as Record<string, string>)[prop];
+    }
+  }
+
+  div.textContent = textarea.value.substring(0, position);
+  // textarea-specific: long sequences of spaces stay collapsed otherwise.
+  if (textarea.tagName.toLowerCase() === 'textarea') {
+    div.textContent = div.textContent.replace(/\s/g, '\u00a0');
+  }
+
+  const span = doc.createElement('span');
+  // Use a non-zero-width character so we get reliable measurements even at
+  // end-of-string. The remaining text afterwards just provides line context.
+  span.textContent = textarea.value.substring(position) || '.';
+  div.appendChild(span);
+
+  const rect = textarea.getBoundingClientRect();
+  const lineHeight =
+    span.offsetHeight ||
+    parseFloat(computed?.lineHeight ?? '0') ||
+    parseFloat(computed?.fontSize ?? '16');
+
+  // Convert mirror coords (which are document-origin relative inside the mirror)
+  // to viewport coords by adding the textarea's viewport position and
+  // subtracting its internal scroll.
+  const top = rect.top + span.offsetTop - textarea.scrollTop;
+  const left = rect.left + span.offsetLeft - textarea.scrollLeft;
+
+  doc.body.removeChild(div);
+
+  return { top, left, height: lineHeight };
+}


### PR DESCRIPTION
## Summary

Adds an emoji keyboard to the chat textarea (used by both single-mind chat and chatroom). Two complementary entry points:

1. **Picker popover** — 😀 button next to the model selector opens a [rimousse](https://github.com/liveblocks/frimousse)-powered grid with search, categories, recents, and a skin-tone selector. Fully offline (bundled mojibase-data, no CDN).
2. **:shortcode autocomplete** — typing :sm at a word boundary opens a cmdk popover anchored at the caret. Enter or Tab replaces :smile with 😄.

## Highlights

- **Offline-first**: installFrimousseDataInterceptor() shims window.fetch/globalThis.fetch to serve bundled mojibase-data JSON from a sentinel URL. No external network calls.
- **Boundary-aware regex** rejects false positives like `12:30`, `C:\path`, `http:`, and shortcodes inside existing image tokens.
- **IME-safe**: composition tracked via `onCompositionStart`/`End` + `isComposing`; popover suppressed and Enter not intercepted while composing.
- **Caret-anchored popover** via mirror-div utility (handles textarea `scrollTop`/`scrollLeft`); rendered through `createPortal` to escape overflow ancestors.
- **Recents + skin tone** persist via `localStorage` (`chamber:emoji:recents:v1`, `chamber:emoji:skinTone:v1`), capped, dedup'd, quota-safe.
- **Lazy loaded** picker chunk; chat input remains snappy.

## Tests

- 18 new tests across `ChatInput.test.tsx`, plus unit tests for `emoji-recents`, `emoji-skin-tone`, `emoji-data`, `textarea-caret`.
- Total: 896 passing, 1 skipped.

## Manual verification

- 😀 picker opens, search works, recents update, skin-tone cycles and persists.
- `:sm` opens shortcode popover; Enter/Tab/click accept; Escape dismisses; Shift+Enter does not accept.
- `12:30`, `C:\foo` correctly do not trigger.

## Version

Minor bump: `0.29.2` → `0.30.0` (user-facing feature).
