### PR TITLE
Fix duplicate Lens hot-load entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.38.2 (2026-05-04)
+
+### Lens
+
+- **Scope hot-loaded Lens views to the active mind** — Lens create/delete watcher events now publish the changed mind ID and the renderer ignores inactive-mind updates, preventing duplicate activity-bar entries when multiple minds expose views with the same ID.
+
 ## v0.38.1 (2026-05-01)
 
 ### Mind registry

--- a/apps/desktop/src/main/ipc/lens.ts
+++ b/apps/desktop/src/main/ipc/lens.ts
@@ -29,9 +29,9 @@ export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindMana
     return viewDiscovery.sendAction(viewId, action, mindPath);
   });
 
-  mindManager.on('lens:viewsChanged', (views: LensViewManifest[]) => {
+  mindManager.on('lens:viewsChanged', (views: LensViewManifest[], mindId: string) => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('lens:viewsChanged', views);
+      win.webContents.send('lens:viewsChanged', views, mindId);
     }
   });
 }

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.test.tsx
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LensViewManifest, MindContext } from '../../shared/types';
+import { installElectronAPI, mockElectronAPI } from '../../test/helpers';
+import { AppStateProvider, useAppState } from '../lib/store';
+import type { AppState } from '../lib/store/state';
+import { useAppSubscriptions } from './useAppSubscriptions';
+
+const activeMind: MindContext = {
+  mindId: 'q-1234',
+  mindPath: 'C:\\agents\\q',
+  identity: { name: 'Q', systemMessage: '' },
+  status: 'ready',
+};
+
+const otherMind: MindContext = {
+  mindId: 'moneypenny-1234',
+  mindPath: 'C:\\agents\\moneypenny',
+  identity: { name: 'Moneypenny', systemMessage: '' },
+  status: 'ready',
+};
+
+const activeView: LensViewManifest = {
+  id: 'briefing',
+  name: 'Briefing',
+  icon: 'newspaper',
+  view: 'briefing',
+  source: 'briefing.json',
+};
+
+const otherView: LensViewManifest = {
+  id: 'briefing',
+  name: 'Other Briefing',
+  icon: 'newspaper',
+  view: 'briefing',
+  source: 'briefing.json',
+};
+
+function wrapper(testInitialState: Partial<AppState>) {
+  return function TestWrapper({ children }: { children: React.ReactNode }) {
+    return <AppStateProvider testInitialState={testInitialState}>{children}</AppStateProvider>;
+  };
+}
+
+describe('useAppSubscriptions', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+  let onViewsChanged: ((views: LensViewManifest[], mindId?: string) => void) | undefined;
+
+  beforeEach(() => {
+    api = installElectronAPI();
+    onViewsChanged = undefined;
+    (api.lens.onViewsChanged as ReturnType<typeof vi.fn>).mockImplementation((callback) => {
+      onViewsChanged = callback;
+      return vi.fn();
+    });
+  });
+
+  it('loads Lens views for the active mind', async () => {
+    (api.lens.getViews as ReturnType<typeof vi.fn>).mockResolvedValue([activeView]);
+
+    const { result } = renderHook(() => {
+      useAppSubscriptions();
+      return useAppState();
+    }, {
+      wrapper: wrapper({ minds: [activeMind], activeMindId: activeMind.mindId }),
+    });
+
+    await waitFor(() => {
+      expect(api.lens.getViews).toHaveBeenCalledWith(activeMind.mindId);
+      expect(result.current.discoveredViews).toEqual([activeView]);
+    });
+  });
+
+  it('ignores Lens hot-load events from inactive minds', async () => {
+    (api.lens.getViews as ReturnType<typeof vi.fn>).mockResolvedValue([activeView]);
+
+    const { result } = renderHook(() => {
+      useAppSubscriptions();
+      return useAppState();
+    }, {
+      wrapper: wrapper({ minds: [activeMind, otherMind], activeMindId: activeMind.mindId }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.discoveredViews).toEqual([activeView]);
+    });
+
+    onViewsChanged?.([otherView], otherMind.mindId);
+
+    expect(result.current.discoveredViews).toEqual([activeView]);
+  });
+
+  it('accepts Lens hot-load events for the active mind', async () => {
+    (api.lens.getViews as ReturnType<typeof vi.fn>).mockResolvedValue([otherView]);
+
+    const { result } = renderHook(() => {
+      useAppSubscriptions();
+      return useAppState();
+    }, {
+      wrapper: wrapper({ minds: [activeMind], activeMindId: activeMind.mindId }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.discoveredViews).toEqual([otherView]);
+    });
+
+    act(() => {
+      onViewsChanged?.([activeView], activeMind.mindId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.discoveredViews).toEqual([activeView]);
+    });
+  });
+});

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.ts
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.ts
@@ -20,11 +20,12 @@ export function useAppSubscriptions() {
 
   // Listen for view discovery changes (file watcher)
   useEffect(() => {
-    const unsub = window.electronAPI.lens.onViewsChanged((views) => {
+    const unsub = window.electronAPI.lens.onViewsChanged((views, mindId) => {
+      if (mindId && mindId !== activeMindId) return;
       dispatch({ type: 'SET_DISCOVERED_VIEWS', payload: views });
     });
     return () => { unsub(); };
-  }, [dispatch]);
+  }, [activeMindId, dispatch]);
 
   // Reload views when active mind changes
   useEffect(() => {
@@ -55,16 +56,17 @@ export function useAppSubscriptions() {
 
   // Fetch discovered Lens views
   useEffect(() => {
-    const connected = minds.length > 0 || !!activeMindId;
-    if (!connected) {
+    if (!activeMindId) {
       viewsLoaded.current = false;
       return;
     }
 
     if (!viewsLoaded.current) {
+      let cancelled = false;
       const loadViews = async () => {
         try {
-          const views = await window.electronAPI.lens.getViews();
+          const views = await window.electronAPI.lens.getViews(activeMindId);
+          if (cancelled) return;
           dispatch({ type: 'SET_DISCOVERED_VIEWS', payload: views });
           viewsLoaded.current = true;
         } catch (err) {
@@ -72,6 +74,9 @@ export function useAppSubscriptions() {
         }
       };
       loadViews();
+      return () => {
+        cancelled = true;
+      };
     }
   }, [minds.length, activeMindId, dispatch]);
 

--- a/apps/web/src/shared/types.ts
+++ b/apps/web/src/shared/types.ts
@@ -208,7 +208,7 @@ export interface ElectronAPI {
     getViewData: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
     refreshView: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
     sendAction: (viewId: string, action: string, mindId?: string) => Promise<Record<string, unknown> | null>;
-    onViewsChanged: (callback: (views: LensViewManifest[]) => void) => () => void;
+    onViewsChanged: (callback: (views: LensViewManifest[], mindId?: string) => void) => () => void;
   };
   auth: {
     getStatus: () => Promise<{ authenticated: boolean; login?: string }>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.38.1",
+      "version": "0.38.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -163,7 +163,8 @@ describe('MindManager', () => {
       onChanged?.();
 
       expect(mockViewDiscovery.startWatching).toHaveBeenCalledWith('/tmp/agents/q', expect.any(Function));
-      expect(listener).toHaveBeenCalledWith(views);
+      expect(mockViewDiscovery.getViews).toHaveBeenCalledWith('/tmp/agents/q');
+      expect(listener).toHaveBeenCalledWith(views, expect.stringMatching(/^q-/));
     });
 
     it('generates a stable mind ID from folder name', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -103,7 +103,7 @@ export class MindManager extends EventEmitter {
         this.viewDiscovery.scan(resolvedMindPath),
       ]);
       this.viewDiscovery.startWatching(resolvedMindPath, () => {
-        this.emit('lens:viewsChanged', this.viewDiscovery.getViews());
+        this.emit('lens:viewsChanged', this.viewDiscovery.getViews(resolvedMindPath), id);
       });
     } catch (err) {
       this.minds.delete(id);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -208,7 +208,7 @@ export interface ElectronAPI {
     getViewData: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
     refreshView: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
     sendAction: (viewId: string, action: string, mindId?: string) => Promise<Record<string, unknown> | null>;
-    onViewsChanged: (callback: (views: LensViewManifest[]) => void) => () => void;
+    onViewsChanged: (callback: (views: LensViewManifest[], mindId?: string) => void) => () => void;
   };
   auth: {
     getStatus: () => Promise<{ authenticated: boolean; login?: string }>;

--- a/tests/e2e/electron/lens-hotload.spec.ts
+++ b/tests/e2e/electron/lens-hotload.spec.ts
@@ -14,15 +14,19 @@ test.describe('electron Lens hot-load smoke', () => {
 
   let app: LaunchedElectronApp | undefined;
   let mindPath = '';
+  let inactiveMindPath = '';
   let userDataPath = '';
   const tempRoots: string[] = [];
 
   test.beforeAll(async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-lens-smoke-'));
     mindPath = path.join(root, 'lens-smoke-mind');
+    inactiveMindPath = path.join(root, 'inactive-lens-smoke-mind');
     userDataPath = path.join(root, 'user-data');
     tempRoots.push(root);
-    seedMind(mindPath);
+    seedMind(mindPath, 'Active Lens Smoke Mind');
+    seedMind(inactiveMindPath, 'Inactive Lens Smoke Mind');
+    writeLensView(inactiveMindPath);
 
     app = await launchElectronApp({
       cdpPort,
@@ -43,11 +47,14 @@ test.describe('electron Lens hot-load smoke', () => {
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await page.waitForLoadState('domcontentloaded');
 
-    const mind = await page.evaluate(async (pathToMind) => {
+    const mind = await page.evaluate(async ({ pathToMind, pathToInactiveMind }) => {
       const loaded = await window.electronAPI.mind.add(pathToMind);
+      await window.electronAPI.mind.add(pathToInactiveMind);
       await window.electronAPI.mind.setActive(loaded.mindId);
       return loaded;
-    }, mindPath);
+    }, { pathToMind: mindPath, pathToInactiveMind: inactiveMindPath });
+
+    await page.getByRole('button', { name: /Active Lens Smoke Mind/ }).click();
 
     await page.evaluate(() => {
       const target = window as typeof window & { __lensHotloadEvents?: string[][] };
@@ -61,8 +68,10 @@ test.describe('electron Lens hot-load smoke', () => {
       () => page.evaluate(async ({ mindId, viewId }) => {
         const views = await window.electronAPI.lens.getViews(mindId);
         return views.some((view) => view.id === viewId);
-      }, { mindId: mind.mindId, viewId: smokeViewId }),
+       }, { mindId: mind.mindId, viewId: smokeViewId }),
     ).toBe(false);
+
+    await expect(page.getByRole('button', { name: 'Smoke Hotload' })).toHaveCount(0);
 
     writeLensView(mindPath);
 
@@ -81,6 +90,8 @@ test.describe('electron Lens hot-load smoke', () => {
       }, smokeViewId),
     ).toBe(true);
 
+    await expect(page.getByRole('button', { name: 'Smoke Hotload' })).toHaveCount(1);
+
     fs.rmSync(path.join(mindPath, '.github', 'lens', smokeViewId), { recursive: true, force: true });
 
     await expect.poll(
@@ -97,15 +108,17 @@ test.describe('electron Lens hot-load smoke', () => {
         return target.__lensHotloadEvents?.some((ids) => !ids.includes(viewId)) ?? false;
       }, smokeViewId),
     ).toBe(true);
+
+    await expect(page.getByRole('button', { name: 'Smoke Hotload' })).toHaveCount(0);
   });
 });
 
-function seedMind(root: string): void {
+function seedMind(root: string, name: string): void {
   fs.mkdirSync(path.join(root, '.github'), { recursive: true });
   fs.writeFileSync(
     path.join(root, 'SOUL.md'),
     [
-      '# Lens Smoke Mind',
+      `# ${name}`,
       '',
       'A deterministic mind used by Electron Lens hot-load smoke tests.',
       '',


### PR DESCRIPTION
## Summary
- Scope Lens hot-load events to the mind whose Lens directory changed.
- Load and apply Lens views only for the active mind in the renderer, with stale async response protection.
- Add unit and Electron UI smoke coverage for active/inactive mind Lens create/delete behavior.

## Tests
- `npm run lint`
- `npm test`
- `npm run test:ui:electron -- tests/e2e/electron/lens-hotload.spec.ts`

## Release
- Patch bump to `0.38.2` with a Lens changelog entry.

## Smoke not run
- `npm run package` skipped; this change does not touch packaging, runtime resolution, installer, or first-launch paths.
