### PR TITLE
Disable hidden ask_user prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.39.4 (2026-05-05)
+
+### Chat
+
+- **Disable hidden ask_user prompts** - Mind and Genesis SDK sessions no longer enable `ask_user` until Chamber has a UI flow to surface and answer those questions. (#58)
+
+### Testing
+
+- **Add live Monica chat smoke** - The existing-mind Electron smoke now sends a real Monica chat turn by default and verifies the live response path.
+
 ## v0.39.3 (2026-05-04)
 
 ### Genesis

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.3",
+  "version": "0.39.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.3",
+      "version": "0.39.4",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.3",
+  "version": "0.39.4",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/genesis/MindScaffold.generateSoul.test.ts
+++ b/packages/services/src/genesis/MindScaffold.generateSoul.test.ts
@@ -119,6 +119,22 @@ describe('MindScaffold.generateSoul — CopilotClientFactory integration', () =>
     expect(mockDestroyClient).toHaveBeenCalledWith(fakeClient);
   });
 
+  it('does not enable ask_user during genesis generation', async () => {
+    const scaffold = new MindScaffold(undefined, fakeFactory as unknown as CopilotClientFactory);
+
+    await scaffold.create({
+      name: 'askless',
+      role: 'assistant',
+      voice: 'neutral',
+      voiceDescription: 'direct',
+      basePath: 'C:\\agents',
+    });
+
+    const sessionConfig = (mockCreateSession.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]?.[0];
+    expect(sessionConfig).toBeDefined();
+    expect(sessionConfig).not.toHaveProperty('onUserInputRequest');
+  });
+
   it('does not scaffold a .github/extensions directory or install remote extensions', async () => {
     const scaffold = new MindScaffold(undefined, fakeFactory as unknown as CopilotClientFactory);
 

--- a/packages/services/src/genesis/MindScaffold.ts
+++ b/packages/services/src/genesis/MindScaffold.ts
@@ -154,7 +154,6 @@ export class MindScaffold {
       streaming: true,
       workingDirectory: mindPath,
       onPermissionRequest: approveAllCompat,
-      onUserInputRequest: async () => ({ answer: 'Proceed with genesis.', wasFreeform: true }),
     };
 
     const session = await client.createSession(

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -600,6 +600,17 @@ describe('MindManager', () => {
       );
     });
 
+    it('does not enable ask_user for task sessions without a user input handler', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      mockCreateSession.mockClear();
+
+      await manager.createTaskSession(mind.mindId, 'task-1');
+
+      const callArg = mockCreateSession.mock.calls[0]?.[0];
+      expect(callArg).toBeDefined();
+      expect(callArg).not.toHaveProperty('onUserInputRequest');
+    });
+
     it('accepts custom onUserInputRequest callback', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       // New SDK UserInputHandler signature: (request: UserInputRequest, invocation) => UserInputResponse

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -4,7 +4,7 @@
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { PermissionHandler } from '@github/copilot-sdk';
+import type { PermissionHandler, SessionConfig } from '@github/copilot-sdk';
 import { Logger } from '../logger';
 
 const log = Logger.create('MindManager');
@@ -368,7 +368,7 @@ export class MindManager extends EventEmitter {
     onPermissionRequest: PermissionHandler = approveAllCompat,
     approveAll = true,
   ): Promise<CopilotSession> {
-    const session = await client.createSession({
+    const sessionConfig: SessionConfig = {
       workingDirectory: mindPath,
       enableConfigDiscovery: true,
       tools,
@@ -380,8 +380,9 @@ export class MindManager extends EventEmitter {
         },
       },
       onPermissionRequest,
-      onUserInputRequest: onUserInputRequest ?? (async () => ({ answer: 'Not available in this context', wasFreeform: true })),
-    });
+      ...(onUserInputRequest ? { onUserInputRequest } : {}),
+    };
+    const session = await client.createSession(sessionConfig);
 
     if (approveAll) {
       await session.rpc.permissions.setApproveAll({ enabled: true });

--- a/tests/e2e/electron/monica-open-existing.spec.ts
+++ b/tests/e2e/electron/monica-open-existing.spec.ts
@@ -7,6 +7,8 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
 
 const cdpPort = Number(process.env.CHAMBER_E2E_MONICA_CDP_PORT ?? 9335);
+const expectedReply = 'CHAMBER_MONICA_READY_ACK';
+const memoryInstruction = `When asked for the Monica smoke acknowledgement, answer exactly ${expectedReply} and no other text.`;
 
 test.describe('electron Monica existing mind smoke', () => {
   test.setTimeout(180_000);
@@ -38,7 +40,7 @@ test.describe('electron Monica existing mind smoke', () => {
     }
   });
 
-  test('opens an existing Monica mind without a live chat turn', async () => {
+  test('opens an existing Monica mind and completes a live chat turn', async () => {
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await page.waitForLoadState('domcontentloaded');
     await expect(page.locator('#root')).not.toBeEmpty();
@@ -72,6 +74,50 @@ test.describe('electron Monica existing mind smoke', () => {
     await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
     expect(mind.identity.name).toBe('Monica');
 
+    const result = await page.evaluate(async ({ expected, mindId }) => {
+      const messageId = `monica-smoke-${Date.now()}`;
+      const events: Array<{ type: string; content?: string; message?: string }> = [];
+      let assistantText = '';
+      let errorMessage = '';
+      let resolveTerminal: () => void = () => undefined;
+      const terminal = new Promise<void>((resolve) => {
+        resolveTerminal = resolve;
+      });
+      const unsubscribe = window.electronAPI.chat.onEvent((receivedMindId, receivedMessageId, event) => {
+        if (receivedMindId !== mindId || receivedMessageId !== messageId) return;
+        events.push(event);
+        if (event.type === 'chunk' || event.type === 'message_final') {
+          assistantText += event.content;
+        }
+        if (event.type === 'error') {
+          errorMessage = event.message;
+          resolveTerminal();
+        }
+        if (event.type === 'done') {
+          resolveTerminal();
+        }
+      });
+
+      try {
+        const send = window.electronAPI.chat.send(
+          mindId,
+          `This is a live Chamber Monica smoke test. Reply with exactly ${expected} and no other text.`,
+          messageId,
+        );
+        const timeout = new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('Timed out waiting for Monica smoke response.')), 180_000);
+        });
+        await Promise.race([Promise.all([send, terminal]), timeout]);
+        return { assistantText, errorMessage, events };
+      } finally {
+        unsubscribe();
+      }
+    }, { expected: expectedReply, mindId: mind.mindId });
+
+    expect(result.errorMessage).toBe('');
+    expect(result.assistantText).toContain(expectedReply);
+    expect(result.events.some((event) => event.type === 'done')).toBe(true);
+
     await page.evaluate((mindId) => window.electronAPI.mind.remove(mindId), mind.mindId);
   });
 });
@@ -85,6 +131,7 @@ function seedMonicaMind(mindPath: string): void {
       '# Monica',
       '',
       'You are Monica, Chamber\'s meticulous, upbeat, systems-minded organizer.',
+      memoryInstruction,
       '',
     ].join('\n'),
   );
@@ -103,7 +150,10 @@ function seedMonicaMind(mindPath: string): void {
     ].join('\n'),
   );
   for (const file of ['memory.md', 'rules.md', 'log.md']) {
-    fs.writeFileSync(path.join(mindPath, '.working-memory', file), '');
+    fs.writeFileSync(
+      path.join(mindPath, '.working-memory', file),
+      file === 'memory.md' ? `${memoryInstruction}\n` : '',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Disables SDK `ask_user` for default mind and Genesis sessions until Chamber has a UI flow for questions.
- Keeps explicit user-input handlers available for flows that already surface questions.
- Adds a live Monica Electron smoke that sends a real chat turn by default.
- Bumps Chamber to v0.39.4 and updates the changelog.

Closes #58
Follow-up: #192

## Validation
- `npx playwright test --config config/playwright.config.ts --project=electron --workers=1 tests/e2e/electron/monica-open-existing.spec.ts`
- `npm run lint`
- `npm test`
- `npm run test:sdk-smoke`