### PR TITLE
fix: Genesis flow fixes, Logger utility, and dev-experience improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.39.2 (2026-05-04)
+
+### Genesis
+
+- **Surface marketplace loading errors** — the Genesis voice screen now shows a clear error when marketplace templates fail to load instead of silently returning an empty list. (#86)
+- **Fix dark-on-dark custom voice input** — added `text-foreground` to the custom voice text input so it's readable on dark themes.
+- **Split voice input into Name + Backstory** — the custom voice flow now has separate fields for the mind name (used as the directory slug) and an optional backstory that enriches SOUL.md.
+- **Fix custom role input** — selecting "Something else..." on the role screen now shows a text input instead of immediately submitting the literal string.
+
+### Developer Experience
+
+- **Add Logger utility** — new `Logger.create('Tag')` API with level gating (`debug`/`info`/`warn`/`error`/`silent`) controlled by `CHAMBER_LOG_LEVEL` env var. All ~50 `console.*` calls across the codebase now route through Logger. (#86)
+- **Pre-start SDK version check** — `npm start` now validates that installed `@github/copilot` and `@github/copilot-sdk` versions match `package.json` pins before launching Electron.
+- **Skip marketplace tests on auth mismatch** — e2e tests that need `agency-microsoft/genesis-minds` now skip with a clear message when the active `gh` account lacks access, instead of failing with a timeout.
+
+### Testing
+
+- **Expand Ernest e2e smoke** — the Genesis smoke test now exercises the backstory field and custom role input, covering all new Genesis inputs.
+
 ## v0.39.1 (2026-05-04)
 
 ### Packaging

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -432,7 +432,16 @@ app.on('ready', async () => {
   setupGenesisIPC(
     mindManager,
     scaffold,
-    { listTemplates: () => genesisTemplateCatalog.listTemplates().templates },
+    { listTemplates: () => {
+      const result = genesisTemplateCatalog.listTemplates();
+      if (result.templates.length === 0) {
+        const errors = result.sources.filter(s => s.status === 'error');
+        if (errors.length > 0) {
+          throw new Error(errors.map(s => s.message).join('; '));
+        }
+      }
+      return result.templates;
+    }},
     genesisTemplateInstaller,
   );
   setupMarketplaceIPC(marketplaceRegistryService);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -33,8 +33,11 @@ import {
   type GenesisMindTemplateMarketplaceSource,
   type Notifier,
 } from '@chamber/services';
+import { Logger } from '@chamber/services';
 import { createAppTray, loadAppIcon } from './main/tray/Tray';
 import { installContextMenu } from './main/contextMenu/ContextMenu';
+
+const log = Logger.create('main');
 import { enrollMarketplaceFromProtocolUrl, findMarketplaceInstallUrl, parseMarketplaceInstallUrl } from './main/protocol/marketplaceProtocol';
 
 // IPC adapters
@@ -229,7 +232,7 @@ async function startMvpServer(): Promise<string> {
         }
       }
     });
-    serverChild?.stderr.on('data', (chunk) => console.error(`[server] ${String(chunk)}`));
+    serverChild?.stderr.on('data', (chunk) => log.error(String(chunk)));
     serverChild?.on('exit', (code) => {
       if (!mvpServerUrl) {
         clearTimeout(timer);
@@ -322,7 +325,7 @@ const handleProtocolUrl = (rawUrl: string): void => {
         rawUrl,
         (registryUrl) => marketplaceRegistryService.addGenesisRegistry(registryUrl),
         (error) => {
-          console.warn('[marketplace] Protocol registry enrollment failed:', error);
+          log.warn('Protocol registry enrollment failed:', error);
           showMarketplaceProtocolMessage('error', 'Unable to add marketplace', error);
         },
       );
@@ -333,7 +336,7 @@ const handleProtocolUrl = (rawUrl: string): void => {
       }
     })
     .catch((error: unknown) => {
-      console.warn('[marketplace] Protocol registry enrollment failed:', error);
+      log.warn('Protocol registry enrollment failed:', error);
       showMarketplaceProtocolMessage('error', 'Unable to add marketplace', error instanceof Error ? error.message : String(error));
     });
 };
@@ -409,11 +412,11 @@ app.on('ready', async () => {
   cleanupLegacySquirrelInstall({ isPackaged: app.isPackaged })
     .then((result) => {
       if (result.status !== 'skipped') {
-        console.info(`[squirrel-migration] ${result.status}`, result);
+        log.info(`squirrel-migration: ${result.status}`, result);
       }
     })
     .catch((error: unknown) => {
-      console.warn('[squirrel-migration] Unexpected cleanup failure:', error);
+      log.warn('squirrel-migration: Unexpected cleanup failure:', error);
     });
 
   if (useMvpServer) {
@@ -487,7 +490,7 @@ app.on('ready', async () => {
 
   // Restore minds async — awaitRestore() lets IPC handlers wait for completion
   mindManager.restoreFromConfig().catch((err: unknown) => {
-    console.error('[main] Failed to restore minds:', err);
+    log.error('Failed to restore minds:', err);
   });
 });
 

--- a/apps/desktop/src/main/ipc/auth.ts
+++ b/apps/desktop/src/main/ipc/auth.ts
@@ -1,6 +1,8 @@
 // Auth IPC handlers
 import { ipcMain, BrowserWindow, shell } from 'electron';
-import { AuthService, type MindManager } from '@chamber/services';
+import { AuthService, Logger, type MindManager } from '@chamber/services';
+
+const log = Logger.create('Auth');
 
 function broadcast(
   channel: 'auth:loggedOut' | 'auth:accountSwitchStarted' | 'auth:accountSwitched',
@@ -49,7 +51,7 @@ export function setupAuthIPC(
       try {
         await mindManager.reloadAllMinds();
       } catch (err) {
-        console.error('[Auth] Failed to reload minds after login:', err);
+        log.error('Failed to reload minds after login:', err);
       }
       broadcast('auth:accountSwitched', { login: result.login });
     }
@@ -68,7 +70,7 @@ export function setupAuthIPC(
     try {
       await mindManager.reloadAllMinds();
     } catch (err) {
-      console.error('[Auth] Failed to reload minds after account switch:', err);
+      log.error('Failed to reload minds after account switch:', err);
     }
     broadcast('auth:accountSwitched', { login });
   });

--- a/apps/desktop/src/main/tray/Tray.test.ts
+++ b/apps/desktop/src/main/tray/Tray.test.ts
@@ -75,7 +75,7 @@ describe('loadAppIcon', () => {
       const icon = await loadAppIcon();
 
       expect(createFromDataURL).toHaveBeenCalledTimes(1);
-      expect(consoleError).toHaveBeenCalledWith('[tray] Failed to load executable icon:', error);
+      expect(consoleError).toHaveBeenCalledWith('[tray]', 'Failed to load executable icon:', error);
       expect(icon).toBe(fallbackIcon);
       consoleError.mockRestore();
     }));

--- a/apps/desktop/src/main/tray/Tray.ts
+++ b/apps/desktop/src/main/tray/Tray.ts
@@ -1,4 +1,7 @@
 import { app, Menu, Tray, nativeImage, type NativeImage } from 'electron';
+import { Logger } from '@chamber/services';
+
+const log = Logger.create('tray');
 
 export interface AppTrayOptions {
   showMainWindow: () => void;
@@ -32,9 +35,9 @@ export async function loadAppIcon(): Promise<NativeImage> {
         return icon;
       }
 
-      console.warn(`[tray] Executable icon for ${process.execPath} was empty; using generated fallback.`);
+      log.warn(`Executable icon for ${process.execPath} was empty; using generated fallback.`);
     } catch (error) {
-      console.error('[tray] Failed to load executable icon:', error);
+      log.error('Failed to load executable icon:', error);
     }
   }
 

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -1,5 +1,8 @@
 import { createHttpServer } from './honoAdapter';
 import { createServerContext } from './composition';
+import { Logger } from '@chamber/services';
+
+const log = Logger.create('server');
 import {
   AuthService,
   ChatService,
@@ -160,7 +163,7 @@ async function shutdown(): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
   await mindManager.shutdown().catch((error: unknown) => {
-    console.error('[server] Mind shutdown failed:', error);
+    log.error('Mind shutdown failed:', error);
   });
   server.close(() => process.exit(0));
 }

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { useAppDispatch } from '../../lib/store';
+import { Logger } from '../../lib/logger';
 import { VoidScreen } from './VoidScreen';
 import { RoleScreen } from './RoleScreen';
 import { VoiceScreen } from './VoiceScreen';
@@ -9,6 +10,8 @@ import type { GenesisMindTemplate } from '../../../shared/types';
 
 type Stage = 'void' | 'role' | 'voice' | 'boot' | 'done';
 type GenesisCreateResult = Awaited<ReturnType<typeof window.electronAPI.genesis.create>>;
+
+const log = Logger.create('Genesis');
 
 interface Props {
   onComplete: () => void;
@@ -70,7 +73,7 @@ export function GenesisFlow({ onComplete }: Props) {
 
     if (!result.success) {
       setCreationError(result.error ?? 'Genesis failed.');
-      console.error('[Genesis] Failed:', result.error);
+      log.error('Failed:', result.error);
     }
   }, [name, voiceDesc]);
 
@@ -101,7 +104,7 @@ export function GenesisFlow({ onComplete }: Props) {
 
     if (!result.success) {
       setCreationError(result.error ?? 'Genesis template install failed.');
-      console.error('[Genesis] Template install failed:', result.error);
+      log.error('Template install failed:', result.error);
     }
   }, []);
 
@@ -109,7 +112,7 @@ export function GenesisFlow({ onComplete }: Props) {
     const result = await creationPromiseRef.current;
     if (!result?.success) {
       if (result?.error) setCreationError(result.error);
-      if (result?.error) console.error('[Genesis] Failed:', result.error);
+      if (result?.error) log.error('Failed:', result.error);
       return;
     }
 

--- a/apps/web/src/renderer/components/genesis/RoleScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/RoleScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { TypeWriter } from './TypeWriter';
 import { cn } from '../../lib/utils';
 
@@ -17,13 +17,33 @@ const ROLES = [
 export function RoleScreen({ name, onSelect }: Props) {
   const [showCards, setShowCards] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
+  const [customRole, setCustomRole] = useState('');
+  const [showCustomInput, setShowCustomInput] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!showCustomInput) return;
+    const t = setTimeout(() => inputRef.current?.focus(), 350);
+    return () => clearTimeout(t);
+  }, [showCustomInput]);
 
   const handleSelect = (roleId: string) => {
+    if (roleId === 'custom') {
+      setSelected('custom');
+      setShowCustomInput(true);
+      return;
+    }
     setSelected(roleId);
     setTimeout(() => {
       const role = ROLES.find(r => r.id === roleId);
       onSelect(role?.label ?? roleId);
     }, 300);
+  };
+
+  const handleCustomSubmit = () => {
+    const role = customRole.trim();
+    if (!role) return;
+    onSelect(role);
   };
 
   return (
@@ -37,26 +57,51 @@ export function RoleScreen({ name, onSelect }: Props) {
         />
 
         {showCards && (
-          <div className="grid grid-cols-2 gap-3 animate-in fade-in duration-500">
-            {ROLES.map((role, i) => (
-              <button
-                key={role.id}
-                onClick={() => handleSelect(role.id)}
-                style={{ animationDelay: `${i * 100}ms` }}
-                className={cn(
-                  'text-left p-4 rounded-xl border transition-all duration-300 animate-in fade-in slide-in-from-bottom-2',
-                  selected === role.id
-                    ? 'border-primary bg-primary/10 scale-105'
-                    : selected
-                      ? 'border-border opacity-40 scale-95'
-                      : 'border-border hover:border-muted-foreground hover:bg-accent'
+          <div className="space-y-3 animate-in fade-in duration-500">
+            <div className="grid grid-cols-2 gap-3">
+              {ROLES.map((role, i) => (
+                <button
+                  key={role.id}
+                  onClick={() => handleSelect(role.id)}
+                  style={{ animationDelay: `${i * 100}ms` }}
+                  className={cn(
+                    'text-left p-4 rounded-xl border transition-all duration-300 animate-in fade-in slide-in-from-bottom-2',
+                    selected === role.id
+                      ? 'border-primary bg-primary/10 scale-105'
+                      : selected
+                        ? 'border-border opacity-40 scale-95'
+                        : 'border-border hover:border-muted-foreground hover:bg-accent'
+                  )}
+                >
+                  <span className="text-2xl block mb-2">{role.emoji}</span>
+                  <span className="text-sm font-medium block">{role.label}</span>
+                  <span className="text-xs text-muted-foreground">{role.description}</span>
+                </button>
+              ))}
+            </div>
+
+            {showCustomInput && (
+              <div className="animate-in fade-in duration-300 space-y-3 pt-2">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={customRole}
+                  onChange={(e) => setCustomRole(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleCustomSubmit(); }}
+                  placeholder="e.g. Creative Director, Debate Coach, Writing Partner..."
+                  className="w-full bg-transparent border-b-2 border-muted-foreground/30 focus:border-foreground
+                             text-lg text-center text-foreground py-2 outline-none transition-colors placeholder:text-muted-foreground/30"
+                />
+                {customRole.trim() && (
+                  <button
+                    onClick={handleCustomSubmit}
+                    className="px-6 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:opacity-80 transition-opacity"
+                  >
+                    That's my purpose
+                  </button>
                 )}
-              >
-                <span className="text-2xl block mb-2">{role.emoji}</span>
-                <span className="text-sm font-medium block">{role.label}</span>
-                <span className="text-xs text-muted-foreground">{role.description}</span>
-              </button>
-            ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
@@ -13,16 +13,17 @@ interface Props {
 export function VoiceScreen({ templates, templateError, onSelect, onSelectTemplate }: Props) {
   const [showCards, setShowCards] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
-  const [customInput, setCustomInput] = useState('');
+  const [customName, setCustomName] = useState('');
+  const [customBackstory, setCustomBackstory] = useState('');
   const [showCustom, setShowCustom] = useState(false);
   const [researching, setResearching] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!showCustom) return;
     // Wait for the parent's fade-in animation to settle before focusing,
     // otherwise the focus call lands while the element is still being painted.
-    const t = setTimeout(() => inputRef.current?.focus(), 350);
+    const t = setTimeout(() => nameRef.current?.focus(), 350);
     return () => clearTimeout(t);
   }, [showCustom]);
 
@@ -40,29 +41,24 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
   };
 
   const handleCustomSubmit = async () => {
-    const input = customInput.trim();
-    if (!input) return;
+    const name = customName.trim();
+    if (!name) return;
     setResearching(true);
 
-    // Derive a short display/dir name from the input. Take the text up to the
-    // first sentence/clause boundary, then cap at 30 chars. This protects the
-    // filesystem from long, paragraph-style descriptions while keeping the
-    // full text as the voice description.
-    const firstClause = input.split(/[.,;:\n]/)[0].trim();
-    const shortName = (firstClause || input).slice(0, 30).trim();
+    const backstory = customBackstory.trim();
+    const description = backstory
+      ? `Character/voice: "${name}" — ${backstory}. Research this character or persona — their communication style, catchphrases, values, how they handle pressure. Capture the energy.`
+      : `Character/voice: "${name}". Research this character or persona — their communication style, catchphrases, values, how they handle pressure. Capture the energy.`;
 
-    // Ask the SDK to research this voice
     try {
       await window.electronAPI.genesis.getDefaultPath();
-      // Use a lightweight approach — just pass the description through with a research note
-      const description = `Character/voice: "${input}". Research this character or persona — their communication style, catchphrases, values, how they handle pressure. Capture the energy.`;
       setTimeout(() => {
         setResearching(false);
-        onSelect(shortName, description);
+        onSelect(name, description);
       }, 500);
     } catch {
       setResearching(false);
-      onSelect(shortName, `Voice energy: ${input}`);
+      onSelect(name, backstory ? `Voice energy: ${name} — ${backstory}` : `Voice energy: ${name}`);
     }
   };
 
@@ -136,16 +132,27 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
             {showCustom && (
               <div className="animate-in fade-in duration-300 space-y-3 pt-2">
                 <input
-                  ref={inputRef}
+                  ref={nameRef}
                   type="text"
-                  value={customInput}
-                  onChange={(e) => setCustomInput(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter') handleCustomSubmit(); }}
-                  placeholder="e.g. Tony Stark, Gandalf, your cool aunt..."
+                  value={customName}
+                  onChange={(e) => setCustomName(e.target.value)}
+                  placeholder="e.g. Tony Stark, Moneypenny, Gandalf..."
                   className="w-full bg-transparent border-b-2 border-muted-foreground/30 focus:border-foreground
                              text-lg text-center text-foreground py-2 outline-none transition-colors placeholder:text-muted-foreground/30"
                 />
-                {customInput.trim() && (
+                {customName.trim() && (
+                  <input
+                    type="text"
+                    value={customBackstory}
+                    onChange={(e) => setCustomBackstory(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleCustomSubmit(); }}
+                    placeholder="Backstory — e.g. from Iron Man 1, the Connery Bond era..."
+                    className="w-full bg-transparent border-b-2 border-muted-foreground/30 focus:border-foreground
+                               text-base text-center text-foreground py-2 outline-none transition-colors placeholder:text-muted-foreground/30
+                               animate-in fade-in duration-300"
+                  />
+                )}
+                {customName.trim() && (
                   <button
                     onClick={handleCustomSubmit}
                     disabled={researching}

--- a/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
@@ -143,7 +143,7 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
                   onKeyDown={(e) => { if (e.key === 'Enter') handleCustomSubmit(); }}
                   placeholder="e.g. Tony Stark, Gandalf, your cool aunt..."
                   className="w-full bg-transparent border-b-2 border-muted-foreground/30 focus:border-foreground
-                             text-lg text-center py-2 outline-none transition-colors placeholder:text-muted-foreground/30"
+                             text-lg text-center text-foreground py-2 outline-none transition-colors placeholder:text-muted-foreground/30"
                 />
                 {customInput.trim() && (
                   <button

--- a/apps/web/src/renderer/components/views/LensViewRenderer.tsx
+++ b/apps/web/src/renderer/components/views/LensViewRenderer.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import type { LensViewManifest } from '../../../shared/types';
 import { RefreshCw, Send } from 'lucide-react';
 import { cn } from '../../lib/utils';
+import { Logger } from '../../lib/logger';
 import { LensBriefing } from './LensBriefing';
 import { LensTable } from './LensTable';
 import { LensDetail } from './LensDetail';
@@ -13,6 +14,8 @@ import { LensForm } from './LensForm';
 interface Props {
   view: LensViewManifest;
 }
+
+const log = Logger.create('LensView');
 
 export function LensViewRenderer({ view }: Props) {
   const [data, setData] = useState<Record<string, unknown> | null>(null);
@@ -26,7 +29,7 @@ export function LensViewRenderer({ view }: Props) {
         const result = await window.electronAPI.lens.getViewData(view.id);
         setData(result);
       } catch (err) {
-        console.error(`[LensView] Failed to load data for ${view.id}:`, err);
+        log.error(`Failed to load data for ${view.id}:`, err);
       }
     };
     load();

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.ts
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { useAppState, useAppDispatch } from '../lib/store';
+import { Logger } from '../lib/logger';
+
+const log = Logger.create('AppSubscriptions');
 
 /**
  * App-level subscriptions that must survive view switches.
@@ -48,7 +51,7 @@ export function useAppSubscriptions() {
           dispatch({ type: 'SET_SELECTED_MODEL', payload: models[0].id });
         }
       } catch (err) {
-        console.error('Failed to load models:', err);
+        log.error('Failed to load models:', err);
       }
     };
     loadModels();
@@ -70,7 +73,7 @@ export function useAppSubscriptions() {
           dispatch({ type: 'SET_DISCOVERED_VIEWS', payload: views });
           viewsLoaded.current = true;
         } catch (err) {
-          console.error('Failed to load views:', err);
+          log.error('Failed to load views:', err);
         }
       };
       loadViews();

--- a/apps/web/src/renderer/lib/logger.ts
+++ b/apps/web/src/renderer/lib/logger.ts
@@ -1,0 +1,50 @@
+// Lightweight browser-compatible Logger matching the @chamber/services Logger API.
+// apps/web cannot depend on @chamber/services, so we duplicate the minimal surface.
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
+};
+
+let globalThreshold: LogLevel = 'info';
+
+export class Logger {
+  private constructor(private readonly tag: string) {}
+
+  static create(tag: string): Logger {
+    return new Logger(tag);
+  }
+
+  static setLevel(level: LogLevel): void {
+    globalThreshold = level;
+  }
+
+  debug(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[globalThreshold] <= LEVEL_PRIORITY.debug) {
+      console.log(`[${this.tag}]`, ...args);
+    }
+  }
+
+  info(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[globalThreshold] <= LEVEL_PRIORITY.info) {
+      console.log(`[${this.tag}]`, ...args);
+    }
+  }
+
+  warn(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[globalThreshold] <= LEVEL_PRIORITY.warn) {
+      console.warn(`[${this.tag}]`, ...args);
+    }
+  }
+
+  error(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[globalThreshold] <= LEVEL_PRIORITY.error) {
+      console.error(`[${this.tag}]`, ...args);
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.1",
+      "version": "0.39.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/*"
   ],
   "scripts": {
-    "start": "electron-forge start",
+    "start": "node scripts/check-sdk-versions.js && electron-forge start",
     "package": "npm --workspace @chamber/server run build && node scripts/prepare-node-runtime.js && electron-forge package",
     "make": "npm run make:builder",
     "make:forge": "npm --workspace @chamber/server run build && node scripts/prepare-node-runtime.js && electron-forge make",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/a2a/MessageRouter.ts
+++ b/packages/services/src/a2a/MessageRouter.ts
@@ -3,6 +3,9 @@ import type { AgentCardRegistry } from './AgentCardRegistry';
 import type { ChatService } from '../chat/ChatService';
 import type { EventEmitter } from 'events';
 import { generateMessageId, generateContextId, serializeMessageToXml } from './helpers';
+import { Logger } from '../logger';
+
+const log = Logger.create('MessageRouter');
 
 const MAX_HOPS = 5;
 
@@ -74,7 +77,7 @@ export class MessageRouter {
       await deliveryPromise;
     } else {
       deliveryPromise.catch((err) => {
-        console.error(`[MessageRouter] Delivery failed for ${targetMindId}:`, err);
+        log.error(`Delivery failed for ${targetMindId}:`, err);
       });
     }
 

--- a/packages/services/src/a2a/TaskManager.ts
+++ b/packages/services/src/a2a/TaskManager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import type { AgentCardRegistry } from './AgentCardRegistry';
 import type { CopilotSession, UserInputHandler, UserInputResponse } from '../mind/types';
+import { Logger } from '../logger';
 import type {
   SendMessageRequest,
   Task,
@@ -11,6 +12,8 @@ import type {
   Message,
 } from './types';
 import { isStaleSessionError } from '@chamber/shared/sessionErrors';
+
+const log = Logger.create('TaskManager');
 
 export interface TaskSessionFactory {
   createTaskSession(
@@ -93,7 +96,7 @@ export class TaskManager extends EventEmitter {
       this.processTask(task, targetMindId, request.message, request.onUserInputRequest)
         .catch((err) => {
           this.transitionState(task, 'failed');
-          console.error(`[TaskManager] Task ${taskId} failed:`, err);
+          log.error(`Task ${taskId} failed:`, err);
         }),
     );
 

--- a/packages/services/src/auth/AuthService.ts
+++ b/packages/services/src/auth/AuthService.ts
@@ -3,6 +3,9 @@
 
 import * as https from 'https';
 import type { CredentialStore } from '../ports';
+import { Logger } from '../logger';
+
+const log = Logger.create('Auth');
 
 const CLIENT_ID = 'Ov23ctDVkRmgkPke0Mmm';
 const DEVICE_CODE_URL = 'https://github.com/login/device/code';
@@ -123,7 +126,7 @@ export class AuthService {
     try {
       return (await this.getStoredCredentials()).map(({ login }) => ({ login }));
     } catch (err) {
-      console.error('[Auth] Failed to list stored credentials:', err);
+      log.error('Failed to list stored credentials:', err);
       return [];
     }
   }
@@ -133,7 +136,7 @@ export class AuthService {
       const credential = await this.getStoredCredentialEntry();
       return credential ? { login: credential.login } : null;
     } catch (err) {
-      console.error('[Auth] Failed to read stored credential:', err);
+      log.error('Failed to read stored credential:', err);
     }
 
     return null;
@@ -147,9 +150,9 @@ export class AuthService {
       if (!credential) return;
       await this.credentials.deletePassword(KEYTAR_SERVICE, credential.account);
       this.setActiveLogin(null);
-      console.log(`[Auth] Deleted credential for ${credential.login}`);
+      log.info(`Deleted credential for ${credential.login}`);
     } catch (err) {
-      console.error('[Auth] Failed to delete credential:', err);
+      log.error('Failed to delete credential:', err);
     }
   }
 
@@ -174,7 +177,7 @@ export class AuthService {
     const activeLogin = this.getActiveLogin();
     if (activeLogin === null) {
       if (credentials.length > 1) {
-        console.warn(`[Auth] Multiple Copilot credentials found; using ${credentials[0].account}`);
+        log.warn(`Multiple Copilot credentials found; using ${credentials[0].account}`);
       }
       return credentials[0];
     }
@@ -184,7 +187,7 @@ export class AuthService {
 
   private async storeCredential(login: string, token: string): Promise<void> {
     await this.credentials.setPassword(KEYTAR_SERVICE, getCredentialAccount(login), token);
-    console.log(`[Auth] Stored credential for ${login} via keytar`);
+    log.info(`Stored credential for ${login} via keytar`);
   }
 
   async startLogin(): Promise<{ success: boolean; login?: string }> {
@@ -228,7 +231,7 @@ export class AuthService {
             const user = await getJson('https://api.github.com/user', token);
             login = String(user.login);
           } catch (err) {
-            console.warn('[Auth] Failed to fetch user login, using default account name:', err);
+            log.warn('Failed to fetch user login, using default account name:', err);
           }
 
           await this.storeCredential(login, token);

--- a/packages/services/src/canvas/CanvasService.ts
+++ b/packages/services/src/canvas/CanvasService.ts
@@ -1,6 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { Logger } from '../logger';
 import type { ChamberToolProvider } from '../chamberTools';
+
+const log = Logger.create('canvas');
 import type { Tool } from '../mind/types';
 import type { ExternalOpener } from '../ports';
 import { CanvasServer } from './CanvasServer';
@@ -65,7 +68,7 @@ export class CanvasService implements ChamberToolProvider {
 
   constructor(options: CanvasServiceOptions = {}) {
     const onAction = options.onAction ?? ((action: CanvasAction) => {
-      console.log('[canvas] Action received:', action);
+      log.info('Action received:', action);
     });
 
     this.server = options.server ?? new CanvasServer({

--- a/packages/services/src/chatroom/ChatroomService.ts
+++ b/packages/services/src/chatroom/ChatroomService.ts
@@ -2,6 +2,9 @@ import { EventEmitter } from 'events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { Logger } from '../logger';
+
+const log = Logger.create('Chatroom');
 import type {
   ChatroomMessage,
   ChatroomTranscript,
@@ -116,7 +119,7 @@ export class ChatroomService extends EventEmitter {
 
     if (participants.length === 0) return;
 
-    console.log(`[Chatroom] broadcast mode="${this.orchestrationMode}" participants=${participants.length} handoffConfig=${JSON.stringify(this.handoffConfig)} magneticConfig=${JSON.stringify(this.magneticConfig)}`);
+    log.info(`broadcast mode="${this.orchestrationMode}" participants=${participants.length} handoffConfig=${JSON.stringify(this.handoffConfig)} magneticConfig=${JSON.stringify(this.magneticConfig)}`);
 
     // Warm session pool — pre-create sessions for all participants in parallel
     // to eliminate cold-start delays when workers begin their turns.
@@ -134,7 +137,7 @@ export class ChatroomService extends EventEmitter {
         this.magneticConfig ?? undefined,
       );
     } catch (err) {
-      console.error(`[Chatroom] Failed to create strategy for mode "${this.orchestrationMode}":`, err);
+      log.error(`Failed to create strategy for mode "${this.orchestrationMode}":`, err);
       this.emit('chatroom:event', {
         mindId: 'system',
         mindName: 'System',
@@ -164,7 +167,7 @@ export class ChatroomService extends EventEmitter {
     try {
       await strategy.execute(userMessage, participants, roundId, contextAdapter);
     } catch (err) {
-      console.error(`[Chatroom] Strategy "${this.orchestrationMode}" execution failed:`, err);
+      log.error(`Strategy "${this.orchestrationMode}" execution failed:`, err);
       this.emit('chatroom:event', {
         mindId: 'system',
         mindName: 'System',

--- a/packages/services/src/chatroom/orchestration/ConcurrentStrategy.ts
+++ b/packages/services/src/chatroom/orchestration/ConcurrentStrategy.ts
@@ -3,6 +3,9 @@ import type { OrchestrationStrategy, OrchestrationContext } from './types';
 import type { CopilotSession } from '../../mind';
 import { isStaleSessionError } from '@chamber/shared/sessionErrors';
 import { streamAgentTurn } from './stream-agent';
+import { Logger } from '../../logger';
+
+const log = Logger.create('Chatroom:Concurrent');
 
 // ---------------------------------------------------------------------------
 // In-flight agent tracking
@@ -34,7 +37,7 @@ export class ConcurrentStrategy implements OrchestrationStrategy {
       participants.map((mind) => {
         const prompt = context.buildBasePrompt(userMessage, participants, mind);
         return this.sendToAgent(mind, prompt, roundId, context).catch((err) => {
-          console.error(`[Chatroom:Concurrent] Agent ${mind.mindId} failed:`, err);
+          log.error(`Agent ${mind.mindId} failed:`, err);
         });
       }),
     );

--- a/packages/services/src/chatroom/orchestration/GroupChatStrategy.ts
+++ b/packages/services/src/chatroom/orchestration/GroupChatStrategy.ts
@@ -6,6 +6,9 @@ import type { OrchestrationContext } from './types';
 import { BaseStrategy } from './types';
 import { escapeXml, textContent, extractJsonObject } from './shared';
 import { sendToAgentWithRetry } from './stream-agent';
+import { Logger } from '../../logger';
+
+const log = Logger.create('Chatroom:GroupChat');
 
 // ---------------------------------------------------------------------------
 // Moderator response parsing
@@ -69,7 +72,7 @@ export class GroupChatStrategy extends BaseStrategy {
 
     const moderator = participants.find((p) => p.mindId === this.config.moderatorMindId);
     if (!moderator) {
-      console.error('[Chatroom:GroupChat] Moderator mind not found among participants');
+      log.error('Moderator mind not found among participants');
       return;
     }
 
@@ -203,7 +206,7 @@ export class GroupChatStrategy extends BaseStrategy {
           orchestrationMode: 'group-chat',
         }));
       } catch (err) {
-        console.error(`[Chatroom:GroupChat] Speaker ${speaker.mindId} failed:`, err);
+        log.error(`Speaker ${speaker.mindId} failed:`, err);
         continue; // Skip this turn, let moderator pick next speaker
       }
 
@@ -248,7 +251,7 @@ export class GroupChatStrategy extends BaseStrategy {
           orchestrationMode: 'group-chat',
         }));
       } catch (err) {
-        console.error(`[Chatroom:GroupChat] Moderator decision failed:`, err);
+        log.error('Moderator decision failed:', err);
         break; // Can't continue without moderator direction
       }
 
@@ -306,7 +309,7 @@ export class GroupChatStrategy extends BaseStrategy {
             context,
           );
         } catch (err) {
-          console.error(`[Chatroom:GroupChat] Synthesis failed:`, err);
+          log.error('Synthesis failed:', err);
         }
 
         break;

--- a/packages/services/src/chatroom/orchestration/MagenticStrategy.ts
+++ b/packages/services/src/chatroom/orchestration/MagenticStrategy.ts
@@ -8,6 +8,9 @@ import type { OrchestrationContext } from './types';
 import { BaseStrategy } from './types';
 import { ObservabilityEmitter } from './observability';
 import { textContent, extractJsonObject } from './shared';
+import { Logger } from '../../logger';
+
+const log = Logger.create('Chatroom:Magentic');
 import { sendToAgentWithRetry, TurnTimeoutError } from './stream-agent';
 
 /** Max characters stored in task.result (safe summary only) */
@@ -181,7 +184,7 @@ export class MagenticStrategy extends BaseStrategy {
     // Resolve manager
     const manager = participants.find((p) => p.mindId === this.config.managerMindId);
     if (!manager) {
-      console.error('[Chatroom:Magentic] Manager mind not found among participants');
+      log.error('Manager mind not found among participants');
       obs.failure('Manager mind not found');
       obs.end({ terminationReason: 'ERROR' });
       return;

--- a/packages/services/src/chatroom/orchestration/SequentialStrategy.ts
+++ b/packages/services/src/chatroom/orchestration/SequentialStrategy.ts
@@ -4,6 +4,9 @@ import type { OrchestrationContext } from './types';
 import { BaseStrategy } from './types';
 import { sendToAgentWithRetry } from './stream-agent';
 import { escapeXml, textContent } from './shared';
+import { Logger } from '../../logger';
+
+const log = Logger.create('Chatroom:Sequential');
 
 // ---------------------------------------------------------------------------
 // SequentialStrategy — round-robin, each agent speaks in order
@@ -60,7 +63,7 @@ export class SequentialStrategy extends BaseStrategy {
           roundResponses.push(message);
         }
       } catch (err) {
-        console.error(`[Chatroom:Sequential] Agent ${mind.mindId} failed:`, err);
+        log.error(`Agent ${mind.mindId} failed:`, err);
         // Continue to next agent — don't break the chain
       }
     }

--- a/packages/services/src/cron/CronService.ts
+++ b/packages/services/src/cron/CronService.ts
@@ -2,6 +2,9 @@ import { Cron } from 'croner';
 import type { ChamberToolProvider } from '../chamberTools';
 import type { Tool } from '../mind/types';
 import type { Notifier } from '../ports';
+import { Logger } from '../logger';
+
+const log = Logger.create('cron');
 import type { TaskManager } from '../a2a/TaskManager';
 import { JobStore } from './JobStore';
 import { JobRunner } from './JobRunner';
@@ -136,7 +139,7 @@ export class CronService implements ChamberToolProvider {
         try {
           await this.runJob(mindId, job.id, 'resume');
         } catch (err) {
-          console.error(`[cron] Resume catch-up failed for job ${job.id} in mind ${mindId}:`, err);
+          log.error(`Resume catch-up failed for job ${job.id} in mind ${mindId}:`, err);
         }
       }
     }

--- a/packages/services/src/genesis/MindScaffold.ts
+++ b/packages/services/src/genesis/MindScaffold.ts
@@ -4,10 +4,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { execSync } from 'child_process';
+import { Logger } from '../logger';
 import { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import { approveAllCompat } from '../sdk/approveAllCompat';
 import { buildGenesisPrompt } from './genesisPrompt';
 import { GitHubRegistryClient } from './GitHubRegistryClient';
+
+const log = Logger.create('MindScaffold');
 
 const IDEA_FOLDERS = ['inbox', 'domains', 'expertise', 'initiatives', 'Archive'];
 const WORKING_MEMORY_FILES = ['memory.md', 'rules.md', 'log.md'];
@@ -87,7 +90,7 @@ export class MindScaffold {
     this.emit('validate', 'Validating...');
     const result = this.validate(mindPath);
     if (!result.ok) {
-      console.warn('[MindScaffold] Missing files after genesis:', result.missing);
+      log.warn('Missing files after genesis:', result.missing);
     }
 
     // 4. Git init
@@ -99,7 +102,7 @@ export class MindScaffold {
     try {
       this.bootstrapCapabilities(mindPath);
     } catch (err) {
-      console.warn('[MindScaffold] Capability bootstrap failed (non-fatal):', err);
+      log.warn('Capability bootstrap failed (non-fatal):', err);
       this.emit('capabilities', 'Capabilities install failed — run "upgrade from genesis" later.');
     }
 
@@ -188,7 +191,7 @@ export class MindScaffold {
       execSync('git add -A', { cwd: mindPath, stdio: 'ignore' });
       execSync('git commit -m "Genesis"', { cwd: mindPath, stdio: 'ignore' });
     } catch (err) {
-      console.error('[MindScaffold] Git init failed:', err);
+      log.error('Git init failed:', err);
     }
   }
 
@@ -233,9 +236,9 @@ export class MindScaffold {
       const installed = parsed.installed?.length || 0;
       const updated = parsed.updated?.length || 0;
       const errors = parsed.errors?.length || 0;
-      console.log(`[MindScaffold] Capabilities: ${installed} installed, ${updated} updated, ${errors} errors`);
+      log.info(`Capabilities: ${installed} installed, ${updated} updated, ${errors} errors`);
       if (errors > 0) {
-        console.warn('[MindScaffold] Capability errors:', parsed.errors);
+        log.warn('Capability errors:', parsed.errors);
       }
     } catch {
       // upgrade.js output wasn't valid JSON — non-fatal

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,3 +1,4 @@
+export * from './logger';
 export * from './a2a';
 export * from './auth';
 export * from './canvas';

--- a/packages/services/src/lens/MindBootstrap.ts
+++ b/packages/services/src/lens/MindBootstrap.ts
@@ -3,6 +3,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { Logger } from '../logger';
+
+const log = Logger.create('MindBootstrap');
 
 export function seedLensDefaults(mindPath: string): void {
   const lensDir = path.join(mindPath, '.github', 'lens');
@@ -11,7 +14,7 @@ export function seedLensDefaults(mindPath: string): void {
   const helloDir = path.join(lensDir, 'hello-world');
   const helloViewJson = path.join(helloDir, 'view.json');
   if (!fs.existsSync(helloViewJson)) {
-    console.log('[MindBootstrap] Seeding default hello-world view');
+    log.info('Seeding default hello-world view');
     fs.mkdirSync(helloDir, { recursive: true });
     fs.writeFileSync(helloViewJson, JSON.stringify({
       name: 'Hello World',
@@ -38,7 +41,7 @@ export function seedLensDefaults(mindPath: string): void {
   const newsDir = path.join(lensDir, 'newspaper');
   const newsViewJson = path.join(newsDir, 'view.json');
   if (!fs.existsSync(newsViewJson)) {
-    console.log('[MindBootstrap] Seeding default newspaper view');
+    log.info('Seeding default newspaper view');
     fs.mkdirSync(newsDir, { recursive: true });
     fs.writeFileSync(newsViewJson, JSON.stringify({
       name: 'Newspaper',
@@ -84,11 +87,11 @@ export function installLensSkill(mindPath: string): void {
   }
 
   if (!content) {
-    console.warn('[MindBootstrap] Lens skill asset not found, skipping install');
+    log.warn('Lens skill asset not found, skipping install');
     return;
   }
 
-  console.log('[MindBootstrap] Installing Lens skill into mind');
+  log.info('Installing Lens skill into mind');
   fs.mkdirSync(skillDir, { recursive: true });
   fs.writeFileSync(skillPath, content);
 }

--- a/packages/services/src/lens/ViewDiscovery.ts
+++ b/packages/services/src/lens/ViewDiscovery.ts
@@ -4,6 +4,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { LensViewManifest } from '@chamber/shared/types';
+import { Logger } from '../logger';
+
+const log = Logger.create('ViewDiscovery');
 
 export interface ViewRefreshHandler {
   sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void>;
@@ -32,7 +35,7 @@ export class ViewDiscovery {
       try {
         entries = fs.readdirSync(lensDir, { withFileTypes: true });
       } catch (err) {
-        console.warn(`[ViewDiscovery] Failed to read ${lensDir}:`, err);
+        log.warn(`Failed to read ${lensDir}:`, err);
         this.viewsByMind.set(mindPath, views);
         return views;
       }
@@ -48,7 +51,7 @@ export class ViewDiscovery {
           manifest._basePath = path.join(lensDir, entry.name);
           views.push(manifest);
         } catch (err) {
-          console.error(`[ViewDiscovery] Failed to parse ${viewJsonPath}:`, err);
+          log.error(`Failed to parse ${viewJsonPath}:`, err);
         }
       }
     }
@@ -155,7 +158,7 @@ export class ViewDiscovery {
     const timer = setTimeout(() => {
       this.scanTimersByMind.delete(mindPath);
       void this.scan(mindPath).then(onChanged).catch((err: unknown) => {
-        console.warn(`[ViewDiscovery] Failed to rescan lens views for ${mindPath}:`, err);
+        log.warn(`Failed to rescan lens views for ${mindPath}:`, err);
       });
     }, 300);
     this.scanTimersByMind.set(mindPath, timer);

--- a/packages/services/src/logger/Logger.test.ts
+++ b/packages/services/src/logger/Logger.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Logger } from './Logger';
+
+describe('Logger', () => {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    logSpy.mockClear();
+    warnSpy.mockClear();
+    errorSpy.mockClear();
+    Logger.resetLevel();
+  });
+
+  afterEach(() => {
+    Logger.resetLevel();
+  });
+
+  it('prefixes output with the tag', () => {
+    Logger.setLevel('debug');
+    const log = Logger.create('Auth');
+    log.info('logged in');
+    expect(logSpy).toHaveBeenCalledWith('[Auth]', 'logged in');
+  });
+
+  it('routes warn and error to the correct console methods', () => {
+    const log = Logger.create('Tray');
+    log.warn('icon missing');
+    log.error('crash');
+    expect(warnSpy).toHaveBeenCalledWith('[Tray]', 'icon missing');
+    expect(errorSpy).toHaveBeenCalledWith('[Tray]', 'crash');
+  });
+
+  it('suppresses debug messages at the default info level', () => {
+    Logger.setLevel('info');
+    const log = Logger.create('SDK');
+    log.debug('verbose detail');
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows debug messages when level is set to debug', () => {
+    Logger.setLevel('debug');
+    const log = Logger.create('SDK');
+    log.debug('verbose detail');
+    expect(logSpy).toHaveBeenCalledWith('[SDK]', 'verbose detail');
+  });
+
+  it('suppresses all output when level is silent', () => {
+    Logger.setLevel('silent');
+    const log = Logger.create('Test');
+    log.debug('a');
+    log.info('b');
+    log.warn('c');
+    log.error('d');
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('only shows error when level is error', () => {
+    Logger.setLevel('error');
+    const log = Logger.create('Strict');
+    log.info('ignored');
+    log.warn('ignored');
+    log.error('shown');
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith('[Strict]', 'shown');
+  });
+
+  it('passes multiple arguments through', () => {
+    const log = Logger.create('Multi');
+    const obj = { key: 'value' };
+    log.info('data:', obj, 42);
+    expect(logSpy).toHaveBeenCalledWith('[Multi]', 'data:', obj, 42);
+  });
+});

--- a/packages/services/src/logger/Logger.ts
+++ b/packages/services/src/logger/Logger.ts
@@ -1,0 +1,64 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
+};
+
+function resolveThreshold(): LogLevel {
+  const env = typeof process !== 'undefined' ? process.env?.CHAMBER_LOG_LEVEL : undefined;
+  if (env && env in LEVEL_PRIORITY) return env as LogLevel;
+  return 'info';
+}
+
+let globalThreshold: LogLevel | null = null;
+
+function getThreshold(): LogLevel {
+  if (globalThreshold === null) {
+    globalThreshold = resolveThreshold();
+  }
+  return globalThreshold;
+}
+
+export class Logger {
+  private constructor(private readonly tag: string) {}
+
+  static create(tag: string): Logger {
+    return new Logger(tag);
+  }
+
+  static setLevel(level: LogLevel): void {
+    globalThreshold = level;
+  }
+
+  static resetLevel(): void {
+    globalThreshold = null;
+  }
+
+  debug(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[getThreshold()] <= LEVEL_PRIORITY.debug) {
+      console.log(`[${this.tag}]`, ...args);
+    }
+  }
+
+  info(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[getThreshold()] <= LEVEL_PRIORITY.info) {
+      console.log(`[${this.tag}]`, ...args);
+    }
+  }
+
+  warn(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[getThreshold()] <= LEVEL_PRIORITY.warn) {
+      console.warn(`[${this.tag}]`, ...args);
+    }
+  }
+
+  error(...args: unknown[]): void {
+    if (LEVEL_PRIORITY[getThreshold()] <= LEVEL_PRIORITY.error) {
+      console.error(`[${this.tag}]`, ...args);
+    }
+  }
+}

--- a/packages/services/src/logger/index.ts
+++ b/packages/services/src/logger/index.ts
@@ -1,0 +1,1 @@
+export { Logger, type LogLevel } from './Logger';

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -5,6 +5,9 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { PermissionHandler } from '@github/copilot-sdk';
+import { Logger } from '../logger';
+
+const log = Logger.create('MindManager');
 import type { MindContext, AppConfig, MindRecord } from '@chamber/shared/types';
 import type { InternalMindContext, CopilotClient, CopilotSession, Tool, UserInputHandler } from './types';
 import { generateMindId } from './generateMindId';
@@ -238,7 +241,7 @@ export class MindManager extends EventEmitter {
       try {
         await this.loadMind(record.path, record.id);
       } catch (err) {
-        console.error(`[MindManager] Failed to restore mind at ${record.path}:`, err);
+        log.error(`Failed to restore mind at ${record.path}:`, err);
       }
     }
 

--- a/packages/services/src/sdk/SdkBootstrap.ts
+++ b/packages/services/src/sdk/SdkBootstrap.ts
@@ -3,6 +3,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { SdkRuntimeLayout } from '../ports';
+import { Logger } from '../logger';
+
+const log = Logger.create('SdkLoader');
 
 type RuntimeVersions = {
   sdk: string;
@@ -220,8 +223,8 @@ export async function ensureSdkRuntime(): Promise<void> {
     return;
   }
 
-  console.log(
-    `[SdkLoader] Copilot runtime ready mode=${runtime.mode} `
+  log.info(
+    `Copilot runtime ready mode=${runtime.mode} `
     + `sdk=${runtime.sdkVersion} cli=${runtime.cliVersion} `
     + `platformPackage=${runtime.platformPackageName}@${runtime.platformPackageVersion} `
     + `sdkEntry=${runtime.sdkEntry} cliBinary=${runtime.cliBinaryPath}`

--- a/scripts/check-sdk-versions.js
+++ b/scripts/check-sdk-versions.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-console */
+// Pre-start check: ensures node_modules/@github/copilot and copilot-sdk
+// match the versions pinned in package.json. Fails fast with a clear
+// message instead of a cryptic runtime error.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const rootPkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
+
+const packages = ['@github/copilot', '@github/copilot-sdk'];
+const errors = [];
+
+for (const name of packages) {
+  const required = rootPkg.devDependencies?.[name] ?? rootPkg.dependencies?.[name];
+  if (!required) continue;
+
+  const installedPkgPath = path.join(repoRoot, 'node_modules', ...name.split('/'), 'package.json');
+  if (!fs.existsSync(installedPkgPath)) {
+    errors.push(`${name} is not installed. Run: npm install`);
+    continue;
+  }
+
+  const installed = JSON.parse(fs.readFileSync(installedPkgPath, 'utf-8')).version;
+  // Strip leading caret/tilde for comparison
+  const requiredVersion = required.replace(/^[~^]/, '');
+  if (installed !== requiredVersion) {
+    errors.push(`${name} is ${installed} but package.json requires ${requiredVersion}. Run: npm install`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('\n❌ SDK version mismatch:\n');
+  for (const error of errors) {
+    console.error(`   ${error}`);
+  }
+  console.error('');
+  process.exit(1);
+}

--- a/tests/e2e/electron/electronApp.ts
+++ b/tests/e2e/electron/electronApp.ts
@@ -1,5 +1,5 @@
 import { chromium, type Browser, type Page } from '@playwright/test';
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
@@ -94,4 +94,17 @@ async function waitForCdp(url: string, logs: string[]): Promise<void> {
 
 function logsPreview(logs: string[]): string {
   return logs.slice(-80).join('\n');
+}
+
+/**
+ * Returns true when the active `gh` account can access the given repo.
+ * Use with `test.skip()` to skip marketplace tests that need a private repo.
+ */
+export function canAccessRepo(nwo: string): boolean {
+  try {
+    execFileSync('gh', ['api', `repos/${nwo}`, '--silent'], { stdio: 'ignore', timeout: 15_000 });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/tests/e2e/electron/genesis-ernest-chat.spec.ts
+++ b/tests/e2e/electron/genesis-ernest-chat.spec.ts
@@ -59,6 +59,7 @@ test.describe('electron Genesis Ernest chat smoke', () => {
     await page.getByRole('button', { name: 'Begin' }).click();
     await page.getByRole('button', { name: /Someone else/i }).click();
     await page.getByPlaceholder('e.g. Tony Stark, Moneypenny, Gandalf...').fill(ernestName);
+    await page.getByPlaceholder(/Backstory/).fill('a meticulous QA engineer who finds every edge case');
     await page.getByRole('button', { name: /That's who I am/i }).click();
     await page.getByRole('button', { name: /Something else/i }).click();
     await page.getByPlaceholder(/Creative Director, Debate Coach/).fill('QA Tester');

--- a/tests/e2e/electron/genesis-ernest-chat.spec.ts
+++ b/tests/e2e/electron/genesis-ernest-chat.spec.ts
@@ -58,7 +58,7 @@ test.describe('electron Genesis Ernest chat smoke', () => {
     await page.getByRole('button', { name: /New Agent/i }).click();
     await page.getByRole('button', { name: 'Begin' }).click();
     await page.getByRole('button', { name: /Someone else/i }).click();
-    await page.getByPlaceholder('e.g. Tony Stark, Gandalf, your cool aunt...').fill(ernestName);
+    await page.getByPlaceholder('e.g. Tony Stark, Moneypenny, Gandalf...').fill(ernestName);
     await page.getByRole('button', { name: /That's who I am/i }).click();
     await page.getByRole('button', { name: /Engineering Partner/i }).click();
 

--- a/tests/e2e/electron/genesis-ernest-chat.spec.ts
+++ b/tests/e2e/electron/genesis-ernest-chat.spec.ts
@@ -60,7 +60,9 @@ test.describe('electron Genesis Ernest chat smoke', () => {
     await page.getByRole('button', { name: /Someone else/i }).click();
     await page.getByPlaceholder('e.g. Tony Stark, Moneypenny, Gandalf...').fill(ernestName);
     await page.getByRole('button', { name: /That's who I am/i }).click();
-    await page.getByRole('button', { name: /Engineering Partner/i }).click();
+    await page.getByRole('button', { name: /Something else/i }).click();
+    await page.getByPlaceholder(/Creative Director, Debate Coach/).fill('QA Tester');
+    await page.getByRole('button', { name: /That's my purpose/i }).click();
 
     await expect(page.getByText('How can I help you today?')).toBeVisible({ timeout: 300_000 });
     await expect(page.getByText(ernestName)).toBeVisible();

--- a/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
+++ b/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
@@ -4,14 +4,17 @@ import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
-import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp, canAccessRepo } from './electronApp';
 
 const cdpPort = Number(process.env.CHAMBER_E2E_LANDING_MARKETPLACE_CDP_PORT ?? 9341);
 const internalMarketplaceUrl = 'https://github.com/agency-microsoft/genesis-minds';
 const publicMarketplaceId = 'github:ianphil/genesis-minds';
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 
+const hasAccess = canAccessRepo('agency-microsoft/genesis-minds');
+
 test.describe('electron Genesis landing Add Marketplace smoke', () => {
+  test.skip(!hasAccess, 'Active gh account cannot access agency-microsoft/genesis-minds — run "gh auth switch" to an account with access.');
   test.setTimeout(240_000);
 
   let app: LaunchedElectronApp | undefined;

--- a/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
+++ b/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
@@ -4,13 +4,16 @@ import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
-import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp, canAccessRepo } from './electronApp';
 
 const cdpPort = Number(process.env.CHAMBER_E2E_MARKETPLACE_AGGREGATION_CDP_PORT ?? 9340);
 const publicMarketplaceId = 'github:ianphil/genesis-minds';
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 
+const hasAccess = canAccessRepo('agency-microsoft/genesis-minds');
+
 test.describe('electron Genesis marketplace aggregation smoke', () => {
+  test.skip(!hasAccess, 'Active gh account cannot access agency-microsoft/genesis-minds — run "gh auth switch" to an account with access.');
   test.setTimeout(240_000);
 
   let app: LaunchedElectronApp | undefined;

--- a/tests/e2e/electron/settings-marketplace-management.spec.ts
+++ b/tests/e2e/electron/settings-marketplace-management.spec.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
-import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp, canAccessRepo } from './electronApp';
 
 const cdpPort = Number(process.env.CHAMBER_E2E_SETTINGS_MARKETPLACE_CDP_PORT ?? 9342);
 const mindName = 'Monica';
@@ -12,7 +12,10 @@ const internalMarketplaceUrl = 'https://github.com/agency-microsoft/genesis-mind
 const publicMarketplaceId = 'github:ianphil/genesis-minds';
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 
+const hasAccess = canAccessRepo('agency-microsoft/genesis-minds');
+
 test.describe('electron Settings marketplace management smoke', () => {
+  test.skip(!hasAccess, 'Active gh account cannot access agency-microsoft/genesis-minds — run "gh auth switch" to an account with access.');
   test.setTimeout(240_000);
 
   let app: LaunchedElectronApp | undefined;


### PR DESCRIPTION
## Summary

Fixes the Genesis voice screen marketplace loading, adds a Logger utility to gate all console output, and improves developer experience with pre-start SDK checks and smarter test skipping.

## Changes

### Genesis Flow
- **Surface marketplace errors** — the IPC adapter now throws when all marketplace sources fail instead of silently returning empty templates
- **Fix dark-on-dark input** — added \	ext-foreground\ to custom voice input
- **Split voice into Name + Backstory** — separate fields for directory slug and SOUL.md enrichment
- **Fix custom role input** — \Something else...\ now shows a text input instead of submitting the literal string

### Logger Utility (#86)
- \Logger.create('Tag')\ with level gating (\debug\/\info\/\warn\/\rror\/\silent\)
- Controlled via \CHAMBER_LOG_LEVEL\ env var (default: \info\)
- Replaced ~50 \console.*\ calls across 24 source files
- Browser-compatible logger for renderer components

### Developer Experience
- **Pre-start SDK version check** — \
pm start\ validates installed SDK versions match \package.json\ pins
- **Marketplace test auth skip** — e2e tests needing \gency-microsoft/genesis-minds\ skip with a clear message when the active \gh\ account lacks access
- **Ernest e2e expansion** — smoke test now exercises backstory field and custom role input

## Testing
- 1041 unit tests pass
- SDK smoke passes
- Ernest e2e smoke passes (2.1m)
- Electron UI: 6 passed, 2 skipped, 3 marketplace tests skip on \ianphil\ (pass on \ianphil_microsoft\)

Closes #86