### PR TITLE
fix: load Genesis marketplaces without gh CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.39.3 (2026-05-04)
+
+### Genesis
+
+- **Load marketplaces without the GitHub CLI** — Genesis marketplace reads now use the GitHub REST API directly, trying public access first and then stored Chamber GitHub credentials for private repositories. (#188)
+- **Improve marketplace access guidance** — inaccessible marketplace errors now point users toward Chamber sign-in and repository permissions instead of `gh auth` account switching. (#188)
+
+### Testing
+
+- **Remove marketplace smoke dependency on `gh`** — Electron marketplace smoke tests now check repository access with the same REST API and stored credential path used by the app. (#188)
+
 ## v0.39.2 (2026-05-04)
 
 ### Genesis

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE,
   GenesisMindTemplateInstaller,
   GenesisMindTemplateMarketplaceCatalog,
+  GitHubRegistryClient,
   CronService,
   IdentityLoader,
   MessageRouter,
@@ -119,16 +120,18 @@ const saveActiveLogin = (login: string | null) => {
   const config = configService.load();
   configService.save({ ...config, activeLogin: login });
 };
+const credentialStore = loadKeytar();
+const githubRegistryClient = GitHubRegistryClient.withCredentialStore(credentialStore);
 const authService = new AuthService(
-  loadKeytar(),
+  credentialStore,
   () => configService.load().activeLogin,
   saveActiveLogin,
   `Chamber/${app.getVersion()}`,
 );
 const scaffold = new MindScaffold();
-const genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(undefined, getGenesisMarketplaceSources);
-const genesisTemplateInstaller = new GenesisMindTemplateInstaller(undefined, clientFactory, getGenesisMarketplaceSources);
-const marketplaceRegistryService = new MarketplaceRegistryService(configService);
+const genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(githubRegistryClient, getGenesisMarketplaceSources);
+const genesisTemplateInstaller = new GenesisMindTemplateInstaller(githubRegistryClient, clientFactory, getGenesisMarketplaceSources);
+const marketplaceRegistryService = new MarketplaceRegistryService(configService, githubRegistryClient);
 const viewDiscovery = new ViewDiscovery();
 
 // --- Services (business rules, all dependencies injected) ---
@@ -435,8 +438,8 @@ app.on('ready', async () => {
   setupGenesisIPC(
     mindManager,
     scaffold,
-    { listTemplates: () => {
-      const result = genesisTemplateCatalog.listTemplates();
+    { listTemplates: async () => {
+      const result = await genesisTemplateCatalog.listTemplates();
       if (result.templates.length === 0) {
         const errors = result.sources.filter(s => s.status === 'error');
         if (errors.length > 0) {

--- a/apps/desktop/src/main/ipc/genesis.test.ts
+++ b/apps/desktop/src/main/ipc/genesis.test.ts
@@ -128,7 +128,7 @@ function createScaffold(): MindScaffold & {
 
 function createCatalog() {
   return {
-    listTemplates: vi.fn(() => [lucyTemplate]),
+    listTemplates: vi.fn().mockResolvedValue([lucyTemplate]),
   };
 }
 

--- a/apps/desktop/src/main/ipc/genesis.ts
+++ b/apps/desktop/src/main/ipc/genesis.ts
@@ -15,7 +15,7 @@ import {
 } from '@chamber/services';
 
 interface GenesisMindTemplateCatalogPort {
-  listTemplates(): GenesisMindTemplate[];
+  listTemplates(): Promise<GenesisMindTemplate[]>;
 }
 
 interface GenesisMindTemplateInstallerPort {
@@ -48,7 +48,7 @@ export function setupGenesisIPC(
   });
 
   ipcMain.handle('genesis:listTemplates', async () => {
-    return templateCatalog.listTemplates();
+    return await templateCatalog.listTemplates();
   });
 
   ipcMain.handle('genesis:create', async (event, config: GenesisConfig) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.2",
+      "version": "0.39.3",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/auth/AuthService.ts
+++ b/packages/services/src/auth/AuthService.ts
@@ -13,10 +13,10 @@ const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 const AUTH_SCOPE = 'read:user,read:org,repo,gist';
 // The previous CredWrite-based implementation used the same service/account shape,
 // so existing Windows credentials remain readable after the switch to keytar.
-const KEYTAR_SERVICE = 'copilot-cli';
-const GITHUB_ACCOUNT_PREFIX = 'https://github.com:';
+export const GITHUB_CREDENTIAL_SERVICE = 'copilot-cli';
+export const GITHUB_ACCOUNT_PREFIX = 'https://github.com:';
 
-interface StoredCredential {
+export interface StoredGitHubCredential {
   login: string;
   account: string;
   password: string;
@@ -30,6 +30,17 @@ export function getLoginFromAccount(account: string): string | null {
   if (!account.startsWith(GITHUB_ACCOUNT_PREFIX)) return null;
   const login = account.slice(GITHUB_ACCOUNT_PREFIX.length).trim();
   return login || null;
+}
+
+export async function listStoredGitHubCredentials(credentials: CredentialStore): Promise<StoredGitHubCredential[]> {
+  return (await credentials.findCredentials(GITHUB_CREDENTIAL_SERVICE))
+    .map((credential) => {
+      const login = getLoginFromAccount(credential.account);
+      if (!login || !credential.password) return null;
+      return { login, account: credential.account, password: credential.password };
+    })
+    .filter((credential): credential is StoredGitHubCredential => credential !== null)
+    .sort((a, b) => a.login.localeCompare(b.login));
 }
 
 export interface AuthProgress {
@@ -148,7 +159,7 @@ export class AuthService {
     try {
       const credential = await this.getStoredCredentialEntry();
       if (!credential) return;
-      await this.credentials.deletePassword(KEYTAR_SERVICE, credential.account);
+      await this.credentials.deletePassword(GITHUB_CREDENTIAL_SERVICE, credential.account);
       this.setActiveLogin(null);
       log.info(`Deleted credential for ${credential.login}`);
     } catch (err) {
@@ -156,21 +167,11 @@ export class AuthService {
     }
   }
 
-  private async getStoredCredentials(): Promise<StoredCredential[]> {
-    const credentials = await this.credentials.findCredentials(KEYTAR_SERVICE);
-    const storedCredentials = credentials
-      .map((credential) => {
-        const login = getLoginFromAccount(credential.account);
-        if (!login || !credential.password) return null;
-        return { login, account: credential.account, password: credential.password };
-      })
-      .filter((credential): credential is StoredCredential => credential !== null)
-      .sort((a, b) => a.login.localeCompare(b.login));
-
-    return storedCredentials;
+  private async getStoredCredentials(): Promise<StoredGitHubCredential[]> {
+    return listStoredGitHubCredentials(this.credentials);
   }
 
-  private async getStoredCredentialEntry(): Promise<StoredCredential | null> {
+  private async getStoredCredentialEntry(): Promise<StoredGitHubCredential | null> {
     const credentials = await this.getStoredCredentials();
     if (credentials.length === 0) return null;
 
@@ -186,7 +187,7 @@ export class AuthService {
   }
 
   private async storeCredential(login: string, token: string): Promise<void> {
-    await this.credentials.setPassword(KEYTAR_SERVICE, getCredentialAccount(login), token);
+    await this.credentials.setPassword(GITHUB_CREDENTIAL_SERVICE, getCredentialAccount(login), token);
     log.info(`Stored credential for ${login} via keytar`);
   }
 

--- a/packages/services/src/auth/index.ts
+++ b/packages/services/src/auth/index.ts
@@ -1,2 +1,9 @@
-export { AuthService, getCredentialAccount, getLoginFromAccount } from './AuthService';
-export type { AuthProgress } from './AuthService';
+export {
+  AuthService,
+  GITHUB_ACCOUNT_PREFIX,
+  GITHUB_CREDENTIAL_SERVICE,
+  getCredentialAccount,
+  getLoginFromAccount,
+  listStoredGitHubCredentials,
+} from './AuthService';
+export type { AuthProgress, StoredGitHubCredential } from './AuthService';

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.test.ts
@@ -6,11 +6,11 @@ class FakeRegistryClient {
   tree: TreeEntry[] = [];
   json = new Map<string, unknown>();
 
-  fetchTree(): TreeEntry[] {
+  async fetchTree(): Promise<TreeEntry[]> {
     return this.tree;
   }
 
-  fetchJsonContent(_owner: string, _repo: string, filePath: string): unknown {
+  async fetchJsonContent(_owner: string, _repo: string, filePath: string): Promise<unknown> {
     const content = this.json.get(filePath);
     if (!content) throw new Error(`Missing JSON fixture for ${filePath}`);
     return content;
@@ -25,10 +25,10 @@ describe('GenesisMindTemplateCatalog', () => {
     seedLucyMarketplace(registryClient);
   });
 
-  it('discovers templates from the default genesis minds marketplace', () => {
+  it('discovers templates from the default genesis minds marketplace', async () => {
     const catalog = new GenesisMindTemplateCatalog(registryClient);
 
-    expect(catalog.listTemplates()).toEqual([
+    await expect(catalog.listTemplates()).resolves.toEqual([
       expect.objectContaining({
         id: 'lucy',
         displayName: 'Lucy',
@@ -59,23 +59,23 @@ describe('GenesisMindTemplateCatalog', () => {
     ]);
   });
 
-  it('throws when a plugin entry points at a missing mind manifest', () => {
+  it('throws when a plugin entry points at a missing mind manifest', async () => {
     registryClient.tree = registryClient.tree.filter((entry) => entry.path !== 'plugins/genesis-minds/minds/lucy/mind.json');
 
     const catalog = new GenesisMindTemplateCatalog(registryClient);
 
-    expect(() => catalog.listTemplates()).toThrow('Template manifest not found: plugins/genesis-minds/minds/lucy/mind.json');
+    await expect(catalog.listTemplates()).rejects.toThrow('Template manifest not found: plugins/genesis-minds/minds/lucy/mind.json');
   });
 
-  it('throws when a required template file is missing', () => {
+  it('throws when a required template file is missing', async () => {
     registryClient.tree = registryClient.tree.filter((entry) => entry.path !== 'plugins/genesis-minds/minds/lucy/SOUL.md');
 
     const catalog = new GenesisMindTemplateCatalog(registryClient);
 
-    expect(() => catalog.listTemplates()).toThrow('Template lucy is missing required file: SOUL.md');
+    await expect(catalog.listTemplates()).rejects.toThrow('Template lucy is missing required file: SOUL.md');
   });
 
-  it('rejects template paths that escape the mind root', () => {
+  it('rejects template paths that escape the mind root', async () => {
     registryClient.json.set('plugins/genesis-minds/minds/lucy/mind.json', {
       ...lucyManifest(),
       requiredFiles: ['../escape.md'],
@@ -84,7 +84,7 @@ describe('GenesisMindTemplateCatalog', () => {
 
     const catalog = new GenesisMindTemplateCatalog(registryClient);
 
-    expect(() => catalog.listTemplates()).toThrow('Template lucy has unsafe required file path: ../escape.md');
+    await expect(catalog.listTemplates()).rejects.toThrow('Template lucy has unsafe required file path: ../escape.md');
   });
 });
 

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
@@ -18,8 +18,8 @@ export const DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE: GenesisMindTemplateMarketplac
 };
 
 interface RegistryClient {
-  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
-  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
+  fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]>;
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown>;
 }
 
 interface PluginMindEntry {
@@ -45,25 +45,25 @@ export class GenesisMindTemplateCatalog {
     private readonly source: GenesisMindTemplateMarketplaceSource = DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE,
   ) {}
 
-  listTemplates(): GenesisMindTemplate[] {
-    const tree = this.registryClient.fetchTree(this.source.owner, this.source.repo, this.source.ref);
+  async listTemplates(): Promise<GenesisMindTemplate[]> {
+    const tree = await this.registryClient.fetchTree(this.source.owner, this.source.repo, this.source.ref);
     const blobPaths = new Set(tree.filter((entry) => entry.type === 'blob').map((entry) => entry.path));
 
     this.requireBlob(blobPaths, 'marketplace-config.json', 'Marketplace config not found');
     const pluginPath = `plugins/${this.source.plugin}/plugin.json`;
     this.requireBlob(blobPaths, pluginPath, `Plugin manifest not found: ${pluginPath}`);
 
-    const plugin = this.readRecord(pluginPath);
+    const plugin = await this.readRecord(pluginPath);
     const entries = this.readMindEntries(plugin, pluginPath);
 
-    return entries.map((entry) => this.readTemplate(entry, blobPaths));
+    return Promise.all(entries.map((entry) => this.readTemplate(entry, blobPaths)));
   }
 
-  private readTemplate(entry: PluginMindEntry, blobPaths: Set<string>): GenesisMindTemplate {
+  private async readTemplate(entry: PluginMindEntry, blobPaths: Set<string>): Promise<GenesisMindTemplate> {
     const manifestPath = this.safeJoin(`plugins/${this.source.plugin}`, entry.manifest, `Plugin mind ${entry.id} has unsafe manifest path`);
     this.requireBlob(blobPaths, manifestPath, `Template manifest not found: ${manifestPath}`);
 
-    const manifest = this.readMindManifest(this.readRecord(manifestPath), manifestPath);
+    const manifest = this.readMindManifest(await this.readRecord(manifestPath), manifestPath);
     const manifestDir = path.posix.dirname(manifestPath);
     const rootPath = this.safeJoin(manifestDir, manifest.root, `Template ${manifest.id} has unsafe root path: ${manifest.root}`);
 
@@ -98,8 +98,8 @@ export class GenesisMindTemplateCatalog {
     };
   }
 
-  private readRecord(filePath: string): Record<string, unknown> {
-    const content = this.registryClient.fetchJsonContent(this.source.owner, this.source.repo, filePath, this.source.ref);
+  private async readRecord(filePath: string): Promise<Record<string, unknown>> {
+    const content = await this.registryClient.fetchJsonContent(this.source.owner, this.source.repo, filePath, this.source.ref);
     if (!isRecord(content)) {
       throw new Error(`Expected ${filePath} to contain a JSON object`);
     }

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
@@ -145,6 +145,14 @@ describe('GenesisMindTemplateInstaller', () => {
     expect(mindPath).toBe(path.join(basePath, 'internal-lucy'));
     expect(readFileSync(path.join(mindPath, 'SOUL.md'), 'utf8')).toBe('# Internal Lucy\n');
   });
+
+  it('rejects templates that exceed the total install size limit', async () => {
+    registryClient.blobs.set('soul', Buffer.alloc(51 * 1024 * 1024));
+    const installer = new GenesisMindTemplateInstaller(registryClient);
+
+    await expect(installer.install({ templateId: 'lucy', basePath }))
+      .rejects.toThrow('Template lucy exceeds the 52428800 byte install limit');
+  });
 });
 
 function seedLucyMarketplace(registryClient: FakeRegistryClient): void {

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
@@ -14,17 +14,17 @@ class FakeRegistryClient {
   json = new Map<string, unknown>();
   blobs = new Map<string, Buffer>();
 
-  fetchTree(owner = 'ianphil', repo = 'genesis-minds'): TreeEntry[] {
+  async fetchTree(owner = 'ianphil', repo = 'genesis-minds'): Promise<TreeEntry[]> {
     return this.treeByRepo.get(repoKey(owner, repo)) ?? this.tree;
   }
 
-  fetchJsonContent(owner: string, repo: string, filePath: string): unknown {
+  async fetchJsonContent(owner: string, repo: string, filePath: string): Promise<unknown> {
     const content = this.json.get(`${repoKey(owner, repo)}:${filePath}`) ?? this.json.get(filePath);
     if (!content) throw new Error(`Missing JSON fixture for ${filePath}`);
     return content;
   }
 
-  fetchBlob(_owner: string, _repo: string, sha: string): Buffer {
+  async fetchBlob(_owner: string, _repo: string, sha: string): Promise<Buffer> {
     const content = this.blobs.get(sha);
     if (!content) throw new Error(`Missing blob fixture for ${sha}`);
     return content;

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
@@ -10,6 +10,7 @@ import type { GenesisMindTemplate, GenesisMindTemplateMarketplaceSource } from '
 
 const IDEA_FOLDERS = ['inbox', 'domains', 'expertise', 'initiatives', 'Archive'];
 const WORKING_MEMORY_FILES = ['memory.md', 'rules.md', 'log.md'];
+const MAX_TEMPLATE_INSTALL_BYTES = 50 * 1024 * 1024;
 
 interface RegistryClient {
   fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]>;
@@ -78,6 +79,7 @@ export class GenesisMindTemplateInstaller {
     const tree = await this.registryClient.fetchTree(template.source.owner, template.source.repo, template.source.ref);
     const templatePrefix = `${template.source.rootPath}/`;
     const entries = tree.filter((entry) => entry.type === 'blob' && entry.path.startsWith(templatePrefix));
+    let totalBytes = 0;
 
     for (const entry of entries) {
       const relativePath = path.posix.relative(template.source.rootPath, entry.path);
@@ -86,6 +88,10 @@ export class GenesisMindTemplateInstaller {
       }
 
       const content = await this.registryClient.fetchBlob(template.source.owner, template.source.repo, entry.sha);
+      totalBytes += content.length;
+      if (totalBytes > MAX_TEMPLATE_INSTALL_BYTES) {
+        throw new Error(`Template ${template.id} exceeds the ${MAX_TEMPLATE_INSTALL_BYTES} byte install limit`);
+      }
       const localPath = path.join(mindPath, ...relativePath.split('/'));
       fs.mkdirSync(path.dirname(localPath), { recursive: true });
       fs.writeFileSync(localPath, content);

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
@@ -12,9 +12,9 @@ const IDEA_FOLDERS = ['inbox', 'domains', 'expertise', 'initiatives', 'Archive']
 const WORKING_MEMORY_FILES = ['memory.md', 'rules.md', 'log.md'];
 
 interface RegistryClient {
-  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
-  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
-  fetchBlob(owner: string, repo: string, sha: string): Buffer;
+  fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]>;
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown>;
+  fetchBlob(owner: string, repo: string, sha: string): Promise<Buffer>;
 }
 
 type ClientFactory = Pick<CopilotClientFactory, 'createClient' | 'destroyClient'>;
@@ -37,7 +37,7 @@ export class GenesisMindTemplateInstaller {
   ) {}
 
   async install(request: GenesisMindTemplateInstallRequest): Promise<string> {
-    const template = this.listTemplates().find((item) =>
+    const template = (await this.listTemplates()).find((item) =>
       item.id === request.templateId
       && (!request.marketplaceId || item.source.marketplaceId === request.marketplaceId)
     );
@@ -47,7 +47,7 @@ export class GenesisMindTemplateInstaller {
 
     const mindPath = path.join(request.basePath, MindScaffold.slugify(template.displayName));
     this.createStructure(mindPath);
-    this.copyTemplateFiles(template, mindPath);
+    await this.copyTemplateFiles(template, mindPath);
 
     const validation = new MindScaffold().validate(mindPath);
     if (!validation.ok) {
@@ -74,8 +74,8 @@ export class GenesisMindTemplateInstaller {
     }
   }
 
-  private copyTemplateFiles(template: GenesisMindTemplate, mindPath: string): void {
-    const tree = this.registryClient.fetchTree(template.source.owner, template.source.repo, template.source.ref);
+  private async copyTemplateFiles(template: GenesisMindTemplate, mindPath: string): Promise<void> {
+    const tree = await this.registryClient.fetchTree(template.source.owner, template.source.repo, template.source.ref);
     const templatePrefix = `${template.source.rootPath}/`;
     const entries = tree.filter((entry) => entry.type === 'blob' && entry.path.startsWith(templatePrefix));
 
@@ -85,7 +85,7 @@ export class GenesisMindTemplateInstaller {
         throw new Error(`Template ${template.id} has unsafe repository file path: ${entry.path}`);
       }
 
-      const content = this.registryClient.fetchBlob(template.source.owner, template.source.repo, entry.sha);
+      const content = await this.registryClient.fetchBlob(template.source.owner, template.source.repo, entry.sha);
       const localPath = path.join(mindPath, ...relativePath.split('/'));
       fs.mkdirSync(path.dirname(localPath), { recursive: true });
       fs.writeFileSync(localPath, content);
@@ -98,9 +98,9 @@ export class GenesisMindTemplateInstaller {
     execSync('git commit -m "Genesis template install"', { cwd: mindPath, stdio: 'ignore' });
   }
 
-  private listTemplates(): GenesisMindTemplate[] {
+  private async listTemplates(): Promise<GenesisMindTemplate[]> {
     if (typeof this.sourceProvider === 'function' || Array.isArray(this.sourceProvider)) {
-      return new GenesisMindTemplateMarketplaceCatalog(this.registryClient, this.sourceProvider).listTemplates().templates;
+      return (await new GenesisMindTemplateMarketplaceCatalog(this.registryClient, this.sourceProvider).listTemplates()).templates;
     }
     return new GenesisMindTemplateCatalog(this.registryClient, this.sourceProvider).listTemplates();
   }

--- a/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.test.ts
@@ -8,7 +8,7 @@ class FakeRegistryClient {
   json = new Map<string, unknown>();
   failingRepos = new Set<string>();
 
-  fetchTree(owner: string, repo: string): TreeEntry[] {
+  async fetchTree(owner: string, repo: string): Promise<TreeEntry[]> {
     const key = repoKey(owner, repo);
     if (this.failingRepos.has(key)) {
       throw new Error('GitHub repository not found');
@@ -16,7 +16,7 @@ class FakeRegistryClient {
     return this.tree.get(key) ?? [];
   }
 
-  fetchJsonContent(owner: string, repo: string, filePath: string): unknown {
+  async fetchJsonContent(owner: string, repo: string, filePath: string): Promise<unknown> {
     const content = this.json.get(`${repoKey(owner, repo)}:${filePath}`);
     if (!content) throw new Error(`Missing JSON fixture for ${filePath}`);
     return content;
@@ -56,10 +56,10 @@ describe('GenesisMindTemplateMarketplaceCatalog', () => {
     seedMarketplace(registryClient, internalSource, 'donna', 'Donna');
   });
 
-  it('aggregates templates from every enabled marketplace and labels their source', () => {
+  it('aggregates templates from every enabled marketplace and labels their source', async () => {
     const catalog = new GenesisMindTemplateMarketplaceCatalog(registryClient, [publicSource, internalSource]);
 
-    expect(catalog.listTemplates()).toEqual({
+    await expect(catalog.listTemplates()).resolves.toEqual({
       templates: [
         expect.objectContaining({
           id: 'lucy',
@@ -87,13 +87,13 @@ describe('GenesisMindTemplateMarketplaceCatalog', () => {
     });
   });
 
-  it('skips disabled marketplaces', () => {
+  it('skips disabled marketplaces', async () => {
     const catalog = new GenesisMindTemplateMarketplaceCatalog(registryClient, [
       publicSource,
       { ...internalSource, enabled: false },
     ]);
 
-    expect(catalog.listTemplates()).toEqual({
+    await expect(catalog.listTemplates()).resolves.toEqual({
       templates: [
         expect.objectContaining({ id: 'lucy' }),
       ],
@@ -104,11 +104,11 @@ describe('GenesisMindTemplateMarketplaceCatalog', () => {
     });
   });
 
-  it('keeps accessible marketplace templates when a private source cannot be read', () => {
+  it('keeps accessible marketplace templates when a private source cannot be read', async () => {
     registryClient.failingRepos.add(repoKey(internalSource.owner, internalSource.repo));
     const catalog = new GenesisMindTemplateMarketplaceCatalog(registryClient, [publicSource, internalSource]);
 
-    expect(catalog.listTemplates()).toEqual({
+    await expect(catalog.listTemplates()).resolves.toEqual({
       templates: [
         expect.objectContaining({ id: 'lucy' }),
       ],

--- a/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateMarketplaceCatalog.ts
@@ -7,8 +7,8 @@ import type {
 } from './templateTypes';
 
 interface RegistryClient {
-  fetchTree(owner: string, repo: string, branch: string): TreeEntry[];
-  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown;
+  fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]>;
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown>;
 }
 
 type SourceProvider =
@@ -21,7 +21,7 @@ export class GenesisMindTemplateMarketplaceCatalog {
     private readonly sourceProvider: SourceProvider = [DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE],
   ) {}
 
-  listTemplates(): GenesisMindTemplateMarketplaceResult {
+  async listTemplates(): Promise<GenesisMindTemplateMarketplaceResult> {
     const templates: GenesisMindTemplateMarketplaceResult['templates'] = [];
     const sources: GenesisMindTemplateMarketplaceStatus[] = [];
 
@@ -33,7 +33,7 @@ export class GenesisMindTemplateMarketplaceCatalog {
       }
 
       try {
-        const sourceTemplates = new GenesisMindTemplateCatalog(this.registryClient, source).listTemplates();
+        const sourceTemplates = await new GenesisMindTemplateCatalog(this.registryClient, source).listTemplates();
         templates.push(...sourceTemplates);
         sources.push({ ...metadata, status: 'ok', templateCount: sourceTemplates.length });
       } catch {

--- a/packages/services/src/genesis/GitHubRegistryClient.test.ts
+++ b/packages/services/src/genesis/GitHubRegistryClient.test.ts
@@ -23,6 +23,7 @@ describe('GitHubRegistryClient', () => {
             'Accept': 'application/vnd.github+json',
             'User-Agent': expect.any(String),
           }),
+          signal: expect.any(AbortSignal),
         }),
       );
     });
@@ -59,6 +60,30 @@ describe('GitHubRegistryClient', () => {
         }),
       );
     });
+
+    it('does not read stored credentials when anonymous access succeeds', async () => {
+      const credentialProvider = vi.fn(async () => [{ login: 'ianphil_microsoft', token: 'secret-token' }]);
+      client = new GitHubRegistryClient({ fetch: fetchMock, credentialProvider });
+      fetchMock.mockResolvedValueOnce(jsonResponse({ tree: [] }));
+
+      await client.fetchTree('ianphil', 'genesis-minds', 'master');
+
+      expect(credentialProvider).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the anonymous error when credential lookup fails', async () => {
+      client = new GitHubRegistryClient({
+        fetch: fetchMock,
+        credentialProvider: async () => {
+          throw new Error('keychain locked');
+        },
+      });
+      fetchMock.mockResolvedValueOnce(new Response('not found', { status: 404, statusText: 'Not Found' }));
+
+      await expect(client.fetchTree('agency-microsoft', 'genesis-minds', 'main'))
+        .rejects.toThrow('GitHub API request failed anonymously: 404 Not Found');
+    });
   });
 
   describe('fetchBlob', () => {
@@ -71,6 +96,17 @@ describe('GitHubRegistryClient', () => {
       const content = await client.fetchBlob('ianphil', 'genesis', 'abc123');
 
       expect(content.toString()).toBe('Hello World');
+    });
+
+    it('rejects blobs over the configured size limit', async () => {
+      client = new GitHubRegistryClient({ fetch: fetchMock, maxBlobBytes: 4 });
+      fetchMock.mockResolvedValueOnce(jsonResponse({
+        content: Buffer.from('Hello').toString('base64'),
+        encoding: 'base64',
+      }));
+
+      await expect(client.fetchBlob('ianphil', 'genesis', 'abc123'))
+        .rejects.toThrow('exceeds the 4 byte limit');
     });
   });
 

--- a/packages/services/src/genesis/GitHubRegistryClient.test.ts
+++ b/packages/services/src/genesis/GitHubRegistryClient.test.ts
@@ -2,52 +2,98 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GitHubRegistryClient } from './GitHubRegistryClient';
 
 describe('GitHubRegistryClient', () => {
-  const fakeExec = vi.fn();
+  const fetchMock = vi.fn<typeof fetch>();
   let client: GitHubRegistryClient;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    client = new GitHubRegistryClient(fakeExec);
+    client = new GitHubRegistryClient({ fetch: fetchMock });
   });
 
   describe('fetchTree', () => {
-    it('calls gh api with correct URL', () => {
-      fakeExec.mockReturnValue(JSON.stringify({ tree: [] }));
-      client.fetchTree('ianphil', 'genesis', 'main');
-      expect(fakeExec).toHaveBeenCalledWith(
-        expect.stringContaining('/repos/ianphil/genesis/git/trees/main'),
-        expect.any(Object),
+    it('fetches the GitHub REST tree endpoint without requiring gh', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ tree: [] }));
+
+      await client.fetchTree('ianphil', 'genesis', 'main');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.github.com/repos/ianphil/genesis/git/trees/main?recursive=1',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Accept': 'application/vnd.github+json',
+            'User-Agent': expect.any(String),
+          }),
+        }),
       );
     });
 
-    it('returns parsed tree entries', () => {
-      fakeExec.mockReturnValue(JSON.stringify({
+    it('returns parsed tree entries', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({
         tree: [{ path: '.github/skills/upgrade/SKILL.md', type: 'blob', sha: 'abc123' }],
       }));
-      const result = client.fetchTree('ianphil', 'genesis', 'main');
+
+      const result = await client.fetchTree('ianphil', 'genesis', 'main');
+
       expect(result).toHaveLength(1);
       expect(result[0].sha).toBe('abc123');
+    });
+
+    it('falls back to stored credentials when anonymous access fails', async () => {
+      client = new GitHubRegistryClient({
+        fetch: fetchMock,
+        credentialProvider: async () => [{ login: 'ianphil_microsoft', token: 'secret-token' }],
+      });
+      fetchMock
+        .mockResolvedValueOnce(new Response('not found', { status: 404, statusText: 'Not Found' }))
+        .mockResolvedValueOnce(jsonResponse({ tree: [] }));
+
+      await client.fetchTree('agency-microsoft', 'genesis-minds', 'main');
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        'https://api.github.com/repos/agency-microsoft/genesis-minds/git/trees/main?recursive=1',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer secret-token',
+          }),
+        }),
+      );
     });
   });
 
   describe('fetchBlob', () => {
-    it('decodes base64 content', () => {
-      fakeExec.mockReturnValue(JSON.stringify({
+    it('decodes base64 content', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({
         content: Buffer.from('Hello World').toString('base64'),
         encoding: 'base64',
       }));
-      const content = client.fetchBlob('ianphil', 'genesis', 'abc123');
+
+      const content = await client.fetchBlob('ianphil', 'genesis', 'abc123');
+
       expect(content.toString()).toBe('Hello World');
     });
   });
 
   describe('fetchJsonContent', () => {
-    it('fetches and parses JSON from repo contents API', () => {
-      fakeExec.mockReturnValue(JSON.stringify({
+    it('fetches and parses JSON from repo contents API', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({
         content: Buffer.from(JSON.stringify({ version: '1.0.0' })).toString('base64'),
       }));
-      const result = client.fetchJsonContent('ianphil', 'genesis', '.github/registry.json', 'main');
+
+      const result = await client.fetchJsonContent('ianphil', 'genesis', '.github/registry.json', 'main');
+
       expect(result).toEqual({ version: '1.0.0' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.github.com/repos/ianphil/genesis/contents/.github/registry.json?ref=main',
+        expect.any(Object),
+      );
     });
   });
 });
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/packages/services/src/genesis/GitHubRegistryClient.ts
+++ b/packages/services/src/genesis/GitHubRegistryClient.ts
@@ -17,6 +17,8 @@ export type GitHubRegistryCredentialProvider = () => Promise<GitHubRegistryCrede
 export interface GitHubRegistryClientOptions {
   fetch?: typeof fetch;
   credentialProvider?: GitHubRegistryCredentialProvider;
+  requestTimeoutMs?: number;
+  maxBlobBytes?: number;
 }
 
 interface GitHubTreeResponse {
@@ -34,10 +36,14 @@ interface GitHubContentResponse {
 export class GitHubRegistryClient {
   private readonly fetchImpl: typeof fetch;
   private readonly credentialProvider: GitHubRegistryCredentialProvider;
+  private readonly requestTimeoutMs: number;
+  private readonly maxBlobBytes: number;
 
   constructor(options: GitHubRegistryClientOptions = {}) {
     this.fetchImpl = options.fetch ?? globalThis.fetch;
     this.credentialProvider = options.credentialProvider ?? (() => Promise.resolve([]));
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.maxBlobBytes = options.maxBlobBytes ?? DEFAULT_MAX_BLOB_BYTES;
   }
 
   static withCredentialStore(credentials: CredentialStore): GitHubRegistryClient {
@@ -64,7 +70,15 @@ export class GitHubRegistryClient {
     if (typeof response.content !== 'string') {
       throw new Error(`GitHub blob response for ${owner}/${repo}@${sha} did not include content`);
     }
-    return Buffer.from(response.content, 'base64');
+    const encodedContent = response.content.replace(/\s/g, '');
+    if (encodedContent.length > maxBase64Length(this.maxBlobBytes)) {
+      throw new Error(`GitHub blob ${owner}/${repo}@${sha} exceeds the ${this.maxBlobBytes} byte limit`);
+    }
+    const content = Buffer.from(encodedContent, 'base64');
+    if (content.length > this.maxBlobBytes) {
+      throw new Error(`GitHub blob ${owner}/${repo}@${sha} exceeds the ${this.maxBlobBytes} byte limit`);
+    }
+    return content;
   }
 
   async fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown> {
@@ -78,28 +92,61 @@ export class GitHubRegistryClient {
   }
 
   private async requestJson<T>(pathAndQuery: string): Promise<T> {
-    const attempts = [
-      { login: null, token: null },
-      ...(await this.credentialProvider()).map((credential) => ({
-        login: credential.login,
-        token: credential.token,
-      })),
-    ];
-    let lastError: Error | null = null;
+    const anonymousAttempt = await this.fetchJsonAttempt<T>(pathAndQuery, null, null);
+    if (anonymousAttempt.ok) {
+      return anonymousAttempt.value;
+    }
 
-    for (const attempt of attempts) {
-      const response = await this.fetchImpl(`https://api.github.com${pathAndQuery}`, {
-        headers: requestHeaders(attempt.token),
-      });
-      if (response.ok) {
-        return await response.json() as T;
+    let lastError = anonymousAttempt.error;
+    for (const credential of await this.safeCredentials()) {
+      const credentialAttempt = await this.fetchJsonAttempt<T>(pathAndQuery, credential.token, credential.login);
+      if (credentialAttempt.ok) {
+        return credentialAttempt.value;
       }
-      lastError = await registryRequestError(response, attempt.login);
+      lastError = credentialAttempt.error;
     }
 
     throw lastError ?? new Error('GitHub API request failed');
   }
+
+  private async fetchJsonAttempt<T>(
+    pathAndQuery: string,
+    token: string | null,
+    login: string | null,
+  ): Promise<{ ok: true; value: T } | { ok: false; error: Error }> {
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), this.requestTimeoutMs);
+    try {
+      const response = await this.fetchImpl(`https://api.github.com${pathAndQuery}`, {
+        headers: requestHeaders(token),
+        signal: abort.signal,
+      });
+      if (response.ok) {
+        return { ok: true, value: await response.json() as T };
+      }
+      return { ok: false, error: await registryRequestError(response, login) };
+    } catch (error) {
+      const account = login ? ` using stored credential "${login}"` : ' anonymously';
+      return {
+        ok: false,
+        error: new Error(`GitHub API request failed${account}: ${error instanceof Error ? error.message : String(error)}`),
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async safeCredentials(): Promise<GitHubRegistryCredential[]> {
+    try {
+      return await this.credentialProvider();
+    } catch {
+      return [];
+    }
+  }
 }
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BLOB_BYTES = 10 * 1024 * 1024;
 
 function requestHeaders(token: string | null): HeadersInit {
   return {
@@ -107,6 +154,10 @@ function requestHeaders(token: string | null): HeadersInit {
     'User-Agent': AuthService.userAgent,
     ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
   };
+}
+
+function maxBase64Length(maxBytes: number): number {
+  return Math.ceil(maxBytes / 3) * 4;
 }
 
 async function registryRequestError(response: Response, login: string | null): Promise<Error> {

--- a/packages/services/src/genesis/GitHubRegistryClient.ts
+++ b/packages/services/src/genesis/GitHubRegistryClient.ts
@@ -1,6 +1,5 @@
-import { execSync } from 'child_process';
-
-type ExecFn = (command: string, options: Record<string, unknown>) => string;
+import { AuthService, listStoredGitHubCredentials } from '../auth';
+import type { CredentialStore } from '../ports';
 
 export interface TreeEntry {
   path: string;
@@ -8,36 +7,136 @@ export interface TreeEntry {
   sha: string;
 }
 
+export interface GitHubRegistryCredential {
+  login: string;
+  token: string;
+}
+
+export type GitHubRegistryCredentialProvider = () => Promise<GitHubRegistryCredential[]>;
+
+export interface GitHubRegistryClientOptions {
+  fetch?: typeof fetch;
+  credentialProvider?: GitHubRegistryCredentialProvider;
+}
+
+interface GitHubTreeResponse {
+  tree: unknown;
+}
+
+interface GitHubBlobResponse {
+  content: unknown;
+}
+
+interface GitHubContentResponse {
+  content: unknown;
+}
+
 export class GitHubRegistryClient {
-  private exec: ExecFn;
+  private readonly fetchImpl: typeof fetch;
+  private readonly credentialProvider: GitHubRegistryCredentialProvider;
 
-  constructor(exec?: ExecFn) {
-    this.exec = exec ?? ((cmd, opts) => execSync(cmd, opts as Parameters<typeof execSync>[1]) as unknown as string);
+  constructor(options: GitHubRegistryClientOptions = {}) {
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.credentialProvider = options.credentialProvider ?? (() => Promise.resolve([]));
   }
 
-  fetchTree(owner: string, repo: string, branch: string): TreeEntry[] {
-    const raw = this.exec(
-      `gh api /repos/${owner}/${repo}/git/trees/${branch}?recursive=1`,
-      { encoding: 'utf8', timeout: 30_000 },
+  static withCredentialStore(credentials: CredentialStore): GitHubRegistryClient {
+    return new GitHubRegistryClient({
+      credentialProvider: async () => (await listStoredGitHubCredentials(credentials))
+        .map((credential) => ({ login: credential.login, token: credential.password })),
+    });
+  }
+
+  async fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]> {
+    const response = await this.requestJson<GitHubTreeResponse>(
+      `/repos/${encodePath(owner)}/${encodePath(repo)}/git/trees/${encodePath(branch)}?recursive=1`,
     );
-    return JSON.parse(raw).tree;
+    if (!Array.isArray(response.tree)) {
+      throw new Error(`GitHub tree response for ${owner}/${repo} did not include a tree array`);
+    }
+    return response.tree.map(parseTreeEntry);
   }
 
-  fetchBlob(owner: string, repo: string, sha: string): Buffer {
-    const raw = this.exec(
-      `gh api /repos/${owner}/${repo}/git/blobs/${sha}`,
-      { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
+  async fetchBlob(owner: string, repo: string, sha: string): Promise<Buffer> {
+    const response = await this.requestJson<GitHubBlobResponse>(
+      `/repos/${encodePath(owner)}/${encodePath(repo)}/git/blobs/${encodePath(sha)}`,
     );
-    const blob = JSON.parse(raw);
-    return Buffer.from(blob.content, 'base64');
+    if (typeof response.content !== 'string') {
+      throw new Error(`GitHub blob response for ${owner}/${repo}@${sha} did not include content`);
+    }
+    return Buffer.from(response.content, 'base64');
   }
 
-  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): unknown {
-    const raw = this.exec(
-      `gh api /repos/${owner}/${repo}/contents/${filePath}?ref=${ref}`,
-      { encoding: 'utf8' },
+  async fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown> {
+    const response = await this.requestJson<GitHubContentResponse>(
+      `/repos/${encodePath(owner)}/${encodePath(repo)}/contents/${encodeFilePath(filePath)}?ref=${encodePath(ref)}`,
     );
-    const content = JSON.parse(raw);
-    return JSON.parse(Buffer.from(content.content, 'base64').toString('utf8'));
+    if (typeof response.content !== 'string') {
+      throw new Error(`GitHub content response for ${owner}/${repo}/${filePath} did not include content`);
+    }
+    return JSON.parse(Buffer.from(response.content, 'base64').toString('utf8'));
   }
+
+  private async requestJson<T>(pathAndQuery: string): Promise<T> {
+    const attempts = [
+      { login: null, token: null },
+      ...(await this.credentialProvider()).map((credential) => ({
+        login: credential.login,
+        token: credential.token,
+      })),
+    ];
+    let lastError: Error | null = null;
+
+    for (const attempt of attempts) {
+      const response = await this.fetchImpl(`https://api.github.com${pathAndQuery}`, {
+        headers: requestHeaders(attempt.token),
+      });
+      if (response.ok) {
+        return await response.json() as T;
+      }
+      lastError = await registryRequestError(response, attempt.login);
+    }
+
+    throw lastError ?? new Error('GitHub API request failed');
+  }
+}
+
+function requestHeaders(token: string | null): HeadersInit {
+  return {
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': AuthService.userAgent,
+    ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+  };
+}
+
+async function registryRequestError(response: Response, login: string | null): Promise<Error> {
+  const message = await response.text().catch(() => '');
+  const account = login ? ` using stored credential "${login}"` : ' anonymously';
+  return new Error(`GitHub API request failed${account}: ${response.status} ${response.statusText}${message ? ` - ${message}` : ''}`);
+}
+
+function parseTreeEntry(value: unknown): TreeEntry {
+  if (!isRecord(value)
+    || typeof value.path !== 'string'
+    || typeof value.type !== 'string'
+    || typeof value.sha !== 'string') {
+    throw new Error('GitHub tree response included an invalid entry');
+  }
+  return {
+    path: value.path,
+    type: value.type,
+    sha: value.sha,
+  };
+}
+
+function encodeFilePath(filePath: string): string {
+  return filePath.split('/').map(encodePath).join('/');
+}
+
+function encodePath(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/services/src/genesis/MarketplaceRegistryService.test.ts
+++ b/packages/services/src/genesis/MarketplaceRegistryService.test.ts
@@ -57,14 +57,6 @@ class FakeRegistryClient {
   }
 }
 
-class FakeGitHubAuthInspector {
-  activeLogin: string | null = 'ianphil';
-
-  async getActiveLogin(): Promise<string | null> {
-    return this.activeLogin;
-  }
-}
-
 const defaultConfig: AppConfig = {
   version: 2,
   minds: [],
@@ -89,14 +81,12 @@ const defaultConfig: AppConfig = {
 describe('MarketplaceRegistryService', () => {
   let config: AppConfig;
   let registryClient: FakeRegistryClient;
-  let authInspector: FakeGitHubAuthInspector;
   let savedConfigs: AppConfig[];
   let save: (next: AppConfig) => void;
 
   beforeEach(() => {
     config = structuredClone(defaultConfig);
     registryClient = new FakeRegistryClient();
-    authInspector = new FakeGitHubAuthInspector();
     savedConfigs = [];
     save = (next: AppConfig) => {
       savedConfigs.push(next);
@@ -105,7 +95,7 @@ describe('MarketplaceRegistryService', () => {
   });
 
   it('adds a GitHub Genesis marketplace registry after validating its manifest', async () => {
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).resolves.toEqual({
       success: true,
@@ -126,29 +116,18 @@ describe('MarketplaceRegistryService', () => {
 
   it('returns a friendly access error without saving inaccessible marketplaces', async () => {
     registryClient.fail = true;
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).resolves.toEqual({
       success: false,
-      error: 'Unable to access marketplace agency-microsoft/genesis-minds with the active GitHub CLI account "ianphil". Chamber uses the GitHub CLI to read marketplace repositories. Run "gh auth status --hostname github.com" to confirm the active account, then run "gh auth switch --user <account-with-access>" or "gh auth login" before trying again.',
+      error: 'Unable to access marketplace agency-microsoft/genesis-minds. Chamber tried the public GitHub API and any stored Chamber GitHub credentials. Sign in to Chamber with an account that can access this repository, or confirm the marketplace URL and repository permissions.',
     });
     expect(savedConfigs).toHaveLength(0);
   });
 
-  it('returns GitHub CLI setup guidance when no active account can be detected', async () => {
-    registryClient.fail = true;
-    authInspector.activeLogin = null;
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
-
-    await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).resolves.toEqual({
-      success: false,
-      error: 'Unable to access marketplace agency-microsoft/genesis-minds. Chamber uses the GitHub CLI to read marketplace repositories. Run "gh auth status --hostname github.com" to confirm the active account, then run "gh auth switch --user <account-with-access>" or "gh auth login" before trying again.',
-    });
-  });
-
   it('returns a manifest validation error without saving malformed marketplaces', async () => {
     registryClient.malformedManifest = true;
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds')).resolves.toEqual({
       success: false,
@@ -159,7 +138,7 @@ describe('MarketplaceRegistryService', () => {
 
   it('returns a manifest validation error when required template files are missing', async () => {
     registryClient.missingRequiredFile = true;
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     await expect(service.refreshGenesisRegistry('github:ianphil/genesis-minds')).resolves.toEqual({
       success: false,
@@ -168,7 +147,7 @@ describe('MarketplaceRegistryService', () => {
   });
 
   it('rejects non-GitHub URLs', async () => {
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     await expect(service.addGenesisRegistry('https://example.com/agency-microsoft/genesis-minds')).resolves.toEqual({
       success: false,
@@ -177,7 +156,7 @@ describe('MarketplaceRegistryService', () => {
   });
 
   it('rejects owner and repo path segments with shell metacharacters before validation', async () => {
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     await expect(service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds&calc')).resolves.toEqual({
       success: false,
@@ -187,7 +166,7 @@ describe('MarketplaceRegistryService', () => {
   });
 
   it('disables, enables, and removes followed marketplaces', async () => {
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
     await service.addGenesisRegistry('https://github.com/agency-microsoft/genesis-minds');
 
     expect(service.setGenesisRegistryEnabled('github:agency-microsoft/genesis-minds', false)).toEqual({
@@ -206,7 +185,7 @@ describe('MarketplaceRegistryService', () => {
   });
 
   it('rejects invalid enabled state without mutating config', () => {
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     expect(service.setGenesisRegistryEnabled('github:ianphil/genesis-minds', 'false')).toEqual({
       success: false,
@@ -216,7 +195,7 @@ describe('MarketplaceRegistryService', () => {
   });
 
   it('does not remove the default marketplace', () => {
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     expect(service.removeGenesisRegistry('github:ianphil/genesis-minds')).toEqual({
       success: false,
@@ -225,7 +204,7 @@ describe('MarketplaceRegistryService', () => {
   });
 
   it('refreshes a followed marketplace by validating access', async () => {
-    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient, authInspector);
+    const service = new MarketplaceRegistryService({ load: () => config, save }, registryClient);
 
     await expect(service.refreshGenesisRegistry('github:ianphil/genesis-minds')).resolves.toEqual({
       success: true,

--- a/packages/services/src/genesis/MarketplaceRegistryService.ts
+++ b/packages/services/src/genesis/MarketplaceRegistryService.ts
@@ -1,11 +1,8 @@
-import { execFile } from 'node:child_process';
 import path from 'node:path';
-import { promisify } from 'node:util';
 import { DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE } from './GenesisMindTemplateCatalog';
-import type { TreeEntry } from './GitHubRegistryClient';
+import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
 import type { AppConfig, MarketplaceRegistry, MarketplaceRegistryActionResult } from '@chamber/shared/types';
 
-const execFileAsync = promisify(execFile);
 const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
 const GITHUB_REPO_PATTERN = /^[A-Za-z0-9._-]+$/;
 const MANIFEST_STRING_FIELDS = ['id', 'displayName', 'description', 'role', 'voice', 'templateVersion', 'root', 'agent'] as const;
@@ -20,53 +17,12 @@ interface RegistryClient {
   fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown>;
 }
 
-interface GitHubAuthInspector {
-  getActiveLogin(): Promise<string | null>;
-}
-
 class MarketplaceManifestError extends Error {}
-
-class AsyncGitHubRegistryClient implements RegistryClient {
-  async fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]> {
-    const { stdout } = await execFileAsync(
-      'gh',
-      ['api', `/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`],
-      { encoding: 'utf8', timeout: 30_000 },
-    );
-    return (JSON.parse(stdout) as { tree: TreeEntry[] }).tree;
-  }
-
-  async fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown> {
-    const { stdout } = await execFileAsync(
-      'gh',
-      ['api', `/repos/${owner}/${repo}/contents/${filePath}?ref=${ref}`],
-      { encoding: 'utf8', timeout: 30_000 },
-    );
-    const content = JSON.parse(stdout) as { content: string };
-    return JSON.parse(Buffer.from(content.content, 'base64').toString('utf8'));
-  }
-}
-
-class AsyncGitHubAuthInspector implements GitHubAuthInspector {
-  async getActiveLogin(): Promise<string | null> {
-    try {
-      const { stdout, stderr } = await execFileAsync(
-        'gh',
-        ['auth', 'status', '--hostname', 'github.com', '--active'],
-        { encoding: 'utf8', timeout: 10_000 },
-      );
-      return parseActiveLogin(`${stdout}\n${stderr}`);
-    } catch (error) {
-      return parseActiveLogin(commandOutput(error));
-    }
-  }
-}
 
 export class MarketplaceRegistryService {
   constructor(
     private readonly configStore: ConfigStore,
-    private readonly registryClient: RegistryClient = new AsyncGitHubRegistryClient(),
-    private readonly authInspector: GitHubAuthInspector = new AsyncGitHubAuthInspector(),
+    private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
   ) {}
 
   listGenesisRegistries(): MarketplaceRegistry[] {
@@ -89,7 +45,7 @@ export class MarketplaceRegistryService {
     } catch (error) {
       return {
         success: false,
-        error: await marketplaceValidationMessage(registry, error, this.authInspector),
+        error: marketplaceValidationMessage(registry, error),
       };
     }
 
@@ -123,7 +79,7 @@ export class MarketplaceRegistryService {
     } catch (error) {
       return {
         success: false,
-        error: await marketplaceValidationMessage(registry, error, this.authInspector),
+        error: marketplaceValidationMessage(registry, error),
       };
     }
   }
@@ -293,32 +249,17 @@ function isSafeRelativePath(value: string): boolean {
   return normalized === '.' || (!normalized.startsWith('..') && !normalized.includes('/../'));
 }
 
-async function marketplaceValidationMessage(
+function marketplaceValidationMessage(
   registry: MarketplaceRegistry,
   error: unknown,
-  authInspector: GitHubAuthInspector,
-): Promise<string> {
+): string {
   if (error instanceof MarketplaceManifestError) {
     return `Marketplace ${registry.label} is invalid: ${error.message}`;
   }
-  const activeLogin = await authInspector.getActiveLogin();
-  const activeAccount = activeLogin ? ` with the active GitHub CLI account "${activeLogin}"` : '';
-  return `Unable to access marketplace ${registry.label}${activeAccount}. Chamber uses the GitHub CLI to read marketplace repositories. Run "gh auth status --hostname github.com" to confirm the active account, then run "gh auth switch --user <account-with-access>" or "gh auth login" before trying again.`;
+  return `Unable to access marketplace ${registry.label}. Chamber tried the public GitHub API and any stored Chamber GitHub credentials. Sign in to Chamber with an account that can access this repository, or confirm the marketplace URL and repository permissions.`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function parseActiveLogin(output: string): string | null {
-  const match = output.match(/Logged in to github\.com account ([^\s]+) /);
-  return match?.[1] ?? null;
-}
-
-function commandOutput(error: unknown): string {
-  if (!isRecord(error)) return String(error);
-  const stdout = typeof error.stdout === 'string' ? error.stdout : '';
-  const stderr = typeof error.stderr === 'string' ? error.stderr : '';
-  const message = error instanceof Error ? error.message : '';
-  return `${stdout}\n${stderr}\n${message}`;
-}

--- a/packages/services/src/genesis/MindScaffold.ts
+++ b/packages/services/src/genesis/MindScaffold.ts
@@ -100,7 +100,7 @@ export class MindScaffold {
     // 5. Bootstrap capabilities (best-effort — mind works without them)
     this.emit('capabilities', 'Installing capabilities...');
     try {
-      this.bootstrapCapabilities(mindPath);
+      await this.bootstrapCapabilities(mindPath);
     } catch (err) {
       log.warn('Capability bootstrap failed (non-fatal):', err);
       this.emit('capabilities', 'Capabilities install failed — run "upgrade from genesis" later.');
@@ -195,7 +195,7 @@ export class MindScaffold {
     }
   }
 
-  private bootstrapCapabilities(mindPath: string): void {
+  private async bootstrapCapabilities(mindPath: string): Promise<void> {
     // 1. Seed registry.json
     this.emit('capabilities', 'Seeding registry...');
     const registryPath = path.join(mindPath, '.github', 'registry.json');
@@ -212,7 +212,7 @@ export class MindScaffold {
 
     // 2. Pull upgrade skill (the bootloader)
     this.emit('capabilities', 'Pulling upgrade skill...');
-    const remoteRegistry = this.pullUpgradeSkill(mindPath);
+    const remoteRegistry = await this.pullUpgradeSkill(mindPath);
 
     // 3. Install only skills — Chamber internalizes extensions.
     const skillNames = Object.keys(remoteRegistry.skills ?? {});
@@ -256,12 +256,12 @@ export class MindScaffold {
     }
   }
 
-  private pullUpgradeSkill(mindPath: string): RemoteRegistry {
+  private async pullUpgradeSkill(mindPath: string): Promise<RemoteRegistry> {
     const [owner, repo] = GENESIS_SOURCE.split('/');
     const upgradePrefix = '.github/skills/upgrade/';
 
     // Fetch the genesis tree
-    const treeEntries = this.registryClient.fetchTree(owner, repo, GENESIS_CHANNEL);
+    const treeEntries = await this.registryClient.fetchTree(owner, repo, GENESIS_CHANNEL);
 
     // Find upgrade skill files
     const upgradeFiles: { path: string; sha: string }[] = [];
@@ -277,14 +277,14 @@ export class MindScaffold {
 
     // Download and write each file
     for (const file of upgradeFiles) {
-      const content = this.registryClient.fetchBlob(owner, repo, file.sha);
+      const content = await this.registryClient.fetchBlob(owner, repo, file.sha);
       const localPath = path.join(mindPath, file.path);
       fs.mkdirSync(path.dirname(localPath), { recursive: true });
       fs.writeFileSync(localPath, content);
     }
 
     // Fetch remote registry to get upgrade version info
-    const remoteRegistry = this.registryClient.fetchJsonContent(owner, repo, '.github/registry.json', GENESIS_CHANNEL) as RemoteRegistry;
+    const remoteRegistry = await this.registryClient.fetchJsonContent(owner, repo, '.github/registry.json', GENESIS_CHANNEL) as RemoteRegistry;
     const upgradeInfo = remoteRegistry.skills?.upgrade;
 
     // Update local registry with upgrade skill

--- a/tests/e2e/electron/electronApp.ts
+++ b/tests/e2e/electron/electronApp.ts
@@ -1,7 +1,8 @@
 import { chromium, type Browser, type Page } from '@playwright/test';
-import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
+import keytar from 'keytar';
 
 export const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
@@ -97,14 +98,29 @@ function logsPreview(logs: string[]): string {
 }
 
 /**
- * Returns true when the active `gh` account can access the given repo.
+ * Returns true when Chamber's public GitHub API access or stored credentials can access the given repo.
  * Use with `test.skip()` to skip marketplace tests that need a private repo.
  */
-export function canAccessRepo(nwo: string): boolean {
-  try {
-    execFileSync('gh', ['api', `repos/${nwo}`, '--silent'], { stdio: 'ignore', timeout: 15_000 });
-    return true;
-  } catch {
-    return false;
+export async function canAccessRepo(nwo: string): Promise<boolean> {
+  if (await canFetchRepo(nwo, null)) return true;
+
+  const credentials = await keytar.findCredentials('copilot-cli');
+  for (const credential of credentials) {
+    if (credential.password && await canFetchRepo(nwo, credential.password)) {
+      return true;
+    }
   }
+
+  return false;
+}
+
+async function canFetchRepo(nwo: string, token: string | null): Promise<boolean> {
+  const response = await fetch(`https://api.github.com/repos/${nwo}`, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': 'Chamber/e2e',
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+    },
+  });
+  return response.ok;
 }

--- a/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
+++ b/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
@@ -11,10 +11,7 @@ const internalMarketplaceUrl = 'https://github.com/agency-microsoft/genesis-mind
 const publicMarketplaceId = 'github:ianphil/genesis-minds';
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 
-const hasAccess = canAccessRepo('agency-microsoft/genesis-minds');
-
 test.describe('electron Genesis landing Add Marketplace smoke', () => {
-  test.skip(!hasAccess, 'Active gh account cannot access agency-microsoft/genesis-minds — run "gh auth switch" to an account with access.');
   test.setTimeout(240_000);
 
   let app: LaunchedElectronApp | undefined;
@@ -23,6 +20,11 @@ test.describe('electron Genesis landing Add Marketplace smoke', () => {
   const tempRoots: string[] = [];
 
   test.beforeAll(async () => {
+    test.skip(
+      !(await canAccessRepo('agency-microsoft/genesis-minds')),
+      'Stored Chamber GitHub credentials cannot access agency-microsoft/genesis-minds.'
+    );
+
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-genesis-landing-marketplace-smoke-'));
     userDataPath = path.join(root, 'user-data');
     genesisBasePath = path.join(root, 'agents');

--- a/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
+++ b/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
@@ -10,10 +10,7 @@ const cdpPort = Number(process.env.CHAMBER_E2E_MARKETPLACE_AGGREGATION_CDP_PORT 
 const publicMarketplaceId = 'github:ianphil/genesis-minds';
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 
-const hasAccess = canAccessRepo('agency-microsoft/genesis-minds');
-
 test.describe('electron Genesis marketplace aggregation smoke', () => {
-  test.skip(!hasAccess, 'Active gh account cannot access agency-microsoft/genesis-minds — run "gh auth switch" to an account with access.');
   test.setTimeout(240_000);
 
   let app: LaunchedElectronApp | undefined;
@@ -22,6 +19,11 @@ test.describe('electron Genesis marketplace aggregation smoke', () => {
   const tempRoots: string[] = [];
 
   test.beforeAll(async () => {
+    test.skip(
+      !(await canAccessRepo('agency-microsoft/genesis-minds')),
+      'Stored Chamber GitHub credentials cannot access agency-microsoft/genesis-minds.'
+    );
+
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-genesis-marketplace-aggregation-smoke-'));
     userDataPath = path.join(root, 'user-data');
     genesisBasePath = path.join(root, 'agents');

--- a/tests/e2e/electron/settings-marketplace-management.spec.ts
+++ b/tests/e2e/electron/settings-marketplace-management.spec.ts
@@ -12,10 +12,7 @@ const internalMarketplaceUrl = 'https://github.com/agency-microsoft/genesis-mind
 const publicMarketplaceId = 'github:ianphil/genesis-minds';
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 
-const hasAccess = canAccessRepo('agency-microsoft/genesis-minds');
-
 test.describe('electron Settings marketplace management smoke', () => {
-  test.skip(!hasAccess, 'Active gh account cannot access agency-microsoft/genesis-minds — run "gh auth switch" to an account with access.');
   test.setTimeout(240_000);
 
   let app: LaunchedElectronApp | undefined;
@@ -24,6 +21,11 @@ test.describe('electron Settings marketplace management smoke', () => {
   const tempRoots: string[] = [];
 
   test.beforeAll(async () => {
+    test.skip(
+      !(await canAccessRepo('agency-microsoft/genesis-minds')),
+      'Stored Chamber GitHub credentials cannot access agency-microsoft/genesis-minds.'
+    );
+
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-settings-marketplace-smoke-'));
     mindPath = path.join(root, 'monica');
     userDataPath = path.join(root, 'user-data');


### PR DESCRIPTION
## Summary

Removes the Genesis marketplace dependency on the GitHub CLI. Marketplace reads now use the GitHub REST API directly, trying anonymous public access first and then stored Chamber GitHub credentials from keytar for private repositories.

## Notable changes

- Replaces `gh api` marketplace reads with async native `fetch` in `GitHubRegistryClient`.
- Reuses Chamber's stored Copilot/GitHub credentials for private marketplace repositories.
- Updates Genesis catalog listing, template installation, marketplace registry validation, and e2e marketplace access checks to use the shared REST client path.
- Replaces GitHub CLI account-switching error copy with Chamber sign-in/repository-permission guidance.
- Preserves `npm start` as an SDK-version preflight only; no `gh` install/auth check added.
- Hardens REST reads after review with anonymous-first credential lookup, request abort timeouts, blob size limits, and total template install size limits.
- Bumps Chamber to v0.39.3 and updates the changelog.

Closes #188

## Validation

- Focused Genesis/marketplace Vitest files passed.
- `npm run lint` passed.
- `npm test` passed: 109 files, 1045 tests.
- `npm run test:sdk-smoke` passed.
- `node scripts/check-sdk-versions.js` passed.
- Electron marketplace smoke tests passed:
  - `genesis-landing-add-marketplace.spec.ts`
  - `genesis-marketplace-aggregation.spec.ts`
  - `settings-marketplace-management.spec.ts`

## Smoke not run

- Packaging smoke skipped by request; this change does not touch packaging, runtime layout, Forge config, installer assets, or the packaged Copilot runtime.
