### PR TITLE
fix: hot-load lens view create and delete events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.31.3 (2026-04-27)
+
+### Lens
+
+- **Hot-load Lens create and delete events** — Lens view discovery now debounces watcher events, rescans on view creation and folder removal, and clears pending rescans when watchers stop so the activity bar stays in sync without restarting Chamber. (#29)
+
 ## v0.31.2 (2026-04-27)
 
 ### Server

--- a/apps/desktop/src/main/ipc/lens.ts
+++ b/apps/desktop/src/main/ipc/lens.ts
@@ -1,6 +1,7 @@
 // Lens IPC handlers — thin adapters for ViewDiscovery
-import { ipcMain } from 'electron';
+import { BrowserWindow, ipcMain } from 'electron';
 import type { MindManager, ViewDiscovery } from '@chamber/services';
+import type { LensViewManifest } from '@chamber/shared/types';
 
 export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindManager): void {
   const resolveMindPath = (mindId?: string): string | undefined => {
@@ -26,5 +27,11 @@ export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindMana
     const mindPath = resolveMindPath(mindId);
     if (!mindPath) return null;
     return viewDiscovery.sendAction(viewId, action, mindPath);
+  });
+
+  mindManager.on('lens:viewsChanged', (views: LensViewManifest[]) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('lens:viewsChanged', views);
+    }
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.31.2",
+      "version": "0.31.3",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/lens/ViewDiscovery.test.ts
+++ b/packages/services/src/lens/ViewDiscovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import * as path from 'path';
 
 vi.mock('electron', () => ({
@@ -237,6 +237,88 @@ describe('ViewDiscovery', () => {
       mockExistsSync.mockReturnValue(false);
       discovery.startWatching('/tmp/mind', vi.fn());
       expect(fs.watch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('startWatching — lens view hot-load', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('rescans and notifies when a view.json is created under lens/', async () => {
+      let lensCallback: (event: string, filename: string) => void = () => {};
+      vi.mocked(fs.watch).mockImplementation((_path: unknown, ...args: unknown[]) => {
+        const cb = args.find(a => typeof a === 'function') as (event: string, filename: string) => void;
+        if (cb) lensCallback = cb;
+        return { close: vi.fn() } as unknown as fs.FSWatcher;
+      });
+
+      let viewExists = false;
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.github', 'lens'))) return true;
+        if (s.endsWith(path.join('new-view', 'view.json'))) return viewExists;
+        return false;
+      });
+      mockReaddirSync.mockImplementation(() => (
+        viewExists
+          ? [{ name: 'new-view', isDirectory: () => true }]
+          : []
+      ) as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'New View', icon: 'eye', view: 'briefing', source: 'data.json' }));
+
+      const onChanged = vi.fn();
+      await discovery.scan('/tmp/mind');
+      discovery.startWatching('/tmp/mind', onChanged);
+
+      viewExists = true;
+      lensCallback('rename', path.join('new-view', 'view.json'));
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(discovery.getViews('/tmp/mind')).toEqual([
+        expect.objectContaining({ id: 'new-view', name: 'New View' }),
+      ]);
+      expect(onChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('rescans and notifies when a view folder is deleted from lens/', async () => {
+      let lensCallback: (event: string, filename: string) => void = () => {};
+      vi.mocked(fs.watch).mockImplementation((_path: unknown, ...args: unknown[]) => {
+        const cb = args.find(a => typeof a === 'function') as (event: string, filename: string) => void;
+        if (cb) lensCallback = cb;
+        return { close: vi.fn() } as unknown as fs.FSWatcher;
+      });
+
+      let viewExists = true;
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.github', 'lens'))) return true;
+        if (s.endsWith(path.join('old-view', 'view.json'))) return viewExists;
+        return false;
+      });
+      mockReaddirSync.mockImplementation(() => (
+        viewExists
+          ? [{ name: 'old-view', isDirectory: () => true }]
+          : []
+      ) as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'Old View', icon: 'eye', view: 'briefing', source: 'data.json' }));
+
+      await discovery.scan('/tmp/mind');
+      expect(discovery.getViews('/tmp/mind')).toHaveLength(1);
+
+      const onChanged = vi.fn();
+      discovery.startWatching('/tmp/mind', onChanged);
+
+      viewExists = false;
+      lensCallback('rename', 'old-view');
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(discovery.getViews('/tmp/mind')).toEqual([]);
+      expect(onChanged).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/services/src/lens/ViewDiscovery.test.ts
+++ b/packages/services/src/lens/ViewDiscovery.test.ts
@@ -202,6 +202,7 @@ describe('ViewDiscovery', () => {
     });
 
     it('transitions to lens/ watcher when lens/ appears', async () => {
+      vi.useFakeTimers();
       const mockClose = vi.fn();
       let parentCallback: (event: string, filename: string) => void = () => {};
       vi.mocked(fs.watch).mockImplementation((_path: unknown, ...args: unknown[]) => {
@@ -225,12 +226,11 @@ describe('ViewDiscovery', () => {
       // Simulate lens/ directory appearing
       lensExists = true;
       parentCallback('rename', 'lens');
+      await vi.advanceTimersByTimeAsync(300);
 
-      // Allow the scan promise to resolve
-      await vi.waitFor(() => {
-        expect(onChanged).toHaveBeenCalled();
-      });
+      expect(onChanged).toHaveBeenCalled();
       expect(mockClose).toHaveBeenCalled();
+      vi.useRealTimers();
     });
 
     it('does nothing when .github/ does not exist either', () => {
@@ -314,6 +314,51 @@ describe('ViewDiscovery', () => {
       discovery.startWatching('/tmp/mind', onChanged);
 
       viewExists = false;
+      lensCallback('rename', 'old-view');
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(discovery.getViews('/tmp/mind')).toEqual([]);
+      expect(onChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears pending rescans when watching stops', async () => {
+      let lensCallback: (event: string, filename: string) => void = () => {};
+      vi.mocked(fs.watch).mockImplementation((_path: unknown, ...args: unknown[]) => {
+        const cb = args.find(a => typeof a === 'function') as (event: string, filename: string) => void;
+        if (cb) lensCallback = cb;
+        return { close: vi.fn() } as unknown as fs.FSWatcher;
+      });
+
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([]);
+
+      const onChanged = vi.fn();
+      discovery.startWatching('/tmp/mind', onChanged);
+
+      lensCallback('rename', 'new-view');
+      discovery.stopWatching('/tmp/mind');
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(mockReaddirSync).not.toHaveBeenCalled();
+      expect(onChanged).not.toHaveBeenCalled();
+    });
+
+    it('treats disappearing lens directories as empty during watcher rescans', async () => {
+      let lensCallback: (event: string, filename: string) => void = () => {};
+      vi.mocked(fs.watch).mockImplementation((_path: unknown, ...args: unknown[]) => {
+        const cb = args.find(a => typeof a === 'function') as (event: string, filename: string) => void;
+        if (cb) lensCallback = cb;
+        return { close: vi.fn() } as unknown as fs.FSWatcher;
+      });
+
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockImplementation(() => {
+        throw Object.assign(new Error('gone'), { code: 'ENOENT' });
+      });
+
+      const onChanged = vi.fn();
+      discovery.startWatching('/tmp/mind', onChanged);
+
       lensCallback('rename', 'old-view');
       await vi.advanceTimersByTimeAsync(300);
 

--- a/packages/services/src/lens/ViewDiscovery.ts
+++ b/packages/services/src/lens/ViewDiscovery.ts
@@ -12,6 +12,7 @@ export interface ViewRefreshHandler {
 export class ViewDiscovery {
   private viewsByMind = new Map<string, LensViewManifest[]>();
   private watchersByMind = new Map<string, fs.FSWatcher[]>();
+  private scanTimersByMind = new Map<string, ReturnType<typeof setTimeout>>();
   private refreshHandler: ViewRefreshHandler | null = null;
 
   constructor(refreshHandler?: ViewRefreshHandler) {
@@ -136,13 +137,21 @@ export class ViewDiscovery {
     const watchers: fs.FSWatcher[] = [];
     try {
       const watcher = fs.watch(lensDir, { recursive: true }, (_eventType, filename) => {
-        if (filename && (filename.endsWith('view.json') || filename.endsWith('.json'))) {
-          setTimeout(() => this.scan(mindPath).then(onChanged), 300);
-        }
+        if (filename) this.scheduleScan(mindPath, onChanged);
       });
       watchers.push(watcher);
     } catch { /* watch not supported */ }
     this.watchersByMind.set(mindPath, watchers);
+  }
+
+  private scheduleScan(mindPath: string, onChanged: () => void): void {
+    const existingTimer = this.scanTimersByMind.get(mindPath);
+    if (existingTimer) clearTimeout(existingTimer);
+    const timer = setTimeout(() => {
+      this.scanTimersByMind.delete(mindPath);
+      void this.scan(mindPath).then(onChanged);
+    }, 300);
+    this.scanTimersByMind.set(mindPath, timer);
   }
 
   stopWatching(mindPath?: string): void {
@@ -150,11 +159,16 @@ export class ViewDiscovery {
       const watchers = this.watchersByMind.get(mindPath) ?? [];
       for (const w of watchers) w.close();
       this.watchersByMind.delete(mindPath);
+      const timer = this.scanTimersByMind.get(mindPath);
+      if (timer) clearTimeout(timer);
+      this.scanTimersByMind.delete(mindPath);
     } else {
       for (const watchers of this.watchersByMind.values()) {
         for (const w of watchers) w.close();
       }
       this.watchersByMind.clear();
+      for (const timer of this.scanTimersByMind.values()) clearTimeout(timer);
+      this.scanTimersByMind.clear();
     }
   }
 

--- a/packages/services/src/lens/ViewDiscovery.ts
+++ b/packages/services/src/lens/ViewDiscovery.ts
@@ -28,7 +28,14 @@ export class ViewDiscovery {
     const lensDir = path.join(mindPath, '.github', 'lens');
 
     if (fs.existsSync(lensDir)) {
-      const entries = fs.readdirSync(lensDir, { withFileTypes: true });
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(lensDir, { withFileTypes: true });
+      } catch (err) {
+        console.warn(`[ViewDiscovery] Failed to read ${lensDir}:`, err);
+        this.viewsByMind.set(mindPath, views);
+        return views;
+      }
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         const viewJsonPath = path.join(lensDir, entry.name, 'view.json');
@@ -121,10 +128,8 @@ export class ViewDiscovery {
         const parentWatcher = fs.watch(githubDir, (_eventType, filename) => {
           if (filename === 'lens' && fs.existsSync(lensDir)) {
             parentWatcher.close();
-            this.scan(mindPath).then(() => {
-              this.watchLensDir(mindPath, lensDir, onChanged);
-              onChanged();
-            });
+            this.watchLensDir(mindPath, lensDir, onChanged);
+            this.scheduleScan(mindPath, onChanged);
           }
         });
         watchers.push(parentWatcher);
@@ -149,7 +154,9 @@ export class ViewDiscovery {
     if (existingTimer) clearTimeout(existingTimer);
     const timer = setTimeout(() => {
       this.scanTimersByMind.delete(mindPath);
-      void this.scan(mindPath).then(onChanged);
+      void this.scan(mindPath).then(onChanged).catch((err: unknown) => {
+        console.warn(`[ViewDiscovery] Failed to rescan lens views for ${mindPath}:`, err);
+      });
     }, 300);
     this.scanTimersByMind.set(mindPath, timer);
   }

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -5,7 +5,7 @@ import type { IdentityLoader } from '../chat/IdentityLoader';
 import type { ChamberToolProvider } from '../chamberTools';
 import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
-import type { AppConfig } from '@chamber/shared/types';
+import type { AppConfig, LensViewManifest } from '@chamber/shared/types';
 
 // --- Mocks ---
 
@@ -75,9 +75,9 @@ const mockConfigService = {
 };
 
 const mockViewDiscovery = {
-  scan: vi.fn(async () => []),
-  getViews: vi.fn(() => []),
-  startWatching: vi.fn(),
+  scan: vi.fn<(_: string) => Promise<LensViewManifest[]>>(async () => []),
+  getViews: vi.fn<() => LensViewManifest[]>(() => []),
+  startWatching: vi.fn<(_: string, __: () => void) => void>(),
   stopWatching: vi.fn(),
   removeMind: vi.fn(),
   setRefreshHandler: vi.fn(),
@@ -130,6 +130,26 @@ describe('MindManager', () => {
         '/tmp/agents/q',
       );
       expect(mockConfigService.save).toHaveBeenCalled();
+    });
+
+    it('starts Lens watching and emits view changes after watcher rescans', async () => {
+      const listener = vi.fn();
+      const views: LensViewManifest[] = [{
+        id: 'smoke-view',
+        name: 'Smoke View',
+        icon: 'table',
+        view: 'table',
+        source: 'data.json',
+      }];
+      mockViewDiscovery.getViews.mockReturnValue(views);
+      manager.on('lens:viewsChanged', listener);
+
+      await manager.loadMind('/tmp/agents/q');
+      const onChanged = mockViewDiscovery.startWatching.mock.calls[0]?.[1];
+      onChanged?.();
+
+      expect(mockViewDiscovery.startWatching).toHaveBeenCalledWith('/tmp/agents/q', expect.any(Function));
+      expect(listener).toHaveBeenCalledWith(views);
     });
 
     it('generates a stable mind ID from folder name', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -98,9 +98,13 @@ export class MindManager extends EventEmitter {
         this.activateProviders(id, resolvedMindPath),
         this.viewDiscovery.scan(resolvedMindPath),
       ]);
+      this.viewDiscovery.startWatching(resolvedMindPath, () => {
+        this.emit('lens:viewsChanged', this.viewDiscovery.getViews());
+      });
     } catch (err) {
       this.minds.delete(id);
       this.pathToId.delete(resolvedMindPath);
+      this.viewDiscovery.removeMind(resolvedMindPath);
       await this.releaseProviders(id).catch(() => { /* noop */ });
       await this.clientFactory.destroyClient(client);
       throw err;

--- a/tests/e2e/electron/lens-hotload.spec.ts
+++ b/tests/e2e/electron/lens-hotload.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_LENS_CDP_PORT ?? 9336);
+const smokeViewId = 'smoke-hotload';
+
+test.describe('electron Lens hot-load smoke', () => {
+  test.setTimeout(180_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let mindPath = '';
+  let userDataPath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-lens-smoke-'));
+    mindPath = path.join(root, 'lens-smoke-mind');
+    userDataPath = path.join(root, 'user-data');
+    tempRoots.push(root);
+    seedMind(mindPath);
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('hot-loads created and deleted Lens views without restarting Electron', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    const mind = await page.evaluate(async (pathToMind) => {
+      const loaded = await window.electronAPI.mind.add(pathToMind);
+      await window.electronAPI.mind.setActive(loaded.mindId);
+      return loaded;
+    }, mindPath);
+
+    await page.evaluate(() => {
+      const target = window as typeof window & { __lensHotloadEvents?: string[][] };
+      target.__lensHotloadEvents = [];
+      window.electronAPI.lens.onViewsChanged((views) => {
+        target.__lensHotloadEvents?.push(views.map((view) => view.id));
+      });
+    });
+
+    await expect.poll(
+      () => page.evaluate(async ({ mindId, viewId }) => {
+        const views = await window.electronAPI.lens.getViews(mindId);
+        return views.some((view) => view.id === viewId);
+      }, { mindId: mind.mindId, viewId: smokeViewId }),
+    ).toBe(false);
+
+    writeLensView(mindPath);
+
+    await expect.poll(
+      () => page.evaluate(async ({ mindId, viewId }) => {
+        const views = await window.electronAPI.lens.getViews(mindId);
+        return views.some((view) => view.id === viewId);
+      }, { mindId: mind.mindId, viewId: smokeViewId }),
+      { timeout: 10_000 },
+    ).toBe(true);
+
+    await expect.poll(
+      () => page.evaluate((viewId) => {
+        const target = window as typeof window & { __lensHotloadEvents?: string[][] };
+        return target.__lensHotloadEvents?.some((ids) => ids.includes(viewId)) ?? false;
+      }, smokeViewId),
+    ).toBe(true);
+
+    fs.rmSync(path.join(mindPath, '.github', 'lens', smokeViewId), { recursive: true, force: true });
+
+    await expect.poll(
+      () => page.evaluate(async ({ mindId, viewId }) => {
+        const views = await window.electronAPI.lens.getViews(mindId);
+        return views.some((view) => view.id === viewId);
+      }, { mindId: mind.mindId, viewId: smokeViewId }),
+      { timeout: 10_000 },
+    ).toBe(false);
+
+    await expect.poll(
+      () => page.evaluate((viewId) => {
+        const target = window as typeof window & { __lensHotloadEvents?: string[][] };
+        return target.__lensHotloadEvents?.some((ids) => !ids.includes(viewId)) ?? false;
+      }, smokeViewId),
+    ).toBe(true);
+  });
+});
+
+function seedMind(root: string): void {
+  fs.mkdirSync(path.join(root, '.github'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'SOUL.md'),
+    [
+      '# Lens Smoke Mind',
+      '',
+      'A deterministic mind used by Electron Lens hot-load smoke tests.',
+      '',
+    ].join('\n'),
+  );
+}
+
+function writeLensView(root: string): void {
+  const viewDir = path.join(root, '.github', 'lens', smokeViewId);
+  fs.mkdirSync(viewDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(viewDir, 'view.json'),
+    JSON.stringify({
+      name: 'Smoke Hotload',
+      icon: 'table',
+      view: 'table',
+      source: 'data.json',
+    }, null, 2),
+  );
+  fs.writeFileSync(path.join(viewDir, 'data.json'), JSON.stringify({ rows: [{ status: 'ok' }] }, null, 2));
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[lens-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixes Lens watcher hot-loading so creating or deleting Lens views updates discovered views without restarting Chamber. The watcher now debounces filesystem events, rescans on directory and file changes, and handles filesystem races during deletion safely.

## Notable changes
- Rescans Lens views for any event under `.github/lens`, not only JSON filename events.
- Debounces per-mind rescans and clears pending timers when watchers stop.
- Treats disappearing Lens directories as empty during watcher rescans instead of producing unhandled rejections.
- Installs the `lens/` watcher before the first debounced scan when `.github/lens` appears.
- Adds regression coverage for create, delete, timer cleanup, and deletion-race paths.
- Bumps Chamber to v0.31.1 and documents the Lens watcher fix in the changelog.

Closes #29

## Validation
- `npm run lint` passed
- `npm test` passed
- Uncle Bob review completed; material findings were addressed