### PR TITLE
fix: prevent duplicate mind sessions from path variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,24 @@ jobs:
 
       - name: Build web
         run: npm --workspace @chamber/web run build
+
+      - name: Detect version bump
+        id: version-bump
+        shell: pwsh
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          $basePackageJson = git show FETCH_HEAD:package.json | ConvertFrom-Json
+          $headPackageJson = Get-Content package.json -Raw | ConvertFrom-Json
+          $baseVersion = [version]$basePackageJson.version
+          $headVersion = [version]$headPackageJson.version
+          $runPackage = $headVersion.Major -gt $baseVersion.Major -or (
+            $headVersion.Major -eq $baseVersion.Major -and $headVersion.Minor -gt $baseVersion.Minor
+          )
+          "run-package=$($runPackage.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          Write-Host "Base package version: $baseVersion"
+          Write-Host "Head package version: $headVersion"
+          Write-Host "Run package: $runPackage"
+
+      - name: Package
+        if: steps.version-bump.outputs.run-package == 'true'
+        run: npm run package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.31.5 (2026-04-27)
+
+### Agent lifecycle
+
+- **Prevent duplicate mind sessions** — loading the same mind folder through equivalent path spellings now returns the existing mind instead of creating another SDK client/session that can collide on extension tool names.
+- **Select reopened minds deterministically** — Open Existing and agent directory selection now activate the mind returned by the load call instead of assuming the last item in the refreshed list is the intended agent.
+
 ## v0.31.4 (2026-04-27)
 
 ### Genesis lifecycle

--- a/apps/desktop/src/main/ipc/genesis.ts
+++ b/apps/desktop/src/main/ipc/genesis.ts
@@ -46,7 +46,7 @@ export function setupGenesisIPC(
       const mind = await mindManager.loadMind(mindPath);
       mindManager.setActiveMind(mind.mindId);
 
-      return { success: true, mindPath };
+      return { success: true, mindId: mind.mindId, mindPath };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (win) win.webContents.send('genesis:progress', { step: 'error', detail: message });

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
@@ -56,7 +56,7 @@ describe('GenesisFlow', () => {
   });
 
   it('waits for genesis.create to load the new mind before completing', async () => {
-    let resolveCreate: (value: { success: true; mindPath: string }) => void = () => {};
+    let resolveCreate: (value: { success: true; mindId: string; mindPath: string }) => void = () => {};
     (api.genesis.create as ReturnType<typeof vi.fn>).mockReturnValue(new Promise((resolve) => {
       resolveCreate = resolve;
     }));
@@ -77,7 +77,7 @@ describe('GenesisFlow', () => {
     expect(api.mind.list).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
 
-    resolveCreate({ success: true, mindPath: createdMind.mindPath });
+    resolveCreate({ success: true, mindId: createdMind.mindId, mindPath: createdMind.mindPath });
 
     await waitFor(() => {
       expect(api.mind.list).toHaveBeenCalled();
@@ -86,7 +86,7 @@ describe('GenesisFlow', () => {
   });
 
   it('selects the mind path returned by genesis.create instead of the last listed mind', async () => {
-    let resolveCreate: (value: { success: true; mindPath: string }) => void = () => {};
+    let resolveCreate: (value: { success: true; mindId?: string; mindPath: string }) => void = () => {};
     (api.genesis.create as ReturnType<typeof vi.fn>).mockReturnValue(new Promise((resolve) => {
       resolveCreate = resolve;
     }));

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -4,14 +4,10 @@ import { VoidScreen } from './VoidScreen';
 import { RoleScreen } from './RoleScreen';
 import { VoiceScreen } from './VoiceScreen';
 import { BootScreen } from './BootScreen';
+import { selectPreferredMind } from '../../lib/mindSelection';
 
 type Stage = 'void' | 'role' | 'voice' | 'boot' | 'done';
 type GenesisCreateResult = Awaited<ReturnType<typeof window.electronAPI.genesis.create>>;
-
-function normalizeMindPath(mindPath: string | undefined): string | null {
-  if (!mindPath) return null;
-  return mindPath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
-}
 
 interface Props {
   onComplete: () => void;
@@ -66,11 +62,7 @@ export function GenesisFlow({ onComplete }: Props) {
 
     const loadedMinds = await window.electronAPI.mind.list();
     dispatch({ type: 'SET_MINDS', payload: loadedMinds });
-    const createdMindPath = normalizeMindPath(result.mindPath);
-    const createdMind = createdMindPath
-      ? loadedMinds.find((mind) => normalizeMindPath(mind.mindPath) === createdMindPath)
-      : undefined;
-    const mindToSelect = createdMind ?? loadedMinds[loadedMinds.length - 1];
+    const mindToSelect = selectPreferredMind(loadedMinds, { mindPath: result.mindPath });
     if (mindToSelect) {
       dispatch({ type: 'SET_ACTIVE_MIND', payload: mindToSelect.mindId });
     }

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -62,7 +62,7 @@ export function GenesisFlow({ onComplete }: Props) {
 
     const loadedMinds = await window.electronAPI.mind.list();
     dispatch({ type: 'SET_MINDS', payload: loadedMinds });
-    const mindToSelect = selectPreferredMind(loadedMinds, { mindPath: result.mindPath });
+    const mindToSelect = selectPreferredMind(loadedMinds, { mindId: result.mindId, mindPath: result.mindPath });
     if (mindToSelect) {
       dispatch({ type: 'SET_ACTIVE_MIND', payload: mindToSelect.mindId });
     }

--- a/apps/web/src/renderer/components/genesis/GenesisGate.test.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisGate.test.tsx
@@ -5,9 +5,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { GenesisGate } from './GenesisGate';
-import { AppStateProvider } from '../../lib/store';
+import { AppStateProvider, useAppState } from '../../lib/store';
 import { useAgentStatus } from '../../hooks/useAgentStatus';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import type { MindContext } from '../../../shared/types';
 
 function TestWrapper({ children }: { children: React.ReactNode }) {
   useAgentStatus();
@@ -17,6 +18,25 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 function renderWithProvider(ui: React.ReactElement) {
   return render(<AppStateProvider><TestWrapper>{ui}</TestWrapper></AppStateProvider>);
 }
+
+function ActiveMindProbe() {
+  const { activeMindId } = useAppState();
+  return <div data-testid="active-mind-id">{activeMindId}</div>;
+}
+
+const existingMind: MindContext = {
+  mindId: 'existing-1234',
+  mindPath: 'C:\\test\\mind',
+  identity: { name: 'Test', systemMessage: '' },
+  status: 'ready',
+};
+
+const otherMind: MindContext = {
+  mindId: 'other-1234',
+  mindPath: 'C:\\test\\other',
+  identity: { name: 'Other', systemMessage: '' },
+  status: 'ready',
+};
 
 describe('GenesisGate', () => {
   let api: ReturnType<typeof mockElectronAPI>;
@@ -79,6 +99,29 @@ describe('GenesisGate', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('alert').textContent).toContain('Invalid mind directory');
+    });
+  });
+
+  it('selects the mind returned by Open Existing when it is already loaded', async () => {
+    (api.mind.selectDirectory as ReturnType<typeof vi.fn>).mockResolvedValue('C:\\test\\mind');
+    (api.mind.add as ReturnType<typeof vi.fn>).mockResolvedValue(existingMind);
+    let callCount = 0;
+    (api.mind.list as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 1) return [];
+      return [existingMind, otherMind];
+    });
+
+    renderWithProvider(<GenesisGate><ActiveMindProbe /></GenesisGate>);
+
+    await waitFor(() => {
+      expect(screen.getByText('Open Existing', { exact: false })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Open Existing', { exact: false }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-mind-id').textContent).toBe(existingMind.mindId);
     });
   });
 

--- a/apps/web/src/renderer/components/genesis/GenesisGate.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisGate.tsx
@@ -3,6 +3,7 @@ import { useAppState, useAppDispatch } from '../../lib/store';
 import { LandingScreen } from './LandingScreen';
 import { GenesisFlow } from './GenesisFlow';
 import { ChamberLoadingScreen } from './ChamberLoadingScreen';
+import { selectPreferredMind } from '../../lib/mindSelection';
 
 interface Props {
   children: React.ReactNode;
@@ -54,11 +55,11 @@ export function GenesisGate({ children }: Props) {
           if (!dirPath) return;
 
           try {
-            await window.electronAPI.mind.add(dirPath);
+            const openedMind = await window.electronAPI.mind.add(dirPath);
             const loadedMinds = await window.electronAPI.mind.list();
             dispatch({ type: 'SET_MINDS', payload: loadedMinds });
-            const newest = loadedMinds[loadedMinds.length - 1];
-            if (newest) dispatch({ type: 'SET_ACTIVE_MIND', payload: newest.mindId });
+            const mindToSelect = selectPreferredMind(loadedMinds, openedMind);
+            if (mindToSelect) dispatch({ type: 'SET_ACTIVE_MIND', payload: mindToSelect.mindId });
             dispatch({ type: 'HIDE_LANDING' });
           } catch (error) {
             setOpenExistingError(error instanceof Error ? error.message : 'Failed to open existing agent.');

--- a/apps/web/src/renderer/hooks/useAgentStatus.test.tsx
+++ b/apps/web/src/renderer/hooks/useAgentStatus.test.tsx
@@ -16,6 +16,13 @@ const fakeMind: MindContext = {
   status: 'ready',
 };
 
+const otherMind: MindContext = {
+  mindId: 'other-1234',
+  mindPath: 'C:\\test\\other',
+  identity: { name: 'Other', systemMessage: '' },
+  status: 'ready',
+};
+
 function wrapper({ children }: { children: React.ReactNode }) {
   return <AppStateProvider>{children}</AppStateProvider>;
 }
@@ -67,6 +74,24 @@ describe('useAgentStatus', () => {
     expect(api.mind.selectDirectory).toHaveBeenCalled();
     expect(api.mind.add).toHaveBeenCalledWith('C:\\test\\mind');
     expect(dirPath).toBe('C:\\test\\mind');
+  });
+
+  it('selectMindDirectory selects the mind returned by mind.add when it already exists', async () => {
+    (api.mind.selectDirectory as ReturnType<typeof vi.fn>).mockResolvedValue('C:\\test\\mind');
+    (api.mind.add as ReturnType<typeof vi.fn>).mockResolvedValue(fakeMind);
+    (api.mind.list as ReturnType<typeof vi.fn>).mockResolvedValue([fakeMind, otherMind]);
+
+    const { result } = renderHook(() => {
+      const agentStatus = useAgentStatus();
+      const state = useAppState();
+      return { agentStatus, state };
+    }, { wrapper });
+
+    await act(async () => {
+      await result.current.agentStatus.selectMindDirectory();
+    });
+
+    expect(result.current.state.activeMindId).toBe(fakeMind.mindId);
   });
 
   it('selectMindDirectory returns null when dialog is cancelled', async () => {

--- a/apps/web/src/renderer/hooks/useAgentStatus.ts
+++ b/apps/web/src/renderer/hooks/useAgentStatus.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { useAppState, useAppDispatch } from '../lib/store';
+import { selectPreferredMind } from '../lib/mindSelection';
 
 export function useAgentStatus() {
   const { minds } = useAppState();
@@ -40,11 +41,11 @@ export function useAgentStatus() {
   const selectMindDirectory = useCallback(async () => {
     const dirPath = await window.electronAPI.mind.selectDirectory();
     if (dirPath) {
-      await window.electronAPI.mind.add(dirPath);
+      const openedMind = await window.electronAPI.mind.add(dirPath);
       const loadedMinds = await window.electronAPI.mind.list();
       dispatch({ type: 'SET_MINDS', payload: loadedMinds });
-      const newest = loadedMinds[loadedMinds.length - 1];
-      if (newest) dispatch({ type: 'SET_ACTIVE_MIND', payload: newest.mindId });
+      const mindToSelect = selectPreferredMind(loadedMinds, openedMind);
+      if (mindToSelect) dispatch({ type: 'SET_ACTIVE_MIND', payload: mindToSelect.mindId });
     }
     return dirPath;
   }, [dispatch]);

--- a/apps/web/src/renderer/lib/mindSelection.test.ts
+++ b/apps/web/src/renderer/lib/mindSelection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { MindContext } from '../../shared/types';
+import { normalizeMindPath, selectPreferredMind } from './mindSelection';
+
+const upperPosixMind: MindContext = {
+  mindId: 'upper',
+  mindPath: '/agents/Foo',
+  identity: { name: 'Foo', systemMessage: '' },
+  status: 'ready',
+};
+
+const lowerPosixMind: MindContext = {
+  mindId: 'lower',
+  mindPath: '/agents/foo',
+  identity: { name: 'foo', systemMessage: '' },
+  status: 'ready',
+};
+
+describe('mindSelection', () => {
+  it('does not collapse distinct POSIX paths by case', () => {
+    expect(normalizeMindPath('/agents/Foo')).toBe('/agents/Foo');
+    expect(normalizeMindPath('/agents/foo')).toBe('/agents/foo');
+
+    expect(selectPreferredMind([upperPosixMind, lowerPosixMind], { mindPath: '/agents/foo' })?.mindId).toBe('lower');
+  });
+
+  it('case-folds Windows-style paths', () => {
+    expect(normalizeMindPath('C:\\Agents\\Foo\\')).toBe('c:/agents/foo');
+  });
+});

--- a/apps/web/src/renderer/lib/mindSelection.ts
+++ b/apps/web/src/renderer/lib/mindSelection.ts
@@ -7,7 +7,10 @@ interface PreferredMind {
 
 export function normalizeMindPath(mindPath: string | undefined): string | null {
   if (!mindPath) return null;
-  return mindPath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  const normalized = mindPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  return /^[a-z]:\//i.test(normalized) || normalized.startsWith('//')
+    ? normalized.toLowerCase()
+    : normalized;
 }
 
 export function selectPreferredMind(

--- a/apps/web/src/renderer/lib/mindSelection.ts
+++ b/apps/web/src/renderer/lib/mindSelection.ts
@@ -1,0 +1,29 @@
+import type { MindContext } from '../../shared/types';
+
+interface PreferredMind {
+  readonly mindId?: string;
+  readonly mindPath?: string;
+}
+
+export function normalizeMindPath(mindPath: string | undefined): string | null {
+  if (!mindPath) return null;
+  return mindPath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
+export function selectPreferredMind(
+  loadedMinds: readonly MindContext[],
+  preferred: PreferredMind | null | undefined,
+): MindContext | null {
+  if (preferred?.mindId) {
+    const byId = loadedMinds.find((mind) => mind.mindId === preferred.mindId);
+    if (byId) return byId;
+  }
+
+  const preferredPath = normalizeMindPath(preferred?.mindPath);
+  if (preferredPath) {
+    const byPath = loadedMinds.find((mind) => normalizeMindPath(mind.mindPath) === preferredPath);
+    if (byPath) return byPath;
+  }
+
+  return loadedMinds[loadedMinds.length - 1] ?? null;
+}

--- a/apps/web/src/shared/types.ts
+++ b/apps/web/src/shared/types.ts
@@ -178,7 +178,7 @@ export interface ElectronAPI {
   genesis: {
     getDefaultPath: () => Promise<string>;
     pickPath: () => Promise<string | null>;
-    create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindPath?: string; error?: string }>;
+    create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
   };
   chatroom: ChatroomAPI;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.31.4",
+      "version": "0.31.5",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -185,6 +185,21 @@ describe('MindManager', () => {
       expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
     });
 
+    it('deduplicates equivalent path spellings before creating another client', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((candidate) => {
+        const normalized = String(candidate).replace(/\\/g, '/').toLowerCase();
+        return normalized === '/tmp/agents/q/soul.md' || normalized === '/tmp/agents/q/.github';
+      });
+
+      const mind1 = await manager.loadMind('/tmp/agents/q');
+      const mind2 = await manager.loadMind('/tmp/agents/Q/');
+
+      expect(mind2.mindId).toBe(mind1.mindId);
+      expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
+      expect(mockCreateSession).toHaveBeenCalledTimes(1);
+      expect(mockProvider.activateMind).toHaveBeenCalledTimes(1);
+    });
+
     it('emits mind:loaded event', async () => {
       const listener = vi.fn();
       manager.on('mind:loaded', listener);

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -13,6 +13,9 @@ vi.mock('fs', () => ({
   existsSync: vi.fn(),
   readdirSync: vi.fn(() => []),
   readFileSync: vi.fn(),
+  realpathSync: Object.assign(vi.fn((candidate: string) => candidate), {
+    native: vi.fn((candidate: string) => candidate),
+  }),
 }));
 
 import * as fs from 'fs';
@@ -109,6 +112,7 @@ describe('MindManager', () => {
     };
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
+    vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => String(candidate));
     manager = new MindManager(
       mockClientFactory as unknown as CopilotClientFactory,
       mockIdentityLoader as unknown as IdentityLoader,
@@ -198,6 +202,24 @@ describe('MindManager', () => {
       expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
       expect(mockCreateSession).toHaveBeenCalledTimes(1);
       expect(mockProvider.activateMind).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates filesystem aliases by realpath before creating another client', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => {
+        const normalized = String(candidate).replace(/\\/g, '/');
+        if (normalized.endsWith('/tmp/aliases/q-link')) {
+          return normalized.slice(0, -'/tmp/aliases/q-link'.length) + '/tmp/agents/q';
+        }
+        return normalized;
+      });
+
+      const mind1 = await manager.loadMind('/tmp/agents/q');
+      const mind2 = await manager.loadMind('/tmp/aliases/q-link');
+
+      expect(mind2.mindId).toBe(mind1.mindId);
+      expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
+      expect(mockCreateSession).toHaveBeenCalledTimes(1);
     });
 
     it('emits mind:loaded event', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -270,7 +270,13 @@ export class MindManager extends EventEmitter {
   }
 
   private mindPathKey(mindPath: string): string {
-    const resolved = path.resolve(mindPath);
+    let resolved = path.resolve(mindPath);
+    try {
+      resolved = fs.realpathSync.native(resolved);
+    } catch {
+      // If the folder disappears mid-load, keep the resolved path so the caller
+      // gets the real load error instead of masking it with canonicalization.
+    }
     return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
   }
 

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -39,9 +39,10 @@ export class MindManager extends EventEmitter {
 
   async loadMind(mindPath: string, mindId?: string): Promise<MindContext> {
     const resolvedMindPath = this.resolveMindPath(mindPath);
+    const mindPathKey = this.mindPathKey(resolvedMindPath);
 
     // Deduplicate — return existing mind
-    const existingId = this.pathToId.get(resolvedMindPath);
+    const existingId = this.pathToId.get(mindPathKey);
     if (existingId && this.minds.has(existingId)) {
       const existing = this.minds.get(existingId);
       if (!existing) throw new Error(`Mind ${existingId} not found`);
@@ -49,20 +50,21 @@ export class MindManager extends EventEmitter {
     }
 
     // Concurrent guard — return in-flight promise
-    const inflight = this.loading.get(resolvedMindPath);
+    const inflight = this.loading.get(mindPathKey);
     if (inflight) return inflight;
 
     const promise = this.doLoadMind(resolvedMindPath, mindId);
-    this.loading.set(resolvedMindPath, promise);
+    this.loading.set(mindPathKey, promise);
     try {
       return await promise;
     } finally {
-      this.loading.delete(resolvedMindPath);
+      this.loading.delete(mindPathKey);
     }
   }
 
   private async doLoadMind(mindPath: string, mindId?: string): Promise<MindContext> {
     const resolvedMindPath = this.resolveMindPath(mindPath);
+    const mindPathKey = this.mindPathKey(resolvedMindPath);
 
     // Use provided ID or generate a new one
     const id = mindId ?? generateMindId(resolvedMindPath);
@@ -91,7 +93,7 @@ export class MindManager extends EventEmitter {
     };
 
     this.minds.set(id, context);
-    this.pathToId.set(resolvedMindPath, id);
+    this.pathToId.set(mindPathKey, id);
 
     try {
       await Promise.all([
@@ -103,7 +105,7 @@ export class MindManager extends EventEmitter {
       });
     } catch (err) {
       this.minds.delete(id);
-      this.pathToId.delete(resolvedMindPath);
+      this.pathToId.delete(mindPathKey);
       this.viewDiscovery.removeMind(resolvedMindPath);
       await this.releaseProviders(id).catch(() => { /* noop */ });
       await this.clientFactory.destroyClient(client);
@@ -131,7 +133,7 @@ export class MindManager extends EventEmitter {
 
     // Remove from maps
     this.minds.delete(mindId);
-    this.pathToId.delete(context.mindPath);
+    this.pathToId.delete(this.mindPathKey(context.mindPath));
 
     // Update active mind if needed
     if (this.activeMindId === mindId) {
@@ -267,6 +269,11 @@ export class MindManager extends EventEmitter {
     return hasSoul || hasGithub;
   }
 
+  private mindPathKey(mindPath: string): string {
+    const resolved = path.resolve(mindPath);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  }
+
   private toExternalContext(ctx: InternalMindContext): MindContext {
     return {
       mindId: ctx.mindId,
@@ -358,7 +365,8 @@ export class MindManager extends EventEmitter {
   }
 
   async sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void> {
-    const mind = this.listMinds().find(m => m.mindPath === mindPath);
+    const requestedMindPathKey = this.mindPathKey(mindPath);
+    const mind = this.listMinds().find(m => this.mindPathKey(m.mindPath) === requestedMindPathKey);
     if (!mind) return;
     const context = this.minds.get(mind.mindId);
     if (!context?.session) return;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -178,7 +178,7 @@ export interface ElectronAPI {
   genesis: {
     getDefaultPath: () => Promise<string>;
     pickPath: () => Promise<string | null>;
-    create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindPath?: string; error?: string }>;
+    create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
   };
   chatroom: ChatroomAPI;

--- a/tests/e2e/electron/monica-open-existing.spec.ts
+++ b/tests/e2e/electron/monica-open-existing.spec.ts
@@ -41,6 +41,8 @@ test.describe('electron Monica existing mind smoke', () => {
   test('opens an existing Monica mind without a live chat turn', async () => {
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#root')).not.toBeEmpty();
+    await expect(page.getByRole('button', { name: /Open Existing/i })).toBeVisible();
 
     const mind = await page.evaluate(async (pathToMind) => {
       const mind = await window.electronAPI.mind.add(pathToMind);
@@ -52,6 +54,19 @@ test.describe('electron Monica existing mind smoke', () => {
       () => page.evaluate(() => window.electronAPI.mind.list().then((minds) => minds.map((item) => item.identity.name))),
     ).toEqual(['Monica']);
 
+    const nestedMindPath = path.join(mindPath, '.github', 'agents');
+    const sameMind = await page.evaluate(async (nestedPathToMind) => {
+      const sameMind = await window.electronAPI.mind.add(nestedPathToMind);
+      await window.electronAPI.mind.setActive(sameMind.mindId);
+      return sameMind;
+    }, nestedMindPath);
+
+    await expect.poll(
+      () => page.evaluate(() => window.electronAPI.mind.list().then((minds) => minds.map((item) => item.identity.name))),
+    ).toEqual(['Monica']);
+
+    expect(sameMind.mindId).toBe(mind.mindId);
+    await expect(page.getByRole('button', { name: 'Monica' })).toHaveCount(1);
     await page.getByRole('button', { name: 'Monica' }).first().click();
     await expect(page.getByText('How can I help you today?')).toBeVisible();
     await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 import packageJson from '../../package.json';
 
@@ -12,5 +13,15 @@ describe('packaging scripts', () => {
         script.indexOf('electron-forge')
       );
     }
+  });
+
+  it('runs PR packaging only for major or minor version bumps', () => {
+    const workflow = readFileSync('.github/workflows/ci.yml', 'utf-8');
+
+    expect(workflow).toContain('id: version-bump');
+    expect(workflow).toContain('$headVersion.Major -gt $baseVersion.Major');
+    expect(workflow).toContain('$headVersion.Minor -gt $baseVersion.Minor');
+    expect(workflow).toContain("if: steps.version-bump.outputs.run-package == 'true'");
+    expect(workflow).toContain('run: npm run package');
   });
 });


### PR DESCRIPTION
## Summary
Prevents duplicate SDK client/session creation when the same mind folder is loaded through equivalent path spellings or filesystem aliases, avoiding extension tool-name clashes that can leave agents stuck at thinking.

This is stacked on #152.

## Notable changes
- Canonicalizes `MindManager` path keys with realpath-backed filesystem identity and preserves fallback behavior when realpath is unavailable.
- Reuses existing loaded minds for equivalent path variants instead of creating another SDK session and provider activation.
- Selects reopened/created minds deterministically by returned mind ID/path instead of the last refreshed list entry.
- Adds renderer selection helper coverage for Windows-style paths without collapsing distinct POSIX paths.
- Adds changelog and patch version bump for v0.31.2.

Closes #33

## Tests
- `npm test -- packages/services/src/mind/MindManager.test.ts apps/web/src/renderer/hooks/useAgentStatus.test.tsx apps/web/src/renderer/components/genesis/GenesisGate.test.tsx apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx`
- `npm test -- apps/web/src/renderer/lib/mindSelection.test.ts apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx apps/web/src/renderer/components/genesis/GenesisGate.test.tsx apps/web/src/renderer/hooks/useAgentStatus.test.tsx packages/services/src/mind/MindManager.test.ts`
- `npm run lint`
- `npm test`
- `npm run test:sdk-smoke`