### PR TITLE
feat: route browser chat through loopback services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.32.0 (2026-04-27)
+
+### Browser loopback chat
+
+- **Route browser chat through real services** — browser mode can now add an existing local mind path through the loopback server and send chat turns through the same `MindManager` and `ChatService` path used by the desktop shell.
+- **Stream browser chat events** — the loopback WebSocket now supports browser token authentication, per-message subscriptions, and chat event fanout so renderer state updates from server-side SDK sessions.
+- **Expand browser client contracts** — `@chamber/client` and wire contracts now cover mind loading, chat send, new conversations, and model listing for the browser API adapter.
+
 ## v0.31.5 (2026-04-27)
 
 ### Agent lifecycle

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@chamber/services": "file:../../packages/services",
+    "@chamber/wire-contracts": "file:../../packages/wire-contracts",
     "@hono/node-server": "^2.0.0",
     "hono": "^4.10.6",
     "keytar": "^7.9.0",

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -10,7 +10,14 @@ export function isLoopbackHost(host: string | undefined): boolean {
 
 export function isAllowedOrigin(origin: string | null, allowedOrigins: ReadonlySet<string>): boolean {
   if (origin === null) return true;
-  return allowedOrigins.has(origin);
+  if (allowedOrigins.has(origin)) return true;
+  try {
+    const parsed = new URL(origin);
+    const withoutPort = `${parsed.protocol}//${parsed.hostname}`;
+    return isLoopbackHost(parsed.hostname) && allowedOrigins.has(withoutPort);
+  } catch {
+    return false;
+  }
 }
 
 export function isAuthorized(authorization: string | null, token: string): boolean {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -54,11 +54,7 @@ ctx.listModels = (mindId) => {
   const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
   return id ? chatService.listModels(id) : [];
 };
-ctx.cancelChat = (messageId) => {
-  const mind = mindManager.listMinds().find((candidate) => candidate.mindId === mindManager.getActiveMindId())
-    ?? mindManager.listMinds()[0];
-  return mind ? chatService.cancelMessage(mind.mindId, messageId) : undefined;
-};
+ctx.cancelChat = (mindId, messageId) => chatService.cancelMessage(mindId, messageId);
 
 ctx.getAuthStatus = async () => {
   const credential = await authService.getStoredCredential();
@@ -81,12 +77,16 @@ ctx.switchAuthAccount = async (login) => {
   authService.setActiveLogin(login);
 };
 ctx.logoutAuth = () => authService.logout();
-ctx.shutdown = () => shutdown();
+ctx.shutdown = () => {
+  void shutdown();
+};
 ctx.handlePrivilegedRequest = createCredentialPrivilegedHandler(keytar as CredentialStore);
 
 const serverControls = createHttpServer({
   ...ctx,
-  shutdown: () => shutdown(),
+  shutdown: () => {
+    void shutdown();
+  },
 });
 const { server } = serverControls;
 
@@ -96,9 +96,19 @@ server.listen(port, '127.0.0.1', () => {
   console.log(JSON.stringify({ type: 'ready', host: '127.0.0.1', port: actualPort, token: ctx.token }));
 });
 
-function shutdown(): void {
+let shuttingDown = false;
+async function shutdown(): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  await mindManager.shutdown().catch((error: unknown) => {
+    console.error('[server] Mind shutdown failed:', error);
+  });
   server.close(() => process.exit(0));
 }
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+process.on('SIGTERM', () => {
+  void shutdown();
+});
+process.on('SIGINT', () => {
+  void shutdown();
+});

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -1,6 +1,16 @@
 import { createHttpServer } from './honoAdapter';
 import { createServerContext } from './composition';
-import { AuthService, type CredentialStore } from '@chamber/services';
+import {
+  AuthService,
+  ChatService,
+  ConfigService,
+  CopilotClientFactory,
+  IdentityLoader,
+  MindManager,
+  TurnQueue,
+  ViewDiscovery,
+  type CredentialStore,
+} from '@chamber/services';
 import keytar from 'keytar';
 import { createCredentialPrivilegedHandler } from './privileged-protocol';
 
@@ -11,10 +21,44 @@ const ctx = createServerContext({
   token: process.env.CHAMBER_SERVER_TOKEN,
   allowedOrigins: [allowedOrigin],
 });
-let activeLogin: string | null = null;
-const authService = new AuthService(keytar as CredentialStore, () => activeLogin, (login) => {
-  activeLogin = login;
+const configService = new ConfigService();
+const saveActiveLogin = (login: string | null) => {
+  const config = configService.load();
+  configService.save({ ...config, activeLogin: login });
+};
+const authService = new AuthService(keytar as CredentialStore, () => configService.load().activeLogin, saveActiveLogin);
+const viewDiscovery = new ViewDiscovery();
+const mindManager = new MindManager(new CopilotClientFactory(), new IdentityLoader(), configService, viewDiscovery);
+const chatService = new ChatService(mindManager, new TurnQueue());
+viewDiscovery.setRefreshHandler({
+  sendBackgroundPrompt: (mindPath, prompt) => mindManager.sendBackgroundPrompt(mindPath, prompt),
 });
+
+ctx.listMinds = () => mindManager.listMinds();
+ctx.addMind = async (mindPath) => {
+  const mind = await mindManager.loadMind(mindPath);
+  mindManager.setActiveMind(mind.mindId);
+  return mind;
+};
+ctx.sendChat = ({ mindId, message, messageId, model, attachments }) =>
+  chatService.sendMessage(
+    mindId,
+    message,
+    messageId,
+    (event) => serverControls.publish(messageId, { mindId, messageId, event }),
+    model,
+    attachments,
+  );
+ctx.newConversation = (mindId) => chatService.newConversation(mindId);
+ctx.listModels = (mindId) => {
+  const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
+  return id ? chatService.listModels(id) : [];
+};
+ctx.cancelChat = (messageId) => {
+  const mind = mindManager.listMinds().find((candidate) => candidate.mindId === mindManager.getActiveMindId())
+    ?? mindManager.listMinds()[0];
+  return mind ? chatService.cancelMessage(mind.mindId, messageId) : undefined;
+};
 
 ctx.getAuthStatus = async () => {
   const credential = await authService.getStoredCredential();
@@ -40,10 +84,11 @@ ctx.logoutAuth = () => authService.logout();
 ctx.shutdown = () => shutdown();
 ctx.handlePrivilegedRequest = createCredentialPrivilegedHandler(keytar as CredentialStore);
 
-const { server } = createHttpServer({
+const serverControls = createHttpServer({
   ...ctx,
   shutdown: () => shutdown(),
 });
+const { server } = serverControls;
 
 server.listen(port, '127.0.0.1', () => {
   const address = server.address();

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -12,6 +12,7 @@ import {
   type CredentialStore,
 } from '@chamber/services';
 import keytar from 'keytar';
+import path from 'node:path';
 import { createCredentialPrivilegedHandler } from './privileged-protocol';
 
 const port = Number(process.env.CHAMBER_SERVER_PORT ?? 0);
@@ -81,6 +82,49 @@ ctx.shutdown = () => {
   void shutdown();
 };
 ctx.handlePrivilegedRequest = createCredentialPrivilegedHandler(keytar as CredentialStore);
+
+if (process.env.CHAMBER_E2E === '1' && process.env.CHAMBER_E2E_FAKE_CHAT === '1') {
+  const fakeMinds = new Map<string, {
+    mindId: string;
+    mindPath: string;
+    identity: { name: string; systemMessage: string };
+    status: 'ready';
+  }>();
+  const fakeReply = process.env.CHAMBER_E2E_FAKE_CHAT_REPLY ?? 'CHAMBER_BROWSER_LOOPBACK_ACK';
+
+  ctx.listMinds = () => Array.from(fakeMinds.values());
+  ctx.addMind = (mindPath) => {
+    const existing = fakeMinds.get(mindPath);
+    if (existing) return existing;
+    const basename = path.basename(mindPath) || 'browser-smoke';
+    const mind = {
+      mindId: `${basename}-e2e`,
+      mindPath,
+      identity: {
+        name: basename,
+        systemMessage: `E2E fake browser mind for ${basename}`,
+      },
+      status: 'ready' as const,
+    };
+    fakeMinds.set(mindPath, mind);
+    return mind;
+  };
+  ctx.sendChat = ({ mindId, messageId }) => {
+    serverControls.publish(messageId, {
+      mindId,
+      messageId,
+      event: { type: 'message_final', sdkMessageId: `e2e-${messageId}`, content: fakeReply },
+    });
+    serverControls.publish(messageId, {
+      mindId,
+      messageId,
+      event: { type: 'done' },
+    });
+  };
+  ctx.newConversation = () => undefined;
+  ctx.cancelChat = () => undefined;
+  ctx.listModels = () => [{ id: 'e2e-fake-model', name: 'E2E Fake Model' }];
+}
 
 const serverControls = createHttpServer({
   ...ctx,

--- a/apps/server/src/composition.ts
+++ b/apps/server/src/composition.ts
@@ -12,6 +12,9 @@ export function createServerContext(options: ServerCompositionOptions = {}): Cha
     token,
     allowedOrigins: new Set(options.allowedOrigins ?? [`http://127.0.0.1`]),
     listMinds: () => [],
+    addMind: async () => {
+      throw new Error('Mind loading is unavailable');
+    },
     getConfig: () => ({ version: 1 }),
     listLensViews: () => [],
     getGenesisStatus: () => ({ ready: false }),
@@ -20,6 +23,9 @@ export function createServerContext(options: ServerCompositionOptions = {}): Cha
     listChamberTools: () => [],
     saveAttachment: async ({ name }) => ({ attachmentId: randomUUID(), name }),
     cancelChat: () => undefined,
+    sendChat: () => undefined,
+    newConversation: () => undefined,
+    listModels: () => [],
     validatePath: () => false,
   };
 }

--- a/apps/server/src/handlers.test.ts
+++ b/apps/server/src/handlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   addMindHandler,
+  cancelChatHandler,
   listModelsHandler,
   newConversationHandler,
   sendChatHandler,
@@ -21,6 +22,22 @@ describe('server handlers', () => {
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ mind: { mindId: 'dude-1234', mindPath: 'C:\\agents\\dude' } });
     expect(addMind).toHaveBeenCalledWith('C:\\agents\\dude');
+  });
+
+  it('surfaces local mind load failures with the original message', async () => {
+    const addMind = vi.fn(async () => {
+      throw new Error('Invalid mind directory');
+    });
+
+    const response = await addMindHandler({
+      method: 'POST',
+      path: '/api/mind/add',
+      headers: new Headers(),
+      body: { mindPath: 'C:\\agents\\bad' },
+    }, makeContext({ addMind }));
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Invalid mind directory' });
   });
 
   it('sends chat through the server context', async () => {
@@ -62,6 +79,21 @@ describe('server handlers', () => {
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ ok: true });
     expect(newConversation).toHaveBeenCalledWith('dude-1234');
+  });
+
+  it('cancels chat for the requested mind', async () => {
+    const cancelChat = vi.fn(async () => undefined);
+
+    const response = await cancelChatHandler({
+      method: 'POST',
+      path: '/api/chat/cancel',
+      headers: new Headers(),
+      body: { mindId: 'dude-1234', messageId: 'assistant-1' },
+    }, makeContext({ cancelChat }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(cancelChat).toHaveBeenCalledWith('dude-1234', 'assistant-1');
   });
 
   it('lists models through the server context', async () => {

--- a/apps/server/src/handlers.test.ts
+++ b/apps/server/src/handlers.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  addMindHandler,
+  listModelsHandler,
+  newConversationHandler,
+  sendChatHandler,
+} from './handlers';
+import type { ChamberCtx } from './types';
+
+describe('server handlers', () => {
+  it('loads an existing local mind through the server context', async () => {
+    const addMind = vi.fn(async (mindPath: string) => ({ mindId: 'dude-1234', mindPath }));
+
+    const response = await addMindHandler({
+      method: 'POST',
+      path: '/api/mind/add',
+      headers: new Headers(),
+      body: { mindPath: 'C:\\agents\\dude' },
+    }, makeContext({ addMind }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ mind: { mindId: 'dude-1234', mindPath: 'C:\\agents\\dude' } });
+    expect(addMind).toHaveBeenCalledWith('C:\\agents\\dude');
+  });
+
+  it('sends chat through the server context', async () => {
+    const sendChat = vi.fn(async () => undefined);
+
+    const response = await sendChatHandler({
+      method: 'POST',
+      path: '/api/chat/send',
+      headers: new Headers(),
+      body: {
+        mindId: 'dude-1234',
+        message: 'Hello',
+        messageId: 'assistant-1',
+        model: 'claude-sonnet',
+      },
+    }, makeContext({ sendChat }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(sendChat).toHaveBeenCalledWith({
+      mindId: 'dude-1234',
+      message: 'Hello',
+      messageId: 'assistant-1',
+      model: 'claude-sonnet',
+      attachments: undefined,
+    });
+  });
+
+  it('starts a new conversation through the server context', async () => {
+    const newConversation = vi.fn(async () => undefined);
+
+    const response = await newConversationHandler({
+      method: 'POST',
+      path: '/api/chat/new',
+      headers: new Headers(),
+      body: { mindId: 'dude-1234' },
+    }, makeContext({ newConversation }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(newConversation).toHaveBeenCalledWith('dude-1234');
+  });
+
+  it('lists models through the server context', async () => {
+    const listModels = vi.fn(async () => [{ id: 'claude-sonnet', name: 'Claude Sonnet' }]);
+
+    const response = await listModelsHandler({
+      method: 'GET',
+      path: '/api/chat/models',
+      headers: new Headers(),
+      query: new URLSearchParams('mindId=dude-1234'),
+    }, makeContext({ listModels }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ models: [{ id: 'claude-sonnet', name: 'Claude Sonnet' }] });
+    expect(listModels).toHaveBeenCalledWith('dude-1234');
+  });
+});
+
+function makeContext(overrides: Partial<ChamberCtx>): ChamberCtx {
+  return {
+    token: 'test-token',
+    allowedOrigins: new Set(['http://127.0.0.1']),
+    listMinds: () => [],
+    ...overrides,
+  };
+}

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -8,6 +8,19 @@ export async function listMindsHandler(_request: ChamberRequest, ctx: ChamberCtx
   return { status: 200, body: { minds: ctx.listMinds() } };
 }
 
+export async function addMindHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
+  const mindPath = typeof request.body === 'object' && request.body !== null && 'mindPath' in request.body
+    ? String((request.body as { mindPath: unknown }).mindPath).trim()
+    : '';
+  if (!mindPath) {
+    return { status: 400, body: { error: 'mindPath is required' } };
+  }
+  if (!ctx.addMind) {
+    return { status: 503, body: { error: 'Mind loading is unavailable' } };
+  }
+  return { status: 200, body: { mind: await ctx.addMind(mindPath) } };
+}
+
 export async function getConfigHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
   return { status: 200, body: await ctx.getConfig?.() ?? { version: 1 } };
 }
@@ -75,4 +88,43 @@ export async function cancelChatHandler(request: ChamberRequest, ctx: ChamberCtx
   }
   await ctx.cancelChat?.(sessionId);
   return { status: 200, body: { ok: true } };
+}
+
+export async function sendChatHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
+  const body = typeof request.body === 'object' && request.body !== null
+    ? request.body as Record<string, unknown>
+    : {};
+  const mindId = typeof body.mindId === 'string' ? body.mindId.trim() : '';
+  const message = typeof body.message === 'string' ? body.message : '';
+  const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
+  if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
+  if (!messageId) return { status: 400, body: { error: 'messageId is required' } };
+  if (!ctx.sendChat) return { status: 503, body: { error: 'Chat is unavailable' } };
+
+  await ctx.sendChat({
+    mindId,
+    message,
+    messageId,
+    model: typeof body.model === 'string' ? body.model : undefined,
+    attachments: Array.isArray(body.attachments)
+      ? body.attachments as never
+      : undefined,
+  });
+  return { status: 200, body: { ok: true } };
+}
+
+export async function newConversationHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
+  const mindId = typeof request.body === 'object' && request.body !== null && 'mindId' in request.body
+    ? String((request.body as { mindId: unknown }).mindId).trim()
+    : '';
+  if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
+  if (!ctx.newConversation) return { status: 503, body: { error: 'Chat is unavailable' } };
+
+  await ctx.newConversation(mindId);
+  return { status: 200, body: { ok: true } };
+}
+
+export async function listModelsHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
+  if (!ctx.listModels) return { status: 503, body: { error: 'Model listing is unavailable' } };
+  return { status: 200, body: { models: await ctx.listModels(request.query?.get('mindId') ?? undefined) } };
 }

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -18,7 +18,11 @@ export async function addMindHandler(request: ChamberRequest, ctx: ChamberCtx): 
   if (!ctx.addMind) {
     return { status: 503, body: { error: 'Mind loading is unavailable' } };
   }
-  return { status: 200, body: { mind: await ctx.addMind(mindPath) } };
+  try {
+    return { status: 200, body: { mind: await ctx.addMind(mindPath) } };
+  } catch (error) {
+    return { status: 400, body: { error: error instanceof Error ? error.message : String(error) } };
+  }
 }
 
 export async function getConfigHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
@@ -80,13 +84,15 @@ export async function uploadAttachmentHandler(request: ChamberRequest, ctx: Cham
 }
 
 export async function cancelChatHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  const sessionId = typeof request.body === 'object' && request.body !== null && 'sessionId' in request.body
-    ? String((request.body as { sessionId: unknown }).sessionId)
+  const mindId = typeof request.body === 'object' && request.body !== null && 'mindId' in request.body
+    ? String((request.body as { mindId: unknown }).mindId).trim()
     : '';
-  if (!sessionId) {
-    return { status: 400, body: { error: 'sessionId is required' } };
-  }
-  await ctx.cancelChat?.(sessionId);
+  const messageId = typeof request.body === 'object' && request.body !== null && 'messageId' in request.body
+    ? String((request.body as { messageId: unknown }).messageId).trim()
+    : '';
+  if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
+  if (!messageId) return { status: 400, body: { error: 'messageId is required' } };
+  await ctx.cancelChat?.(mindId, messageId);
   return { status: 200, body: { ok: true } };
 }
 

--- a/apps/server/src/honoAdapter.test.ts
+++ b/apps/server/src/honoAdapter.test.ts
@@ -3,6 +3,7 @@ import type { IncomingHttpHeaders } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { WebSocketServer } from 'ws';
+import { WebSocket } from 'ws';
 import { createHttpServer } from './honoAdapter';
 import type { ChamberCtx } from './types';
 
@@ -112,6 +113,35 @@ describe('createHttpServer', () => {
 
     expect(response.statusCode).toBe(400);
     expect(JSON.parse(response.body)).toEqual({ error: 'Privileged request body must be valid JSON.' });
+  });
+
+  it('accepts browser WebSocket auth via token query and fans out published chat events', async () => {
+    const { port } = await startServer({});
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/events?token=${TOKEN}`, {
+      headers: { origin: ORIGIN },
+    });
+
+    try {
+      await waitForOpen(ws);
+      const ready = waitForMessage(ws, (message) => message.type === 'subscription:ready');
+      ws.send(JSON.stringify({ type: 'subscribe', sessionId: 'assistant-1' }));
+      await ready;
+
+      currentServer?.publish('assistant-1', {
+        mindId: 'dude-1234',
+        messageId: 'assistant-1',
+        event: { type: 'done' },
+      });
+
+      const event = await waitForMessage(ws, (message) => message.type === 'chat:event');
+      expect(event.payload).toEqual({
+        mindId: 'dude-1234',
+        messageId: 'assistant-1',
+        event: { type: 'done' },
+      });
+    } finally {
+      ws.close();
+    }
   });
 });
 
@@ -232,4 +262,24 @@ async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> 
   } finally {
     if (timeout) clearTimeout(timeout);
   }
+}
+
+async function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return;
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+}
+
+async function waitForMessage(
+  ws: WebSocket,
+  predicate: (message: { type?: string; payload?: unknown }) => boolean,
+): Promise<{ type?: string; payload?: unknown }> {
+  return withTimeout(new Promise((resolve) => {
+    ws.on('message', (data) => {
+      const message = JSON.parse(String(data)) as { type?: string; payload?: unknown };
+      if (predicate(message)) resolve(message);
+    });
+  }), 'Timed out waiting for WebSocket message');
 }

--- a/apps/server/src/honoAdapter.test.ts
+++ b/apps/server/src/honoAdapter.test.ts
@@ -118,7 +118,7 @@ describe('createHttpServer', () => {
   it('accepts browser WebSocket auth via token query and fans out published chat events', async () => {
     const { port } = await startServer({});
     const ws = new WebSocket(`ws://127.0.0.1:${port}/events?token=${TOKEN}`, {
-      headers: { origin: ORIGIN },
+      headers: { origin: `${ORIGIN}:${port}` },
     });
 
     try {

--- a/apps/server/src/honoAdapter.ts
+++ b/apps/server/src/honoAdapter.ts
@@ -4,6 +4,7 @@ import { getRequestListener } from '@hono/node-server';
 import { createServer } from 'node:http';
 import { WebSocketServer } from 'ws';
 import {
+  addMindHandler,
   cancelChatHandler,
   getAuthStatusHandler,
   getConfigHandler,
@@ -12,14 +13,18 @@ import {
   listAuthAccountsHandler,
   listChamberToolsHandler,
   listLensViewsHandler,
+  listModelsHandler,
   listMindsHandler,
   logoutAuthHandler,
+  newConversationHandler,
+  sendChatHandler,
   switchAuthAccountHandler,
   uploadAttachmentHandler,
 } from './handlers';
 import { isAllowedOrigin, isAuthorized } from './auth';
 import type { ChamberCtx, ChamberRequest, ChamberResponse } from './types';
 import { parsePrivilegedRequest, PrivilegedProtocolError } from './privileged-protocol';
+import { WIRE_PROTOCOL_VERSION } from '@chamber/wire-contracts';
 
 function toRequest(c: Context): ChamberRequest {
   const url = new URL(c.req.url);
@@ -99,6 +104,11 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
   };
 
   app.get('/api/mind/list', authenticated(listMindsHandler));
+  app.post('/api/mind/add', async (c) => {
+    const authFailure = requireAuth(c, ctx);
+    if (authFailure) return authFailure;
+    return send(c, await addMindHandler(await toRequestWithBody(c), ctx));
+  });
   app.get('/api/config', authenticated(getConfigHandler));
   app.get('/api/lens/list', authenticated(listLensViewsHandler));
   app.get('/api/genesis/status', authenticated(getGenesisStatusHandler));
@@ -130,6 +140,17 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
     if (authFailure) return authFailure;
     return send(c, await cancelChatHandler(await toRequestWithBody(c), ctx));
   });
+  app.post('/api/chat/send', async (c) => {
+    const authFailure = requireAuth(c, ctx);
+    if (authFailure) return authFailure;
+    return send(c, await sendChatHandler(await toRequestWithBody(c), ctx));
+  });
+  app.post('/api/chat/new', async (c) => {
+    const authFailure = requireAuth(c, ctx);
+    if (authFailure) return authFailure;
+    return send(c, await newConversationHandler(await toRequestWithBody(c), ctx));
+  });
+  app.get('/api/chat/models', authenticated(listModelsHandler));
   app.post('/api/privileged', async (c) => {
     const authFailure = requireAuth(c, ctx);
     if (authFailure) return authFailure;
@@ -166,10 +187,22 @@ export function createHttpServer(ctx: ChamberCtx) {
   const app = createHonoApp(ctx);
   const server = createServer(getRequestListener((request) => app.fetch(request)));
   const wsServer = new WebSocketServer({ noServer: true });
+  const subscriptions = new Map<string, Set<import('ws').WebSocket>>();
+  const publish = (sessionId: string, event: unknown): void => {
+    ctx.publish?.(sessionId, event);
+    for (const ws of subscriptions.get(sessionId) ?? []) {
+      if (ws.readyState === ws.OPEN) {
+        ws.send(JSON.stringify({ version: WIRE_PROTOCOL_VERSION, type: 'chat:event', payload: event }));
+      }
+    }
+  };
 
   server.on('upgrade', (request, socket, head) => {
+    const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
     const origin = request.headers.origin ?? null;
-    const authorization = request.headers.authorization ?? null;
+    const authorization = request.headers.authorization ?? (
+      requestUrl.searchParams.has('token') ? `Bearer ${requestUrl.searchParams.get('token')}` : null
+    );
     if (!isAllowedOrigin(origin, ctx.allowedOrigins) || !isAuthorized(authorization, ctx.token)) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
       socket.destroy();
@@ -177,15 +210,26 @@ export function createHttpServer(ctx: ChamberCtx) {
     }
     wsServer.handleUpgrade(request, socket, head, (ws) => {
       ws.send(JSON.stringify({ type: 'hello', version: 1 }));
+      const subscribed = new Set<string>();
       ws.on('message', (data) => {
         const message = JSON.parse(data.toString()) as { type?: string; sessionId?: string; event?: unknown };
         if (message.type === 'subscribe' && message.sessionId) {
-          ctx.publish?.(message.sessionId, { type: 'subscribed' });
+          subscribed.add(message.sessionId);
+          const sockets = subscriptions.get(message.sessionId) ?? new Set();
+          sockets.add(ws);
+          subscriptions.set(message.sessionId, sockets);
           ws.send(JSON.stringify({ version: 1, type: 'subscription:ready', payload: { sessionId: message.sessionId } }));
+        }
+      });
+      ws.on('close', () => {
+        for (const sessionId of subscribed) {
+          const sockets = subscriptions.get(sessionId);
+          sockets?.delete(ws);
+          if (sockets?.size === 0) subscriptions.delete(sessionId);
         }
       });
     });
   });
 
-  return { server, wsServer };
+  return { server, wsServer, publish };
 }

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -59,7 +59,7 @@ export interface ChamberCtx {
   publish?: (sessionId: string, event: unknown) => void;
   validatePath?: (candidate: string) => boolean;
   saveAttachment?: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
-  cancelChat?: (sessionId: string) => Promise<void> | void;
+  cancelChat?: (mindId: string, messageId: string) => Promise<void> | void;
   sendChat?: (request: ServerSendChatRequest) => Promise<void> | void;
   newConversation?: (mindId: string) => Promise<void> | void;
   listModels?: (mindId?: string) => unknown[] | Promise<unknown[]>;

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -28,10 +28,25 @@ export interface ServerAuthLoginResult {
   error?: string;
 }
 
+export interface ServerChatAttachment {
+  name: string;
+  mimeType: string;
+  data: string;
+}
+
+export interface ServerSendChatRequest {
+  mindId: string;
+  message: string;
+  messageId: string;
+  model?: string;
+  attachments?: ServerChatAttachment[];
+}
+
 export interface ChamberCtx {
   token: string;
   allowedOrigins: ReadonlySet<string>;
   listMinds: () => unknown[];
+  addMind?: (mindPath: string) => unknown | Promise<unknown>;
   getConfig?: () => unknown | Promise<unknown>;
   listLensViews?: () => unknown | Promise<unknown>;
   getGenesisStatus?: () => unknown | Promise<unknown>;
@@ -45,6 +60,9 @@ export interface ChamberCtx {
   validatePath?: (candidate: string) => boolean;
   saveAttachment?: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
   cancelChat?: (sessionId: string) => Promise<void> | void;
+  sendChat?: (request: ServerSendChatRequest) => Promise<void> | void;
+  newConversation?: (mindId: string) => Promise<void> | void;
+  listModels?: (mindId?: string) => unknown[] | Promise<unknown[]>;
   shutdown?: () => void;
   handlePrivilegedRequest?: (request: PrivilegedRequest) => Promise<PrivilegedResponse>;
 }

--- a/apps/web/src/browserApi.test.ts
+++ b/apps/web/src/browserApi.test.ts
@@ -26,6 +26,7 @@ vi.mock('@chamber/client', () => ({
 
 class MockWebSocket extends EventTarget {
   static readonly OPEN = 1;
+  static acknowledgeSubscriptions = true;
   readyState = MockWebSocket.OPEN;
 
   constructor(url: URL) {
@@ -36,7 +37,7 @@ class MockWebSocket extends EventTarget {
 
   send(data: string): void {
     const message = JSON.parse(data) as { type?: string; sessionId?: string };
-    if (message.type === 'subscribe' && message.sessionId) {
+    if (MockWebSocket.acknowledgeSubscriptions && message.type === 'subscribe' && message.sessionId) {
       queueMicrotask(() => this.dispatchEvent(new MessageEvent('message', {
         data: JSON.stringify({ type: 'subscription:ready', payload: { sessionId: message.sessionId } }),
       })));
@@ -61,6 +62,7 @@ describe('installBrowserApi', () => {
     listMinds.mockResolvedValue([mind]);
     listModels.mockResolvedValue([{ id: 'claude-sonnet', name: 'Claude Sonnet' }]);
     startNewConversation.mockResolvedValue({ ok: true });
+    MockWebSocket.acknowledgeSubscriptions = true;
     vi.stubGlobal('WebSocket', MockWebSocket);
     Reflect.deleteProperty(window, 'electronAPI');
     const { installBrowserApi } = await import('./browserApi');
@@ -81,5 +83,25 @@ describe('installBrowserApi', () => {
       model: 'claude-sonnet',
       attachments: undefined,
     });
+  });
+
+  it('cancels chat with the requested mind id', async () => {
+    await window.electronAPI.chat.stop('dude-1234', 'assistant-1');
+    expect(cancelChat).toHaveBeenCalledWith('dude-1234', 'assistant-1');
+  });
+
+  it('rejects chat send when the event subscription is not acknowledged', async () => {
+    vi.useFakeTimers();
+    try {
+      MockWebSocket.acknowledgeSubscriptions = false;
+
+      const sendPromise = window.electronAPI.chat.send('dude-1234', 'Hello', 'assistant-1');
+      const rejection = expect(sendPromise).rejects.toThrow('Timed out waiting for Chamber event subscription.');
+      await vi.advanceTimersByTimeAsync(10_000);
+      await rejection;
+      expect(sendChat).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/browserApi.test.ts
+++ b/apps/web/src/browserApi.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MindContext } from './shared/types';
+
+const addMind = vi.fn();
+const sendChat = vi.fn();
+const cancelChat = vi.fn();
+const listMinds = vi.fn();
+const listModels = vi.fn();
+const startNewConversation = vi.fn();
+
+vi.mock('@chamber/client', () => ({
+  ChamberClient: vi.fn(function ChamberClient() {
+    return {
+    addMind,
+    sendChat,
+    cancelChat,
+    listMinds,
+    listModels,
+    startNewConversation,
+    };
+  }),
+}));
+
+class MockWebSocket extends EventTarget {
+  static readonly OPEN = 1;
+  readyState = MockWebSocket.OPEN;
+
+  constructor(url: URL) {
+    super();
+    void url;
+    queueMicrotask(() => this.dispatchEvent(new Event('open')));
+  }
+
+  send(data: string): void {
+    const message = JSON.parse(data) as { type?: string; sessionId?: string };
+    if (message.type === 'subscribe' && message.sessionId) {
+      queueMicrotask(() => this.dispatchEvent(new MessageEvent('message', {
+        data: JSON.stringify({ type: 'subscription:ready', payload: { sessionId: message.sessionId } }),
+      })));
+    }
+  }
+}
+
+describe('installBrowserApi', () => {
+  const mind: MindContext = {
+    mindId: 'dude-1234',
+    mindPath: 'C:\\agents\\dude',
+    identity: { name: 'Dude', systemMessage: '' },
+    status: 'ready',
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    addMind.mockResolvedValue(mind);
+    sendChat.mockResolvedValue({ ok: true });
+    cancelChat.mockResolvedValue({ ok: true });
+    listMinds.mockResolvedValue([mind]);
+    listModels.mockResolvedValue([{ id: 'claude-sonnet', name: 'Claude Sonnet' }]);
+    startNewConversation.mockResolvedValue({ ok: true });
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    Reflect.deleteProperty(window, 'electronAPI');
+    const { installBrowserApi } = await import('./browserApi');
+    installBrowserApi();
+  });
+
+  it('loads local minds through the loopback client', async () => {
+    await expect(window.electronAPI.mind.add('C:\\agents\\dude')).resolves.toBe(mind);
+    expect(addMind).toHaveBeenCalledWith('C:\\agents\\dude');
+  });
+
+  it('sends chat through the loopback client', async () => {
+    await window.electronAPI.chat.send('dude-1234', 'Hello', 'assistant-1', 'claude-sonnet');
+    expect(sendChat).toHaveBeenCalledWith({
+      mindId: 'dude-1234',
+      message: 'Hello',
+      messageId: 'assistant-1',
+      model: 'claude-sonnet',
+      attachments: undefined,
+    });
+  });
+});

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -32,6 +32,7 @@ export function installBrowserApi(): void {
 
   const client = createClient();
   const authProgressHandlers = new Set<(progress: AuthProgress) => void>();
+  const chatEventHandlers = new Set<Parameters<ElectronAPI['chat']['onEvent']>[0]>();
   const accountSwitchStartedHandlers = new Set<(data: { login: string }) => void>();
   const accountSwitchedHandlers = new Set<(data: { login: string }) => void>();
   const loggedOutHandlers = new Set<() => void>();
@@ -40,24 +41,84 @@ export function installBrowserApi(): void {
       handler(progress);
     }
   };
+  let eventSocket: WebSocket | null = null;
+  let openSocketPromise: Promise<WebSocket> | null = null;
+  const pendingSubscriptions = new Map<string, () => void>();
+  const openEventSocket = (): Promise<WebSocket> => {
+    if (eventSocket?.readyState === WebSocket.OPEN) return Promise.resolve(eventSocket);
+    if (openSocketPromise) return openSocketPromise;
+
+    const url = new URL('/events', window.location.origin);
+    url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    url.searchParams.set('token', new URLSearchParams(window.location.search).get('token') ?? '');
+
+    openSocketPromise = new Promise((resolve, reject) => {
+      const ws = new WebSocket(url);
+      eventSocket = ws;
+      ws.addEventListener('open', () => resolve(ws), { once: true });
+      ws.addEventListener('error', () => reject(new Error('Failed to open Chamber event socket.')), { once: true });
+      ws.addEventListener('message', (message) => {
+        const envelope = JSON.parse(String(message.data)) as { type?: string; payload?: unknown };
+        if (envelope.type === 'subscription:ready') {
+          const payload = envelope.payload as { sessionId?: string };
+          if (payload.sessionId) {
+            pendingSubscriptions.get(payload.sessionId)?.();
+            pendingSubscriptions.delete(payload.sessionId);
+          }
+          return;
+        }
+        if (envelope.type === 'chat:event') {
+          const payload = envelope.payload as {
+            mindId: string;
+            messageId: string;
+            event: Parameters<Parameters<ElectronAPI['chat']['onEvent']>[0]>[2];
+          };
+          for (const handler of chatEventHandlers) {
+            handler(payload.mindId, payload.messageId, payload.event);
+          }
+        }
+      });
+      ws.addEventListener('close', () => {
+        if (eventSocket === ws) eventSocket = null;
+        if (openSocketPromise) openSocketPromise = null;
+      });
+    });
+    return openSocketPromise;
+  };
+  const subscribeToChatEvents = async (messageId: string): Promise<void> => {
+    const ws = await openEventSocket();
+    await new Promise<void>((resolve) => {
+      pendingSubscriptions.set(messageId, resolve);
+      ws.send(JSON.stringify({ type: 'subscribe', sessionId: messageId }));
+    });
+  };
   const api: ElectronAPI = {
     chat: {
-      send: async () => undefined,
+      send: async (mindId, message, messageId, model, attachments) => {
+        await subscribeToChatEvents(messageId);
+        await client.sendChat({ mindId, message, messageId, model, attachments });
+      },
       stop: async (_mindId, messageId) => {
         await client.cancelChat(messageId);
       },
-      newConversation: async () => undefined,
-      listModels: async (): Promise<ModelInfo[]> => [],
-      onEvent: () => noopUnsubscribe,
+      newConversation: async (mindId) => {
+        await client.startNewConversation(mindId);
+      },
+      listModels: (): Promise<ModelInfo[]> => client.listModels(),
+      onEvent: (callback) => {
+        chatEventHandlers.add(callback);
+        void openEventSocket();
+        return () => {
+          chatEventHandlers.delete(callback);
+        };
+      },
     },
     mind: {
-      add: async (mindPath): Promise<MindContext> => {
-        throw new Error(`Adding minds is desktop-only in browser mode: ${mindPath}`);
-      },
+      add: (mindPath): Promise<MindContext> => client.addMind(mindPath) as Promise<MindContext>,
       remove: async () => undefined,
       list: () => client.listMinds() as Promise<MindContext[]>,
       setActive: async () => undefined,
-      selectDirectory: async () => null,
+      selectDirectory: async () => window.prompt('Enter a local agent folder path on this computer:')?.trim() || null,
       openWindow: async (mindId) => {
         window.open(`/?mindId=${encodeURIComponent(mindId)}`, '_blank', 'noopener,noreferrer');
       },

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -4,6 +4,7 @@ import type { AgentCard, ListTasksResponse, Task } from './shared/a2a-types';
 import type { ChatroomAPI, ChatroomMessage, TaskLedgerItem } from './shared/chatroom-types';
 
 const noopUnsubscribe = () => undefined;
+const SUBSCRIPTION_TIMEOUT_MS = 10_000;
 
 type AuthProgress = Parameters<ElectronAPI['auth']['onProgress']>[0] extends (progress: infer TProgress) => void
   ? TProgress
@@ -43,7 +44,11 @@ export function installBrowserApi(): void {
   };
   let eventSocket: WebSocket | null = null;
   let openSocketPromise: Promise<WebSocket> | null = null;
-  const pendingSubscriptions = new Map<string, () => void>();
+  const pendingSubscriptions = new Map<string, {
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>();
   const openEventSocket = (): Promise<WebSocket> => {
     if (eventSocket?.readyState === WebSocket.OPEN) return Promise.resolve(eventSocket);
     if (openSocketPromise) return openSocketPromise;
@@ -62,7 +67,11 @@ export function installBrowserApi(): void {
         if (envelope.type === 'subscription:ready') {
           const payload = envelope.payload as { sessionId?: string };
           if (payload.sessionId) {
-            pendingSubscriptions.get(payload.sessionId)?.();
+            const pending = pendingSubscriptions.get(payload.sessionId);
+            if (pending) {
+              clearTimeout(pending.timer);
+              pending.resolve();
+            }
             pendingSubscriptions.delete(payload.sessionId);
           }
           return;
@@ -81,15 +90,31 @@ export function installBrowserApi(): void {
       ws.addEventListener('close', () => {
         if (eventSocket === ws) eventSocket = null;
         if (openSocketPromise) openSocketPromise = null;
+        const error = new Error('Chamber event socket closed before subscription was ready.');
+        for (const [sessionId, pending] of pendingSubscriptions) {
+          clearTimeout(pending.timer);
+          pending.reject(error);
+          pendingSubscriptions.delete(sessionId);
+        }
       });
     });
     return openSocketPromise;
   };
   const subscribeToChatEvents = async (messageId: string): Promise<void> => {
     const ws = await openEventSocket();
-    await new Promise<void>((resolve) => {
-      pendingSubscriptions.set(messageId, resolve);
-      ws.send(JSON.stringify({ type: 'subscribe', sessionId: messageId }));
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingSubscriptions.delete(messageId);
+        reject(new Error('Timed out waiting for Chamber event subscription.'));
+      }, SUBSCRIPTION_TIMEOUT_MS);
+      pendingSubscriptions.set(messageId, { resolve, reject, timer });
+      try {
+        ws.send(JSON.stringify({ type: 'subscribe', sessionId: messageId }));
+      } catch (error) {
+        clearTimeout(timer);
+        pendingSubscriptions.delete(messageId);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
     });
   };
   const api: ElectronAPI = {
@@ -98,8 +123,8 @@ export function installBrowserApi(): void {
         await subscribeToChatEvents(messageId);
         await client.sendChat({ mindId, message, messageId, model, attachments });
       },
-      stop: async (_mindId, messageId) => {
-        await client.cancelChat(messageId);
+      stop: async (mindId, messageId) => {
+        await client.cancelChat(mindId, messageId);
       },
       newConversation: async (mindId) => {
         await client.startNewConversation(mindId);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': 'http://127.0.0.1:33441',
+      '/events': {
+        target: 'ws://127.0.0.1:33441',
+        ws: true,
+      },
       '/ws': {
         target: 'ws://127.0.0.1:33441',
         ws: true,

--- a/config/playwright.config.ts
+++ b/config/playwright.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,
       env: {
+        CHAMBER_E2E: '1',
+        CHAMBER_E2E_FAKE_CHAT: '1',
+        CHAMBER_E2E_FAKE_CHAT_REPLY: 'CHAMBER_BROWSER_LOOPBACK_ACK',
         CHAMBER_SERVER_PORT: '33441',
         CHAMBER_SERVER_TOKEN: 'e2e-token',
         CHAMBER_ALLOWED_ORIGIN: 'http://127.0.0.1:4173',

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
       "version": "0.31.0",
       "dependencies": {
         "@chamber/services": "file:../../packages/services",
+        "@chamber/wire-contracts": "file:../../packages/wire-contracts",
         "@hono/node-server": "^2.0.0",
         "hono": "^4.10.6",
         "keytar": "^7.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.31.5",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.31.5",
+      "version": "0.32.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "chamber",
-  "version": "0.31.5",
+  "version": "0.32.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChamberClient } from './index';
+
+describe('ChamberClient', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })));
+  });
+
+  it('loads a local mind path through the loopback server', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({
+      mind: { mindId: 'dude-1234', mindPath: 'C:\\agents\\dude', identity: { name: 'Dude', systemMessage: '' }, status: 'ready' },
+    }), { status: 200 }));
+    const client = new ChamberClient({ baseUrl: 'http://127.0.0.1:3000', token: 'token', origin: 'http://127.0.0.1' });
+
+    const mind = await client.addMind('C:\\agents\\dude');
+
+    expect(mind.mindId).toBe('dude-1234');
+    expect(fetch).toHaveBeenCalledWith(new URL('/api/mind/add', 'http://127.0.0.1:3000'), expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ mindPath: 'C:\\agents\\dude' }),
+    }));
+  });
+
+  it('sends chat through the loopback server', async () => {
+    const client = new ChamberClient({ baseUrl: 'http://127.0.0.1:3000', token: 'token', origin: 'http://127.0.0.1' });
+
+    await client.sendChat({ mindId: 'dude-1234', message: 'Hello', messageId: 'assistant-1' });
+
+    expect(fetch).toHaveBeenCalledWith(new URL('/api/chat/send', 'http://127.0.0.1:3000'), expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ mindId: 'dude-1234', message: 'Hello', messageId: 'assistant-1' }),
+    }));
+  });
+});

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -31,4 +31,22 @@ describe('ChamberClient', () => {
       body: JSON.stringify({ mindId: 'dude-1234', message: 'Hello', messageId: 'assistant-1' }),
     }));
   });
+
+  it('cancels chat with the target mind and message id', async () => {
+    const client = new ChamberClient({ baseUrl: 'http://127.0.0.1:3000', token: 'token', origin: 'http://127.0.0.1' });
+
+    await client.cancelChat('dude-1234', 'assistant-1');
+
+    expect(fetch).toHaveBeenCalledWith(new URL('/api/chat/cancel', 'http://127.0.0.1:3000'), expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ mindId: 'dude-1234', messageId: 'assistant-1' }),
+    }));
+  });
+
+  it('includes server error messages in thrown errors', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Invalid mind directory' }), { status: 400 }));
+    const client = new ChamberClient({ baseUrl: 'http://127.0.0.1:3000', token: 'token', origin: 'http://127.0.0.1' });
+
+    await expect(client.addMind('C:\\bad')).rejects.toThrow('Invalid mind directory');
+  });
 });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -125,8 +125,8 @@ export class ChamberClient {
     return readJson(response, 'upload attachment');
   }
 
-  async cancelChat(sessionId: string): Promise<CommandResponse> {
-    return this.post('/api/chat/cancel', { sessionId });
+  async cancelChat(mindId: string, messageId: string): Promise<CommandResponse> {
+    return this.post('/api/chat/cancel', { mindId, messageId });
   }
 
   async sendChat(request: SendChatRequest): Promise<CommandResponse> {
@@ -169,7 +169,17 @@ export class ChamberClient {
 
 async function readJson<TBody>(response: Response, operation: string): Promise<TBody> {
   if (!response.ok) {
-    throw new Error(`Failed to ${operation}: ${response.status}`);
+    const body = await response.text();
+    let message = body.trim();
+    try {
+      const parsed = JSON.parse(body) as { error?: unknown };
+      if (typeof parsed.error === 'string' && parsed.error.trim()) {
+        message = parsed.error;
+      }
+    } catch {
+      // Non-JSON response bodies are still useful as-is.
+    }
+    throw new Error(`Failed to ${operation}: ${response.status}${message ? ` - ${message}` : ''}`);
   }
   return response.json() as Promise<TBody>;
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,12 @@
-import type { CommandResponse, ListMindsResponse, MindDto } from '@chamber/wire-contracts';
+import type {
+  AddMindResponse,
+  CommandResponse,
+  ListModelsResponse,
+  ListMindsResponse,
+  MindDto,
+  ModelDto,
+  SendChatRequest,
+} from '@chamber/wire-contracts';
 
 export interface AuthProgressDto {
   step: string;
@@ -26,6 +34,11 @@ export class ChamberClient {
   async listMinds(): Promise<MindDto[]> {
     const body = await this.get<ListMindsResponse>('/api/mind/list');
     return body.minds;
+  }
+
+  async addMind(mindPath: string): Promise<MindDto> {
+    const body = await this.post<AddMindResponse>('/api/mind/add', { mindPath });
+    return body.mind;
   }
 
   async getConfig(): Promise<unknown> {
@@ -114,6 +127,20 @@ export class ChamberClient {
 
   async cancelChat(sessionId: string): Promise<CommandResponse> {
     return this.post('/api/chat/cancel', { sessionId });
+  }
+
+  async sendChat(request: SendChatRequest): Promise<CommandResponse> {
+    return this.post('/api/chat/send', request);
+  }
+
+  async startNewConversation(mindId: string): Promise<CommandResponse> {
+    return this.post('/api/chat/new', { mindId });
+  }
+
+  async listModels(mindId?: string): Promise<ModelDto[]> {
+    const query = mindId ? `?mindId=${encodeURIComponent(mindId)}` : '';
+    const body = await this.get<ListModelsResponse>(`/api/chat/models${query}`);
+    return body.models;
   }
 
   private async get<TBody = unknown>(path: string): Promise<TBody> {

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -16,6 +16,9 @@ const mockMindManager = {
     if (mindId === 'valid-mind') {
       return { session: mockSession, client: { listModels: vi.fn(async () => [{ id: 'm1', name: 'Model 1' }]) } };
     }
+    if (mindId === 'broken-models') {
+      return { session: mockSession, client: { listModels: vi.fn(async () => { throw new Error('model discovery failed'); }) } };
+    }
     return undefined;
   }),
   recreateSession: vi.fn(),
@@ -80,6 +83,10 @@ describe('ChatService', () => {
     it('returns empty array for invalid mind', async () => {
       const models = await svc.listModels('nonexistent');
       expect(models).toEqual([]);
+    });
+
+    it('surfaces model discovery failures', async () => {
+      await expect(svc.listModels('broken-models')).rejects.toThrow('model discovery failed');
     });
   });
 

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -207,17 +207,13 @@ export class ChatService {
   }
 
   async listModels(mindId: string): Promise<ModelInfo[]> {
-    try {
-      const context = this.mindManager.getMind(mindId);
-      if (!context?.client) return [];
-      // The SDK caches models forever per CopilotClient instance.
-      // Clear the cache so we always get a fresh list from the CLI.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (context.client as any).modelsCache = null;
-      const models = await context.client.listModels();
-      return models.map((m: { id: string; name: string }) => ({ id: m.id, name: m.name }));
-    } catch {
-      return [];
-    }
+    const context = this.mindManager.getMind(mindId);
+    if (!context?.client) return [];
+    // The SDK caches models forever per CopilotClient instance.
+    // Clear the cache so we always get a fresh list from the CLI.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (context.client as any).modelsCache = null;
+    const models = await context.client.listModels();
+    return models.map((m: { id: string; name: string }) => ({ id: m.id, name: m.name }));
   }
 }

--- a/packages/wire-contracts/src/index.ts
+++ b/packages/wire-contracts/src/index.ts
@@ -33,6 +33,41 @@ export interface ListMindsResponse {
   readonly minds: MindDto[];
 }
 
+export interface AddMindRequest {
+  readonly mindPath: string;
+}
+
+export interface AddMindResponse {
+  readonly mind: MindDto;
+}
+
+export interface ChatAttachmentDto {
+  readonly name: string;
+  readonly mimeType: string;
+  readonly data: string;
+}
+
+export interface SendChatRequest {
+  readonly mindId: string;
+  readonly message: string;
+  readonly messageId: string;
+  readonly model?: string;
+  readonly attachments?: ChatAttachmentDto[];
+}
+
+export interface NewConversationRequest {
+  readonly mindId: string;
+}
+
+export interface ModelDto {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface ListModelsResponse {
+  readonly models: ModelDto[];
+}
+
 export interface CommandResponse {
   readonly ok: true;
 }

--- a/packages/wire-contracts/src/index.ts
+++ b/packages/wire-contracts/src/index.ts
@@ -59,6 +59,11 @@ export interface NewConversationRequest {
   readonly mindId: string;
 }
 
+export interface CancelChatRequest {
+  readonly mindId: string;
+  readonly messageId: string;
+}
+
 export interface ModelDto {
   readonly id: string;
   readonly name: string;

--- a/tests/e2e/web/browser-loopback-chat.spec.ts
+++ b/tests/e2e/web/browser-loopback-chat.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const expectedReply = 'CHAMBER_BROWSER_LOOPBACK_ACK';
+
+test.describe('web browser loopback chat smoke', () => {
+  let root = '';
+  let mindPath = '';
+
+  test.beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-browser-chat-smoke-'));
+    mindPath = path.join(root, 'monica-browser');
+    seedBrowserMind(mindPath);
+  });
+
+  test.afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('adds a local mind and receives chat events over the loopback WebSocket', async ({ page }) => {
+    await page.goto('/?token=e2e-token');
+    await expect(page.locator('#root')).not.toBeEmpty();
+
+    const result = await page.evaluate(async ({ pathToMind, expected }) => {
+      const mind = await window.electronAPI.mind.add(pathToMind);
+      const messageId = `browser-loopback-smoke-${Date.now()}`;
+      const events: Array<{ type: string; content?: string; message?: string }> = [];
+      let assistantText = '';
+      let errorMessage = '';
+      let resolveTerminal: () => void = () => undefined;
+      const terminal = new Promise<void>((resolve) => {
+        resolveTerminal = resolve;
+      });
+      const unsubscribe = window.electronAPI.chat.onEvent((mindId, receivedMessageId, event) => {
+        if (mindId !== mind.mindId || receivedMessageId !== messageId) return;
+        events.push(event);
+        if (event.type === 'chunk' || event.type === 'message_final') {
+          assistantText += event.content;
+        }
+        if (event.type === 'error') {
+          errorMessage = event.message;
+          resolveTerminal();
+        }
+        if (event.type === 'done') {
+          resolveTerminal();
+        }
+      });
+
+      try {
+        const send = window.electronAPI.chat.send(
+          mind.mindId,
+          `This is a browser loopback smoke test. Reply with ${expected}.`,
+          messageId,
+        );
+        const timeout = new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('Timed out waiting for browser loopback chat events.')), 10_000);
+        });
+        await Promise.race([Promise.all([send, terminal]), timeout]);
+        return { mindName: mind.identity.name, assistantText, errorMessage, events };
+      } finally {
+        unsubscribe();
+      }
+    }, { pathToMind: mindPath, expected: expectedReply });
+
+    expect(result.mindName).toBe('monica-browser');
+    expect(result.errorMessage).toBe('');
+    expect(result.assistantText).toContain(expectedReply);
+    expect(result.events.some((event) => event.type === 'done')).toBe(true);
+  });
+});
+
+function seedBrowserMind(rootPath: string): void {
+  fs.mkdirSync(path.join(rootPath, '.github', 'agents'), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootPath, 'SOUL.md'),
+    [
+      '# Monica Browser',
+      '',
+      'A deterministic local mind used by the browser loopback chat smoke test.',
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(rootPath, '.github', 'agents', 'monica-browser.agent.md'),
+    [
+      '---',
+      'name: Monica Browser',
+      'description: Browser loopback smoke-test persona',
+      '---',
+      '',
+      '# Monica Browser Agent',
+      '',
+      'Exercise the browser loopback transport without requiring a live model turn.',
+      '',
+    ].join('\n'),
+  );
+}


### PR DESCRIPTION
## Summary
Brings browser mode closer to local agent chat parity by routing local mind loading and chat turns through the loopback server, real server-side services, and a browser-safe event WebSocket.

## Notable changes
- Adds wire contracts and `@chamber/client` methods for local mind loading, chat send/cancel/new conversation, and model listing.
- Adds authenticated loopback server routes for mind add, chat send/cancel/new conversation, and model listing.
- Composes real `MindManager` and `ChatService` in the standalone server process, including cleanup on shutdown.
- Replaces browser API stubs for local mind add and chat with loopback client calls plus per-message WebSocket subscriptions.
- Hardens WebSocket subscription timeout/error handling, loopback origin matching, cancel targeting by mind ID, and API error messages.
- Fixes web smoke server path resolution from the Playwright config cwd.
- Adds changelog and minor version bump for v0.32.0.

Closes #135

## Tests
- `npm test -- apps/server/src/handlers.test.ts apps/server/src/honoAdapter.test.ts packages/client/src/index.test.ts apps/web/src/browserApi.test.ts`
- `npm test -- apps/server/src/handlers.test.ts apps/server/src/honoAdapter.test.ts packages/client/src/index.test.ts apps/web/src/browserApi.test.ts packages/services/src/chat/ChatService.test.ts`
- `npm run lint`
- `npm test`
- `npm run packaged:smoke`
- `npm run test:server-sdk-smoke`
- `npm run test:ui:web`