### PR TITLE
Remove legacy Forge macOS signing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.39.1 (2026-05-04)
+
+### Packaging
+
+- **Remove legacy Forge macOS signing wiring** — macOS signing now has a single electron-builder path through `CHAMBER_MACOS_SIGNING`, keeping the current Windows release workflow independent of future Apple certificate setup. (#179)
+
 ## v0.39.0 (2026-05-04)
 
 ### macOS

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -10,12 +10,6 @@ import { FusesPlugin } from '@electron-forge/plugin-fuses';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
 import { PACKAGED_RENDERER_NAME } from './config/packaged-renderer.cjs';
 
-const enableMacOSSigning = process.platform === 'darwin' && process.env.ENABLE_MACOS_SIGNING === 'true';
-const enableMacOSNotarization =
-  enableMacOSSigning &&
-  Boolean(process.env.APPLE_ID) &&
-  Boolean(process.env.APPLE_ID_PASSWORD) &&
-  Boolean(process.env.APPLE_TEAM_ID);
 const APP_ICON_PATH = path.resolve(__dirname, 'assets', 'app');
 const WINDOWS_ICON_PATH = `${APP_ICON_PATH}.ico`;
 
@@ -49,23 +43,6 @@ const config: ForgeConfig = {
       },
     ],
     extraResource: ['./resources/node', './resources/copilot-runtime', './apps/server/dist', './node_modules/keytar'],
-    ...(enableMacOSSigning
-      ? {
-          osxSign: {},
-          ...(enableMacOSNotarization
-            ? {
-                osxNotarize: {
-                   
-                  appleId: process.env.APPLE_ID!,
-                   
-                  appleIdPassword: process.env.APPLE_ID_PASSWORD!,
-                   
-                  teamId: process.env.APPLE_TEAM_ID!,
-                },
-              }
-            : {}),
-        }
-      : {}),
   },
   publishers: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary
- Remove the legacy Forge macOS signing/notarization wiring and old `ENABLE_MACOS_SIGNING` path.
- Keep macOS signing centralized on the current electron-builder config via `CHAMBER_MACOS_SIGNING`.
- Patch bump to `0.39.1` with a packaging changelog entry.

## Issue
Refs #179

## Tests
- `npm test -- --run tests/regression/forge-config.test.ts tests/regression/packaging-scripts.test.ts`
- `npm run lint`
- `npm test`
- `npm run package`

## Smoke not run
- `npm run make:sandbox` skipped; this cleanup does not change the Windows installer/update behavior beyond removing unused Forge macOS signing config.
