### PR TITLE
fix: surface browser-only write action errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.32.4 (2026-04-27)
+
+### Browser mode
+
+- **Surface unsupported write actions** — browser fallback APIs now throw explicit `Not available in browser mode` errors for unsupported write operations instead of silently resolving no-ops, while subscription handlers still return no-op unsubscribe functions. (#143)
+
 ## v0.32.3 (2026-04-27)
 
 ### Chat input

--- a/apps/web/src/browserApi.test.ts
+++ b/apps/web/src/browserApi.test.ts
@@ -104,4 +104,50 @@ describe('installBrowserApi', () => {
       vi.useRealTimers();
     }
   });
+
+  it('rejects browser-mode write APIs that cannot be executed without the desktop shell', async () => {
+    await expect(window.electronAPI.mind.remove('dude-1234')).rejects.toThrow(
+      'Not available in browser mode',
+    );
+    await expect(window.electronAPI.mind.setActive('dude-1234')).rejects.toThrow(
+      'Not available in browser mode',
+    );
+    await expect(window.electronAPI.lens.sendAction('view-1', 'save')).rejects.toThrow(
+      'Not available in browser mode',
+    );
+    await expect(window.electronAPI.chatroom.send('hello')).rejects.toThrow(
+      'Not available in browser mode',
+    );
+    await expect(window.electronAPI.chatroom.clear()).rejects.toThrow(
+      'Not available in browser mode',
+    );
+    await expect(window.electronAPI.chatroom.stop()).rejects.toThrow(
+      'Not available in browser mode',
+    );
+    await expect(window.electronAPI.chatroom.setOrchestration('concurrent')).rejects.toThrow(
+      'Not available in browser mode',
+    );
+  });
+
+  it('throws explicit unavailable errors for browser window controls', () => {
+    expect(() => window.electronAPI.window.minimize()).toThrow('Not available in browser mode');
+    expect(() => window.electronAPI.window.maximize()).toThrow('Not available in browser mode');
+  });
+
+  it('keeps browser-mode subscription APIs as no-op unsubscribe functions', () => {
+    const unsubscribes = [
+      window.electronAPI.mind.onMindChanged(() => undefined),
+      window.electronAPI.lens.onViewsChanged(() => undefined),
+      window.electronAPI.genesis.onProgress(() => undefined),
+      window.electronAPI.a2a.onIncoming(() => undefined),
+      window.electronAPI.a2a.onTaskStatusUpdate(() => undefined),
+      window.electronAPI.a2a.onTaskArtifactUpdate(() => undefined),
+      window.electronAPI.chatroom.onEvent(() => undefined),
+    ];
+
+    for (const unsubscribe of unsubscribes) {
+      expect(typeof unsubscribe).toBe('function');
+      expect(unsubscribe()).toBeUndefined();
+    }
+  });
 });

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -6,6 +6,10 @@ import type { ChatroomAPI, ChatroomMessage, TaskLedgerItem } from './shared/chat
 const noopUnsubscribe = () => undefined;
 const SUBSCRIPTION_TIMEOUT_MS = 10_000;
 
+function unavailable(operation: string): never {
+  throw new Error(`Not available in browser mode: ${operation}.`);
+}
+
 type AuthProgress = Parameters<ElectronAPI['auth']['onProgress']>[0] extends (progress: infer TProgress) => void
   ? TProgress
   : never;
@@ -17,12 +21,12 @@ function createClient(): ChamberClient {
 
 function createBrowserChatroomApi(): ChatroomAPI {
   return {
-    send: async () => undefined,
+    send: async () => unavailable('chatroom send'),
     history: async (): Promise<ChatroomMessage[]> => [],
     taskLedger: async (): Promise<TaskLedgerItem[]> => [],
-    clear: async () => undefined,
-    stop: async () => undefined,
-    setOrchestration: async () => undefined,
+    clear: async () => unavailable('chatroom clear'),
+    stop: async () => unavailable('chatroom stop'),
+    setOrchestration: async () => unavailable('chatroom orchestration changes'),
     getOrchestration: async () => ({ mode: 'concurrent', config: null }),
     onEvent: () => noopUnsubscribe,
   };
@@ -140,9 +144,9 @@ export function installBrowserApi(): void {
     },
     mind: {
       add: (mindPath): Promise<MindContext> => client.addMind(mindPath) as Promise<MindContext>,
-      remove: async () => undefined,
+      remove: async () => unavailable('mind removal'),
       list: () => client.listMinds() as Promise<MindContext[]>,
-      setActive: async () => undefined,
+      setActive: async () => unavailable('active mind changes'),
       selectDirectory: async () => window.prompt('Enter a local agent folder path on this computer:')?.trim() || null,
       openWindow: async (mindId) => {
         window.open(`/?mindId=${encodeURIComponent(mindId)}`, '_blank', 'noopener,noreferrer');
@@ -153,7 +157,7 @@ export function installBrowserApi(): void {
       getViews: async (): Promise<LensViewManifest[]> => [],
       getViewData: async () => null,
       refreshView: async () => null,
-      sendAction: async () => null,
+      sendAction: async () => unavailable('Lens write actions'),
       onViewsChanged: () => noopUnsubscribe,
     },
     auth: {
@@ -225,8 +229,8 @@ export function installBrowserApi(): void {
       cancelTask: async (taskId) => ({ error: `Task cancellation is unavailable in browser mode: ${taskId}` }),
     },
     window: {
-      minimize: () => undefined,
-      maximize: () => undefined,
+      minimize: () => unavailable('window minimize'),
+      maximize: () => unavailable('window maximize'),
       close: () => window.close(),
     },
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.32.3",
+      "version": "0.32.4",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary
Makes unsupported browser-mode write actions fail explicitly instead of silently reporting success.

## Notable changes
- Adds a shared unavailable-error path for browser fallback APIs that cannot run without the desktop shell.
- Rejects unsupported mind, Lens, and chatroom write operations with `Not available in browser mode` errors.
- Keeps subscription APIs returning no-op unsubscribe functions and covers both behaviors with browser API tests.

Closes #143

## Testing
- npm run lint
- npm test