### PR TITLE
Fix mind registry pruning after failed restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.38.1 (2026-05-01)
+
+### Mind registry
+
+- **Preserve minds after restore failures** — Chamber now keeps configured mind records when a startup restore attempt fails, so a transient runtime, filesystem, or validation error cannot silently prune the registry on shutdown. (#180)
+
 ## v0.38.0 (2026-04-30)
 
 ### Genesis marketplace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -86,6 +86,16 @@ const mockViewDiscovery = {
   setRefreshHandler: vi.fn(),
 };
 
+function lastSavedConfig(): AppConfig {
+  const config = mockConfigService.save.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+  if (!config) throw new Error('Expected config to be saved');
+  return config;
+}
+
+function savedMindIds(config: AppConfig): string[] {
+  return config.minds.map(record => record.id).sort();
+}
+
 describe('MindManager', () => {
   let manager: MindManager;
 
@@ -261,6 +271,15 @@ describe('MindManager', () => {
       const config = mockConfigService.save.mock.calls.at(-1)?.[0];
       expect(config?.activeMindId).toBe(mind2.mindId);
     });
+
+    it('explicit unload still prunes the unloaded mind from persisted config', async () => {
+      const mind1 = await manager.loadMind('/tmp/agents/q');
+      const mind2 = await manager.loadMind('/tmp/agents/fox');
+
+      await manager.unloadMind(mind1.mindId);
+
+      expect(savedMindIds(lastSavedConfig())).toEqual([mind2.mindId]);
+    });
   });
 
   describe('listMinds', () => {
@@ -353,6 +372,81 @@ describe('MindManager', () => {
       await manager.restoreFromConfig();
       expect(manager.listMinds()).toHaveLength(1);
       expect(manager.listMinds()[0].identity.name).toBe('good');
+      consoleSpy.mockRestore();
+    });
+
+    it('preserves failed restore records when shutdown persists config', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        const normalized = String(p).replace(/\\/g, '/');
+        return normalized === '/tmp/agents/good/SOUL.md' || normalized === '/tmp/agents/good/.github';
+      });
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [
+          { id: 'good-a1b2', path: '/tmp/agents/good' },
+          { id: 'bad-c3d4', path: '/tmp/agents/bad' },
+        ],
+        activeMindId: 'good-a1b2',
+        activeLogin: 'alice',
+        theme: 'dark',
+      });
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+      await manager.restoreFromConfig();
+      mockConfigService.save.mockClear();
+      await manager.shutdown();
+
+      expect(savedMindIds(lastSavedConfig())).toEqual(['bad-c3d4', 'good-a1b2']);
+      consoleSpy.mockRestore();
+    });
+
+    it('preserves activeMindId when the active mind fails to restore', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        const normalized = String(p).replace(/\\/g, '/');
+        return normalized === '/tmp/agents/good/SOUL.md' || normalized === '/tmp/agents/good/.github';
+      });
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [
+          { id: 'bad-c3d4', path: '/tmp/agents/bad' },
+          { id: 'good-a1b2', path: '/tmp/agents/good' },
+        ],
+        activeMindId: 'bad-c3d4',
+        activeLogin: 'alice',
+        theme: 'dark',
+      });
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+      await manager.restoreFromConfig();
+      expect(manager.getActiveMindId()).toBe('good-a1b2');
+      mockConfigService.save.mockClear();
+      await manager.shutdown();
+
+      expect(lastSavedConfig().activeMindId).toBe('bad-c3d4');
+      consoleSpy.mockRestore();
+    });
+
+    it('preserves every configured mind when all restores fail', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [
+          { id: 'q-a1b2', path: '/tmp/agents/q' },
+          { id: 'fox-c3d4', path: '/tmp/agents/fox' },
+        ],
+        activeMindId: 'q-a1b2',
+        activeLogin: 'alice',
+        theme: 'dark',
+      });
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+      await manager.restoreFromConfig();
+      mockConfigService.save.mockClear();
+      await manager.shutdown();
+
+      const config = lastSavedConfig();
+      expect(savedMindIds(config)).toEqual(['fox-c3d4', 'q-a1b2']);
+      expect(config.activeMindId).toBe('q-a1b2');
       consoleSpy.mockRestore();
     });
 
@@ -664,6 +758,33 @@ describe('MindManager', () => {
       // No save should have an empty minds array (which would be the mid-unload state)
       const emptyMindsSaves = saveCalls.filter((call: unknown[]) => (call[0] as { minds: unknown[] }).minds.length === 0);
       expect(emptyMindsSaves).toHaveLength(0);
+    });
+
+    it('does not drop failed restore records during reload', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        const normalized = String(p).replace(/\\/g, '/');
+        return normalized === '/tmp/agents/good/SOUL.md' || normalized === '/tmp/agents/good/.github';
+      });
+      mockConfigService.load.mockReturnValue({
+        version: 2,
+        minds: [
+          { id: 'good-a1b2', path: '/tmp/agents/good' },
+          { id: 'bad-c3d4', path: '/tmp/agents/bad' },
+        ],
+        activeMindId: 'bad-c3d4',
+        activeLogin: 'alice',
+        theme: 'dark',
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+      await manager.restoreFromConfig();
+      mockConfigService.save.mockClear();
+
+      await manager.reloadAllMinds();
+
+      for (const [config] of mockConfigService.save.mock.calls as Array<[AppConfig]>) {
+        expect(savedMindIds(config)).toEqual(['bad-c3d4', 'good-a1b2']);
+      }
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -19,7 +19,9 @@ export class MindManager extends EventEmitter {
   private minds = new Map<string, InternalMindContext>();
   private pathToId = new Map<string, string>();
   private loading = new Map<string, Promise<MindContext>>();
+  private knownMindRecords = new Map<string, MindRecord>();
   private activeMindId: string | null = null;
+  private persistedActiveMindId: string | null = null;
   private restorePromise: Promise<void> | null = null;
   private reloading = false;
   private providers: ChamberToolProvider[] = [];
@@ -112,6 +114,8 @@ export class MindManager extends EventEmitter {
       throw err;
     }
 
+    this.knownMindRecords.set(id, { id, path: resolvedMindPath });
+
     // Persist
     this.persistConfig();
 
@@ -121,7 +125,16 @@ export class MindManager extends EventEmitter {
 
   async unloadMind(mindId: string): Promise<void> {
     const context = this.minds.get(mindId);
-    if (!context) return;
+    if (!context) {
+      const removedKnownRecord = this.knownMindRecords.delete(mindId);
+      if (!removedKnownRecord) return;
+      if (this.persistedActiveMindId === mindId) {
+        this.persistedActiveMindId = this.activeMindId;
+      }
+      this.persistConfig();
+      this.emit('mind:unloaded', mindId);
+      return;
+    }
 
     await this.releaseProviders(mindId);
 
@@ -134,11 +147,15 @@ export class MindManager extends EventEmitter {
     // Remove from maps
     this.minds.delete(mindId);
     this.pathToId.delete(this.mindPathKey(context.mindPath));
+    this.knownMindRecords.delete(mindId);
 
     // Update active mind if needed
     if (this.activeMindId === mindId) {
       const remaining = Array.from(this.minds.keys());
       this.activeMindId = remaining.length > 0 ? remaining[0] : null;
+    }
+    if (this.persistedActiveMindId === mindId) {
+      this.persistedActiveMindId = this.activeMindId;
     }
 
     // Persist
@@ -158,6 +175,7 @@ export class MindManager extends EventEmitter {
   setActiveMind(mindId: string): void {
     if (this.minds.has(mindId)) {
       this.activeMindId = mindId;
+      this.persistedActiveMindId = mindId;
     }
   }
 
@@ -191,11 +209,8 @@ export class MindManager extends EventEmitter {
     const existingConfig = this.configService.load();
     const configSnapshot: AppConfig = {
       version: 2,
-      minds: Array.from(this.minds.values()).map((mind) => ({
-        id: mind.mindId,
-        path: mind.mindPath,
-      })),
-      activeMindId: this.activeMindId,
+      minds: this.getPersistedMindRecords(),
+      activeMindId: this.getPersistedActiveMindId(),
       activeLogin: existingConfig.activeLogin,
       theme: existingConfig.theme,
     };
@@ -217,6 +232,8 @@ export class MindManager extends EventEmitter {
 
   private async doRestore(): Promise<void> {
     const config = this.configService.load();
+    this.knownMindRecords = new Map(config.minds.map(record => [record.id, { ...record }]));
+    this.persistedActiveMindId = config.activeMindId;
     for (const record of config.minds) {
       try {
         await this.loadMind(record.path, record.id);
@@ -391,17 +408,34 @@ export class MindManager extends EventEmitter {
   private persistConfig(): void {
     if (this.reloading) return;
     const existingConfig = this.configService.load();
-    const minds: MindRecord[] = Array.from(this.minds.values()).map(m => ({
-      id: m.mindId,
-      path: m.mindPath,
-    }));
     const config: AppConfig = {
       version: 2,
-      minds,
-      activeMindId: this.activeMindId,
+      minds: this.getPersistedMindRecords(),
+      activeMindId: this.getPersistedActiveMindId(),
       activeLogin: existingConfig.activeLogin,
       theme: existingConfig.theme,
     };
     this.configService.save(config);
+  }
+
+  private getPersistedMindRecords(): MindRecord[] {
+    const records = new Map(this.knownMindRecords);
+    for (const mind of this.minds.values()) {
+      records.set(mind.mindId, {
+        id: mind.mindId,
+        path: mind.mindPath,
+      });
+    }
+    return Array.from(records.values());
+  }
+
+  private getPersistedActiveMindId(): string | null {
+    if (
+      this.persistedActiveMindId &&
+      (this.minds.has(this.persistedActiveMindId) || this.knownMindRecords.has(this.persistedActiveMindId))
+    ) {
+      return this.persistedActiveMindId;
+    }
+    return this.activeMindId;
   }
 }


### PR DESCRIPTION
Fixes #180

## Summary

- Preserve configured mind records when `restoreFromConfig()` cannot load a mind during startup.
- Keep the persisted active mind ID separate from the runtime fallback active mind, so a transient restore failure does not silently rewrite `activeMindId` on shutdown.
- Keep explicit unload behavior pruning records as before, and preserve failed records through `reloadAllMinds()` snapshots.
- Bump the patch version and add a changelog entry per `CONTRIBUTING.md`.

## Validation

- `npm test -- packages/services/src/mind/MindManager.test.ts` — 49 passed
- `npm run lint` — clean (`tsc --noEmit`, ESLint, dependency-cruiser)
- `npm test` — full suite passed (107 files, 1027 tests)

## Notes

- No config schema, IPC, renderer, SDK runtime, or security-boundary changes.
- Earlier full-suite attempts exposed unrelated flaky tests (`ChatInput.test.tsx` shortcode popover and `CanvasServer.test.ts` bridge injection timeout); each failed file passed when rerun in isolation, and the final full suite passed.