### PR TITLE
fix: keep emoji shortcode suggestions visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.32.3 (2026-04-27)
+
+### Chat input
+
+- **Keep emoji shortcode suggestions visible** — shortcode autocomplete now flips above the caret near the bottom edge and clamps within the viewport so suggestions are not clipped. (#157)
+
 ## v0.32.2 (2026-04-27)
 
 ### Release packaging

--- a/apps/web/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.test.tsx
@@ -1,11 +1,15 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ChatInput } from './ChatInput';
 import type { ModelInfo } from '../../../shared/types';
+
+const caretCoords = vi.hoisted(() => ({
+  current: { top: 100, left: 50, height: 16 },
+}));
 
 // jsdom does not provide ResizeObserver; cmdk needs it.
 class MockResizeObserver {
@@ -23,7 +27,7 @@ if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
 // Stub the textarea-caret util — jsdom returns 0 for layout, so we provide
 // stable coordinates that the tests can assert against.
 vi.mock('../../lib/textarea-caret', () => ({
-  getTextareaCaretCoords: () => ({ top: 100, left: 50, height: 16 }),
+  getTextareaCaretCoords: () => caretCoords.current,
 }));
 
 const defaultProps = {
@@ -134,6 +138,12 @@ describe('ChatInput', () => {
   });
 
   describe(':shortcode autocomplete', () => {
+    afterEach(() => {
+      caretCoords.current = { top: 100, left: 50, height: 16 };
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    });
+
     function typeWithCaret(textarea: HTMLTextAreaElement, value: string) {
       // Set caret at the end of the new value so detection sees the trailing token.
       Object.defineProperty(textarea, 'selectionStart', { configurable: true, value: value.length });
@@ -150,6 +160,17 @@ describe('ChatInput', () => {
       const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
       typeWithCaret(ta, ':sm');
       await expectShortcodeOpen();
+    });
+
+    it('opens shortcode suggestions above the caret when the bottom viewport edge would clip them', async () => {
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 180 });
+      caretCoords.current = { top: 150, left: 50, height: 16 };
+      render(<ChatInput {...defaultProps} />);
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+      typeWithCaret(ta, ':sm');
+      const popover = await expectShortcodeOpen();
+      expect(popover.style.top).toBe('8px');
+      expect(popover.getAttribute('data-side')).toBe('top');
     });
 
     it('does not open for ":" alone', () => {

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -39,6 +39,10 @@ interface Props {
 }
 
 const IMAGE_TOKEN_RE = /\[📷 ([^\]]+)\]/g;
+const SHORTCODE_POPOVER_GAP = 4;
+const SHORTCODE_POPOVER_MARGIN = 8;
+const SHORTCODE_POPOVER_MAX_HEIGHT = 240;
+const SHORTCODE_POPOVER_MIN_WIDTH = 220;
 
 // Boundary-aware shortcode detector. Matches a `:foo` token at the caret
 // where:
@@ -52,6 +56,17 @@ interface ShortcodeMatch {
   start: number;
   /** Query text minus the leading colon. */
   query: string;
+}
+
+interface ShortcodeAnchor {
+  top: number;
+  left: number;
+  height: number;
+}
+
+interface ShortcodePopoverPlacement {
+  side: 'top' | 'bottom';
+  style: React.CSSProperties;
 }
 
 function detectShortcode(text: string, caret: number): ShortcodeMatch | null {
@@ -101,6 +116,35 @@ function readAsBase64(file: Blob): Promise<string> {
   });
 }
 
+function getShortcodePopoverPlacement(anchor: ShortcodeAnchor): ShortcodePopoverPlacement {
+  const viewportHeight = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerHeight;
+  const viewportWidth = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerWidth;
+  const maxHeight = Math.min(
+    SHORTCODE_POPOVER_MAX_HEIGHT,
+    Math.max(0, viewportHeight - SHORTCODE_POPOVER_MARGIN * 2),
+  );
+  const bottomTop = anchor.top + anchor.height + SHORTCODE_POPOVER_GAP;
+  const wouldClipBottom = bottomTop + maxHeight > viewportHeight - SHORTCODE_POPOVER_MARGIN;
+  const top = wouldClipBottom
+    ? Math.max(SHORTCODE_POPOVER_MARGIN, anchor.top - maxHeight - SHORTCODE_POPOVER_GAP)
+    : bottomTop;
+  const left = Math.min(
+    Math.max(SHORTCODE_POPOVER_MARGIN, anchor.left),
+    Math.max(SHORTCODE_POPOVER_MARGIN, viewportWidth - SHORTCODE_POPOVER_MIN_WIDTH - SHORTCODE_POPOVER_MARGIN),
+  );
+
+  return {
+    side: wouldClipBottom ? 'top' : 'bottom',
+    style: {
+      position: 'fixed',
+      top,
+      left,
+      zIndex: 60,
+      maxHeight,
+    },
+  };
+}
+
 export function ChatInput({ onSend, onStop, isStreaming, disabled, availableModels, selectedModel, onModelChange, placeholder }: Props) {
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<ChatImageAttachment[]>([]);
@@ -108,7 +152,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   const [shortcodeMatch, setShortcodeMatch] = useState<ShortcodeMatch | null>(null);
   const [shortcodeResults, setShortcodeResults] = useState<EmojiRecord[]>([]);
   const [shortcodeIndex, setShortcodeIndex] = useState(0);
-  const [shortcodeAnchor, setShortcodeAnchor] = useState<{ top: number; left: number; height: number } | null>(null);
+  const [shortcodeAnchor, setShortcodeAnchor] = useState<ShortcodeAnchor | null>(null);
   const isComposingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const pastedSeq = useRef(0);
@@ -353,6 +397,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   };
 
   const canSubmit = (input.trim().length > 0 || attachments.length > 0) && !disabled;
+  const shortcodePopoverPlacement = shortcodeAnchor
+    ? getShortcodePopoverPlacement(shortcodeAnchor)
+    : null;
 
   return (
     <div className="border-t border-border px-4 py-3">
@@ -475,13 +522,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
               role="listbox"
               aria-label="Emoji shortcode suggestions"
               data-testid="shortcode-popover"
-              style={{
-                position: 'fixed',
-                top: shortcodeAnchor.top + shortcodeAnchor.height + 4,
-                left: shortcodeAnchor.left,
-                zIndex: 60,
-              }}
-              className="min-w-[220px] rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
+              data-side={shortcodePopoverPlacement?.side}
+              style={shortcodePopoverPlacement?.style}
+              className="min-w-[220px] overflow-hidden rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
             >
               <Command shouldFilter={false}>
                 <CommandList>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.32.2",
+      "version": "0.32.3",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary
Keeps emoji shortcode autocomplete suggestions visible when the chat composer is near the bottom of the viewport.

## Notable changes
- Adds viewport-aware placement for the shortcode suggestions popover so it flips above the caret before clipping at the bottom edge.
- Clamps the suggestions menu within viewport margins and keeps it portaled outside clipped composer containers.
- Adds a regression test for bottom-edge placement.

Closes #157

## Testing
- npm run lint
- npm test