### PR TITLE
feat: install Genesis mind templates from marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.33.0 (2026-04-27)
+
+### Genesis marketplace templates
+
+- **Install predefined Genesis minds from templates** — Genesis onboarding can now discover marketplace-backed mind templates, install predefined minds such as Lucy without live SDK generation, and surface hard failures instead of silently falling back to generated creation. (#162)
+
 ## v0.32.4 (2026-04-27)
 
 ### Browser mode

--- a/apps/desktop/src/main/ipc/genesis.test.ts
+++ b/apps/desktop/src/main/ipc/genesis.test.ts
@@ -69,6 +69,8 @@ describe('setupGenesisIPC', () => {
   it('installs a predefined template and activates the loaded mind', async () => {
     const mindManager = createMindManager();
     const installer = createInstaller();
+    const mockSend = vi.fn();
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue({ webContents: { send: mockSend } } as never);
     setupGenesisIPC(mindManager, createScaffold(), createCatalog(), installer);
 
     await expect(getHandler('genesis:createFromTemplate')(EVT, { templateId: 'lucy', basePath: 'C:\\agents' })).resolves.toEqual({
@@ -80,6 +82,7 @@ describe('setupGenesisIPC', () => {
     expect(installer.install).toHaveBeenCalledWith({ templateId: 'lucy', basePath: 'C:\\agents' });
     expect(mindManager.loadMind).toHaveBeenCalledWith('C:\\agents\\lucy');
     expect(mindManager.setActiveMind).toHaveBeenCalledWith('lucy-1234');
+    expect(mockSend).toHaveBeenCalledWith('genesis:progress', { step: 'complete', detail: 'Genesis template install complete.' });
   });
 
   it('returns a clear error when predefined template install fails without generating a custom mind', async () => {

--- a/apps/desktop/src/main/ipc/genesis.test.ts
+++ b/apps/desktop/src/main/ipc/genesis.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  dialog: { showOpenDialog: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+}));
+
+vi.mock('@chamber/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@chamber/services')>();
+  return {
+    ...actual,
+    seedLensDefaults: vi.fn(),
+    installLensSkill: vi.fn(),
+  };
+});
+
+import { ipcMain, BrowserWindow } from 'electron';
+import type { IpcMainInvokeEvent } from 'electron';
+import { setupGenesisIPC } from './genesis';
+import type { GenesisMindTemplate, MindManager, MindScaffold } from '@chamber/services';
+
+type InvokeHandler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
+
+const EVT = { sender: {} } as IpcMainInvokeEvent;
+
+const lucyTemplate: GenesisMindTemplate = {
+  id: 'lucy',
+  displayName: 'Lucy',
+  description: 'A calm Chief of Staff mind.',
+  role: 'Chief of Staff',
+  voice: 'Vanilla, calm, helpful, and precise',
+  templateVersion: '0.1.0',
+  agent: '.github/agents/lucy.agent.md',
+  requiredFiles: ['SOUL.md'],
+  source: {
+    owner: 'ianphil',
+    repo: 'genesis-minds',
+    ref: 'master',
+    plugin: 'genesis-minds',
+    manifestPath: 'plugins/genesis-minds/minds/lucy/mind.json',
+    rootPath: 'plugins/genesis-minds/minds/lucy',
+  },
+};
+
+describe('setupGenesisIPC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue({ webContents: { send: vi.fn() } } as never);
+  });
+
+  it('registers template listing and install handlers', () => {
+    setupGenesisIPC(createMindManager(), createScaffold(), createCatalog(), createInstaller());
+
+    const channels = vi.mocked(ipcMain.handle).mock.calls.map((call) => call[0]);
+
+    expect(channels).toContain('genesis:listTemplates');
+    expect(channels).toContain('genesis:createFromTemplate');
+  });
+
+  it('lists predefined templates from the catalog', async () => {
+    const catalog = createCatalog();
+    setupGenesisIPC(createMindManager(), createScaffold(), catalog, createInstaller());
+
+    await expect(getHandler('genesis:listTemplates')(EVT)).resolves.toEqual([lucyTemplate]);
+    expect(catalog.listTemplates).toHaveBeenCalled();
+  });
+
+  it('installs a predefined template and activates the loaded mind', async () => {
+    const mindManager = createMindManager();
+    const installer = createInstaller();
+    setupGenesisIPC(mindManager, createScaffold(), createCatalog(), installer);
+
+    await expect(getHandler('genesis:createFromTemplate')(EVT, { templateId: 'lucy', basePath: 'C:\\agents' })).resolves.toEqual({
+      success: true,
+      mindId: 'lucy-1234',
+      mindPath: 'C:\\agents\\lucy',
+    });
+
+    expect(installer.install).toHaveBeenCalledWith({ templateId: 'lucy', basePath: 'C:\\agents' });
+    expect(mindManager.loadMind).toHaveBeenCalledWith('C:\\agents\\lucy');
+    expect(mindManager.setActiveMind).toHaveBeenCalledWith('lucy-1234');
+  });
+
+  it('returns a clear error when predefined template install fails without generating a custom mind', async () => {
+    const scaffold = createScaffold();
+    const installer = createInstaller();
+    installer.install.mockRejectedValue(new Error('marketplace unavailable'));
+    setupGenesisIPC(createMindManager(), scaffold, createCatalog(), installer);
+
+    await expect(getHandler('genesis:createFromTemplate')(EVT, { templateId: 'lucy', basePath: 'C:\\agents' })).resolves.toEqual({
+      success: false,
+      error: 'marketplace unavailable',
+    });
+
+    expect(scaffold.create).not.toHaveBeenCalled();
+  });
+});
+
+function getHandler(name: string): InvokeHandler {
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((item) => item[0] === name);
+  if (!call) throw new Error(`no handler registered for ${name}`);
+  return call[1] as InvokeHandler;
+}
+
+function createMindManager(): MindManager & {
+  loadMind: ReturnType<typeof vi.fn>;
+  setActiveMind: ReturnType<typeof vi.fn>;
+} {
+  return {
+    loadMind: vi.fn().mockResolvedValue({ mindId: 'lucy-1234' }),
+    setActiveMind: vi.fn(),
+  } as unknown as MindManager & { loadMind: ReturnType<typeof vi.fn>; setActiveMind: ReturnType<typeof vi.fn> };
+}
+
+function createScaffold(): MindScaffold & {
+  create: ReturnType<typeof vi.fn>;
+  setProgressHandler: ReturnType<typeof vi.fn>;
+} {
+  return {
+    create: vi.fn(),
+    setProgressHandler: vi.fn(),
+  } as unknown as MindScaffold & { create: ReturnType<typeof vi.fn>; setProgressHandler: ReturnType<typeof vi.fn> };
+}
+
+function createCatalog() {
+  return {
+    listTemplates: vi.fn(() => [lucyTemplate]),
+  };
+}
+
+function createInstaller() {
+  return {
+    install: vi.fn().mockResolvedValue('C:\\agents\\lucy'),
+  };
+}

--- a/apps/desktop/src/main/ipc/genesis.ts
+++ b/apps/desktop/src/main/ipc/genesis.ts
@@ -74,7 +74,9 @@ export function setupGenesisIPC(
     try {
       if (win) win.webContents.send('genesis:progress', { step: 'template', detail: 'Installing Genesis mind template...' });
       const mindPath = await templateInstaller.install(request);
-      return await activateCreatedMind(mindManager, mindPath);
+      const result = await activateCreatedMind(mindManager, mindPath);
+      if (win) win.webContents.send('genesis:progress', { step: 'complete', detail: 'Genesis template install complete.' });
+      return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (win) win.webContents.send('genesis:progress', { step: 'error', detail: message });

--- a/apps/desktop/src/main/ipc/genesis.ts
+++ b/apps/desktop/src/main/ipc/genesis.ts
@@ -2,11 +2,31 @@
 import { ipcMain, dialog, BrowserWindow } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { MindManager, MindScaffold, installLensSkill, seedLensDefaults, type GenesisConfig } from '@chamber/services';
+import {
+  GenesisMindTemplateCatalog,
+  GenesisMindTemplateInstaller,
+  MindManager,
+  MindScaffold,
+  installLensSkill,
+  seedLensDefaults,
+  type GenesisConfig,
+  type GenesisMindTemplate,
+  type GenesisMindTemplateInstallRequest,
+} from '@chamber/services';
+
+interface GenesisMindTemplateCatalogPort {
+  listTemplates(): GenesisMindTemplate[];
+}
+
+interface GenesisMindTemplateInstallerPort {
+  install(request: GenesisMindTemplateInstallRequest): Promise<string>;
+}
 
 export function setupGenesisIPC(
   mindManager: MindManager,
   scaffold: MindScaffold,
+  templateCatalog: GenesisMindTemplateCatalogPort = new GenesisMindTemplateCatalog(),
+  templateInstaller: GenesisMindTemplateInstallerPort = new GenesisMindTemplateInstaller(),
 ): void {
 
   ipcMain.handle('genesis:getDefaultPath', async () => {
@@ -27,6 +47,10 @@ export function setupGenesisIPC(
     return result.filePaths[0];
   });
 
+  ipcMain.handle('genesis:listTemplates', async () => {
+    return templateCatalog.listTemplates();
+  });
+
   ipcMain.handle('genesis:create', async (event, config: GenesisConfig) => {
     const win = BrowserWindow.fromWebContents(event.sender);
 
@@ -36,23 +60,38 @@ export function setupGenesisIPC(
 
     try {
       const mindPath = await scaffold.create(config);
-      appendE2EGenesisMemory(mindPath);
-
-      // Bootstrap Lens defaults
-      seedLensDefaults(mindPath);
-      installLensSkill(mindPath);
-
-      // Load into MindManager (creates client, session, scans views)
-      const mind = await mindManager.loadMind(mindPath);
-      mindManager.setActiveMind(mind.mindId);
-
-      return { success: true, mindId: mind.mindId, mindPath };
+      return await activateCreatedMind(mindManager, mindPath);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (win) win.webContents.send('genesis:progress', { step: 'error', detail: message });
       return { success: false, error: message };
     }
   });
+
+  ipcMain.handle('genesis:createFromTemplate', async (event, request: GenesisMindTemplateInstallRequest) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+
+    try {
+      if (win) win.webContents.send('genesis:progress', { step: 'template', detail: 'Installing Genesis mind template...' });
+      const mindPath = await templateInstaller.install(request);
+      return await activateCreatedMind(mindManager, mindPath);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (win) win.webContents.send('genesis:progress', { step: 'error', detail: message });
+      return { success: false, error: message };
+    }
+  });
+}
+
+async function activateCreatedMind(mindManager: MindManager, mindPath: string): Promise<{ success: true; mindId: string; mindPath: string }> {
+  appendE2EGenesisMemory(mindPath);
+  seedLensDefaults(mindPath);
+  installLensSkill(mindPath);
+
+  const mind = await mindManager.loadMind(mindPath);
+  mindManager.setActiveMind(mind.mindId);
+
+  return { success: true, mindId: mind.mindId, mindPath };
 }
 
 function getDefaultGenesisBasePath(): string {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -44,7 +44,9 @@ const electronAPI: ElectronAPI = {
   genesis: {
     getDefaultPath: () => ipcRenderer.invoke('genesis:getDefaultPath'),
     pickPath: () => ipcRenderer.invoke('genesis:pickPath'),
+    listTemplates: () => ipcRenderer.invoke('genesis:listTemplates'),
     create: (config) => ipcRenderer.invoke('genesis:create', config),
+    createFromTemplate: (request) => ipcRenderer.invoke('genesis:createFromTemplate', request),
     onProgress: (callback) => createIpcListener(ipcRenderer, 'genesis:progress', callback),
   },
   chatroom: {

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -215,7 +215,9 @@ export function installBrowserApi(): void {
     genesis: {
       getDefaultPath: async () => '',
       pickPath: async () => null,
+      listTemplates: async () => [],
       create: async () => ({ success: false, error: 'Genesis setup is desktop-only in browser mode.' }),
+      createFromTemplate: async () => ({ success: false, error: 'Genesis template install is desktop-only in browser mode.' }),
       onProgress: () => noopUnsubscribe,
     },
     chatroom: createBrowserChatroomApi(),

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
@@ -7,15 +7,29 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { GenesisFlow } from './GenesisFlow';
 import { AppStateProvider, useAppState } from '../../lib/store';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
-import type { MindContext } from '../../../shared/types';
+import type { GenesisMindTemplate, MindContext } from '../../../shared/types';
 
 vi.mock('./VoidScreen', () => ({
   VoidScreen: ({ onBegin }: { onBegin: () => void }) => <button onClick={onBegin}>Begin</button>,
 }));
 
 vi.mock('./VoiceScreen', () => ({
-  VoiceScreen: ({ onSelect }: { onSelect: (voice: string, description: string) => void }) => (
-    <button onClick={() => onSelect('Test Agent', 'Test voice')}>Choose voice</button>
+  VoiceScreen: ({
+    templates,
+    templateError,
+    onSelect,
+    onSelectTemplate,
+  }: {
+    templates: GenesisMindTemplate[];
+    templateError: string | null;
+    onSelect: (voice: string, description: string) => void;
+    onSelectTemplate: (template: GenesisMindTemplate) => void;
+  }) => (
+    <div>
+      {templateError ? <div role="alert">{templateError}</div> : null}
+      <button onClick={() => onSelect('Test Agent', 'Test voice')}>Choose voice</button>
+      {templates[0] ? <button onClick={() => onSelectTemplate(templates[0])}>Choose template</button> : null}
+    </div>
   ),
 }));
 
@@ -43,6 +57,25 @@ const otherMind: MindContext = {
   status: 'ready',
 };
 
+const lucyTemplate: GenesisMindTemplate = {
+  id: 'lucy',
+  displayName: 'Lucy',
+  description: 'A calm Chief of Staff mind.',
+  role: 'Chief of Staff',
+  voice: 'Vanilla, calm, helpful, and precise',
+  templateVersion: '0.1.0',
+  agent: '.github/agents/lucy.agent.md',
+  requiredFiles: ['SOUL.md'],
+  source: {
+    owner: 'ianphil',
+    repo: 'genesis-minds',
+    ref: 'master',
+    plugin: 'genesis-minds',
+    manifestPath: 'plugins/genesis-minds/minds/lucy/mind.json',
+    rootPath: 'plugins/genesis-minds/minds/lucy',
+  },
+};
+
 function ActiveMindProbe() {
   const { activeMindId } = useAppState();
   return <div data-testid="active-mind-id">{activeMindId}</div>;
@@ -53,6 +86,7 @@ describe('GenesisFlow', () => {
 
   beforeEach(() => {
     api = installElectronAPI();
+    (api.genesis.listTemplates as ReturnType<typeof vi.fn>).mockResolvedValue([lucyTemplate]);
   });
 
   it('waits for genesis.create to load the new mind before completing', async () => {
@@ -109,5 +143,77 @@ describe('GenesisFlow', () => {
     await waitFor(() => {
       expect(screen.getByTestId('active-mind-id').textContent).toBe(createdMind.mindId);
     });
+  });
+
+  it('installs predefined marketplace templates without invoking generated creation', async () => {
+    let resolveCreate: (value: { success: true; mindId: string; mindPath: string }) => void = () => {};
+    (api.genesis.createFromTemplate as ReturnType<typeof vi.fn>).mockReturnValue(new Promise((resolve) => {
+      resolveCreate = resolve;
+    }));
+    (api.mind.list as ReturnType<typeof vi.fn>).mockResolvedValue([createdMind]);
+    const onComplete = vi.fn();
+
+    render(
+      <AppStateProvider>
+        <GenesisFlow onComplete={onComplete} />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Begin'));
+    fireEvent.click(await screen.findByText('Choose template'));
+    fireEvent.click(await screen.findByText('Boot complete'));
+
+    expect(api.genesis.createFromTemplate).toHaveBeenCalledWith({ templateId: 'lucy', basePath: 'C:\\Users\\test\\agents' });
+    expect(api.genesis.create).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+
+    resolveCreate({ success: true, mindId: createdMind.mindId, mindPath: createdMind.mindPath });
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('keeps custom selection on the generated create path', async () => {
+    render(
+      <AppStateProvider>
+        <GenesisFlow onComplete={vi.fn()} />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Begin'));
+    fireEvent.click(screen.getByText('Choose voice'));
+    fireEvent.click(await screen.findByText('Choose role'));
+
+    await waitFor(() => {
+      expect(api.genesis.create).toHaveBeenCalledWith({
+        name: 'Test Agent',
+        role: 'Chief of Staff',
+        voice: 'Test Agent',
+        voiceDescription: 'Test voice',
+        basePath: 'C:\\Users\\test\\agents',
+      });
+    });
+    expect(api.genesis.createFromTemplate).not.toHaveBeenCalled();
+  });
+
+  it('shows marketplace template failures and blocks completion', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+    (api.genesis.createFromTemplate as ReturnType<typeof vi.fn>).mockResolvedValue({ success: false, error: 'marketplace unavailable' });
+    const onComplete = vi.fn();
+
+    render(
+      <AppStateProvider>
+        <GenesisFlow onComplete={onComplete} />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Begin'));
+    fireEvent.click(await screen.findByText('Choose template'));
+
+    expect((await screen.findByRole('alert')).textContent).toBe('marketplace unavailable');
+
+    expect(onComplete).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 });

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -5,6 +5,7 @@ import { RoleScreen } from './RoleScreen';
 import { VoiceScreen } from './VoiceScreen';
 import { BootScreen } from './BootScreen';
 import { selectPreferredMind } from '../../lib/mindSelection';
+import type { GenesisMindTemplate } from '../../../shared/types';
 
 type Stage = 'void' | 'role' | 'voice' | 'boot' | 'done';
 type GenesisCreateResult = Awaited<ReturnType<typeof window.electronAPI.genesis.create>>;
@@ -19,14 +20,30 @@ export function GenesisFlow({ onComplete }: Props) {
   const [role, setRole] = useState('');
   // Store voice description for the create call
   const [voiceDesc, setVoiceDesc] = useState('');
+  const [templates, setTemplates] = useState<GenesisMindTemplate[]>([]);
+  const [templateError, setTemplateError] = useState<string | null>(null);
+  const [creationError, setCreationError] = useState<string | null>(null);
   const creationPromiseRef = useRef<Promise<GenesisCreateResult> | null>(null);
   const dispatch = useAppDispatch();
 
-  const handleBegin = useCallback(() => setStage('voice'), []);
+  const loadTemplates = useCallback(async () => {
+    setTemplateError(null);
+    try {
+      setTemplates(await window.electronAPI.genesis.listTemplates());
+    } catch (error) {
+      setTemplateError(error instanceof Error ? error.message : String(error));
+    }
+  }, []);
+
+  const handleBegin = useCallback(() => {
+    setStage('voice');
+    void loadTemplates();
+  }, [loadTemplates]);
 
   const handleRole= useCallback(async (r: string) => {
     setRole(r);
     setStage('boot');
+    setCreationError(null);
 
     const defaultPath = await window.electronAPI.genesis.getDefaultPath();
     const creationPromise = window.electronAPI.genesis.create({
@@ -43,6 +60,7 @@ export function GenesisFlow({ onComplete }: Props) {
     const result = await creationPromise;
 
     if (!result.success) {
+      setCreationError(result.error ?? 'Genesis failed.');
       console.error('[Genesis] Failed:', result.error);
     }
   }, [name, voiceDesc]);
@@ -53,9 +71,34 @@ export function GenesisFlow({ onComplete }: Props) {
     setTimeout(() => setStage('role'), 300);
   }, []);
 
+  const handleTemplateSelect = useCallback(async (template: GenesisMindTemplate) => {
+    setName(template.displayName);
+    setRole(template.role);
+    setVoiceDesc(template.voice);
+    setStage('boot');
+    setCreationError(null);
+
+    const defaultPath = await window.electronAPI.genesis.getDefaultPath();
+    const creationPromise = window.electronAPI.genesis.createFromTemplate({
+      templateId: template.id,
+      basePath: defaultPath,
+    }).catch((error: unknown) => ({
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }));
+    creationPromiseRef.current = creationPromise;
+    const result = await creationPromise;
+
+    if (!result.success) {
+      setCreationError(result.error ?? 'Genesis template install failed.');
+      console.error('[Genesis] Template install failed:', result.error);
+    }
+  }, []);
+
   const handleBootComplete = useCallback(async () => {
     const result = await creationPromiseRef.current;
     if (!result?.success) {
+      if (result?.error) setCreationError(result.error);
       if (result?.error) console.error('[Genesis] Failed:', result.error);
       return;
     }
@@ -75,11 +118,27 @@ export function GenesisFlow({ onComplete }: Props) {
     case 'void':
       return <VoidScreen onBegin={handleBegin} />;
     case 'voice':
-      return <VoiceScreen onSelect={handleVoiceWithDesc} />;
+      return (
+        <VoiceScreen
+          templates={templates}
+          templateError={templateError}
+          onSelect={handleVoiceWithDesc}
+          onSelectTemplate={handleTemplateSelect}
+        />
+      );
     case 'role':
       return <RoleScreen name={name} onSelect={handleRole} />;
     case 'boot':
-      return <BootScreen name={name} role={role} onComplete={handleBootComplete} />;
+      return (
+        <>
+          <BootScreen name={name} role={role} onComplete={handleBootComplete} />
+          {creationError ? (
+            <div role="alert" className="fixed top-6 left-1/2 z-[60] -translate-x-1/2 rounded-lg border border-red-500/40 bg-black px-4 py-2 text-sm text-red-300">
+              {creationError}
+            </div>
+          ) : null}
+        </>
+      );
     case 'done':
       return null;
     default:

--- a/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
@@ -1,50 +1,16 @@
 import React, { useState } from 'react';
 import { TypeWriter } from './TypeWriter';
 import { cn } from '../../lib/utils';
+import type { GenesisMindTemplate } from '../../../shared/types';
 
 interface Props {
+  templates: GenesisMindTemplate[];
+  templateError: string | null;
   onSelect: (voice: string, description: string) => void;
+  onSelectTemplate: (template: GenesisMindTemplate) => void;
 }
 
-const VOICES = [
-  {
-    id: 'moneypenny',
-    name: 'Miss Moneypenny',
-    energy: 'Poised, warm, devastatingly dry',
-    sample: '"Your desk is ready — though I should warn you, the inbox is rather empty."',
-    era: 'Lois Maxwell era, 1960s-70s. Quiet authority, effortless charm, mahogany-desk sophistication.',
-  },
-  {
-    id: 'jarvis',
-    name: 'Jarvis',
-    energy: 'Precise, capable, quietly witty',
-    sample: '"I\'ve taken the liberty of organizing your priorities. Shall I walk you through them?"',
-    era: 'Calm competence. Anticipates needs. Dry humor under pressure.',
-  },
-  {
-    id: 'alfred',
-    name: 'Alfred',
-    energy: 'Dignified, caring, gently firm',
-    sample: '"I trust you slept well, sir. I\'ve prepared a summary of overnight developments."',
-    era: 'Unwavering loyalty. Gentle wisdom. Knows when to push back.',
-  },
-  {
-    id: 'austin',
-    name: 'Austin Powers',
-    energy: 'Enthusiastic, irreverent, fun',
-    sample: '"Yeah baby! Let\'s see what\'s shaking in the inbox today!"',
-    era: 'Infectious energy. Doesn\'t take things too seriously. Gets things done with flair.',
-  },
-  {
-    id: 'data',
-    name: 'Commander Data',
-    energy: 'Analytical, curious, earnest',
-    sample: '"I have completed my analysis of pending items. There are 7 requiring your attention."',
-    era: 'Precise and thorough. Genuinely curious about humans. Strives to understand context.',
-  },
-];
-
-export function VoiceScreen({ onSelect }: Props) {
+export function VoiceScreen({ templates, templateError, onSelect, onSelectTemplate }: Props) {
   const [showCards, setShowCards] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [customInput, setCustomInput] = useState('');
@@ -57,10 +23,11 @@ export function VoiceScreen({ onSelect }: Props) {
       setShowCustom(true);
       return;
     }
-    setSelected(voiceId);
-    const voice = VOICES.find(v => v.id === voiceId);
-    if (!voice) return;
-    setTimeout(() => onSelect(voice.name, `${voice.energy}. ${voice.era}`), 400);
+  };
+
+  const handleTemplateSelect = (template: GenesisMindTemplate) => {
+    setSelected(template.id);
+    setTimeout(() => onSelectTemplate(template), 400);
   };
 
   const handleCustomSubmit = async () => {
@@ -94,14 +61,26 @@ export function VoiceScreen({ onSelect }: Props) {
 
         {showCards && (
           <div className="space-y-3 animate-in fade-in duration-500">
-            {VOICES.map((voice, i) => (
+            {templateError ? (
+              <div role="alert" className="w-full rounded-xl border border-red-500/40 bg-red-500/10 p-4 text-left text-sm text-red-300">
+                {templateError}
+              </div>
+            ) : null}
+
+            {!templateError && templates.length === 0 ? (
+              <div className="w-full rounded-xl border border-border p-4 text-sm text-muted-foreground">
+                Loading predefined Genesis minds...
+              </div>
+            ) : null}
+
+            {templates.map((template, i) => (
               <button
-                key={voice.id}
-                onClick={() => handleSelect(voice.id)}
+                key={template.id}
+                onClick={() => handleTemplateSelect(template)}
                 style={{ animationDelay: `${i * 100}ms` }}
                 className={cn(
                   'w-full text-left p-4 rounded-xl border transition-all duration-300 animate-in fade-in slide-in-from-bottom-2',
-                  selected === voice.id
+                  selected === template.id
                     ? 'border-primary bg-primary/10'
                     : selected
                       ? 'border-border opacity-30'
@@ -109,17 +88,17 @@ export function VoiceScreen({ onSelect }: Props) {
                 )}
               >
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium">{voice.name}</span>
-                  <span className="text-xs text-muted-foreground">{voice.energy}</span>
+                  <span className="text-sm font-medium">{template.displayName}</span>
+                  <span className="text-xs text-muted-foreground">{template.role}</span>
                 </div>
-                <p className="text-xs text-muted-foreground italic">{voice.sample}</p>
+                <p className="text-xs text-muted-foreground italic">{template.description}</p>
               </button>
             ))}
 
             {/* Custom option */}
             <button
               onClick={() => handleSelect('custom')}
-              style={{ animationDelay: `${VOICES.length * 100}ms` }}
+              style={{ animationDelay: `${templates.length * 100}ms` }}
               className={cn(
                 'w-full text-left p-4 rounded-xl border transition-all duration-300 animate-in fade-in slide-in-from-bottom-2',
                 selected === 'custom'

--- a/apps/web/src/shared/types.ts
+++ b/apps/web/src/shared/types.ts
@@ -178,7 +178,9 @@ export interface ElectronAPI {
   genesis: {
     getDefaultPath: () => Promise<string>;
     pickPath: () => Promise<string | null>;
+    listTemplates: () => Promise<GenesisMindTemplate[]>;
     create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
+    createFromTemplate: (request: { templateId: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
   };
   chatroom: ChatroomAPI;
@@ -195,6 +197,25 @@ export interface ElectronAPI {
     minimize: () => void;
     maximize: () => void;
     close: () => void;
+  };
+}
+
+export interface GenesisMindTemplate {
+  id: string;
+  displayName: string;
+  description: string;
+  role: string;
+  voice: string;
+  templateVersion: string;
+  agent: string;
+  requiredFiles: string[];
+  source: {
+    owner: string;
+    repo: string;
+    ref: string;
+    plugin: string;
+    manifestPath: string;
+    rootPath: string;
   };
 }
 

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -144,7 +144,9 @@ export function mockElectronAPI(): ElectronAPI {
     genesis: {
       getDefaultPath: vi.fn().mockResolvedValue('C:\\Users\\test\\agents'),
       pickPath: vi.fn().mockResolvedValue(null),
+      listTemplates: vi.fn().mockResolvedValue([]),
       create: vi.fn().mockResolvedValue({ success: true }),
+      createFromTemplate: vi.fn().mockResolvedValue({ success: true }),
       onProgress: vi.fn().mockReturnValue(vi.fn()),
     },
     chatroom: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.32.4",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.32.4",
+      "version": "0.33.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.32.4",
+  "version": "0.33.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GenesisMindTemplateCatalog } from './GenesisMindTemplateCatalog';
+import type { TreeEntry } from './GitHubRegistryClient';
+
+class FakeRegistryClient {
+  tree: TreeEntry[] = [];
+  json = new Map<string, unknown>();
+
+  fetchTree(): TreeEntry[] {
+    return this.tree;
+  }
+
+  fetchJsonContent(_owner: string, _repo: string, filePath: string): unknown {
+    const content = this.json.get(filePath);
+    if (!content) throw new Error(`Missing JSON fixture for ${filePath}`);
+    return content;
+  }
+}
+
+describe('GenesisMindTemplateCatalog', () => {
+  let registryClient: FakeRegistryClient;
+
+  beforeEach(() => {
+    registryClient = new FakeRegistryClient();
+    seedLucyMarketplace(registryClient);
+  });
+
+  it('discovers templates from the default genesis minds marketplace', () => {
+    const catalog = new GenesisMindTemplateCatalog(registryClient);
+
+    expect(catalog.listTemplates()).toEqual([
+      expect.objectContaining({
+        id: 'lucy',
+        displayName: 'Lucy',
+        description: 'A calm Chief of Staff mind.',
+        role: 'Chief of Staff',
+        voice: 'Vanilla, calm, helpful, and precise',
+        templateVersion: '0.1.0',
+        source: {
+          owner: 'ianphil',
+          repo: 'genesis-minds',
+          ref: 'master',
+          plugin: 'genesis-minds',
+          manifestPath: 'plugins/genesis-minds/minds/lucy/mind.json',
+          rootPath: 'plugins/genesis-minds/minds/lucy',
+        },
+        requiredFiles: [
+          'SOUL.md',
+          'mind-index.md',
+          '.github/agents/lucy.agent.md',
+          '.working-memory/memory.md',
+          '.working-memory/rules.md',
+          '.working-memory/log.md',
+        ],
+      }),
+    ]);
+  });
+
+  it('throws when a plugin entry points at a missing mind manifest', () => {
+    registryClient.tree = registryClient.tree.filter((entry) => entry.path !== 'plugins/genesis-minds/minds/lucy/mind.json');
+
+    const catalog = new GenesisMindTemplateCatalog(registryClient);
+
+    expect(() => catalog.listTemplates()).toThrow('Template manifest not found: plugins/genesis-minds/minds/lucy/mind.json');
+  });
+
+  it('throws when a required template file is missing', () => {
+    registryClient.tree = registryClient.tree.filter((entry) => entry.path !== 'plugins/genesis-minds/minds/lucy/SOUL.md');
+
+    const catalog = new GenesisMindTemplateCatalog(registryClient);
+
+    expect(() => catalog.listTemplates()).toThrow('Template lucy is missing required file: SOUL.md');
+  });
+
+  it('rejects template paths that escape the mind root', () => {
+    registryClient.json.set('plugins/genesis-minds/minds/lucy/mind.json', {
+      ...lucyManifest(),
+      requiredFiles: ['../escape.md'],
+    });
+    registryClient.tree.push({ path: 'plugins/genesis-minds/minds/escape.md', type: 'blob', sha: 'escape' });
+
+    const catalog = new GenesisMindTemplateCatalog(registryClient);
+
+    expect(() => catalog.listTemplates()).toThrow('Template lucy has unsafe required file path: ../escape.md');
+  });
+});
+
+function seedLucyMarketplace(registryClient: FakeRegistryClient): void {
+  registryClient.tree = [
+    { path: 'marketplace-config.json', type: 'blob', sha: 'marketplace' },
+    { path: 'plugins/genesis-minds/plugin.json', type: 'blob', sha: 'plugin' },
+    { path: 'plugins/genesis-minds/agency.json', type: 'blob', sha: 'agency' },
+    { path: 'plugins/genesis-minds/minds/lucy/mind.json', type: 'blob', sha: 'manifest' },
+    { path: 'plugins/genesis-minds/minds/lucy/SOUL.md', type: 'blob', sha: 'soul' },
+    { path: 'plugins/genesis-minds/minds/lucy/mind-index.md', type: 'blob', sha: 'index' },
+    { path: 'plugins/genesis-minds/minds/lucy/.github/agents/lucy.agent.md', type: 'blob', sha: 'agent' },
+    { path: 'plugins/genesis-minds/minds/lucy/.working-memory/memory.md', type: 'blob', sha: 'memory' },
+    { path: 'plugins/genesis-minds/minds/lucy/.working-memory/rules.md', type: 'blob', sha: 'rules' },
+    { path: 'plugins/genesis-minds/minds/lucy/.working-memory/log.md', type: 'blob', sha: 'log' },
+  ];
+  registryClient.json.set('plugins/genesis-minds/plugin.json', {
+    name: 'genesis-minds',
+    minds: [{ id: 'lucy', manifest: 'minds/lucy/mind.json' }],
+  });
+  registryClient.json.set('plugins/genesis-minds/minds/lucy/mind.json', lucyManifest());
+}
+
+function lucyManifest(): Record<string, unknown> {
+  return {
+    id: 'lucy',
+    displayName: 'Lucy',
+    description: 'A calm Chief of Staff mind.',
+    role: 'Chief of Staff',
+    voice: 'Vanilla, calm, helpful, and precise',
+    templateVersion: '0.1.0',
+    root: '.',
+    agent: '.github/agents/lucy.agent.md',
+    requiredFiles: [
+      'SOUL.md',
+      'mind-index.md',
+      '.github/agents/lucy.agent.md',
+      '.working-memory/memory.md',
+      '.working-memory/rules.md',
+      '.working-memory/log.md',
+    ],
+  };
+}

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
@@ -1,0 +1,169 @@
+import path from 'node:path';
+import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
+import type {
+  GenesisMindTemplate,
+  GenesisMindTemplateMarketplaceSource,
+} from './templateTypes';
+
+export const DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE: GenesisMindTemplateMarketplaceSource = {
+  owner: 'ianphil',
+  repo: 'genesis-minds',
+  ref: 'master',
+  plugin: 'genesis-minds',
+};
+
+interface RegistryClient {
+  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
+}
+
+interface PluginMindEntry {
+  id: string;
+  manifest: string;
+}
+
+interface MindManifest {
+  id: string;
+  displayName: string;
+  description: string;
+  role: string;
+  voice: string;
+  templateVersion: string;
+  root: string;
+  agent: string;
+  requiredFiles: string[];
+}
+
+export class GenesisMindTemplateCatalog {
+  constructor(
+    private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
+    private readonly source: GenesisMindTemplateMarketplaceSource = DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE,
+  ) {}
+
+  listTemplates(): GenesisMindTemplate[] {
+    const tree = this.registryClient.fetchTree(this.source.owner, this.source.repo, this.source.ref);
+    const blobPaths = new Set(tree.filter((entry) => entry.type === 'blob').map((entry) => entry.path));
+
+    this.requireBlob(blobPaths, 'marketplace-config.json', 'Marketplace config not found');
+    const pluginPath = `plugins/${this.source.plugin}/plugin.json`;
+    this.requireBlob(blobPaths, pluginPath, `Plugin manifest not found: ${pluginPath}`);
+
+    const plugin = this.readRecord(pluginPath);
+    const entries = this.readMindEntries(plugin, pluginPath);
+
+    return entries.map((entry) => this.readTemplate(entry, blobPaths));
+  }
+
+  private readTemplate(entry: PluginMindEntry, blobPaths: Set<string>): GenesisMindTemplate {
+    const manifestPath = this.safeJoin(`plugins/${this.source.plugin}`, entry.manifest, `Plugin mind ${entry.id} has unsafe manifest path`);
+    this.requireBlob(blobPaths, manifestPath, `Template manifest not found: ${manifestPath}`);
+
+    const manifest = this.readMindManifest(this.readRecord(manifestPath), manifestPath);
+    const manifestDir = path.posix.dirname(manifestPath);
+    const rootPath = this.safeJoin(manifestDir, manifest.root, `Template ${manifest.id} has unsafe root path: ${manifest.root}`);
+
+    for (const file of manifest.requiredFiles) {
+      if (!isSafeRelativePath(file)) {
+        throw new Error(`Template ${manifest.id} has unsafe required file path: ${file}`);
+      }
+      const templateFilePath = path.posix.join(rootPath, file);
+      this.requireBlob(blobPaths, templateFilePath, `Template ${manifest.id} is missing required file: ${file}`);
+    }
+
+    return {
+      id: manifest.id,
+      displayName: manifest.displayName,
+      description: manifest.description,
+      role: manifest.role,
+      voice: manifest.voice,
+      templateVersion: manifest.templateVersion,
+      agent: manifest.agent,
+      requiredFiles: manifest.requiredFiles,
+      source: {
+        owner: this.source.owner,
+        repo: this.source.repo,
+        ref: this.source.ref,
+        plugin: this.source.plugin,
+        manifestPath,
+        rootPath,
+      },
+    };
+  }
+
+  private readRecord(filePath: string): Record<string, unknown> {
+    const content = this.registryClient.fetchJsonContent(this.source.owner, this.source.repo, filePath, this.source.ref);
+    if (!isRecord(content)) {
+      throw new Error(`Expected ${filePath} to contain a JSON object`);
+    }
+    return content;
+  }
+
+  private readMindEntries(plugin: Record<string, unknown>, pluginPath: string): PluginMindEntry[] {
+    const minds = plugin.minds;
+    if (!Array.isArray(minds)) {
+      throw new Error(`Plugin manifest ${pluginPath} must define a minds array`);
+    }
+
+    return minds.map((entry, index) => {
+      if (!isRecord(entry) || typeof entry.id !== 'string' || typeof entry.manifest !== 'string') {
+        throw new Error(`Plugin manifest ${pluginPath} has invalid minds entry at index ${index}`);
+      }
+      return { id: entry.id, manifest: entry.manifest };
+    });
+  }
+
+  private readMindManifest(manifest: Record<string, unknown>, manifestPath: string): MindManifest {
+    const required = ['id', 'displayName', 'description', 'role', 'voice', 'templateVersion', 'root', 'agent'] as const;
+    for (const key of required) {
+      if (typeof manifest[key] !== 'string') {
+        throw new Error(`Template manifest ${manifestPath} must define string field: ${key}`);
+      }
+    }
+    if (!Array.isArray(manifest.requiredFiles) || manifest.requiredFiles.some((file) => typeof file !== 'string')) {
+      throw new Error(`Template manifest ${manifestPath} must define requiredFiles as a string array`);
+    }
+
+    return {
+      id: stringField(manifest, 'id'),
+      displayName: stringField(manifest, 'displayName'),
+      description: stringField(manifest, 'description'),
+      role: stringField(manifest, 'role'),
+      voice: stringField(manifest, 'voice'),
+      templateVersion: stringField(manifest, 'templateVersion'),
+      root: stringField(manifest, 'root'),
+      agent: stringField(manifest, 'agent'),
+      requiredFiles: manifest.requiredFiles,
+    };
+  }
+
+  private requireBlob(blobPaths: Set<string>, filePath: string, message: string): void {
+    if (!blobPaths.has(filePath)) {
+      throw new Error(message);
+    }
+  }
+
+  private safeJoin(base: string, relativePath: string, message: string): string {
+    if (!isSafeRelativePath(relativePath)) {
+      throw new Error(message);
+    }
+    return path.posix.normalize(path.posix.join(base, relativePath));
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string') {
+    throw new Error(`Expected string field: ${key}`);
+  }
+  return value;
+}
+
+function isSafeRelativePath(value: string): boolean {
+  if (!value || path.posix.isAbsolute(value)) return false;
+  const normalized = path.posix.normalize(value);
+  return normalized === '.' || (!normalized.startsWith('..') && !normalized.includes('/../'));
+}

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GenesisMindTemplateInstaller } from './GenesisMindTemplateInstaller';
+import type { TreeEntry } from './GitHubRegistryClient';
+
+vi.mock('node:child_process', () => ({ execSync: vi.fn() }));
+
+class FakeRegistryClient {
+  tree: TreeEntry[] = [];
+  json = new Map<string, unknown>();
+  blobs = new Map<string, Buffer>();
+
+  fetchTree(): TreeEntry[] {
+    return this.tree;
+  }
+
+  fetchJsonContent(_owner: string, _repo: string, filePath: string): unknown {
+    const content = this.json.get(filePath);
+    if (!content) throw new Error(`Missing JSON fixture for ${filePath}`);
+    return content;
+  }
+
+  fetchBlob(_owner: string, _repo: string, sha: string): Buffer {
+    const content = this.blobs.get(sha);
+    if (!content) throw new Error(`Missing blob fixture for ${sha}`);
+    return content;
+  }
+}
+
+describe('GenesisMindTemplateInstaller', () => {
+  let basePath: string;
+  let registryClient: FakeRegistryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    basePath = mkdtempSync(path.join(os.tmpdir(), 'chamber-template-install-'));
+    registryClient = new FakeRegistryClient();
+    seedLucyMarketplace(registryClient);
+  });
+
+  afterEach(() => {
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  it('installs the selected template into the local minds directory', async () => {
+    const installer = new GenesisMindTemplateInstaller(registryClient);
+
+    const mindPath = await installer.install({ templateId: 'lucy', basePath });
+
+    expect(mindPath).toBe(path.join(basePath, 'lucy'));
+    expect(readFileSync(path.join(mindPath, 'SOUL.md'), 'utf8')).toBe('# Lucy\n');
+    expect(readFileSync(path.join(mindPath, '.github', 'agents', 'lucy.agent.md'), 'utf8')).toBe('---\nname: lucy\n---\n');
+    expect(readFileSync(path.join(mindPath, '.working-memory', 'memory.md'), 'utf8')).toBe('# Memory\n');
+    expect(execSync).toHaveBeenCalledWith('git init', { cwd: mindPath, stdio: 'ignore' });
+    expect(execSync).toHaveBeenCalledWith('git add -A', { cwd: mindPath, stdio: 'ignore' });
+    expect(execSync).toHaveBeenCalledWith('git commit -m "Genesis template install"', { cwd: mindPath, stdio: 'ignore' });
+  });
+
+  it('throws when the installed template fails validation', async () => {
+    registryClient.tree = registryClient.tree.filter((entry) => entry.path !== 'plugins/genesis-minds/minds/lucy/.working-memory/log.md');
+
+    const installer = new GenesisMindTemplateInstaller(registryClient);
+
+    await expect(installer.install({ templateId: 'lucy', basePath })).rejects.toThrow('Template lucy is missing required file: .working-memory/log.md');
+  });
+
+  it('rejects template roots that would escape the marketplace mind folder', async () => {
+    registryClient.json.set('plugins/genesis-minds/minds/lucy/mind.json', {
+      ...lucyManifest(),
+      root: '..',
+    });
+
+    const installer = new GenesisMindTemplateInstaller(registryClient);
+
+    await expect(installer.install({ templateId: 'lucy', basePath })).rejects.toThrow('Template lucy has unsafe root path: ..');
+  });
+
+  it('does not create a Copilot client or invoke SDK generation', async () => {
+    const installer = new GenesisMindTemplateInstaller(registryClient, {
+      createClient: vi.fn(async () => {
+        throw new Error('SDK generation should not run');
+      }),
+      destroyClient: vi.fn(),
+    });
+
+    await installer.install({ templateId: 'lucy', basePath });
+
+    expect(installer.clientFactory.createClient).not.toHaveBeenCalled();
+  });
+});
+
+function seedLucyMarketplace(registryClient: FakeRegistryClient): void {
+  registryClient.tree = [
+    { path: 'marketplace-config.json', type: 'blob', sha: 'marketplace' },
+    { path: 'plugins/genesis-minds/plugin.json', type: 'blob', sha: 'plugin' },
+    { path: 'plugins/genesis-minds/agency.json', type: 'blob', sha: 'agency' },
+    { path: 'plugins/genesis-minds/minds/lucy/mind.json', type: 'blob', sha: 'manifest' },
+    { path: 'plugins/genesis-minds/minds/lucy/SOUL.md', type: 'blob', sha: 'soul' },
+    { path: 'plugins/genesis-minds/minds/lucy/mind-index.md', type: 'blob', sha: 'index' },
+    { path: 'plugins/genesis-minds/minds/lucy/.github/agents/lucy.agent.md', type: 'blob', sha: 'agent' },
+    { path: 'plugins/genesis-minds/minds/lucy/.working-memory/memory.md', type: 'blob', sha: 'memory' },
+    { path: 'plugins/genesis-minds/minds/lucy/.working-memory/rules.md', type: 'blob', sha: 'rules' },
+    { path: 'plugins/genesis-minds/minds/lucy/.working-memory/log.md', type: 'blob', sha: 'log' },
+  ];
+  registryClient.json.set('plugins/genesis-minds/plugin.json', {
+    name: 'genesis-minds',
+    minds: [{ id: 'lucy', manifest: 'minds/lucy/mind.json' }],
+  });
+  registryClient.json.set('plugins/genesis-minds/minds/lucy/mind.json', lucyManifest());
+  registryClient.blobs.set('manifest', Buffer.from(JSON.stringify(lucyManifest(), null, 2)));
+  registryClient.blobs.set('soul', Buffer.from('# Lucy\n'));
+  registryClient.blobs.set('index', Buffer.from('# Mind Index\n'));
+  registryClient.blobs.set('agent', Buffer.from('---\nname: lucy\n---\n'));
+  registryClient.blobs.set('memory', Buffer.from('# Memory\n'));
+  registryClient.blobs.set('rules', Buffer.from('# Rules\n'));
+  registryClient.blobs.set('log', Buffer.from('# Log\n'));
+}
+
+function lucyManifest(): Record<string, unknown> {
+  return {
+    id: 'lucy',
+    displayName: 'Lucy',
+    description: 'A calm Chief of Staff mind.',
+    role: 'Chief of Staff',
+    voice: 'Vanilla, calm, helpful, and precise',
+    templateVersion: '0.1.0',
+    root: '.',
+    agent: '.github/agents/lucy.agent.md',
+    requiredFiles: [
+      'SOUL.md',
+      'mind-index.md',
+      '.github/agents/lucy.agent.md',
+      '.working-memory/memory.md',
+      '.working-memory/rules.md',
+      '.working-memory/log.md',
+    ],
+  };
+}

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { CopilotClientFactory } from '../sdk/CopilotClientFactory';
+import { GenesisMindTemplateCatalog } from './GenesisMindTemplateCatalog';
+import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
+import { MindScaffold } from './MindScaffold';
+import type { GenesisMindTemplate, GenesisMindTemplateMarketplaceSource } from './templateTypes';
+
+const IDEA_FOLDERS = ['inbox', 'domains', 'expertise', 'initiatives', 'Archive'];
+const WORKING_MEMORY_FILES = ['memory.md', 'rules.md', 'log.md'];
+
+interface RegistryClient {
+  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
+  fetchBlob(owner: string, repo: string, sha: string): Buffer;
+}
+
+type ClientFactory = Pick<CopilotClientFactory, 'createClient' | 'destroyClient'>;
+
+export interface GenesisMindTemplateInstallRequest {
+  templateId: string;
+  basePath: string;
+}
+
+export class GenesisMindTemplateInstaller {
+  constructor(
+    private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
+    public readonly clientFactory: ClientFactory = new CopilotClientFactory(),
+    private readonly source?: GenesisMindTemplateMarketplaceSource,
+  ) {}
+
+  async install(request: GenesisMindTemplateInstallRequest): Promise<string> {
+    const catalog = new GenesisMindTemplateCatalog(this.registryClient, this.source);
+    const template = catalog.listTemplates().find((item) => item.id === request.templateId);
+    if (!template) {
+      throw new Error(`Genesis mind template not found: ${request.templateId}`);
+    }
+
+    const mindPath = path.join(request.basePath, MindScaffold.slugify(template.displayName));
+    this.createStructure(mindPath);
+    this.copyTemplateFiles(template, mindPath);
+
+    const validation = new MindScaffold().validate(mindPath);
+    if (!validation.ok) {
+      throw new Error(`Installed template ${template.id} is invalid: ${validation.missing.join(', ')}`);
+    }
+
+    this.initGit(mindPath);
+    return mindPath;
+  }
+
+  private createStructure(mindPath: string): void {
+    for (const folder of IDEA_FOLDERS) {
+      fs.mkdirSync(path.join(mindPath, folder), { recursive: true });
+    }
+    fs.mkdirSync(path.join(mindPath, '.github', 'agents'), { recursive: true });
+    fs.mkdirSync(path.join(mindPath, '.github', 'skills'), { recursive: true });
+    fs.mkdirSync(path.join(mindPath, '.working-memory'), { recursive: true });
+
+    for (const file of WORKING_MEMORY_FILES) {
+      const filePath = path.join(mindPath, '.working-memory', file);
+      if (!fs.existsSync(filePath)) {
+        fs.writeFileSync(filePath, '');
+      }
+    }
+  }
+
+  private copyTemplateFiles(template: GenesisMindTemplate, mindPath: string): void {
+    const tree = this.registryClient.fetchTree(template.source.owner, template.source.repo, template.source.ref);
+    const templatePrefix = `${template.source.rootPath}/`;
+    const entries = tree.filter((entry) => entry.type === 'blob' && entry.path.startsWith(templatePrefix));
+
+    for (const entry of entries) {
+      const relativePath = path.posix.relative(template.source.rootPath, entry.path);
+      if (!isSafeRelativePath(relativePath)) {
+        throw new Error(`Template ${template.id} has unsafe repository file path: ${entry.path}`);
+      }
+
+      const content = this.registryClient.fetchBlob(template.source.owner, template.source.repo, entry.sha);
+      const localPath = path.join(mindPath, ...relativePath.split('/'));
+      fs.mkdirSync(path.dirname(localPath), { recursive: true });
+      fs.writeFileSync(localPath, content);
+    }
+  }
+
+  private initGit(mindPath: string): void {
+    execSync('git init', { cwd: mindPath, stdio: 'ignore' });
+    execSync('git add -A', { cwd: mindPath, stdio: 'ignore' });
+    execSync('git commit -m "Genesis template install"', { cwd: mindPath, stdio: 'ignore' });
+  }
+}
+
+function isSafeRelativePath(value: string): boolean {
+  if (!value || path.posix.isAbsolute(value)) return false;
+  const normalized = path.posix.normalize(value);
+  return normalized !== '.' && !normalized.startsWith('..') && !normalized.includes('/../');
+}

--- a/packages/services/src/genesis/index.ts
+++ b/packages/services/src/genesis/index.ts
@@ -3,3 +3,7 @@ export type { GenesisConfig, GenesisProgress } from './MindScaffold';
 export { buildGenesisPrompt } from './genesisPrompt';
 export type { GenesisPromptInput } from './genesisPrompt';
 export { GitHubRegistryClient } from './GitHubRegistryClient';
+export { GenesisMindTemplateCatalog, DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE } from './GenesisMindTemplateCatalog';
+export { GenesisMindTemplateInstaller } from './GenesisMindTemplateInstaller';
+export type { GenesisMindTemplateInstallRequest } from './GenesisMindTemplateInstaller';
+export type { GenesisMindTemplate, GenesisMindTemplateMarketplaceSource, GenesisMindTemplateSource } from './templateTypes';

--- a/packages/services/src/genesis/templateTypes.ts
+++ b/packages/services/src/genesis/templateTypes.ts
@@ -1,0 +1,27 @@
+export interface GenesisMindTemplateSource {
+  owner: string;
+  repo: string;
+  ref: string;
+  plugin: string;
+  manifestPath: string;
+  rootPath: string;
+}
+
+export interface GenesisMindTemplate {
+  id: string;
+  displayName: string;
+  description: string;
+  role: string;
+  voice: string;
+  templateVersion: string;
+  agent: string;
+  requiredFiles: string[];
+  source: GenesisMindTemplateSource;
+}
+
+export interface GenesisMindTemplateMarketplaceSource {
+  owner: string;
+  repo: string;
+  ref: string;
+  plugin: string;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -178,7 +178,9 @@ export interface ElectronAPI {
   genesis: {
     getDefaultPath: () => Promise<string>;
     pickPath: () => Promise<string | null>;
+    listTemplates: () => Promise<GenesisMindTemplate[]>;
     create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
+    createFromTemplate: (request: { templateId: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
   };
   chatroom: ChatroomAPI;
@@ -195,6 +197,25 @@ export interface ElectronAPI {
     minimize: () => void;
     maximize: () => void;
     close: () => void;
+  };
+}
+
+export interface GenesisMindTemplate {
+  id: string;
+  displayName: string;
+  description: string;
+  role: string;
+  voice: string;
+  templateVersion: string;
+  agent: string;
+  requiredFiles: string[];
+  source: {
+    owner: string;
+    repo: string;
+    ref: string;
+    plugin: string;
+    manifestPath: string;
+    rootPath: string;
   };
 }
 

--- a/scripts/sandbox-test.js
+++ b/scripts/sandbox-test.js
@@ -44,7 +44,8 @@ if (!fs.existsSync(appAsarPath)) {
 
 const appAsarFiles = asar.listPackage(appAsarPath);
 const rendererEntry = '/.vite/renderer/main_window/index.html';
-if (!appAsarFiles.includes(rendererEntry)) {
+const normalizedAppAsarFiles = appAsarFiles.map((file) => file.replaceAll('\\', '/'));
+if (!normalizedAppAsarFiles.includes(rendererEntry)) {
   console.error(`Packaged app is missing renderer entry ${rendererEntry}.`);
   process.exit(1);
 }

--- a/tests/e2e/electron/genesis-lucy-template.spec.ts
+++ b/tests/e2e/electron/genesis-lucy-template.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_LUCY_TEMPLATE_CDP_PORT ?? 9338);
+const lucyName = 'Lucy';
+
+test.describe('electron Genesis Lucy template smoke', () => {
+  test.setTimeout(240_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let userDataPath = '';
+  let genesisBasePath = '';
+  let lucyPath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-genesis-lucy-template-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    genesisBasePath = path.join(root, 'agents');
+    lucyPath = path.join(genesisBasePath, 'lucy');
+    tempRoots.push(root);
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+        CHAMBER_E2E_GENESIS_BASE_PATH: genesisBasePath,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('installs Lucy from the Genesis minds marketplace template', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('button', { name: /New Agent/i }).click();
+    await page.getByRole('button', { name: 'Begin' }).click();
+    await expect(page.getByRole('button', { name: /Lucy/i })).toBeVisible({ timeout: 60_000 });
+    await page.getByRole('button', { name: /Lucy/i }).click();
+
+    await expect(page.getByText('How can I help you today?')).toBeVisible({ timeout: 120_000 });
+    await expect(page.getByText(lucyName)).toBeVisible();
+    await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
+
+    expect(fs.existsSync(path.join(lucyPath, 'SOUL.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(lucyPath, 'SOUL.md'), 'utf-8')).toContain('I am Lucy, a calm and practical Chief of Staff.');
+    expect(fs.readFileSync(path.join(lucyPath, '.github', 'agents', 'lucy.agent.md'), 'utf-8')).toContain('name: lucy');
+    expect(fs.readFileSync(path.join(lucyPath, '.working-memory', 'memory.md'), 'utf-8')).toContain('Lucy is a Genesis-created mind template');
+
+    const result = await page.evaluate(async (name) => {
+      const minds = await window.electronAPI.mind.list();
+      const mind = minds.find((candidate) => candidate.identity.name === name);
+      if (!mind) throw new Error(`Created mind ${name} was not loaded.`);
+      return { mindName: mind.identity.name, mindPath: mind.mindPath };
+    }, lucyName);
+
+    expect(result.mindName).toBe(lucyName);
+    expect(result.mindPath.toLowerCase()).toBe(lucyPath.toLowerCase());
+  });
+});
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[genesis-lucy-template-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Installs predefined Genesis minds from the default `ianphil/genesis-minds` marketplace instead of generating them at runtime. The first vertical slice is Lucy: Chamber discovers the marketplace template, installs it deterministically, loads/activates the mind, and keeps custom Genesis creation on the existing SDK-backed path.

## Changes

- Add Genesis marketplace catalog discovery and validation for `ianphil/genesis-minds@master`.
- Add a template installer that downloads/copies selected mind template files without invoking SDK generation.
- Expose `genesis:listTemplates` and `genesis:createFromTemplate` through IPC/preload/browser API contracts.
- Update Genesis onboarding so predefined templates route through template install while custom voices still use `genesis:create`.
- Surface hard visible errors for marketplace fetch/install failures instead of falling back to generated creation.
- Add a live Electron Lucy smoke test for the marketplace-backed path.
- Fix Windows Sandbox preflight path normalization for ASAR entries returned with Windows separators.
- Bump Chamber to v0.33.0 and add the changelog entry.

## Notes

The required Lucy seed content is already live in `ianphil/genesis-minds@master`, which Chamber uses as the default marketplace source.

Closes #162

## Validation

- `npm run lint`
- `npm test`
- `npm run test:sdk-smoke`
- `npm run typecheck`
- `npm run test:server-sdk-smoke`
- `npm run test:ui:web`
- `npm run test:ui:electron`
- `npm run packaged:smoke`
- `npm run test:ui:electron -- tests/e2e/electron/genesis-lucy-template.spec.ts`
- `npm run sandbox` against fresh `npm run make` artifacts