### PR TITLE
fix: improve Genesis voice card readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.34.2 (2026-04-29)
+
+### Genesis
+
+- **Improve voice card readability** — bump card text sizes and use explicit foreground color with semibold weight on mind names so they stand out against the dark background.
+
 ## v0.34.1 (2026-04-28)
 
 ### Packaging

--- a/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
@@ -88,10 +88,10 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
                 )}
               >
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium">{template.displayName}</span>
-                  <span className="text-xs text-muted-foreground">{template.role}</span>
+                  <span className="text-base font-semibold text-foreground">{template.displayName}</span>
+                  <span className="text-sm text-muted-foreground">{template.role}</span>
                 </div>
-                <p className="text-xs text-muted-foreground italic">{template.description}</p>
+                <p className="text-sm text-muted-foreground/80 italic">{template.description}</p>
               </button>
             ))}
 
@@ -109,10 +109,10 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
               )}
             >
               <div className="flex items-center justify-between mb-1">
-                <span className="text-sm font-medium">✏️ Someone else...</span>
-                <span className="text-xs text-muted-foreground">Describe a character or energy</span>
+                <span className="text-base font-semibold text-foreground">✏️ Someone else...</span>
+                <span className="text-sm text-muted-foreground">Describe a character or energy</span>
               </div>
-              <p className="text-xs text-muted-foreground italic">"Tell me who inspires the voice and I'll research them."</p>
+              <p className="text-sm text-muted-foreground/80 italic">"Tell me who inspires the voice and I'll research them."</p>
             </button>
 
             {/* Custom input */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.34.1",
+      "version": "0.34.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
Bump card text sizes and use explicit foreground color with semibold weight on mind names so they stand out against the dark background.

v0.34.2