### PR TITLE
fix: recover Copilot runtime promotion on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.32.2 (2026-04-27)
+
+### Release packaging
+
+- **Recover Copilot runtime promotion on Windows** — release packaging now falls back to copying the staged Copilot runtime when Windows refuses the final directory rename with `EPERM`, preventing the Forge prePackage hook from failing on release runners.
+
 ## v0.32.1 (2026-04-27)
 
 ### Windows packaging

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/scripts/prepare-copilot-runtime.js
+++ b/scripts/prepare-copilot-runtime.js
@@ -225,29 +225,47 @@ function smokeTestRuntime(binaryPath, expectedCliVersion) {
   }
 }
 
-function promoteRuntime() {
-  fs.rmSync(backupDir, { recursive: true, force: true });
+function isRecoverableRenameError(error) {
+  return error
+    && typeof error === 'object'
+    && (error.code === 'EPERM' || error.code === 'EXDEV');
+}
+
+function promoteDirectory(dirs, fsImpl = fs) {
+  fsImpl.rmSync(dirs.backupDir, { recursive: true, force: true });
 
   let movedExistingTarget = false;
   try {
-    if (fs.existsSync(targetDir)) {
-      fs.renameSync(targetDir, backupDir);
+    if (fsImpl.existsSync(dirs.targetDir)) {
+      fsImpl.renameSync(dirs.targetDir, dirs.backupDir);
       movedExistingTarget = true;
     }
 
-    fs.renameSync(stagingDir, targetDir);
-    fs.rmSync(backupDir, { recursive: true, force: true });
-  } catch (error) {
-    if (fs.existsSync(targetDir)) {
-      fs.rmSync(targetDir, { recursive: true, force: true });
+    try {
+      fsImpl.renameSync(dirs.stagingDir, dirs.targetDir);
+    } catch (error) {
+      if (!isRecoverableRenameError(error)) {
+        throw error;
+      }
+      fsImpl.rmSync(dirs.targetDir, { recursive: true, force: true });
+      fsImpl.cpSync(dirs.stagingDir, dirs.targetDir, { recursive: true });
     }
-    if (movedExistingTarget && fs.existsSync(backupDir)) {
-      fs.renameSync(backupDir, targetDir);
+    fsImpl.rmSync(dirs.backupDir, { recursive: true, force: true });
+  } catch (error) {
+    if (fsImpl.existsSync(dirs.targetDir)) {
+      fsImpl.rmSync(dirs.targetDir, { recursive: true, force: true });
+    }
+    if (movedExistingTarget && fsImpl.existsSync(dirs.backupDir)) {
+      fsImpl.renameSync(dirs.backupDir, dirs.targetDir);
     }
     throw error;
   } finally {
-    fs.rmSync(stagingDir, { recursive: true, force: true });
+    fsImpl.rmSync(dirs.stagingDir, { recursive: true, force: true });
   }
+}
+
+function promoteRuntime() {
+  promoteDirectory({ stagingDir, targetDir, backupDir });
 }
 
 function prepareCopilotRuntime({ targetPlatform, targetArch }) {
@@ -331,6 +349,7 @@ module.exports = {
   getPlatformBinaryPath,
   getPlatformPackageName,
   prepareCopilotRuntime,
+  promoteDirectory,
   readRequiredVersions,
   validateRuntimeDir,
 };

--- a/tests/regression/prepare-copilot-runtime.test.ts
+++ b/tests/regression/prepare-copilot-runtime.test.ts
@@ -1,13 +1,24 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 async function loadPrepareRuntime(): Promise<{
   assertHostMatchesTarget: (platform: string, arch: string) => void;
   getPlatformPackageName: (platform: string, arch: string) => string;
+  promoteDirectory: (
+    dirs: { stagingDir: string; targetDir: string; backupDir: string },
+    fsImpl?: typeof fs,
+  ) => void;
 }> {
   const module = await import('../../scripts/prepare-copilot-runtime.js');
   return ('default' in module ? module.default : module) as {
     assertHostMatchesTarget: (platform: string, arch: string) => void;
     getPlatformPackageName: (platform: string, arch: string) => string;
+    promoteDirectory: (
+      dirs: { stagingDir: string; targetDir: string; backupDir: string },
+      fsImpl?: typeof fs,
+    ) => void;
   };
 }
 
@@ -29,5 +40,34 @@ describe('prepare-copilot-runtime', () => {
     expect(() => assertHostMatchesTarget(otherPlatform, process.arch)).toThrow(
       'Cross-compiling the Copilot runtime is unsupported.'
     );
+  });
+
+  it('falls back to copying the staged runtime when Windows refuses directory promotion', async () => {
+    const { promoteDirectory } = await loadPrepareRuntime();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-copilot-runtime-promote-'));
+    const stagingDir = path.join(root, 'copilot-runtime.new');
+    const targetDir = path.join(root, 'copilot-runtime');
+    const backupDir = path.join(root, 'copilot-runtime.old');
+    fs.mkdirSync(path.join(stagingDir, 'node_modules', '@github'), { recursive: true });
+    fs.writeFileSync(path.join(stagingDir, 'node_modules', '@github', 'sentinel.txt'), 'ready');
+    const fsWithLockedRename = {
+      ...fs,
+      renameSync: (oldPath: fs.PathLike, newPath: fs.PathLike) => {
+        if (String(oldPath) === stagingDir && String(newPath) === targetDir) {
+          throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' });
+        }
+        return fs.renameSync(oldPath, newPath);
+      },
+    } as typeof fs;
+
+    try {
+      promoteDirectory({ stagingDir, targetDir, backupDir }, fsWithLockedRename);
+
+      expect(fs.readFileSync(path.join(targetDir, 'node_modules', '@github', 'sentinel.txt'), 'utf-8')).toBe('ready');
+      expect(fs.existsSync(stagingDir)).toBe(false);
+      expect(fs.existsSync(backupDir)).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes the release packaging failure where Windows runners can return EPERM while promoting the staged Copilot runtime directory.\n\nChanges:\n- Fall back to copying the staged Copilot runtime when the final directory rename fails with EPERM or EXDEV.\n- Add a regression test that simulates the Windows rename failure.\n- Bump Chamber to v0.32.2 with a changelog entry.\n\nValidation:\n- npx vitest run --config config\\vitest.config.ts tests\\regression\\prepare-copilot-runtime.test.ts\n- npm run lint\n- npm test\n- npm run make