### PR TITLE
Aggregate Genesis marketplace registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.35.0 (2026-04-30)
+
+### Genesis marketplace
+
+- **Aggregate followed Genesis marketplaces** — Chamber now persists the default public Genesis marketplace in app config and discovers templates across enabled marketplace registries while preserving accessible sources when a private/internal registry cannot be read. (#169)
+
 ## v0.34.2 (2026-04-29)
 
 ### Genesis

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -15,6 +15,9 @@ import {
   ChatService,
   ConfigService,
   CopilotClientFactory,
+  DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE,
+  GenesisMindTemplateInstaller,
+  GenesisMindTemplateMarketplaceCatalog,
   CronService,
   IdentityLoader,
   MessageRouter,
@@ -26,6 +29,7 @@ import {
   configureSdkRuntimeLayout,
   type AppPaths,
   type CredentialStore,
+  type GenesisMindTemplateMarketplaceSource,
   type Notifier,
 } from '@chamber/services';
 import { createAppTray, loadAppIcon } from './main/tray/Tray';
@@ -103,6 +107,8 @@ const notifier: Notifier = {
 const clientFactory = new CopilotClientFactory();
 const identityLoader = new IdentityLoader();
 const configService = new ConfigService();
+const getGenesisMarketplaceSources = (): GenesisMindTemplateMarketplaceSource[] =>
+  configService.load().marketplaceRegistries ?? [DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE];
 const saveActiveLogin = (login: string | null) => {
   const config = configService.load();
   configService.save({ ...config, activeLogin: login });
@@ -114,6 +120,8 @@ const authService = new AuthService(
   `Chamber/${app.getVersion()}`,
 );
 const scaffold = new MindScaffold();
+const genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(undefined, getGenesisMarketplaceSources);
+const genesisTemplateInstaller = new GenesisMindTemplateInstaller(undefined, clientFactory, getGenesisMarketplaceSources);
 const viewDiscovery = new ViewDiscovery();
 
 // --- Services (business rules, all dependencies injected) ---
@@ -346,7 +354,12 @@ app.on('ready', async () => {
     windowIcon,
   });
   setupLensIPC(viewDiscovery, mindManager);
-  setupGenesisIPC(mindManager, scaffold);
+  setupGenesisIPC(
+    mindManager,
+    scaffold,
+    { listTemplates: () => genesisTemplateCatalog.listTemplates().templates },
+    genesisTemplateInstaller,
+  );
   setupAuthIPC(authService, mindManager);
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager);
   setupChatroomIPC(chatroomService);

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
@@ -163,7 +163,11 @@ describe('GenesisFlow', () => {
     fireEvent.click(await screen.findByText('Choose template'));
     fireEvent.click(await screen.findByText('Boot complete'));
 
-    expect(api.genesis.createFromTemplate).toHaveBeenCalledWith({ templateId: 'lucy', basePath: 'C:\\Users\\test\\agents' });
+    expect(api.genesis.createFromTemplate).toHaveBeenCalledWith({
+      templateId: 'lucy',
+      marketplaceId: undefined,
+      basePath: 'C:\\Users\\test\\agents',
+    });
     expect(api.genesis.create).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
 

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -81,6 +81,7 @@ export function GenesisFlow({ onComplete }: Props) {
     const defaultPath = await window.electronAPI.genesis.getDefaultPath();
     const creationPromise = window.electronAPI.genesis.createFromTemplate({
       templateId: template.id,
+      marketplaceId: template.source.marketplaceId,
       basePath: defaultPath,
     }).catch((error: unknown) => ({
       success: false,

--- a/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
@@ -26,7 +26,7 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
   };
 
   const handleTemplateSelect = (template: GenesisMindTemplate) => {
-    setSelected(template.id);
+    setSelected(templateKey(template));
     setTimeout(() => onSelectTemplate(template), 400);
   };
 
@@ -75,12 +75,12 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
 
             {templates.map((template, i) => (
               <button
-                key={template.id}
+                key={templateKey(template)}
                 onClick={() => handleTemplateSelect(template)}
                 style={{ animationDelay: `${i * 100}ms` }}
                 className={cn(
                   'w-full text-left p-4 rounded-xl border transition-all duration-300 animate-in fade-in slide-in-from-bottom-2',
-                  selected === template.id
+                  selected === templateKey(template)
                     ? 'border-primary bg-primary/10'
                     : selected
                       ? 'border-border opacity-30'
@@ -144,4 +144,8 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
       </div>
     </div>
   );
+}
+
+function templateKey(template: GenesisMindTemplate): string {
+  return `${template.source.marketplaceId ?? `${template.source.owner}/${template.source.repo}`}:${template.id}`;
 }

--- a/apps/web/src/shared/types.ts
+++ b/apps/web/src/shared/types.ts
@@ -96,6 +96,18 @@ export interface MindRecord {
   path: string;
 }
 
+export interface MarketplaceRegistry {
+  id: string;
+  label: string;
+  url: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  plugin: string;
+  enabled: boolean;
+  isDefault: boolean;
+}
+
 export interface ModelInfo {
   id: string;
   name: string;
@@ -113,6 +125,7 @@ export interface AppConfig {
   activeMindId: string | null;
   activeLogin: string | null;
   theme: 'light' | 'dark' | 'system';
+  marketplaceRegistries?: MarketplaceRegistry[];
 }
 
 export interface LensViewManifest {
@@ -261,6 +274,9 @@ export interface GenesisMindTemplate {
     plugin: string;
     manifestPath: string;
     rootPath: string;
+    marketplaceId?: string;
+    marketplaceLabel?: string;
+    marketplaceUrl?: string;
   };
 }
 

--- a/apps/web/src/shared/types.ts
+++ b/apps/web/src/shared/types.ts
@@ -222,7 +222,7 @@ export interface ElectronAPI {
     pickPath: () => Promise<string | null>;
     listTemplates: () => Promise<GenesisMindTemplate[]>;
     create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
-    createFromTemplate: (request: { templateId: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
+    createFromTemplate: (request: { templateId: string; marketplaceId?: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
   };
   chatroom: ChatroomAPI;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.34.2",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.34.2",
+      "version": "0.35.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.34.2",
+  "version": "0.35.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/config/ConfigService.migration.test.ts
+++ b/packages/services/src/config/ConfigService.migration.test.ts
@@ -10,6 +10,20 @@ vi.mock('fs', () => ({
 import * as fs from 'fs';
 import { ConfigService } from './ConfigService';
 
+const DEFAULT_MARKETPLACES = [
+  {
+    id: 'github:ianphil/genesis-minds',
+    label: 'Public Genesis Minds',
+    url: 'https://github.com/ianphil/genesis-minds',
+    owner: 'ianphil',
+    repo: 'genesis-minds',
+    ref: 'master',
+    plugin: 'genesis-minds',
+    enabled: true,
+    isDefault: true,
+  },
+];
+
 const mockReadFileSync = vi.mocked(fs.readFileSync);
 const mockWriteFileSync = vi.mocked(fs.writeFileSync);
 const mockMkdirSync = vi.mocked(fs.mkdirSync);
@@ -34,13 +48,27 @@ describe('ConfigService (v1→v2 migration)', () => {
   it('returns default v2 config when file is missing', () => {
     mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
     const config = svc.load();
-    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' });
+    expect(config).toEqual({
+      version: 2,
+      minds: [],
+      activeMindId: null,
+      activeLogin: null,
+      theme: 'dark',
+      marketplaceRegistries: DEFAULT_MARKETPLACES,
+    });
   });
 
   it('returns default v2 config for invalid JSON', () => {
     mockReadFileSync.mockReturnValue('not json');
     const config = svc.load();
-    expect(config).toEqual({ version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' });
+    expect(config).toEqual({
+      version: 2,
+      minds: [],
+      activeMindId: null,
+      activeLogin: null,
+      theme: 'dark',
+      marketplaceRegistries: DEFAULT_MARKETPLACES,
+    });
   });
 
   it('creates directory and writes v2 config', () => {

--- a/packages/services/src/config/ConfigService.test.ts
+++ b/packages/services/src/config/ConfigService.test.ts
@@ -12,7 +12,27 @@ import * as fs from 'fs';
 import { ConfigService } from './ConfigService';
 import type { AppConfig } from '@chamber/shared/types';
 
-const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' };
+const DEFAULT_MARKETPLACES = [
+  {
+    id: 'github:ianphil/genesis-minds',
+    label: 'Public Genesis Minds',
+    url: 'https://github.com/ianphil/genesis-minds',
+    owner: 'ianphil',
+    repo: 'genesis-minds',
+    ref: 'master',
+    plugin: 'genesis-minds',
+    enabled: true,
+    isDefault: true,
+  },
+];
+const DEFAULT_CONFIG: AppConfig = {
+  version: 2,
+  minds: [],
+  activeMindId: null,
+  activeLogin: null,
+  theme: 'dark',
+  marketplaceRegistries: DEFAULT_MARKETPLACES,
+};
 
 describe('ConfigService', () => {
   let svc: ConfigService;
@@ -22,13 +42,33 @@ describe('ConfigService', () => {
   });
 
   describe('load', () => {
-    it('returns v2 config as-is', () => {
-      const v2: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }], activeMindId: 'q-a1b2', activeLogin: 'alice', theme: 'light' };
+    it('returns v2 marketplace registries as-is when the default is present', () => {
+      const v2: AppConfig = {
+        version: 2,
+        minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }],
+        activeMindId: 'q-a1b2',
+        activeLogin: 'alice',
+        theme: 'light',
+        marketplaceRegistries: [
+          ...DEFAULT_MARKETPLACES,
+          {
+            id: 'github:contoso/genesis-minds',
+            label: 'Contoso',
+            url: 'https://github.com/contoso/genesis-minds',
+            owner: 'contoso',
+            repo: 'genesis-minds',
+            ref: 'main',
+            plugin: 'genesis-minds',
+            enabled: true,
+            isDefault: false,
+          },
+        ],
+      };
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(v2));
       expect(svc.load()).toEqual(v2);
     });
 
-    it('backfills activeLogin for legacy v2 configs', () => {
+    it('backfills activeLogin and the default public marketplace for legacy v2 configs', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         version: 2,
         minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }],
@@ -42,6 +82,7 @@ describe('ConfigService', () => {
         activeMindId: 'q-a1b2',
         activeLogin: null,
         theme: 'light',
+        marketplaceRegistries: DEFAULT_MARKETPLACES,
       });
     });
 
@@ -88,6 +129,7 @@ describe('ConfigService', () => {
         activeMindId: 'q-a1b2',
         activeLogin: 'alice',
         theme: 'dark',
+        marketplaceRegistries: DEFAULT_MARKETPLACES,
       };
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(v2));
       const result = svc.load();
@@ -99,7 +141,14 @@ describe('ConfigService', () => {
 
   describe('save', () => {
     it('creates directory and writes v2 JSON', () => {
-      const config: AppConfig = { version: 2, minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }], activeMindId: 'q-a1b2', activeLogin: 'alice', theme: 'dark' };
+      const config: AppConfig = {
+        version: 2,
+        minds: [{ id: 'q-a1b2', path: '/tmp/agents/q' }],
+        activeMindId: 'q-a1b2',
+        activeLogin: 'alice',
+        theme: 'dark',
+        marketplaceRegistries: DEFAULT_MARKETPLACES,
+      };
       svc.save(config);
       expect(vi.mocked(fs.mkdirSync)).toHaveBeenCalledWith(expect.any(String), {
         recursive: true,
@@ -113,7 +162,7 @@ describe('ConfigService', () => {
 
     it('writes config under an injected config directory', () => {
       const configDir = path.join('tmp', 'chamber-e2e-user-data');
-      const config: AppConfig = { version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' };
+      const config: AppConfig = { ...DEFAULT_CONFIG };
       new ConfigService(configDir).save(config);
 
       expect(vi.mocked(fs.mkdirSync)).toHaveBeenCalledWith(configDir, {

--- a/packages/services/src/config/ConfigService.test.ts
+++ b/packages/services/src/config/ConfigService.test.ts
@@ -86,6 +86,29 @@ describe('ConfigService', () => {
       });
     });
 
+    it('preserves a saved disabled state for the default public marketplace', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [],
+        activeMindId: null,
+        activeLogin: null,
+        theme: 'dark',
+        marketplaceRegistries: [
+          {
+            ...DEFAULT_MARKETPLACES[0],
+            enabled: false,
+          },
+        ],
+      }));
+
+      expect(svc.load().marketplaceRegistries).toEqual([
+        {
+          ...DEFAULT_MARKETPLACES[0],
+          enabled: false,
+        },
+      ]);
+    });
+
     it('migrates v1 config with mindPath to v2', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ mindPath: '/tmp/agents/q', theme: 'light' }),

--- a/packages/services/src/config/ConfigService.ts
+++ b/packages/services/src/config/ConfigService.ts
@@ -2,12 +2,31 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { generateMindId } from '../mind';
-import type { AppConfig, AppConfigV1, MindRecord } from '@chamber/shared/types';
+import type { AppConfig, AppConfigV1, MarketplaceRegistry, MindRecord } from '@chamber/shared/types';
 
 const CONFIG_DIR = path.join(os.homedir(), '.chamber');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 
-const DEFAULT_CONFIG: AppConfig = { version: 2, minds: [], activeMindId: null, activeLogin: null, theme: 'dark' };
+export const DEFAULT_MARKETPLACE_REGISTRY: MarketplaceRegistry = {
+  id: 'github:ianphil/genesis-minds',
+  label: 'Public Genesis Minds',
+  url: 'https://github.com/ianphil/genesis-minds',
+  owner: 'ianphil',
+  repo: 'genesis-minds',
+  ref: 'master',
+  plugin: 'genesis-minds',
+  enabled: true,
+  isDefault: true,
+};
+
+const DEFAULT_CONFIG: AppConfig = {
+  version: 2,
+  minds: [],
+  activeMindId: null,
+  activeLogin: null,
+  theme: 'dark',
+  marketplaceRegistries: [DEFAULT_MARKETPLACE_REGISTRY],
+};
 
 export class ConfigService {
   /** @deprecated Use generateMindId() from mind/generateMindId instead */
@@ -54,6 +73,7 @@ export class ConfigService {
       activeMindId: typeof raw.activeMindId === 'string' ? raw.activeMindId : null,
       activeLogin: typeof raw.activeLogin === 'string' ? raw.activeLogin : null,
       theme,
+      marketplaceRegistries: this.normalizeMarketplaceRegistries(raw.marketplaceRegistries),
     });
   }
 
@@ -68,7 +88,15 @@ export class ConfigService {
       activeMindId: id,
       activeLogin: null,
       theme: v1.theme ?? 'dark',
+      marketplaceRegistries: [DEFAULT_MARKETPLACE_REGISTRY],
     };
+  }
+
+  private normalizeMarketplaceRegistries(raw: unknown): MarketplaceRegistry[] {
+    const registries = Array.isArray(raw)
+      ? raw.filter(isMarketplaceRegistry)
+      : [];
+    return deduplicateRegistries([DEFAULT_MARKETPLACE_REGISTRY, ...registries]);
   }
 
   private deduplicateMinds(config: AppConfig): AppConfig {
@@ -82,4 +110,31 @@ export class ConfigService {
     }
     return { ...config, minds: deduped };
   }
+}
+
+function isMarketplaceRegistry(value: unknown): value is MarketplaceRegistry {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return typeof record.id === 'string'
+    && typeof record.label === 'string'
+    && typeof record.url === 'string'
+    && typeof record.owner === 'string'
+    && typeof record.repo === 'string'
+    && typeof record.ref === 'string'
+    && typeof record.plugin === 'string'
+    && typeof record.enabled === 'boolean'
+    && typeof record.isDefault === 'boolean';
+}
+
+function deduplicateRegistries(registries: MarketplaceRegistry[]): MarketplaceRegistry[] {
+  const seen = new Set<string>();
+  const deduped: MarketplaceRegistry[] = [];
+  for (const registry of registries) {
+    if (seen.has(registry.id)) continue;
+    seen.add(registry.id);
+    deduped.push({ ...registry });
+  }
+  return deduped;
 }

--- a/packages/services/src/config/ConfigService.ts
+++ b/packages/services/src/config/ConfigService.ts
@@ -96,7 +96,7 @@ export class ConfigService {
     const registries = Array.isArray(raw)
       ? raw.filter(isMarketplaceRegistry)
       : [];
-    return deduplicateRegistries([DEFAULT_MARKETPLACE_REGISTRY, ...registries]);
+    return deduplicateRegistries([...registries, DEFAULT_MARKETPLACE_REGISTRY]);
   }
 
   private deduplicateMinds(config: AppConfig): AppConfig {

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.test.ts
@@ -36,14 +36,17 @@ describe('GenesisMindTemplateCatalog', () => {
         role: 'Chief of Staff',
         voice: 'Vanilla, calm, helpful, and precise',
         templateVersion: '0.1.0',
-        source: {
+        source: expect.objectContaining({
           owner: 'ianphil',
           repo: 'genesis-minds',
           ref: 'master',
           plugin: 'genesis-minds',
           manifestPath: 'plugins/genesis-minds/minds/lucy/mind.json',
           rootPath: 'plugins/genesis-minds/minds/lucy',
-        },
+          marketplaceId: 'github:ianphil/genesis-minds',
+          marketplaceLabel: 'Public Genesis Minds',
+          marketplaceUrl: 'https://github.com/ianphil/genesis-minds',
+        }),
         requiredFiles: [
           'SOUL.md',
           'mind-index.md',

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
@@ -6,10 +6,15 @@ import type {
 } from './templateTypes';
 
 export const DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE: GenesisMindTemplateMarketplaceSource = {
+  id: 'github:ianphil/genesis-minds',
+  label: 'Public Genesis Minds',
+  url: 'https://github.com/ianphil/genesis-minds',
   owner: 'ianphil',
   repo: 'genesis-minds',
   ref: 'master',
   plugin: 'genesis-minds',
+  enabled: true,
+  isDefault: true,
 };
 
 interface RegistryClient {
@@ -86,6 +91,9 @@ export class GenesisMindTemplateCatalog {
         plugin: this.source.plugin,
         manifestPath,
         rootPath,
+        marketplaceId: this.source.id ?? marketplaceId(this.source),
+        marketplaceLabel: this.source.label ?? `${this.source.owner}/${this.source.repo}`,
+        marketplaceUrl: this.source.url ?? `https://github.com/${this.source.owner}/${this.source.repo}`,
       },
     };
   }
@@ -166,4 +174,8 @@ function isSafeRelativePath(value: string): boolean {
   if (!value || path.posix.isAbsolute(value)) return false;
   const normalized = path.posix.normalize(value);
   return normalized === '.' || (!normalized.startsWith('..') && !normalized.includes('/../'));
+}
+
+function marketplaceId(source: GenesisMindTemplateMarketplaceSource): string {
+  return `github:${source.owner}/${source.repo}`;
 }

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
@@ -10,15 +10,16 @@ vi.mock('node:child_process', () => ({ execSync: vi.fn() }));
 
 class FakeRegistryClient {
   tree: TreeEntry[] = [];
+  treeByRepo = new Map<string, TreeEntry[]>();
   json = new Map<string, unknown>();
   blobs = new Map<string, Buffer>();
 
-  fetchTree(): TreeEntry[] {
-    return this.tree;
+  fetchTree(owner = 'ianphil', repo = 'genesis-minds'): TreeEntry[] {
+    return this.treeByRepo.get(repoKey(owner, repo)) ?? this.tree;
   }
 
-  fetchJsonContent(_owner: string, _repo: string, filePath: string): unknown {
-    const content = this.json.get(filePath);
+  fetchJsonContent(owner: string, repo: string, filePath: string): unknown {
+    const content = this.json.get(`${repoKey(owner, repo)}:${filePath}`) ?? this.json.get(filePath);
     if (!content) throw new Error(`Missing JSON fixture for ${filePath}`);
     return content;
   }
@@ -90,6 +91,60 @@ describe('GenesisMindTemplateInstaller', () => {
 
     expect(installer.clientFactory.createClient).not.toHaveBeenCalled();
   });
+
+  it('installs the selected marketplace when template ids overlap', async () => {
+    seedMarketplace(registryClient, {
+      owner: 'ianphil',
+      repo: 'genesis-minds',
+      ref: 'master',
+      plugin: 'genesis-minds',
+      id: 'github:ianphil/genesis-minds',
+      label: 'Public Genesis Minds',
+      url: 'https://github.com/ianphil/genesis-minds',
+      enabled: true,
+    }, 'Lucy', '# Public Lucy\n');
+    seedMarketplace(registryClient, {
+      owner: 'agency-microsoft',
+      repo: 'genesis-minds',
+      ref: 'main',
+      plugin: 'genesis-minds',
+      id: 'github:agency-microsoft/genesis-minds',
+      label: 'Agency Microsoft',
+      url: 'https://github.com/agency-microsoft/genesis-minds',
+      enabled: true,
+    }, 'Internal Lucy', '# Internal Lucy\n');
+    const installer = new GenesisMindTemplateInstaller(registryClient, undefined, [
+      {
+        owner: 'ianphil',
+        repo: 'genesis-minds',
+        ref: 'master',
+        plugin: 'genesis-minds',
+        id: 'github:ianphil/genesis-minds',
+        label: 'Public Genesis Minds',
+        url: 'https://github.com/ianphil/genesis-minds',
+        enabled: true,
+      },
+      {
+        owner: 'agency-microsoft',
+        repo: 'genesis-minds',
+        ref: 'main',
+        plugin: 'genesis-minds',
+        id: 'github:agency-microsoft/genesis-minds',
+        label: 'Agency Microsoft',
+        url: 'https://github.com/agency-microsoft/genesis-minds',
+        enabled: true,
+      },
+    ]);
+
+    const mindPath = await installer.install({
+      templateId: 'lucy',
+      marketplaceId: 'github:agency-microsoft/genesis-minds',
+      basePath,
+    });
+
+    expect(mindPath).toBe(path.join(basePath, 'internal-lucy'));
+    expect(readFileSync(path.join(mindPath, 'SOUL.md'), 'utf8')).toBe('# Internal Lucy\n');
+  });
 });
 
 function seedLucyMarketplace(registryClient: FakeRegistryClient): void {
@@ -138,4 +193,56 @@ function lucyManifest(): Record<string, unknown> {
       '.working-memory/log.md',
     ],
   };
+}
+
+function seedMarketplace(
+  registryClient: FakeRegistryClient,
+  source: {
+    owner: string;
+    repo: string;
+    ref: string;
+    plugin: string;
+    id: string;
+    label: string;
+    url: string;
+    enabled: boolean;
+  },
+  displayName: string,
+  soulContent: string,
+): void {
+  const key = repoKey(source.owner, source.repo);
+  const manifestPath = `plugins/${source.plugin}/minds/lucy/mind.json`;
+  registryClient.treeByRepo.set(key, [
+    { path: 'marketplace-config.json', type: 'blob', sha: `${key}-marketplace` },
+    { path: `plugins/${source.plugin}/plugin.json`, type: 'blob', sha: `${key}-plugin` },
+    { path: manifestPath, type: 'blob', sha: `${key}-manifest` },
+    { path: `plugins/${source.plugin}/minds/lucy/SOUL.md`, type: 'blob', sha: `${key}-soul` },
+    { path: `plugins/${source.plugin}/minds/lucy/mind-index.md`, type: 'blob', sha: `${key}-index` },
+    { path: `plugins/${source.plugin}/minds/lucy/.github/agents/lucy.agent.md`, type: 'blob', sha: `${key}-agent` },
+    { path: `plugins/${source.plugin}/minds/lucy/.working-memory/memory.md`, type: 'blob', sha: `${key}-memory` },
+    { path: `plugins/${source.plugin}/minds/lucy/.working-memory/rules.md`, type: 'blob', sha: `${key}-rules` },
+    { path: `plugins/${source.plugin}/minds/lucy/.working-memory/log.md`, type: 'blob', sha: `${key}-log` },
+  ]);
+  registryClient.json.set(`${key}:plugins/${source.plugin}/plugin.json`, {
+    name: source.plugin,
+    minds: [{ id: 'lucy', manifest: 'minds/lucy/mind.json' }],
+  });
+  registryClient.json.set(`${key}:${manifestPath}`, {
+    ...lucyManifest(),
+    displayName,
+  });
+  registryClient.blobs.set(`${key}-manifest`, Buffer.from(JSON.stringify({
+    ...lucyManifest(),
+    displayName,
+  }, null, 2)));
+  registryClient.blobs.set(`${key}-soul`, Buffer.from(soulContent));
+  registryClient.blobs.set(`${key}-index`, Buffer.from('# Mind Index\n'));
+  registryClient.blobs.set(`${key}-agent`, Buffer.from('---\nname: lucy\n---\n'));
+  registryClient.blobs.set(`${key}-memory`, Buffer.from('# Memory\n'));
+  registryClient.blobs.set(`${key}-rules`, Buffer.from('# Rules\n'));
+  registryClient.blobs.set(`${key}-log`, Buffer.from('# Log\n'));
+}
+
+function repoKey(owner: string, repo: string): string {
+  return `${owner}/${repo}`;
 }

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { CopilotClientFactory } from '../sdk/CopilotClientFactory';
-import { GenesisMindTemplateCatalog } from './GenesisMindTemplateCatalog';
+import { DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE, GenesisMindTemplateCatalog } from './GenesisMindTemplateCatalog';
+import { GenesisMindTemplateMarketplaceCatalog } from './GenesisMindTemplateMarketplaceCatalog';
 import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
 import { MindScaffold } from './MindScaffold';
 import type { GenesisMindTemplate, GenesisMindTemplateMarketplaceSource } from './templateTypes';
@@ -17,6 +18,10 @@ interface RegistryClient {
 }
 
 type ClientFactory = Pick<CopilotClientFactory, 'createClient' | 'destroyClient'>;
+type SourceProvider =
+  | GenesisMindTemplateMarketplaceSource
+  | GenesisMindTemplateMarketplaceSource[]
+  | (() => GenesisMindTemplateMarketplaceSource[]);
 
 export interface GenesisMindTemplateInstallRequest {
   templateId: string;
@@ -27,12 +32,11 @@ export class GenesisMindTemplateInstaller {
   constructor(
     private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
     public readonly clientFactory: ClientFactory = new CopilotClientFactory(),
-    private readonly source?: GenesisMindTemplateMarketplaceSource,
+    private readonly sourceProvider: SourceProvider = DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE,
   ) {}
 
   async install(request: GenesisMindTemplateInstallRequest): Promise<string> {
-    const catalog = new GenesisMindTemplateCatalog(this.registryClient, this.source);
-    const template = catalog.listTemplates().find((item) => item.id === request.templateId);
+    const template = this.listTemplates().find((item) => item.id === request.templateId);
     if (!template) {
       throw new Error(`Genesis mind template not found: ${request.templateId}`);
     }
@@ -88,6 +92,13 @@ export class GenesisMindTemplateInstaller {
     execSync('git init', { cwd: mindPath, stdio: 'ignore' });
     execSync('git add -A', { cwd: mindPath, stdio: 'ignore' });
     execSync('git commit -m "Genesis template install"', { cwd: mindPath, stdio: 'ignore' });
+  }
+
+  private listTemplates(): GenesisMindTemplate[] {
+    if (typeof this.sourceProvider === 'function' || Array.isArray(this.sourceProvider)) {
+      return new GenesisMindTemplateMarketplaceCatalog(this.registryClient, this.sourceProvider).listTemplates().templates;
+    }
+    return new GenesisMindTemplateCatalog(this.registryClient, this.sourceProvider).listTemplates();
   }
 }
 

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
@@ -25,6 +25,7 @@ type SourceProvider =
 
 export interface GenesisMindTemplateInstallRequest {
   templateId: string;
+  marketplaceId?: string;
   basePath: string;
 }
 
@@ -36,7 +37,10 @@ export class GenesisMindTemplateInstaller {
   ) {}
 
   async install(request: GenesisMindTemplateInstallRequest): Promise<string> {
-    const template = this.listTemplates().find((item) => item.id === request.templateId);
+    const template = this.listTemplates().find((item) =>
+      item.id === request.templateId
+      && (!request.marketplaceId || item.source.marketplaceId === request.marketplaceId)
+    );
     if (!template) {
       throw new Error(`Genesis mind template not found: ${request.templateId}`);
     }

--- a/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GenesisMindTemplateMarketplaceCatalog } from './GenesisMindTemplateMarketplaceCatalog';
+import type { TreeEntry } from './GitHubRegistryClient';
+import type { GenesisMindTemplateMarketplaceSource } from './templateTypes';
+
+class FakeRegistryClient {
+  tree = new Map<string, TreeEntry[]>();
+  json = new Map<string, unknown>();
+  failingRepos = new Set<string>();
+
+  fetchTree(owner: string, repo: string): TreeEntry[] {
+    const key = repoKey(owner, repo);
+    if (this.failingRepos.has(key)) {
+      throw new Error('GitHub repository not found');
+    }
+    return this.tree.get(key) ?? [];
+  }
+
+  fetchJsonContent(owner: string, repo: string, filePath: string): unknown {
+    const content = this.json.get(`${repoKey(owner, repo)}:${filePath}`);
+    if (!content) throw new Error(`Missing JSON fixture for ${filePath}`);
+    return content;
+  }
+}
+
+const publicSource: GenesisMindTemplateMarketplaceSource = {
+  id: 'github:ianphil/genesis-minds',
+  label: 'Public Genesis Minds',
+  url: 'https://github.com/ianphil/genesis-minds',
+  owner: 'ianphil',
+  repo: 'genesis-minds',
+  ref: 'master',
+  plugin: 'genesis-minds',
+  enabled: true,
+  isDefault: true,
+};
+
+const internalSource: GenesisMindTemplateMarketplaceSource = {
+  id: 'github:agency-microsoft/genesis-minds',
+  label: 'Agency Microsoft',
+  url: 'https://github.com/agency-microsoft/genesis-minds',
+  owner: 'agency-microsoft',
+  repo: 'genesis-minds',
+  ref: 'main',
+  plugin: 'genesis-minds',
+  enabled: true,
+  isDefault: false,
+};
+
+describe('GenesisMindTemplateMarketplaceCatalog', () => {
+  let registryClient: FakeRegistryClient;
+
+  beforeEach(() => {
+    registryClient = new FakeRegistryClient();
+    seedMarketplace(registryClient, publicSource, 'lucy', 'Lucy');
+    seedMarketplace(registryClient, internalSource, 'donna', 'Donna');
+  });
+
+  it('aggregates templates from every enabled marketplace and labels their source', () => {
+    const catalog = new GenesisMindTemplateMarketplaceCatalog(registryClient, [publicSource, internalSource]);
+
+    expect(catalog.listTemplates()).toEqual({
+      templates: [
+        expect.objectContaining({
+          id: 'lucy',
+          displayName: 'Lucy',
+          source: expect.objectContaining({
+            marketplaceId: 'github:ianphil/genesis-minds',
+            marketplaceLabel: 'Public Genesis Minds',
+            marketplaceUrl: 'https://github.com/ianphil/genesis-minds',
+          }),
+        }),
+        expect.objectContaining({
+          id: 'donna',
+          displayName: 'Donna',
+          source: expect.objectContaining({
+            marketplaceId: 'github:agency-microsoft/genesis-minds',
+            marketplaceLabel: 'Agency Microsoft',
+            marketplaceUrl: 'https://github.com/agency-microsoft/genesis-minds',
+          }),
+        }),
+      ],
+      sources: [
+        expect.objectContaining({ id: 'github:ianphil/genesis-minds', status: 'ok', templateCount: 1 }),
+        expect.objectContaining({ id: 'github:agency-microsoft/genesis-minds', status: 'ok', templateCount: 1 }),
+      ],
+    });
+  });
+
+  it('skips disabled marketplaces', () => {
+    const catalog = new GenesisMindTemplateMarketplaceCatalog(registryClient, [
+      publicSource,
+      { ...internalSource, enabled: false },
+    ]);
+
+    expect(catalog.listTemplates()).toEqual({
+      templates: [
+        expect.objectContaining({ id: 'lucy' }),
+      ],
+      sources: [
+        expect.objectContaining({ id: 'github:ianphil/genesis-minds', status: 'ok', templateCount: 1 }),
+        expect.objectContaining({ id: 'github:agency-microsoft/genesis-minds', status: 'disabled', templateCount: 0 }),
+      ],
+    });
+  });
+
+  it('keeps accessible marketplace templates when a private source cannot be read', () => {
+    registryClient.failingRepos.add(repoKey(internalSource.owner, internalSource.repo));
+    const catalog = new GenesisMindTemplateMarketplaceCatalog(registryClient, [publicSource, internalSource]);
+
+    expect(catalog.listTemplates()).toEqual({
+      templates: [
+        expect.objectContaining({ id: 'lucy' }),
+      ],
+      sources: [
+        expect.objectContaining({ id: 'github:ianphil/genesis-minds', status: 'ok', templateCount: 1 }),
+        expect.objectContaining({
+          id: 'github:agency-microsoft/genesis-minds',
+          status: 'error',
+          templateCount: 0,
+          message: 'Unable to access marketplace Agency Microsoft. Check your GitHub sign-in or repository access.',
+        }),
+      ],
+    });
+  });
+});
+
+function seedMarketplace(
+  registryClient: FakeRegistryClient,
+  source: GenesisMindTemplateMarketplaceSource,
+  mindId: string,
+  displayName: string,
+): void {
+  const key = repoKey(source.owner, source.repo);
+  const manifestPath = `plugins/${source.plugin}/minds/${mindId}/mind.json`;
+  registryClient.tree.set(key, [
+    { path: 'marketplace-config.json', type: 'blob', sha: `${mindId}-marketplace` },
+    { path: `plugins/${source.plugin}/plugin.json`, type: 'blob', sha: `${mindId}-plugin` },
+    { path: manifestPath, type: 'blob', sha: `${mindId}-manifest` },
+    { path: `plugins/${source.plugin}/minds/${mindId}/SOUL.md`, type: 'blob', sha: `${mindId}-soul` },
+    { path: `plugins/${source.plugin}/minds/${mindId}/mind-index.md`, type: 'blob', sha: `${mindId}-index` },
+    { path: `plugins/${source.plugin}/minds/${mindId}/.github/agents/${mindId}.agent.md`, type: 'blob', sha: `${mindId}-agent` },
+    { path: `plugins/${source.plugin}/minds/${mindId}/.working-memory/memory.md`, type: 'blob', sha: `${mindId}-memory` },
+    { path: `plugins/${source.plugin}/minds/${mindId}/.working-memory/rules.md`, type: 'blob', sha: `${mindId}-rules` },
+    { path: `plugins/${source.plugin}/minds/${mindId}/.working-memory/log.md`, type: 'blob', sha: `${mindId}-log` },
+  ]);
+  registryClient.json.set(`${key}:plugins/${source.plugin}/plugin.json`, {
+    name: source.plugin,
+    minds: [{ id: mindId, manifest: `minds/${mindId}/mind.json` }],
+  });
+  registryClient.json.set(`${key}:${manifestPath}`, {
+    id: mindId,
+    displayName,
+    description: `${displayName} description.`,
+    role: 'Chief of Staff',
+    voice: 'Calm and precise',
+    templateVersion: '0.1.0',
+    root: '.',
+    agent: `.github/agents/${mindId}.agent.md`,
+    requiredFiles: [
+      'SOUL.md',
+      'mind-index.md',
+      `.github/agents/${mindId}.agent.md`,
+      '.working-memory/memory.md',
+      '.working-memory/rules.md',
+      '.working-memory/log.md',
+    ],
+  });
+}
+
+function repoKey(owner: string, repo: string): string {
+  return `${owner}/${repo}`;
+}

--- a/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.ts
@@ -1,0 +1,65 @@
+import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
+import { GenesisMindTemplateCatalog, DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE } from './GenesisMindTemplateCatalog';
+import type {
+  GenesisMindTemplateMarketplaceResult,
+  GenesisMindTemplateMarketplaceSource,
+  GenesisMindTemplateMarketplaceStatus,
+} from './templateTypes';
+
+interface RegistryClient {
+  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
+}
+
+type SourceProvider =
+  | GenesisMindTemplateMarketplaceSource[]
+  | (() => GenesisMindTemplateMarketplaceSource[]);
+
+export class GenesisMindTemplateMarketplaceCatalog {
+  constructor(
+    private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
+    private readonly sourceProvider: SourceProvider = [DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE],
+  ) {}
+
+  listTemplates(): GenesisMindTemplateMarketplaceResult {
+    const templates: GenesisMindTemplateMarketplaceResult['templates'] = [];
+    const sources: GenesisMindTemplateMarketplaceStatus[] = [];
+
+    for (const source of this.getSources()) {
+      const metadata = sourceMetadata(source);
+      if (source.enabled === false) {
+        sources.push({ ...metadata, status: 'disabled', templateCount: 0 });
+        continue;
+      }
+
+      try {
+        const sourceTemplates = new GenesisMindTemplateCatalog(this.registryClient, source).listTemplates();
+        templates.push(...sourceTemplates);
+        sources.push({ ...metadata, status: 'ok', templateCount: sourceTemplates.length });
+      } catch {
+        sources.push({
+          ...metadata,
+          status: 'error',
+          templateCount: 0,
+          message: `Unable to access marketplace ${metadata.label}. Check your GitHub sign-in or repository access.`,
+        });
+      }
+    }
+
+    return { templates, sources };
+  }
+
+  private getSources(): GenesisMindTemplateMarketplaceSource[] {
+    return typeof this.sourceProvider === 'function'
+      ? this.sourceProvider()
+      : this.sourceProvider;
+  }
+}
+
+function sourceMetadata(source: GenesisMindTemplateMarketplaceSource): Pick<GenesisMindTemplateMarketplaceStatus, 'id' | 'label' | 'url'> {
+  return {
+    id: source.id ?? `github:${source.owner}/${source.repo}`,
+    label: source.label ?? `${source.owner}/${source.repo}`,
+    url: source.url ?? `https://github.com/${source.owner}/${source.repo}`,
+  };
+}

--- a/packages/services/src/genesis/index.ts
+++ b/packages/services/src/genesis/index.ts
@@ -4,6 +4,13 @@ export { buildGenesisPrompt } from './genesisPrompt';
 export type { GenesisPromptInput } from './genesisPrompt';
 export { GitHubRegistryClient } from './GitHubRegistryClient';
 export { GenesisMindTemplateCatalog, DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE } from './GenesisMindTemplateCatalog';
+export { GenesisMindTemplateMarketplaceCatalog } from './GenesisMindTemplateMarketplaceCatalog';
 export { GenesisMindTemplateInstaller } from './GenesisMindTemplateInstaller';
 export type { GenesisMindTemplateInstallRequest } from './GenesisMindTemplateInstaller';
-export type { GenesisMindTemplate, GenesisMindTemplateMarketplaceSource, GenesisMindTemplateSource } from './templateTypes';
+export type {
+  GenesisMindTemplate,
+  GenesisMindTemplateMarketplaceResult,
+  GenesisMindTemplateMarketplaceSource,
+  GenesisMindTemplateMarketplaceStatus,
+  GenesisMindTemplateSource,
+} from './templateTypes';

--- a/packages/services/src/genesis/templateTypes.ts
+++ b/packages/services/src/genesis/templateTypes.ts
@@ -5,6 +5,9 @@ export interface GenesisMindTemplateSource {
   plugin: string;
   manifestPath: string;
   rootPath: string;
+  marketplaceId?: string;
+  marketplaceLabel?: string;
+  marketplaceUrl?: string;
 }
 
 export interface GenesisMindTemplate {
@@ -20,8 +23,29 @@ export interface GenesisMindTemplate {
 }
 
 export interface GenesisMindTemplateMarketplaceSource {
+  id?: string;
+  label?: string;
+  url?: string;
   owner: string;
   repo: string;
   ref: string;
   plugin: string;
+  enabled?: boolean;
+  isDefault?: boolean;
+}
+
+export type GenesisMindTemplateMarketplaceStatusKind = 'ok' | 'disabled' | 'error';
+
+export interface GenesisMindTemplateMarketplaceStatus {
+  id: string;
+  label: string;
+  url: string;
+  status: GenesisMindTemplateMarketplaceStatusKind;
+  templateCount: number;
+  message?: string;
+}
+
+export interface GenesisMindTemplateMarketplaceResult {
+  templates: GenesisMindTemplate[];
+  sources: GenesisMindTemplateMarketplaceStatus[];
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -96,6 +96,18 @@ export interface MindRecord {
   path: string;
 }
 
+export interface MarketplaceRegistry {
+  id: string;
+  label: string;
+  url: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  plugin: string;
+  enabled: boolean;
+  isDefault: boolean;
+}
+
 export interface ModelInfo {
   id: string;
   name: string;
@@ -113,6 +125,7 @@ export interface AppConfig {
   activeMindId: string | null;
   activeLogin: string | null;
   theme: 'light' | 'dark' | 'system';
+  marketplaceRegistries?: MarketplaceRegistry[];
 }
 
 export interface LensViewManifest {
@@ -261,6 +274,9 @@ export interface GenesisMindTemplate {
     plugin: string;
     manifestPath: string;
     rootPath: string;
+    marketplaceId?: string;
+    marketplaceLabel?: string;
+    marketplaceUrl?: string;
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -222,7 +222,7 @@ export interface ElectronAPI {
     pickPath: () => Promise<string | null>;
     listTemplates: () => Promise<GenesisMindTemplate[]>;
     create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
-    createFromTemplate: (request: { templateId: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
+    createFromTemplate: (request: { templateId: string; marketplaceId?: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
   };
   chatroom: ChatroomAPI;

--- a/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
+++ b/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_MARKETPLACE_AGGREGATION_CDP_PORT ?? 9340);
+const publicMarketplaceId = 'github:ianphil/genesis-minds';
+const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
+
+test.describe('electron Genesis marketplace aggregation smoke', () => {
+  test.skip(
+    process.env.CHAMBER_E2E_INTERNAL_MARKETPLACE !== '1',
+    'Set CHAMBER_E2E_INTERNAL_MARKETPLACE=1 with gh access to agency-microsoft/genesis-minds to run this smoke.'
+  );
+  test.setTimeout(240_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let userDataPath = '';
+  let genesisBasePath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-genesis-marketplace-aggregation-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    genesisBasePath = path.join(root, 'agents');
+    tempRoots.push(root);
+
+    seedMarketplaceConfig(userDataPath);
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+        CHAMBER_E2E_GENESIS_BASE_PATH: genesisBasePath,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('shows duplicate public and internal marketplace templates as separate source-aware cards', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('button', { name: /New Agent/i }).click();
+    await page.getByRole('button', { name: 'Begin' }).click();
+    await expect(page.getByRole('button', { name: /Lucy/i }).first()).toBeVisible({ timeout: 90_000 });
+
+    const templates = await page.evaluate(async () => window.electronAPI.genesis.listTemplates());
+    const lucyTemplates = templates.filter((template) => template.id === 'lucy');
+
+    expect(lucyTemplates.map((template) => template.source.marketplaceId).sort()).toEqual([
+      internalMarketplaceId,
+      publicMarketplaceId,
+    ]);
+    await expect(page.getByRole('button', { name: /Lucy/i })).toHaveCount(2);
+  });
+});
+
+function seedMarketplaceConfig(userDataPath: string): void {
+  fs.mkdirSync(userDataPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDataPath, 'config.json'),
+    JSON.stringify({
+      version: 2,
+      minds: [],
+      activeMindId: null,
+      activeLogin: null,
+      theme: 'dark',
+      marketplaceRegistries: [
+        {
+          id: publicMarketplaceId,
+          label: 'Public Genesis Minds',
+          url: 'https://github.com/ianphil/genesis-minds',
+          owner: 'ianphil',
+          repo: 'genesis-minds',
+          ref: 'master',
+          plugin: 'genesis-minds',
+          enabled: true,
+          isDefault: true,
+        },
+        {
+          id: internalMarketplaceId,
+          label: 'Agency Microsoft Genesis Minds',
+          url: 'https://github.com/agency-microsoft/genesis-minds',
+          owner: 'agency-microsoft',
+          repo: 'genesis-minds',
+          ref: 'main',
+          plugin: 'genesis-minds',
+          enabled: true,
+          isDefault: false,
+        },
+      ],
+    }, null, 2)
+  );
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[genesis-marketplace-aggregation-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Persist the default public Genesis marketplace in Chamber config and backfill it for legacy configs.
- Add a multi-source Genesis marketplace catalog that aggregates enabled registries and keeps accessible templates visible when a private/internal registry cannot be read.
- Wire desktop Genesis template discovery/install to the persisted marketplace list and preserve marketplace identity for duplicate template IDs.
- Bump to v0.35.0 and add the changelog entry.

## Validation

- `npm run lint`
- `npm test`
- Uncle Bob review run; fixed findings for default marketplace disabled-state persistence and duplicate template ID disambiguation.

Closes #169
Refs #117
Refs #118
Refs #106