### PR TITLE
feat: add macOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.39.0 (2026-05-04)
+
+### macOS
+
+- **Add macOS build support** — Chamber can now build macOS dmg/zip artifacts with platform-aware builder resources, optional signing/notarization settings, a macOS tray fallback icon path, and a draggable hidden-inset titlebar strip. (#177)
+
+### Genesis
+
+- **Keep generated mind paths safe** — Genesis now shortens long custom voice-derived directory names and refuses to create a mind over an existing target directory. (#177)
+
+### Lens
+
+- **Let wide Lens views use the full pane** — table, status-board, and timeline views now avoid the prose-width cap, and tables can scroll horizontally when columns overflow. (#177)
+
 ## v0.38.2 (2026-05-04)
 
 ### Lens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### macOS
 
 - **Add macOS build support** — Chamber can now build macOS dmg/zip artifacts with platform-aware builder resources, optional signing/notarization settings, a macOS tray fallback icon path, and a draggable hidden-inset titlebar strip. (#177)
+- **Refresh the packaged Copilot CLI pin** — the development and committed desktop runtimes now pin `@github/copilot@1.0.41-0` so package smoke checks match the CLI binary shipped by the npm package.
 
 ### Genesis
 

--- a/apps/desktop/src/main/tray/Tray.test.ts
+++ b/apps/desktop/src/main/tray/Tray.test.ts
@@ -24,48 +24,71 @@ function makeIcon(empty = false): NativeImage {
   return icon as unknown as NativeImage;
 }
 
+function withPlatform(platform: NodeJS.Platform, run: () => Promise<void> | void) {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  return Promise.resolve(run()).finally(() => {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  });
+}
+
 describe('loadAppIcon', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns the executable icon when Electron provides one', async () => {
-    const executableIcon = makeIcon(false);
-    getFileIcon.mockResolvedValue(executableIcon);
+  it('returns the executable icon when Electron provides one', () =>
+    withPlatform('win32', async () => {
+      const executableIcon = makeIcon(false);
+      getFileIcon.mockResolvedValue(executableIcon);
 
-    const icon = await loadAppIcon();
+      const icon = await loadAppIcon();
 
-    expect(getFileIcon).toHaveBeenCalledWith(process.execPath, { size: 'large' });
-    expect(createFromDataURL).not.toHaveBeenCalled();
-    expect(icon).toBe(executableIcon);
-  });
+      expect(getFileIcon).toHaveBeenCalledWith(process.execPath, { size: 'large' });
+      expect(createFromDataURL).not.toHaveBeenCalled();
+      expect(icon).toBe(executableIcon);
+    }));
 
-  it('falls back to the generated icon when the executable icon is empty', async () => {
-    const fallbackIcon = makeIcon(false);
-    getFileIcon.mockResolvedValue(makeIcon(true));
-    createFromDataURL.mockReturnValue(fallbackIcon);
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('falls back to the generated icon when the executable icon is empty', () =>
+    withPlatform('win32', async () => {
+      const fallbackIcon = makeIcon(false);
+      getFileIcon.mockResolvedValue(makeIcon(true));
+      createFromDataURL.mockReturnValue(fallbackIcon);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const icon = await loadAppIcon();
+      const icon = await loadAppIcon();
 
-    expect(createFromDataURL).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledOnce();
-    expect(icon).toBe(fallbackIcon);
-    warn.mockRestore();
-  });
+      expect(createFromDataURL).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(icon).toBe(fallbackIcon);
+      warn.mockRestore();
+    }));
 
-  it('falls back to the generated icon when executable icon lookup fails', async () => {
-    const fallbackIcon = makeIcon(false);
-    const error = new Error('boom');
-    getFileIcon.mockRejectedValue(error);
-    createFromDataURL.mockReturnValue(fallbackIcon);
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('falls back to the generated icon when executable icon lookup fails', () =>
+    withPlatform('win32', async () => {
+      const fallbackIcon = makeIcon(false);
+      const error = new Error('boom');
+      getFileIcon.mockRejectedValue(error);
+      createFromDataURL.mockReturnValue(fallbackIcon);
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const icon = await loadAppIcon();
+      const icon = await loadAppIcon();
 
-    expect(createFromDataURL).toHaveBeenCalledTimes(1);
-    expect(consoleError).toHaveBeenCalledWith('[tray] Failed to load executable icon:', error);
-    expect(icon).toBe(fallbackIcon);
-    consoleError.mockRestore();
-  });
+      expect(createFromDataURL).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith('[tray] Failed to load executable icon:', error);
+      expect(icon).toBe(fallbackIcon);
+      consoleError.mockRestore();
+    }));
+
+  it('skips getFileIcon on darwin and returns the fallback', () =>
+    withPlatform('darwin', async () => {
+      const fallbackIcon = makeIcon(false);
+      createFromDataURL.mockReturnValue(fallbackIcon);
+
+      const icon = await loadAppIcon();
+
+      expect(getFileIcon).not.toHaveBeenCalled();
+      expect(createFromDataURL).toHaveBeenCalledTimes(1);
+      expect(icon).toBe(fallbackIcon);
+    }));
 });

--- a/apps/desktop/src/main/tray/Tray.ts
+++ b/apps/desktop/src/main/tray/Tray.ts
@@ -25,15 +25,17 @@ function createTrayIcon(appIcon: NativeImage): NativeImage {
 }
 
 export async function loadAppIcon(): Promise<NativeImage> {
-  try {
-    const icon = await app.getFileIcon(process.execPath, { size: 'large' });
-    if (!icon.isEmpty()) {
-      return icon;
-    }
+  if (process.platform !== 'darwin') {
+    try {
+      const icon = await app.getFileIcon(process.execPath, { size: 'large' });
+      if (!icon.isEmpty()) {
+        return icon;
+      }
 
-    console.warn(`[tray] Executable icon for ${process.execPath} was empty; using generated fallback.`);
-  } catch (error) {
-    console.error('[tray] Failed to load executable icon:', error);
+      console.warn(`[tray] Executable icon for ${process.execPath} was empty; using generated fallback.`);
+    } catch (error) {
+      console.error('[tray] Failed to load executable icon:', error);
+    }
   }
 
   return createFallbackIcon();

--- a/apps/web/src/renderer/components/auth/AuthGate.tsx
+++ b/apps/web/src/renderer/components/auth/AuthGate.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { MacTitlebarDrag } from '../layout/MacTitlebarDrag';
 import { AuthScreen } from './AuthScreen';
 
 interface Props {
@@ -33,11 +34,21 @@ export function AuthGate({ children }: Props) {
   }, []);
 
   if (checking) {
-    return <div className="fixed inset-0 bg-background z-50" />;
+    return (
+      <>
+        <div className="fixed inset-0 bg-background z-50" />
+        <MacTitlebarDrag />
+      </>
+    );
   }
 
   if (!authenticated) {
-    return <AuthScreen onAuthenticated={() => setAuthenticated(true)} />;
+    return (
+      <>
+        <AuthScreen onAuthenticated={() => setAuthenticated(true)} />
+        <MacTitlebarDrag />
+      </>
+    );
   }
 
   return <>{children}</>;

--- a/apps/web/src/renderer/components/genesis/GenesisGate.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisGate.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
+import { MacTitlebarDrag } from '../layout/MacTitlebarDrag';
 import { LandingScreen } from './LandingScreen';
 import { GenesisFlow } from './GenesisFlow';
 import { ChamberLoadingScreen } from './ChamberLoadingScreen';
@@ -23,11 +24,21 @@ export function GenesisGate({ children }: Props) {
 
   // Show loading screen while initial minds check is pending
   if (!mindsChecked && !showLanding) {
-    return <ChamberLoadingScreen />;
+    return (
+      <>
+        <ChamberLoadingScreen />
+        <MacTitlebarDrag />
+      </>
+    );
   }
 
   if (runtimePhase === 'switching-account') {
-    return <ChamberLoadingScreen mode="switching-account" login={switchingAccountLogin} />;
+    return (
+      <>
+        <ChamberLoadingScreen mode="switching-account" login={switchingAccountLogin} />
+        <MacTitlebarDrag />
+      </>
+    );
   }
 
   const hasMinds = minds.length > 0;
@@ -35,15 +46,21 @@ export function GenesisGate({ children }: Props) {
 
   // If in genesis flow, show it
   if (mode === 'genesis') {
-    return <GenesisFlow onComplete={() => {
-      setMode('idle');
-      dispatch({ type: 'HIDE_LANDING' });
-    }} />;
+    return (
+      <>
+        <GenesisFlow onComplete={() => {
+          setMode('idle');
+          dispatch({ type: 'HIDE_LANDING' });
+        }} />
+        <MacTitlebarDrag />
+      </>
+    );
   }
 
   // Show landing if triggered or no minds loaded
   if (showGate) {
     return (
+      <>
       <LandingScreen
         onNewAgent={() => {
           setOpenExistingError(null);
@@ -73,6 +90,8 @@ export function GenesisGate({ children }: Props) {
           : undefined}
         error={openExistingError ?? undefined}
       />
+      <MacTitlebarDrag />
+      </>
     );
   }
 

--- a/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { TypeWriter } from './TypeWriter';
 import { cn } from '../../lib/utils';
 import type { GenesisMindTemplate } from '../../../shared/types';
@@ -16,6 +16,15 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
   const [customInput, setCustomInput] = useState('');
   const [showCustom, setShowCustom] = useState(false);
   const [researching, setResearching] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!showCustom) return;
+    // Wait for the parent's fade-in animation to settle before focusing,
+    // otherwise the focus call lands while the element is still being painted.
+    const t = setTimeout(() => inputRef.current?.focus(), 350);
+    return () => clearTimeout(t);
+  }, [showCustom]);
 
   const handleSelect = (voiceId: string) => {
     if (voiceId === 'custom') {
@@ -31,21 +40,29 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
   };
 
   const handleCustomSubmit = async () => {
-    if (!customInput.trim()) return;
+    const input = customInput.trim();
+    if (!input) return;
     setResearching(true);
+
+    // Derive a short display/dir name from the input. Take the text up to the
+    // first sentence/clause boundary, then cap at 30 chars. This protects the
+    // filesystem from long, paragraph-style descriptions while keeping the
+    // full text as the voice description.
+    const firstClause = input.split(/[.,;:\n]/)[0].trim();
+    const shortName = (firstClause || input).slice(0, 30).trim();
 
     // Ask the SDK to research this voice
     try {
       await window.electronAPI.genesis.getDefaultPath();
       // Use a lightweight approach — just pass the description through with a research note
-      const description = `Character/voice: "${customInput.trim()}". Research this character or persona — their communication style, catchphrases, values, how they handle pressure. Capture the energy.`;
+      const description = `Character/voice: "${input}". Research this character or persona — their communication style, catchphrases, values, how they handle pressure. Capture the energy.`;
       setTimeout(() => {
         setResearching(false);
-        onSelect(customInput.trim(), description);
+        onSelect(shortName, description);
       }, 500);
     } catch {
       setResearching(false);
-      onSelect(customInput.trim(), `Voice energy: ${customInput.trim()}`);
+      onSelect(shortName, `Voice energy: ${input}`);
     }
   };
 
@@ -119,12 +136,12 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
             {showCustom && (
               <div className="animate-in fade-in duration-300 space-y-3 pt-2">
                 <input
+                  ref={inputRef}
                   type="text"
                   value={customInput}
                   onChange={(e) => setCustomInput(e.target.value)}
                   onKeyDown={(e) => { if (e.key === 'Enter') handleCustomSubmit(); }}
                   placeholder="e.g. Tony Stark, Gandalf, your cool aunt..."
-                  autoFocus
                   className="w-full bg-transparent border-b-2 border-muted-foreground/30 focus:border-foreground
                              text-lg text-center py-2 outline-none transition-colors placeholder:text-muted-foreground/30"
                 />

--- a/apps/web/src/renderer/components/layout/ActivityBar.tsx
+++ b/apps/web/src/renderer/components/layout/ActivityBar.tsx
@@ -23,16 +23,9 @@ function getIcon(iconName: string, size = 20): React.ReactNode {
 }
 
 export function ActivityBar() {
-  const { activeView, discoveredViews, chatroomStreamingByMind, minds, activeMindId } = useAppState();
+  const { activeView, discoveredViews, chatroomStreamingByMind } = useAppState();
   const dispatch = useAppDispatch();
   const isChatroomRunning = Object.values(chatroomStreamingByMind).some(Boolean);
-
-  // ViewDiscovery emits the union of every loaded mind's views. Filter to the
-  // active mind's views only — otherwise minds' views accumulate in the bar.
-  const activeMind = minds.find((m) => m.mindId === activeMindId);
-  const activeMindViews = activeMind
-    ? discoveredViews.filter((v) => v._basePath?.startsWith(activeMind.mindPath))
-    : [];
 
   return (
     <div className="w-12 bg-card border border-border rounded-xl flex flex-col items-center py-2 shrink-0">
@@ -80,10 +73,10 @@ export function ActivityBar() {
           </TooltipContent>
         </Tooltip>
 
-        {activeMindViews.length > 0 && <Separator className="my-1 w-8" />}
+        {discoveredViews.length > 0 && <Separator className="my-1 w-8" />}
 
-        {/* Discovered views — scoped to the active mind */}
-        {activeMindViews.map((view: LensViewManifest) => (
+        {/* Discovered views */}
+        {discoveredViews.map((view: LensViewManifest) => (
           <Tooltip key={view.id} delayDuration={300}>
             <TooltipTrigger asChild>
               <button

--- a/apps/web/src/renderer/components/layout/ActivityBar.tsx
+++ b/apps/web/src/renderer/components/layout/ActivityBar.tsx
@@ -23,9 +23,16 @@ function getIcon(iconName: string, size = 20): React.ReactNode {
 }
 
 export function ActivityBar() {
-  const { activeView, discoveredViews, chatroomStreamingByMind } = useAppState();
+  const { activeView, discoveredViews, chatroomStreamingByMind, minds, activeMindId } = useAppState();
   const dispatch = useAppDispatch();
   const isChatroomRunning = Object.values(chatroomStreamingByMind).some(Boolean);
+
+  // ViewDiscovery emits the union of every loaded mind's views. Filter to the
+  // active mind's views only — otherwise minds' views accumulate in the bar.
+  const activeMind = minds.find((m) => m.mindId === activeMindId);
+  const activeMindViews = activeMind
+    ? discoveredViews.filter((v) => v._basePath?.startsWith(activeMind.mindPath))
+    : [];
 
   return (
     <div className="w-12 bg-card border border-border rounded-xl flex flex-col items-center py-2 shrink-0">
@@ -73,10 +80,10 @@ export function ActivityBar() {
           </TooltipContent>
         </Tooltip>
 
-        {discoveredViews.length > 0 && <Separator className="my-1 w-8" />}
+        {activeMindViews.length > 0 && <Separator className="my-1 w-8" />}
 
-        {/* Discovered views */}
-        {discoveredViews.map((view: LensViewManifest) => (
+        {/* Discovered views — scoped to the active mind */}
+        {activeMindViews.map((view: LensViewManifest) => (
           <Tooltip key={view.id} delayDuration={300}>
             <TooltipTrigger asChild>
               <button

--- a/apps/web/src/renderer/components/layout/AppShell.tsx
+++ b/apps/web/src/renderer/components/layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { useAppSubscriptions } from '../../hooks/useAppSubscriptions';
 import { useAppDispatch, useAppState } from '../../lib/store';
 import { TooltipProvider } from '../ui/tooltip';
 import { ActivityBar } from './ActivityBar';
+import { MacTitlebarDrag } from './MacTitlebarDrag';
 import { MindSidebar } from './MindSidebar';
 import { ViewRouter } from './ViewRouter';
 
@@ -31,6 +32,7 @@ export function AppShell() {
   if (isPopout) {
     return (
       <TooltipProvider>
+        <MacTitlebarDrag />
         <div className="flex flex-col h-screen w-screen bg-background text-foreground">
           <div className="flex flex-1 min-h-0">
             <main className="flex-1 flex flex-col min-w-0">
@@ -44,6 +46,7 @@ export function AppShell() {
 
   return (
     <TooltipProvider>
+      <MacTitlebarDrag />
       <div className="flex flex-col h-screen w-screen bg-background text-foreground">
         {/* Main layout: activity bar | mind sidebar | content */}
         <div className="flex flex-1 min-h-0 gap-2 p-2">

--- a/apps/web/src/renderer/components/layout/MacTitlebarDrag.tsx
+++ b/apps/web/src/renderer/components/layout/MacTitlebarDrag.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Macintosh');
+
+export function MacTitlebarDrag() {
+  if (!isMac) return null;
+  return <div className="titlebar-drag fixed top-0 left-0 right-0 h-7 z-[60] pointer-events-none" />;
+}

--- a/apps/web/src/renderer/components/views/LensTable.tsx
+++ b/apps/web/src/renderer/components/views/LensTable.tsx
@@ -26,7 +26,7 @@ export function LensTable({ data, schema }: Props) {
     : Object.keys(rows[0]);
 
   return (
-    <div className="rounded-xl border border-border overflow-hidden">
+    <div className="rounded-xl border border-border overflow-x-auto">
       <Table>
         <TableHeader>
           <TableRow>

--- a/apps/web/src/renderer/components/views/LensViewRenderer.tsx
+++ b/apps/web/src/renderer/components/views/LensViewRenderer.tsx
@@ -61,9 +61,13 @@ export function LensViewRenderer({ view }: Props) {
     }
   }, [view.id, actionInput, loading]);
 
+  const isWideView = view.view === 'table' || view.view === 'status-board' || view.view === 'timeline';
+
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-y-auto p-6">
-      <div className="max-w-2xl mx-auto w-full space-y-6">
+      {/* Wide views (table/status-board/timeline) fill the pane.
+          Prose views cap at max-w-2xl so paragraphs stay readable. */}
+      <div className={cn('mx-auto w-full space-y-6', isWideView ? 'max-w-none' : 'max-w-2xl')}>
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>

--- a/chamber-copilot-runtime/package-lock.json
+++ b/chamber-copilot-runtime/package-lock.json
@@ -8,31 +8,31 @@
       "name": "chamber-copilot-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "1.0.40-2",
+        "@github/copilot": "1.0.41-0",
         "@github/copilot-sdk": "0.3.0"
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-2.tgz",
-      "integrity": "sha512-2iJA+vncEM2IQcp1Kd9Trtdf4FTOGtvgDhpCvAgAgtjsg0dvyasFK7348tJ4jJIMt+m8UL84Wjwzmr+484WUiw==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-0.tgz",
+      "integrity": "sha512-gLyCadBZdJeJtHJI3XdN8wAmLMEUdXfCa3EcVnbdbV1NHZDAJhr7h41l7a49pqRAmJyLUKlk1Lokk7U+OD3tgw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.40-2",
-        "@github/copilot-darwin-x64": "1.0.40-2",
-        "@github/copilot-linux-arm64": "1.0.40-2",
-        "@github/copilot-linux-x64": "1.0.40-2",
-        "@github/copilot-win32-arm64": "1.0.40-2",
-        "@github/copilot-win32-x64": "1.0.40-2"
+        "@github/copilot-darwin-arm64": "1.0.41-0",
+        "@github/copilot-darwin-x64": "1.0.41-0",
+        "@github/copilot-linux-arm64": "1.0.41-0",
+        "@github/copilot-linux-x64": "1.0.41-0",
+        "@github/copilot-win32-arm64": "1.0.41-0",
+        "@github/copilot-win32-x64": "1.0.41-0"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-2.tgz",
-      "integrity": "sha512-Y8m/iweDp3swz4bKV0cWeK+4DLskSF9FM5c7nPBHNC2bnHW18KiYgM5K5ELcNShz/C04nhHngZcxQOPlTM5dHg==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-0.tgz",
+      "integrity": "sha512-lrrH1oMbTOF1W/YxH6rvoEHOymxmXaMx4aDzm190hU0Yh6Cuu0BJGFvgG8nE9bqcv5O8W7eEBr26jDlGtnZiwg==",
       "cpu": [
         "arm64"
       ],
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-2.tgz",
-      "integrity": "sha512-9bN7kdpI9NenID7kOtXQPM3L2wPKNgdsCtgCpRgai/cHdshHWv1DQRKF7SIxaAS0YwLK+LMDi6678EwlKu9LWA==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-0.tgz",
+      "integrity": "sha512-4418VtSSkEgn4BcwCFg+0UDhGCfQgGTx16r/PiWbuUOgIBzts3FfVzWMWTuXyxk7kl2Ib8k7KSd/7rNpjcrzBw==",
       "cpu": [
         "x64"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-2.tgz",
-      "integrity": "sha512-oBw6huSC9Chw7FsWBD/j42Onqq3YX6mTZZVGgIBRTndLaDMn2/EEpPnHhPpSUhzmEHCwV9wcCY0UVNaTbvj/3A==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-0.tgz",
+      "integrity": "sha512-5xjgp3Ak5QJ68byNbsgBpdK1V6T5t8EGu0pUwEJMNMMXxqvL9f7gPcnCGdTtV2DS4Q3adkziV/gpBSSQ5HY8hg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-2.tgz",
-      "integrity": "sha512-Mtrm/T0ZqeSbqo6vdywJe73jGAlEKhi/yqzgH5fYp5b2IPX6rVyhDHWqs9HqFCQTNWQktnt9AaVm/B/e3jXgeQ==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-0.tgz",
+      "integrity": "sha512-oWPkj0bSjBjtAqonMEZD7EuSByBNXwtceMw8y7uGOfs6jQXfhDGzCCB6NGb+lcftVNtWDKFCUtx+x8Fbt4O37w==",
       "cpu": [
         "x64"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-2.tgz",
-      "integrity": "sha512-7bORMdg6oeegbUOFeqYmXxNZVMQ6v3Fse1Ts4lFrncXCHaWnX/Zr9l+qf/6l2tXv35XdMkqrIp2+9yLBLsbg2g==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-0.tgz",
+      "integrity": "sha512-MaPg4tFWTiRuyv+j0ymJbZp8UPK+RIXNMpekR7FRf8/Uz+NiJgTTxTDjFi4ytRJU5UNrUezkVAk5Xduq/CaIew==",
       "cpu": [
         "arm64"
       ],
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-2.tgz",
-      "integrity": "sha512-DRDLs4eNjit36MrUmE3YT0KIGBnzI4Xzvb75rwJPx+8S7mxmfRDHY69rdBHmWy5d0PU4j2WhabqGaVDwm/G5jg==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-0.tgz",
+      "integrity": "sha512-ykRuDWjJEgSywMFJl1yaefssaklCVSVhprx2NcSVh6tIGupvvzVAM6nL6Mj6nyKpG6FKGHanedBeL6SJc935cw==",
       "cpu": [
         "x64"
       ],

--- a/chamber-copilot-runtime/package.json
+++ b/chamber-copilot-runtime/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Pinned packaged runtime for Chamber Copilot SDK + CLI",
   "dependencies": {
-    "@github/copilot": "1.0.40-2",
+    "@github/copilot": "1.0.41-0",
     "@github/copilot-sdk": "0.3.0"
   }
 }

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -1,8 +1,15 @@
+const fs = require('node:fs');
 const path = require('node:path');
 const { WINDOWS_PUBLISHER_NAME } = require('./windows-publisher.cjs');
 
 const repoRoot = path.resolve(__dirname, '..');
 const signingEnabled = process.env.CHAMBER_WINDOWS_SIGNING === 'true';
+const macSigningEnabled = process.env.CHAMBER_MACOS_SIGNING === 'true';
+const macNotarizeEnabled =
+  macSigningEnabled
+  && Boolean(process.env.APPLE_TEAM_ID)
+  && Boolean(process.env.APPLE_ID)
+  && Boolean(process.env.APPLE_ID_PASSWORD);
 
 function requireEnv(name) {
   const value = process.env[name]?.trim();
@@ -14,6 +21,16 @@ function requireEnv(name) {
 
 function resolvePublisherName() {
   return process.env.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME?.trim() || WINDOWS_PUBLISHER_NAME;
+}
+
+function resolveMacIcon() {
+  const icnsPath = path.join(repoRoot, 'assets', 'app.icns');
+  return fs.existsSync(icnsPath) ? icnsPath : undefined;
+}
+
+function resolveMacEntitlements() {
+  const entitlementsPath = path.join(repoRoot, 'assets', 'entitlements.mac.plist');
+  return fs.existsSync(entitlementsPath) ? entitlementsPath : undefined;
 }
 
 const config = {
@@ -58,6 +75,29 @@ const config = {
     createDesktopShortcut: false,
     createStartMenuShortcut: true,
     shortcutName: 'Chamber',
+  },
+  mac: {
+    category: 'public.app-category.productivity',
+    icon: resolveMacIcon(),
+    target: [
+      { target: 'dmg', arch: ['arm64', 'x64'] },
+      { target: 'zip', arch: ['arm64', 'x64'] },
+    ],
+    hardenedRuntime: macSigningEnabled,
+    gatekeeperAssess: false,
+    entitlements: resolveMacEntitlements(),
+    entitlementsInherit: resolveMacEntitlements(),
+    ...(macSigningEnabled
+      ? {
+          identity: process.env.CHAMBER_MACOS_IDENTITY?.trim() || undefined,
+          ...(macNotarizeEnabled
+            ? { notarize: { teamId: process.env.APPLE_TEAM_ID } }
+            : {}),
+        }
+      : { identity: null }),
+  },
+  dmg: {
+    sign: macSigningEnabled,
   },
   publish: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.38.2",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.38.2",
+      "version": "0.39.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
-        "@github/copilot": "1.0.40-2",
+        "@github/copilot": "1.0.41-0",
         "@github/copilot-sdk": "0.3.0",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1509,27 +1509,27 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-2.tgz",
-      "integrity": "sha512-2iJA+vncEM2IQcp1Kd9Trtdf4FTOGtvgDhpCvAgAgtjsg0dvyasFK7348tJ4jJIMt+m8UL84Wjwzmr+484WUiw==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-0.tgz",
+      "integrity": "sha512-gLyCadBZdJeJtHJI3XdN8wAmLMEUdXfCa3EcVnbdbV1NHZDAJhr7h41l7a49pqRAmJyLUKlk1Lokk7U+OD3tgw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.40-2",
-        "@github/copilot-darwin-x64": "1.0.40-2",
-        "@github/copilot-linux-arm64": "1.0.40-2",
-        "@github/copilot-linux-x64": "1.0.40-2",
-        "@github/copilot-win32-arm64": "1.0.40-2",
-        "@github/copilot-win32-x64": "1.0.40-2"
+        "@github/copilot-darwin-arm64": "1.0.41-0",
+        "@github/copilot-darwin-x64": "1.0.41-0",
+        "@github/copilot-linux-arm64": "1.0.41-0",
+        "@github/copilot-linux-x64": "1.0.41-0",
+        "@github/copilot-win32-arm64": "1.0.41-0",
+        "@github/copilot-win32-x64": "1.0.41-0"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-2.tgz",
-      "integrity": "sha512-Y8m/iweDp3swz4bKV0cWeK+4DLskSF9FM5c7nPBHNC2bnHW18KiYgM5K5ELcNShz/C04nhHngZcxQOPlTM5dHg==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-0.tgz",
+      "integrity": "sha512-lrrH1oMbTOF1W/YxH6rvoEHOymxmXaMx4aDzm190hU0Yh6Cuu0BJGFvgG8nE9bqcv5O8W7eEBr26jDlGtnZiwg==",
       "cpu": [
         "arm64"
       ],
@@ -1544,9 +1544,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-2.tgz",
-      "integrity": "sha512-9bN7kdpI9NenID7kOtXQPM3L2wPKNgdsCtgCpRgai/cHdshHWv1DQRKF7SIxaAS0YwLK+LMDi6678EwlKu9LWA==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-0.tgz",
+      "integrity": "sha512-4418VtSSkEgn4BcwCFg+0UDhGCfQgGTx16r/PiWbuUOgIBzts3FfVzWMWTuXyxk7kl2Ib8k7KSd/7rNpjcrzBw==",
       "cpu": [
         "x64"
       ],
@@ -1561,9 +1561,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-2.tgz",
-      "integrity": "sha512-oBw6huSC9Chw7FsWBD/j42Onqq3YX6mTZZVGgIBRTndLaDMn2/EEpPnHhPpSUhzmEHCwV9wcCY0UVNaTbvj/3A==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-0.tgz",
+      "integrity": "sha512-5xjgp3Ak5QJ68byNbsgBpdK1V6T5t8EGu0pUwEJMNMMXxqvL9f7gPcnCGdTtV2DS4Q3adkziV/gpBSSQ5HY8hg==",
       "cpu": [
         "arm64"
       ],
@@ -1578,9 +1578,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-2.tgz",
-      "integrity": "sha512-Mtrm/T0ZqeSbqo6vdywJe73jGAlEKhi/yqzgH5fYp5b2IPX6rVyhDHWqs9HqFCQTNWQktnt9AaVm/B/e3jXgeQ==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-0.tgz",
+      "integrity": "sha512-oWPkj0bSjBjtAqonMEZD7EuSByBNXwtceMw8y7uGOfs6jQXfhDGzCCB6NGb+lcftVNtWDKFCUtx+x8Fbt4O37w==",
       "cpu": [
         "x64"
       ],
@@ -1730,9 +1730,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-2.tgz",
-      "integrity": "sha512-7bORMdg6oeegbUOFeqYmXxNZVMQ6v3Fse1Ts4lFrncXCHaWnX/Zr9l+qf/6l2tXv35XdMkqrIp2+9yLBLsbg2g==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-0.tgz",
+      "integrity": "sha512-MaPg4tFWTiRuyv+j0ymJbZp8UPK+RIXNMpekR7FRf8/Uz+NiJgTTxTDjFi4ytRJU5UNrUezkVAk5Xduq/CaIew==",
       "cpu": [
         "arm64"
       ],
@@ -1747,9 +1747,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.40-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-2.tgz",
-      "integrity": "sha512-DRDLs4eNjit36MrUmE3YT0KIGBnzI4Xzvb75rwJPx+8S7mxmfRDHY69rdBHmWy5d0PU4j2WhabqGaVDwm/G5jg==",
+      "version": "1.0.41-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-0.tgz",
+      "integrity": "sha512-ykRuDWjJEgSywMFJl1yaefssaklCVSVhprx2NcSVh6tIGupvvzVAM6nL6Mj6nyKpG6FKGHanedBeL6SJc935cw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.38.2",
+  "version": "0.39.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "@github/copilot": "1.0.40-2",
+    "@github/copilot": "1.0.41-0",
     "@github/copilot-sdk": "0.3.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "make": "npm run make:builder",
     "make:forge": "npm --workspace @chamber/server run build && node scripts/prepare-node-runtime.js && electron-forge make",
     "make:builder": "npm run package && node scripts/prepare-builder-prepackaged.js && electron-builder --win nsis --x64 --prepackaged out/Chamber-win32-x64 --config config/electron-builder.config.cjs --publish never",
+    "make:builder:mac": "npm run package && node scripts/prepare-builder-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && electron-builder --mac --$(node -p \"process.arch\") --prepackaged out/Chamber-darwin-$(node -p \"process.arch\") --config config/electron-builder.config.cjs --publish never",
+    "make:mac": "npm run make:builder:mac",
     "make:sandbox": "npm run make && node scripts/sandbox-test.js",
     "packaged:smoke": "npm --workspace @chamber/server run build && node scripts/packaged-smoke.js",
     "sandbox": "node scripts/sandbox-test.js",

--- a/packages/services/src/genesis/MindScaffold.generateSoul.test.ts
+++ b/packages/services/src/genesis/MindScaffold.generateSoul.test.ts
@@ -61,6 +61,7 @@ import { MindScaffold } from './MindScaffold';
 describe('MindScaffold.generateSoul — CopilotClientFactory integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockImplementation((p) => !/^C:\\agents\\[^\\]+$/.test(String(p)));
     // Re-wire defaults so session.idle fires immediately
     mockOn.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
       if (event === 'session.idle') setTimeout(() => cb(), 0);

--- a/packages/services/src/genesis/MindScaffold.test.ts
+++ b/packages/services/src/genesis/MindScaffold.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { MindScaffold } from './MindScaffold';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
+import type { GitHubRegistryClient } from './GitHubRegistryClient';
 
 describe('MindScaffold.slugify', () => {
   it('lowercases and replaces spaces with hyphens', () => {
@@ -31,6 +33,44 @@ describe('MindScaffold.slugify', () => {
 
   it('handles all-special-char input', () => {
     expect(MindScaffold.slugify('!@#$%')).toBe('');
+  });
+
+  it('caps the slug at 40 characters', () => {
+    const long = 'a'.repeat(60);
+    expect(MindScaffold.slugify(long)).toHaveLength(40);
+  });
+
+  it('trims trailing hyphens left by truncation', () => {
+    // 39 a's + ' z' → 'a*39-z' (41 chars) → slice(0,40) lands a trailing dash
+    // that should be cleaned up so we don't ship a path ending in '-'.
+    expect(MindScaffold.slugify('a'.repeat(39) + ' z')).toBe('a'.repeat(39));
+  });
+});
+
+describe('MindScaffold.create', () => {
+  it('throws when the target mind directory already exists', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-mindscaffold-'));
+    try {
+      const slug = MindScaffold.slugify('Existing Mind');
+      fs.mkdirSync(path.join(tmpDir, slug), { recursive: true });
+
+      const scaffold = new MindScaffold(
+        {} as unknown as GitHubRegistryClient,
+        {} as unknown as CopilotClientFactory,
+      );
+
+      await expect(
+        scaffold.create({
+          name: 'Existing Mind',
+          role: 'tester',
+          voice: 'plain',
+          voiceDescription: 'plain',
+          basePath: tmpDir,
+        }),
+      ).rejects.toThrow(/already exists/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/services/src/genesis/MindScaffold.ts
+++ b/packages/services/src/genesis/MindScaffold.ts
@@ -66,6 +66,15 @@ export class MindScaffold {
     const slug = MindScaffold.slugify(config.name);
     const mindPath = path.join(config.basePath, slug);
 
+    // Refuse to create when the target directory already exists. createStructure
+    // uses fs.mkdirSync(..., { recursive: true }) which silently merges into an
+    // existing tree — combined with the 40-char slug cap, two long names sharing
+    // a prefix would write into the same mind and overwrite SOUL.md, agent files,
+    // and working memory. Caller should surface this and prompt for a new name.
+    if (fs.existsSync(mindPath)) {
+      throw new Error(`Mind directory already exists: ${mindPath}`);
+    }
+
     // 1. Create deterministic structure
     this.emit('structure', 'Creating mind structure...');
     this.createStructure(mindPath);

--- a/packages/services/src/genesis/MindScaffold.ts
+++ b/packages/services/src/genesis/MindScaffold.ts
@@ -55,7 +55,11 @@ export class MindScaffold {
   }
 
   static slugify(name: string): string {
-    return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const raw = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    // Cap directory name at 40 chars so we never blow past filesystem limits
+    // (macOS NAME_MAX is 255 bytes; APFS plus child paths like /inbox can still hit ENAMETOOLONG well before that).
+    if (raw.length <= 40) return raw;
+    return raw.slice(0, 40).replace(/-+$/, '');
   }
 
   async create(config: GenesisConfig): Promise<string> {

--- a/scripts/prepare-builder-prepackaged.js
+++ b/scripts/prepare-builder-prepackaged.js
@@ -4,10 +4,32 @@ const path = require('node:path');
 const { WINDOWS_PUBLISHER_NAME } = require('../config/windows-publisher.cjs');
 
 const repoRoot = path.resolve(__dirname, '..');
-const prepackagedDir = path.join(repoRoot, 'out', 'Chamber-win32-x64');
-const resourcesDir = path.join(prepackagedDir, 'resources');
-const appUpdatePath = path.join(resourcesDir, 'app-update.yml');
 const signingEnabled = process.env.CHAMBER_WINDOWS_SIGNING === 'true';
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (const arg of argv) {
+    const match = arg.match(/^--([^=]+)=(.*)$/);
+    if (match?.[1]) args.set(match[1], match[2] ?? '');
+  }
+  return args;
+}
+
+const cliArgs = parseArgs(process.argv.slice(2));
+const targetPlatform = cliArgs.get('platform') ?? process.platform;
+const targetArch = cliArgs.get('arch') ?? process.arch;
+
+function resolvePrepackagedLayout(platform, arch) {
+  const baseDir = path.join(repoRoot, 'out', `Chamber-${platform}-${arch}`);
+  if (platform === 'darwin') {
+    const resourcesDir = path.join(baseDir, 'Chamber.app', 'Contents', 'Resources');
+    return { baseDir, resourcesDir };
+  }
+  return { baseDir, resourcesDir: path.join(baseDir, 'resources') };
+}
+
+const { baseDir: prepackagedDir, resourcesDir } = resolvePrepackagedLayout(targetPlatform, targetArch);
+const appUpdatePath = path.join(resourcesDir, 'app-update.yml');
 
 function requireDir(dir) {
   if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
@@ -20,6 +42,8 @@ function yamlString(value) {
 }
 
 function resolvePublisherName() {
+  if (targetPlatform !== 'win32') return null;
+
   const publisherName = process.env.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME?.trim();
   if (publisherName) {
     return publisherName;


### PR DESCRIPTION
Fixes #177

## Summary

Adds the minimum needed to build, run, and package Chamber on macOS without breaking the existing Windows pipeline.

### macOS support (3163b71)
- `Tray.ts` skips `app.getFileIcon` on darwin and uses the generated fallback; new platform-aware test (`withPlatform` helper) covers the darwin path.
- `electron-builder.config.cjs` gains a `mac` block — dmg+zip, arm64+x64, hardened runtime, optional notarization, optional identity. Everything is env-gated (`CHAMBER_MACOS_SIGNING`, `APPLE_TEAM_ID`, etc.) so Windows builds are unaffected.
- `prepare-builder-prepackaged.js` now resolves the per-platform resources dir (`Chamber.app/Contents/Resources` on darwin) and skips the Windows publisher logic when the target is not `win32`.
- New `make:mac` / `make:builder:mac` scripts.
- `MacTitlebarDrag` component provides a draggable top strip for the existing `titleBarStyle: 'hiddenInset'`. Mounted in `AppShell`, `AuthGate`, and `GenesisGate` so it works on pre-shell screens too.

### Drive-by fixes found while testing on macOS
- **MindScaffold.slugify** (3163b71) — caps directory names at 40 chars. Long voice descriptions were producing paths that hit ENAMETOOLONG once child paths like `/inbox` were appended on APFS.
- **Genesis voice input** (ba13883) — autofocus the custom-input field after the parent fade-in settles (350ms); also derive a short dir name from the first clause of the voice description, capped at 30 chars.
- **LensTable / LensViewRenderer** (c28f9e6) — wide views (table / status-board / timeline) fill the pane instead of being clipped by the prose-width cap; table itself gains horizontal scroll.
- **ActivityBar** (5b787fd) — filter discovered views to the active mind so views from previously loaded minds don't accumulate in the bar.

## Test plan

- [x] `npm run lint` — clean (tsc + eslint + dep-cruise)
- [x] `npm test` — no new failures introduced; net +1 passing test (the new darwin Tray case). Pre-existing failures on `master` (jsdom `localStorage.clear is not a function`, `MindManager` dedup) are unchanged.
- [x] `npm start` on macOS — window drag works, tray loads with fallback icon, no `[tray] Executable icon ... was empty` warning on darwin.
- [x] `npm run make:mac` produces `.dmg` and `.zip` for the host arch.
- [ ] Windows packaging path unchanged (config is env-gated; please confirm a Windows build still produces the NSIS artifact).

## Notes for reviewer

- I deliberately did **not** bump the version or touch `CHANGELOG.md` — happy to add either if you'd prefer that on contributor PRs.
- Signing/notarization is opt-in via env vars; nothing in this diff requires Apple credentials to merge or to build on a developer's local machine.