### PR TITLE
Add Genesis landing marketplace enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.36.0 (2026-04-30)
+
+### Genesis marketplace
+
+- **Add first-run marketplace enrollment** — the Genesis landing screen now includes an Add Marketplace path backed by desktop IPC and validation so users can enroll internal Genesis marketplace repositories by URL without editing config files. (#170)
+
 ## v0.35.0 (2026-04-30)
 
 ### Genesis marketplace

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -21,6 +21,7 @@ import {
   CronService,
   IdentityLoader,
   MessageRouter,
+  MarketplaceRegistryService,
   MindManager,
   MindScaffold,
   TaskManager,
@@ -40,6 +41,7 @@ import { setupChatIPC } from './main/ipc/chat';
 import { setupMindIPC } from './main/ipc/mind';
 import { setupLensIPC } from './main/ipc/lens';
 import { setupGenesisIPC } from './main/ipc/genesis';
+import { setupMarketplaceIPC } from './main/ipc/marketplace';
 import { setupAuthIPC } from './main/ipc/auth';
 import { setupA2AIPC } from './main/ipc/a2a';
 import { setupChatroomIPC } from './main/ipc/chatroom';
@@ -122,6 +124,7 @@ const authService = new AuthService(
 const scaffold = new MindScaffold();
 const genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(undefined, getGenesisMarketplaceSources);
 const genesisTemplateInstaller = new GenesisMindTemplateInstaller(undefined, clientFactory, getGenesisMarketplaceSources);
+const marketplaceRegistryService = new MarketplaceRegistryService(configService);
 const viewDiscovery = new ViewDiscovery();
 
 // --- Services (business rules, all dependencies injected) ---
@@ -360,6 +363,7 @@ app.on('ready', async () => {
     { listTemplates: () => genesisTemplateCatalog.listTemplates().templates },
     genesisTemplateInstaller,
   );
+  setupMarketplaceIPC(marketplaceRegistryService);
   setupAuthIPC(authService, mindManager);
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager);
   setupChatroomIPC(chatroomService);

--- a/apps/desktop/src/main/ipc/marketplace.ts
+++ b/apps/desktop/src/main/ipc/marketplace.ts
@@ -1,0 +1,12 @@
+import { ipcMain } from 'electron';
+import type { MarketplaceRegistryService } from '@chamber/services';
+
+export function setupMarketplaceIPC(marketplaceRegistryService: MarketplaceRegistryService): void {
+  ipcMain.handle('marketplace:listGenesisRegistries', async () => {
+    return marketplaceRegistryService.listGenesisRegistries();
+  });
+
+  ipcMain.handle('marketplace:addGenesisRegistry', async (_event, url: string) => {
+    return marketplaceRegistryService.addGenesisRegistry(url);
+  });
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -49,6 +49,10 @@ const electronAPI: ElectronAPI = {
     createFromTemplate: (request) => ipcRenderer.invoke('genesis:createFromTemplate', request),
     onProgress: (callback) => createIpcListener(ipcRenderer, 'genesis:progress', callback),
   },
+  marketplace: {
+    listGenesisRegistries: () => ipcRenderer.invoke('marketplace:listGenesisRegistries'),
+    addGenesisRegistry: (url) => ipcRenderer.invoke('marketplace:addGenesisRegistry', url),
+  },
   chatroom: {
     send: (message: string, model?: string) => ipcRenderer.invoke('chatroom:send', message, model),
     history: () => ipcRenderer.invoke('chatroom:history'),

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -220,6 +220,10 @@ export function installBrowserApi(): void {
       createFromTemplate: async () => ({ success: false, error: 'Genesis template install is desktop-only in browser mode.' }),
       onProgress: () => noopUnsubscribe,
     },
+    marketplace: {
+      listGenesisRegistries: async () => [],
+      addGenesisRegistry: async () => ({ success: false, error: 'Marketplace management is desktop-only in browser mode.' }),
+    },
     chatroom: createBrowserChatroomApi(),
     updater: {
       getState: async () => ({

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx
@@ -2,15 +2,28 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { GenesisFlow } from './GenesisFlow';
 import { AppStateProvider, useAppState } from '../../lib/store';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
 import type { GenesisMindTemplate, MindContext } from '../../../shared/types';
 
 vi.mock('./VoidScreen', () => ({
-  VoidScreen: ({ onBegin }: { onBegin: () => void }) => <button onClick={onBegin}>Begin</button>,
+  VoidScreen: ({
+    onBegin,
+    onAddMarketplace,
+  }: {
+    onBegin: () => void;
+    onAddMarketplace: (url: string) => Promise<{ success: boolean; message: string }>;
+  }) => (
+    <div>
+      <button onClick={onBegin}>Begin</button>
+      <button onClick={() => { void onAddMarketplace('https://github.com/agency-microsoft/genesis-minds'); }}>
+        Add Marketplace
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('./VoiceScreen', () => ({
@@ -87,6 +100,10 @@ describe('GenesisFlow', () => {
   beforeEach(() => {
     api = installElectronAPI();
     (api.genesis.listTemplates as ReturnType<typeof vi.fn>).mockResolvedValue([lucyTemplate]);
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('waits for genesis.create to load the new mind before completing', async () => {
@@ -199,6 +216,21 @@ describe('GenesisFlow', () => {
       });
     });
     expect(api.genesis.createFromTemplate).not.toHaveBeenCalled();
+  });
+
+  it('adds a marketplace from the landing page and refreshes templates', async () => {
+    render(
+      <AppStateProvider>
+        <GenesisFlow onComplete={vi.fn()} />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Add Marketplace'));
+
+    await waitFor(() => {
+      expect(api.marketplace.addGenesisRegistry).toHaveBeenCalledWith('https://github.com/agency-microsoft/genesis-minds');
+    });
+    expect(api.genesis.listTemplates).toHaveBeenCalled();
   });
 
   it('shows marketplace template failures and blocks completion', async () => {

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -40,6 +40,15 @@ export function GenesisFlow({ onComplete }: Props) {
     void loadTemplates();
   }, [loadTemplates]);
 
+  const handleAddMarketplace = useCallback(async (url: string): Promise<{ success: boolean; message: string }> => {
+    const result = await window.electronAPI.marketplace.addGenesisRegistry(url);
+    if (!result.success) {
+      return { success: false, message: result.error };
+    }
+    await loadTemplates();
+    return { success: true, message: `Added ${result.registry.label}. It will appear in New Agent templates.` };
+  }, [loadTemplates]);
+
   const handleRole= useCallback(async (r: string) => {
     setRole(r);
     setStage('boot');
@@ -117,7 +126,7 @@ export function GenesisFlow({ onComplete }: Props) {
 
   switch (stage) {
     case 'void':
-      return <VoidScreen onBegin={handleBegin} />;
+      return <VoidScreen onBegin={handleBegin} onAddMarketplace={handleAddMarketplace} />;
     case 'voice':
       return (
         <VoiceScreen

--- a/apps/web/src/renderer/components/genesis/VoidScreen.test.tsx
+++ b/apps/web/src/renderer/components/genesis/VoidScreen.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { useEffect } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { VoidScreen } from './VoidScreen';
+
+vi.mock('./TypeWriter', () => ({
+  TypeWriter: ({
+    text,
+    onComplete,
+  }: {
+    text: string;
+    onComplete?: () => void;
+  }) => {
+    useEffect(() => {
+      onComplete?.();
+    }, [onComplete]);
+    return <span>{text}</span>;
+  },
+}));
+
+describe('VoidScreen', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('adds a marketplace from the landing screen', async () => {
+    const onAddMarketplace = vi.fn().mockResolvedValue({
+      success: true,
+      message: 'Added agency-microsoft/genesis-minds.',
+    });
+
+    render(<VoidScreen onBegin={vi.fn()} onAddMarketplace={onAddMarketplace} />);
+
+    const addButton = await screen.findByText('Add Marketplace', undefined, { timeout: 8_000 });
+    fireEvent.click(addButton);
+    fireEvent.change(screen.getByLabelText('Marketplace repository URL'), {
+      target: { value: 'https://github.com/agency-microsoft/genesis-minds' },
+    });
+    fireEvent.click(screen.getByText('Add marketplace'));
+
+    await waitFor(() => {
+      expect(onAddMarketplace).toHaveBeenCalledWith('https://github.com/agency-microsoft/genesis-minds');
+    });
+    expect((await screen.findByRole('status')).textContent).toBe('Added agency-microsoft/genesis-minds.');
+  });
+
+  it('shows friendly marketplace enrollment errors', async () => {
+    const onAddMarketplace = vi.fn().mockResolvedValue({
+      success: false,
+      message: 'Check your GitHub sign-in or repository access.',
+    });
+
+    render(<VoidScreen onBegin={vi.fn()} onAddMarketplace={onAddMarketplace} />);
+
+    fireEvent.click(await screen.findByText('Add Marketplace', undefined, { timeout: 8_000 }));
+    fireEvent.change(screen.getByLabelText('Marketplace repository URL'), {
+      target: { value: 'https://github.com/agency-microsoft/genesis-minds' },
+    });
+    fireEvent.click(screen.getByText('Add marketplace'));
+
+    expect((await screen.findByRole('status')).textContent).toBe('Check your GitHub sign-in or repository access.');
+  });
+});

--- a/apps/web/src/renderer/components/genesis/VoidScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoidScreen.tsx
@@ -3,6 +3,7 @@ import { TypeWriter } from './TypeWriter';
 
 interface Props {
   onBegin: () => void;
+  onAddMarketplace: (url: string) => Promise<{ success: boolean; message: string }>;
 }
 
 const BOOT_LINES = [
@@ -14,10 +15,14 @@ const BOOT_LINES = [
   '> awaiting genesis.',
 ];
 
-export function VoidScreen({ onBegin }: Props) {
+export function VoidScreen({ onBegin, onAddMarketplace }: Props) {
   const [lineIndex, setLineIndex] = useState(0);
   const [showButton, setShowButton] = useState(false);
   const [lines, setLines] = useState<string[]>([]);
+  const [showMarketplaceForm, setShowMarketplaceForm] = useState(false);
+  const [marketplaceUrl, setMarketplaceUrl] = useState('');
+  const [marketplaceMessage, setMarketplaceMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [addingMarketplace, setAddingMarketplace] = useState(false);
 
   const handleLineComplete = useCallback(() => {
     if (lineIndex < BOOT_LINES.length - 1) {
@@ -53,14 +58,69 @@ export function VoidScreen({ onBegin }: Props) {
       </div>
 
       {showButton && (
-        <button
-          onClick={onBegin}
-          className="mt-12 px-8 py-3 rounded-lg border border-green-500/30 text-green-500 font-mono text-sm
-                     hover:bg-green-500/10 transition-all duration-300
-                     animate-pulse hover:animate-none"
-        >
-          Begin
-        </button>
+        <div className="mt-12 flex w-full max-w-md flex-col items-center gap-4 px-8">
+          <div className="flex flex-wrap justify-center gap-3">
+            <button
+              onClick={onBegin}
+              className="px-8 py-3 rounded-lg border border-green-500/30 text-green-500 font-mono text-sm
+                         hover:bg-green-500/10 transition-all duration-300
+                         animate-pulse hover:animate-none"
+            >
+              Begin
+            </button>
+            <button
+              onClick={() => setShowMarketplaceForm((value) => !value)}
+              className="px-8 py-3 rounded-lg border border-green-500/20 text-green-500/80 font-mono text-sm
+                         hover:bg-green-500/10 hover:text-green-500 transition-all duration-300"
+            >
+              Add Marketplace
+            </button>
+          </div>
+
+          {showMarketplaceForm ? (
+            <form
+              className="w-full space-y-3 rounded-lg border border-green-500/20 bg-green-500/5 p-4 font-mono"
+              onSubmit={(event) => {
+                event.preventDefault();
+                setAddingMarketplace(true);
+                setMarketplaceMessage(null);
+                void onAddMarketplace(marketplaceUrl)
+                  .then((result) => {
+                    setMarketplaceMessage({
+                      type: result.success ? 'success' : 'error',
+                      text: result.message,
+                    });
+                    if (result.success) setMarketplaceUrl('');
+                  })
+                  .finally(() => setAddingMarketplace(false));
+              }}
+            >
+              <label className="block text-left text-xs text-green-500/80" htmlFor="marketplace-url">
+                Marketplace repository URL
+              </label>
+              <input
+                id="marketplace-url"
+                type="url"
+                value={marketplaceUrl}
+                onChange={(event) => setMarketplaceUrl(event.target.value)}
+                placeholder="https://github.com/agency-microsoft/genesis-minds"
+                className="w-full rounded-md border border-green-500/20 bg-black px-3 py-2 text-sm text-green-500 outline-none placeholder:text-green-500/30 focus:border-green-500/60"
+              />
+              <button
+                type="submit"
+                disabled={addingMarketplace}
+                className="w-full rounded-md border border-green-500/30 px-3 py-2 text-sm text-green-500 hover:bg-green-500/10 disabled:opacity-50"
+              >
+                {addingMarketplace ? 'Adding...' : 'Add marketplace'}
+              </button>
+              {marketplaceMessage ? (
+                <p role="status" className={marketplaceMessage.type === 'success' ? 'text-xs text-green-400' : 'text-xs text-red-300'}>
+                  {marketplaceMessage.text}
+                </p>
+              ) : null}
+            </form>
+          ) : null}
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/shared/types.ts
+++ b/apps/web/src/shared/types.ts
@@ -108,6 +108,10 @@ export interface MarketplaceRegistry {
   isDefault: boolean;
 }
 
+export type MarketplaceRegistryActionResult =
+  | { success: true; registry: MarketplaceRegistry }
+  | { success: false; error: string };
+
 export interface ModelInfo {
   id: string;
   name: string;
@@ -224,6 +228,10 @@ export interface ElectronAPI {
     create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     createFromTemplate: (request: { templateId: string; marketplaceId?: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
+  };
+  marketplace: {
+    listGenesisRegistries: () => Promise<MarketplaceRegistry[]>;
+    addGenesisRegistry: (url: string) => Promise<MarketplaceRegistryActionResult>;
   };
   chatroom: ChatroomAPI;
   updater: {

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -150,6 +150,20 @@ export function mockElectronAPI(): ElectronAPI {
       createFromTemplate: vi.fn().mockResolvedValue({ success: true }),
       onProgress: vi.fn().mockReturnValue(vi.fn()),
     },
+    marketplace: {
+      listGenesisRegistries: vi.fn().mockResolvedValue([]),
+      addGenesisRegistry: vi.fn().mockResolvedValue({ success: true, registry: {
+        id: 'github:agency-microsoft/genesis-minds',
+        label: 'agency-microsoft/genesis-minds',
+        url: 'https://github.com/agency-microsoft/genesis-minds',
+        owner: 'agency-microsoft',
+        repo: 'genesis-minds',
+        ref: 'main',
+        plugin: 'genesis-minds',
+        enabled: true,
+        isDefault: false,
+      } }),
+    },
     chatroom: {
       send: vi.fn().mockResolvedValue(undefined),
       history: vi.fn().mockResolvedValue([]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/genesis/MarketplaceRegistryService.test.ts
+++ b/packages/services/src/genesis/MarketplaceRegistryService.test.ts
@@ -6,7 +6,7 @@ import type { TreeEntry } from './GitHubRegistryClient';
 class FakeRegistryClient {
   fail = false;
 
-  fetchTree(): TreeEntry[] {
+  async fetchTree(): Promise<TreeEntry[]> {
     if (this.fail) throw new Error('not found');
     return [
       { path: 'marketplace-config.json', type: 'blob', sha: 'marketplace' },
@@ -21,7 +21,7 @@ class FakeRegistryClient {
     ];
   }
 
-  fetchJsonContent(_owner: string, _repo: string, filePath: string): unknown {
+  async fetchJsonContent(_owner: string, _repo: string, filePath: string): Promise<unknown> {
     if (filePath.endsWith('plugin.json')) {
       return { name: 'genesis-minds', minds: [{ id: 'donna', manifest: 'minds/donna/mind.json' }] };
     }
@@ -83,10 +83,10 @@ describe('MarketplaceRegistryService', () => {
     };
   });
 
-  it('adds a GitHub Genesis marketplace registry after validating its manifest', () => {
+  it('adds a GitHub Genesis marketplace registry after validating its manifest', async () => {
     const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
-    expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).toEqual({
+    await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).resolves.toEqual({
       success: true,
       registry: {
         id: 'github:agency-microsoft/genesis-minds',
@@ -103,23 +103,33 @@ describe('MarketplaceRegistryService', () => {
     expect(config.marketplaceRegistries).toHaveLength(2);
   });
 
-  it('returns a friendly access error without saving inaccessible marketplaces', () => {
+  it('returns a friendly access error without saving inaccessible marketplaces', async () => {
     registryClient.fail = true;
     const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
-    expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).toEqual({
+    await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).resolves.toEqual({
       success: false,
       error: 'Unable to access marketplace agency-microsoft/genesis-minds. Check your GitHub sign-in or repository access.',
     });
     expect(savedConfigs).toHaveLength(0);
   });
 
-  it('rejects non-GitHub URLs', () => {
+  it('rejects non-GitHub URLs', async () => {
     const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
-    expect(service.addGenesisRegistry('https://example.com/agency-microsoft/genesis-minds')).toEqual({
+    await expect(service.addGenesisRegistry('https://example.com/agency-microsoft/genesis-minds')).resolves.toEqual({
       success: false,
       error: 'Marketplace URLs must point to github.com repositories.',
     });
+  });
+
+  it('rejects owner and repo path segments with shell metacharacters before validation', async () => {
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
+
+    await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds&calc')).resolves.toEqual({
+      success: false,
+      error: 'Marketplace URLs must include a valid GitHub owner and repository name.',
+    });
+    expect(savedConfigs).toHaveLength(0);
   });
 });

--- a/packages/services/src/genesis/MarketplaceRegistryService.test.ts
+++ b/packages/services/src/genesis/MarketplaceRegistryService.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { MarketplaceRegistryService } from './MarketplaceRegistryService';
+import type { AppConfig } from '@chamber/shared/types';
+import type { TreeEntry } from './GitHubRegistryClient';
+
+class FakeRegistryClient {
+  fail = false;
+
+  fetchTree(): TreeEntry[] {
+    if (this.fail) throw new Error('not found');
+    return [
+      { path: 'marketplace-config.json', type: 'blob', sha: 'marketplace' },
+      { path: 'plugins/genesis-minds/plugin.json', type: 'blob', sha: 'plugin' },
+      { path: 'plugins/genesis-minds/minds/donna/mind.json', type: 'blob', sha: 'manifest' },
+      { path: 'plugins/genesis-minds/minds/donna/SOUL.md', type: 'blob', sha: 'soul' },
+      { path: 'plugins/genesis-minds/minds/donna/mind-index.md', type: 'blob', sha: 'index' },
+      { path: 'plugins/genesis-minds/minds/donna/.github/agents/donna.agent.md', type: 'blob', sha: 'agent' },
+      { path: 'plugins/genesis-minds/minds/donna/.working-memory/memory.md', type: 'blob', sha: 'memory' },
+      { path: 'plugins/genesis-minds/minds/donna/.working-memory/rules.md', type: 'blob', sha: 'rules' },
+      { path: 'plugins/genesis-minds/minds/donna/.working-memory/log.md', type: 'blob', sha: 'log' },
+    ];
+  }
+
+  fetchJsonContent(_owner: string, _repo: string, filePath: string): unknown {
+    if (filePath.endsWith('plugin.json')) {
+      return { name: 'genesis-minds', minds: [{ id: 'donna', manifest: 'minds/donna/mind.json' }] };
+    }
+    return {
+      id: 'donna',
+      displayName: 'Donna',
+      description: 'Internal chief of staff.',
+      role: 'Chief of Staff',
+      voice: 'Direct and precise',
+      templateVersion: '0.1.0',
+      root: '.',
+      agent: '.github/agents/donna.agent.md',
+      requiredFiles: [
+        'SOUL.md',
+        'mind-index.md',
+        '.github/agents/donna.agent.md',
+        '.working-memory/memory.md',
+        '.working-memory/rules.md',
+        '.working-memory/log.md',
+      ],
+    };
+  }
+}
+
+const defaultConfig: AppConfig = {
+  version: 2,
+  minds: [],
+  activeMindId: null,
+  activeLogin: null,
+  theme: 'dark',
+  marketplaceRegistries: [
+    {
+      id: 'github:ianphil/genesis-minds',
+      label: 'Public Genesis Minds',
+      url: 'https://github.com/ianphil/genesis-minds',
+      owner: 'ianphil',
+      repo: 'genesis-minds',
+      ref: 'master',
+      plugin: 'genesis-minds',
+      enabled: true,
+      isDefault: true,
+    },
+  ],
+};
+
+describe('MarketplaceRegistryService', () => {
+  let config: AppConfig;
+  let registryClient: FakeRegistryClient;
+  let savedConfigs: AppConfig[];
+  let save: (next: AppConfig) => void;
+
+  beforeEach(() => {
+    config = structuredClone(defaultConfig);
+    registryClient = new FakeRegistryClient();
+    savedConfigs = [];
+    save = (next: AppConfig) => {
+      savedConfigs.push(next);
+      config = next;
+    };
+  });
+
+  it('adds a GitHub Genesis marketplace registry after validating its manifest', () => {
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
+
+    expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).toEqual({
+      success: true,
+      registry: {
+        id: 'github:agency-microsoft/genesis-minds',
+        label: 'agency-microsoft/genesis-minds',
+        url: 'https://github.com/agency-microsoft/genesis-minds',
+        owner: 'agency-microsoft',
+        repo: 'genesis-minds',
+        ref: 'main',
+        plugin: 'genesis-minds',
+        enabled: true,
+        isDefault: false,
+      },
+    });
+    expect(config.marketplaceRegistries).toHaveLength(2);
+  });
+
+  it('returns a friendly access error without saving inaccessible marketplaces', () => {
+    registryClient.fail = true;
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
+
+    expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).toEqual({
+      success: false,
+      error: 'Unable to access marketplace agency-microsoft/genesis-minds. Check your GitHub sign-in or repository access.',
+    });
+    expect(savedConfigs).toHaveLength(0);
+  });
+
+  it('rejects non-GitHub URLs', () => {
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
+
+    expect(service.addGenesisRegistry('https://example.com/agency-microsoft/genesis-minds')).toEqual({
+      success: false,
+      error: 'Marketplace URLs must point to github.com repositories.',
+    });
+  });
+});

--- a/packages/services/src/genesis/MarketplaceRegistryService.ts
+++ b/packages/services/src/genesis/MarketplaceRegistryService.ts
@@ -1,6 +1,12 @@
-import { DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE, GenesisMindTemplateCatalog } from './GenesisMindTemplateCatalog';
-import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE } from './GenesisMindTemplateCatalog';
+import type { TreeEntry } from './GitHubRegistryClient';
 import type { AppConfig, MarketplaceRegistry, MarketplaceRegistryActionResult } from '@chamber/shared/types';
+
+const execFileAsync = promisify(execFile);
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const GITHUB_REPO_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 interface ConfigStore {
   load(): AppConfig;
@@ -8,21 +14,42 @@ interface ConfigStore {
 }
 
 interface RegistryClient {
-  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
-  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
+  fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]>;
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown>;
+}
+
+class AsyncGitHubRegistryClient implements RegistryClient {
+  async fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]> {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['api', `/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`],
+      { encoding: 'utf8', timeout: 30_000 },
+    );
+    return (JSON.parse(stdout) as { tree: TreeEntry[] }).tree;
+  }
+
+  async fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown> {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['api', `/repos/${owner}/${repo}/contents/${filePath}?ref=${ref}`],
+      { encoding: 'utf8', timeout: 30_000 },
+    );
+    const content = JSON.parse(stdout) as { content: string };
+    return JSON.parse(Buffer.from(content.content, 'base64').toString('utf8'));
+  }
 }
 
 export class MarketplaceRegistryService {
   constructor(
     private readonly configStore: ConfigStore,
-    private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
+    private readonly registryClient: RegistryClient = new AsyncGitHubRegistryClient(),
   ) {}
 
   listGenesisRegistries(): MarketplaceRegistry[] {
     return this.configStore.load().marketplaceRegistries ?? [DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE as MarketplaceRegistry];
   }
 
-  addGenesisRegistry(rawUrl: string): MarketplaceRegistryActionResult {
+  async addGenesisRegistry(rawUrl: string): Promise<MarketplaceRegistryActionResult> {
     let registry: MarketplaceRegistry;
     try {
       registry = parseGitHubMarketplaceUrl(rawUrl);
@@ -34,7 +61,7 @@ export class MarketplaceRegistryService {
     }
 
     try {
-      new GenesisMindTemplateCatalog(this.registryClient, registry).listTemplates();
+      await validateGenesisMarketplace(this.registryClient, registry);
     } catch {
       return {
         success: false,
@@ -85,6 +112,9 @@ function parseGitHubMarketplaceUrl(rawUrl: string): MarketplaceRegistry {
   if (!owner || !repo) {
     throw new Error('Marketplace URLs must include an owner and repository.');
   }
+  if (!GITHUB_OWNER_PATTERN.test(owner) || !GITHUB_REPO_PATTERN.test(repo)) {
+    throw new Error('Marketplace URLs must include a valid GitHub owner and repository name.');
+  }
 
   return {
     id: `github:${owner}/${repo}`,
@@ -97,4 +127,36 @@ function parseGitHubMarketplaceUrl(rawUrl: string): MarketplaceRegistry {
     enabled: true,
     isDefault: false,
   };
+}
+
+async function validateGenesisMarketplace(registryClient: RegistryClient, registry: MarketplaceRegistry): Promise<void> {
+  const tree = await registryClient.fetchTree(registry.owner, registry.repo, registry.ref);
+  const blobPaths = new Set(tree.filter((entry) => entry.type === 'blob').map((entry) => entry.path));
+
+  requireBlob(blobPaths, 'marketplace-config.json');
+  const pluginPath = `plugins/${registry.plugin}/plugin.json`;
+  requireBlob(blobPaths, pluginPath);
+
+  const plugin = await registryClient.fetchJsonContent(registry.owner, registry.repo, pluginPath, registry.ref);
+  if (!isRecord(plugin) || !Array.isArray(plugin.minds)) {
+    throw new Error(`Plugin manifest ${pluginPath} must define a minds array`);
+  }
+
+  for (const entry of plugin.minds) {
+    if (!isRecord(entry) || typeof entry.manifest !== 'string') {
+      throw new Error(`Plugin manifest ${pluginPath} has an invalid minds entry`);
+    }
+    const manifestPath = `plugins/${registry.plugin}/${entry.manifest}`;
+    requireBlob(blobPaths, manifestPath);
+  }
+}
+
+function requireBlob(blobPaths: Set<string>, filePath: string): void {
+  if (!blobPaths.has(filePath)) {
+    throw new Error(`Marketplace missing required file: ${filePath}`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/services/src/genesis/MarketplaceRegistryService.ts
+++ b/packages/services/src/genesis/MarketplaceRegistryService.ts
@@ -1,0 +1,100 @@
+import { DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE, GenesisMindTemplateCatalog } from './GenesisMindTemplateCatalog';
+import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
+import type { AppConfig, MarketplaceRegistry, MarketplaceRegistryActionResult } from '@chamber/shared/types';
+
+interface ConfigStore {
+  load(): AppConfig;
+  save(config: AppConfig): void;
+}
+
+interface RegistryClient {
+  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
+}
+
+export class MarketplaceRegistryService {
+  constructor(
+    private readonly configStore: ConfigStore,
+    private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
+  ) {}
+
+  listGenesisRegistries(): MarketplaceRegistry[] {
+    return this.configStore.load().marketplaceRegistries ?? [DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE as MarketplaceRegistry];
+  }
+
+  addGenesisRegistry(rawUrl: string): MarketplaceRegistryActionResult {
+    let registry: MarketplaceRegistry;
+    try {
+      registry = parseGitHubMarketplaceUrl(rawUrl);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    try {
+      new GenesisMindTemplateCatalog(this.registryClient, registry).listTemplates();
+    } catch {
+      return {
+        success: false,
+        error: `Unable to access marketplace ${registry.label}. Check your GitHub sign-in or repository access.`,
+      };
+    }
+
+    const config = this.configStore.load();
+    const registries = config.marketplaceRegistries ?? [DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE as MarketplaceRegistry];
+    const existingIndex = registries.findIndex((item) => item.id === registry.id);
+    const nextRegistries = [...registries];
+    if (existingIndex >= 0) {
+      nextRegistries[existingIndex] = { ...nextRegistries[existingIndex], enabled: true };
+      registry = nextRegistries[existingIndex];
+    } else {
+      nextRegistries.push(registry);
+    }
+
+    this.configStore.save({ ...config, marketplaceRegistries: nextRegistries });
+    return { success: true, registry };
+  }
+}
+
+function parseGitHubMarketplaceUrl(rawUrl: string): MarketplaceRegistry {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    throw new Error('Enter a GitHub marketplace repository URL.');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error('Enter a valid GitHub repository URL.');
+  }
+
+  if (url.hostname !== 'github.com') {
+    throw new Error('Marketplace URLs must point to github.com repositories.');
+  }
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    throw new Error('Marketplace URLs must include an owner and repository.');
+  }
+
+  const owner = segments[0];
+  const repo = segments[1].replace(/\.git$/, '');
+  if (!owner || !repo) {
+    throw new Error('Marketplace URLs must include an owner and repository.');
+  }
+
+  return {
+    id: `github:${owner}/${repo}`,
+    label: `${owner}/${repo}`,
+    url: `https://github.com/${owner}/${repo}`,
+    owner,
+    repo,
+    ref: 'main',
+    plugin: 'genesis-minds',
+    enabled: true,
+    isDefault: false,
+  };
+}

--- a/packages/services/src/genesis/index.ts
+++ b/packages/services/src/genesis/index.ts
@@ -6,6 +6,7 @@ export { GitHubRegistryClient } from './GitHubRegistryClient';
 export { GenesisMindTemplateCatalog, DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE } from './GenesisMindTemplateCatalog';
 export { GenesisMindTemplateMarketplaceCatalog } from './GenesisMindTemplateMarketplaceCatalog';
 export { GenesisMindTemplateInstaller } from './GenesisMindTemplateInstaller';
+export { MarketplaceRegistryService } from './MarketplaceRegistryService';
 export type { GenesisMindTemplateInstallRequest } from './GenesisMindTemplateInstaller';
 export type {
   GenesisMindTemplate,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -108,6 +108,10 @@ export interface MarketplaceRegistry {
   isDefault: boolean;
 }
 
+export type MarketplaceRegistryActionResult =
+  | { success: true; registry: MarketplaceRegistry }
+  | { success: false; error: string };
+
 export interface ModelInfo {
   id: string;
   name: string;
@@ -224,6 +228,10 @@ export interface ElectronAPI {
     create: (config: { name: string; role: string; voice: string; voiceDescription: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     createFromTemplate: (request: { templateId: string; marketplaceId?: string; basePath: string }) => Promise<{ success: boolean; mindId?: string; mindPath?: string; error?: string }>;
     onProgress: (callback: (progress: { step: string; detail: string }) => void) => () => void;
+  };
+  marketplace: {
+    listGenesisRegistries: () => Promise<MarketplaceRegistry[]>;
+    addGenesisRegistry: (url: string) => Promise<MarketplaceRegistryActionResult>;
   };
   chatroom: ChatroomAPI;
   updater: {

--- a/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
+++ b/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_LANDING_MARKETPLACE_CDP_PORT ?? 9341);
+const internalMarketplaceUrl = 'https://github.com/agency-microsoft/genesis-minds';
+const publicMarketplaceId = 'github:ianphil/genesis-minds';
+const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
+
+test.describe('electron Genesis landing Add Marketplace smoke', () => {
+  test.setTimeout(240_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let userDataPath = '';
+  let genesisBasePath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-genesis-landing-marketplace-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    genesisBasePath = path.join(root, 'agents');
+    tempRoots.push(root);
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+        CHAMBER_E2E_GENESIS_BASE_PATH: genesisBasePath,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('adds the internal marketplace from first-run Genesis and refreshes template choices', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('button', { name: /New Agent/i }).click();
+    await page.getByRole('button', { name: 'Add Marketplace' }).click();
+    await page.getByLabel('Marketplace repository URL').fill(internalMarketplaceUrl);
+    await page.getByRole('button', { name: 'Add marketplace', exact: true }).click();
+
+    await expect(page.getByRole('status')).toContainText('Added agency-microsoft/genesis-minds', { timeout: 90_000 });
+
+    const registries = await page.evaluate(async () => window.electronAPI.marketplace.listGenesisRegistries());
+    expect(registries.find((registry) => registry.id === internalMarketplaceId)).toMatchObject({
+      enabled: true,
+      owner: 'agency-microsoft',
+      repo: 'genesis-minds',
+    });
+
+    await page.getByRole('button', { name: 'Begin' }).click();
+    await expect(page.getByRole('button', { name: /Lucy/i }).first()).toBeVisible({ timeout: 90_000 });
+
+    const templates = await page.evaluate(async () => window.electronAPI.genesis.listTemplates());
+    expect(templates.filter((template) => template.id === 'lucy').map((template) => template.source.marketplaceId).sort()).toEqual([
+      internalMarketplaceId,
+      publicMarketplaceId,
+    ]);
+  });
+});
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[genesis-landing-marketplace-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}

--- a/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
+++ b/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
@@ -11,10 +11,6 @@ const publicMarketplaceId = 'github:ianphil/genesis-minds';
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 
 test.describe('electron Genesis marketplace aggregation smoke', () => {
-  test.skip(
-    process.env.CHAMBER_E2E_INTERNAL_MARKETPLACE !== '1',
-    'Set CHAMBER_E2E_INTERNAL_MARKETPLACE=1 with gh access to agency-microsoft/genesis-minds to run this smoke.'
-  );
   test.setTimeout(240_000);
 
   let app: LaunchedElectronApp | undefined;


### PR DESCRIPTION
## Summary

- Add a first-run **Add Marketplace** path to the Genesis landing screen.
- Add desktop marketplace IPC and a `MarketplaceRegistryService` that validates Genesis marketplace repos before saving them.
- Refresh Genesis templates after marketplace enrollment and surface friendly access/auth errors.
- Harden URL handling by validating GitHub owner/repo names before any `gh` call and using async `execFile` validation with bounded timeouts.
- Bump to v0.36.0 and add the changelog entry.

## Validation

- `npx vitest run packages/services/src/genesis/MarketplaceRegistryService.test.ts apps/web/src/renderer/components/genesis/VoidScreen.test.tsx apps/web/src/renderer/components/genesis/GenesisFlow.test.tsx`
- `npm run lint`
- `npm test`
- Uncle Bob review run; fixed findings for shell metacharacter validation and synchronous main-thread marketplace validation.

Closes #170
Refs #117
Refs #118
Refs #106