### PR TITLE
Validate SDK chat event contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.39.5 (2026-05-05)
+
+### SDK
+
+- **Validate SDK chat event contracts** - Chat streaming now validates the SDK event fields Chamber consumes before mapping them into UI events, surfacing clear contract mismatch errors when SDK drift would otherwise produce broken chat output.
+
 ## v0.39.4 (2026-05-05)
 
 ### Chat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -32,7 +32,8 @@
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
-        "ws": "^8.20.0"
+        "ws": "^8.20.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
@@ -16681,10 +16682,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,
@@ -100,7 +100,8 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
-    "ws": "^8.20.0"
+    "ws": "^8.20.0",
+    "zod": "^4.4.3"
   },
   "overrides": {
     "@electron-forge/plugin-fuses": {

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -57,6 +57,37 @@ describe('ChatService', () => {
       await svc.sendMessage('nonexistent', 'hello', 'msg-1', emit);
       expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     });
+
+    it('emits a clear error when the SDK chat event contract drifts', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      let deltaListener: ((event: unknown) => void) | undefined;
+
+      mockSession.on.mockImplementation(
+        (event: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+          if (event === 'assistant.message_delta' && cb) {
+            deltaListener = cb as (event: unknown) => void;
+          }
+          return vi.fn();
+        },
+      );
+      mockSession.send.mockImplementation(async () => {
+        deltaListener?.({ data: { id: 'sdk-message-1', text: 'hello' } });
+      });
+
+      try {
+        const emit = vi.fn();
+        await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+        expect(emit).toHaveBeenCalledWith({
+          type: 'error',
+          message: 'SDK contract mismatch for assistant.message_delta',
+        });
+        expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+      } finally {
+        consoleError.mockRestore();
+        mockSession.send.mockResolvedValue(undefined);
+      }
+    });
   });
 
   describe('cancelMessage', () => {

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -5,7 +5,21 @@ import type { MindManager } from '../mind';
 import type { ChatEvent, ChatImageAttachment, ModelInfo } from '@chamber/shared/types';
 import type { CopilotSession } from '../mind/types';
 import { isStaleSessionError, SEND_TIMEOUT_MS, DEFAULT_TURN_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
+import { Logger } from '../logger';
+import {
+  SdkChatEventContractError,
+  getSdkSessionErrorMessage,
+  mapSdkAssistantMessage,
+  mapSdkAssistantMessageDelta,
+  mapSdkAssistantReasoningDelta,
+  mapSdkToolExecutionComplete,
+  mapSdkToolExecutionPartialResult,
+  mapSdkToolExecutionProgress,
+  mapSdkToolExecutionStart,
+} from '../sdk/sdkChatEventMapper';
 import { TurnQueue } from './TurnQueue';
+
+const log = Logger.create('ChatService');
 
 export class ChatService {
   private abortControllers = new Map<string, AbortController>();
@@ -64,74 +78,57 @@ export class ChatService {
   ): Promise<void>{
     const unsubs: (() => void)[] = [];
     const guard = (fn: () => void) => { if (!abortController.signal.aborted) fn(); };
+    let sdkContractFailed = false;
+    const failSdkContract = (error: unknown) => {
+      if (abortController.signal.aborted || sdkContractFailed) return;
+      sdkContractFailed = true;
+      const message = error instanceof SdkChatEventContractError
+        ? error.message
+        : 'SDK contract mismatch while streaming chat';
+      log.error(message, error);
+      emit({ type: 'error', message });
+      abortController.abort();
+    };
+    const emitMapped = (mapper: () => ChatEvent | null) => {
+      try {
+        const mapped = mapper();
+        if (mapped) guard(() => emit(mapped));
+      } catch (error) {
+        failSdkContract(error);
+      }
+    };
 
     try {
       // Text streaming
       unsubs.push(session.on('assistant.message_delta', (event) => {
-        guard(() => emit({
-          type: 'chunk',
-          sdkMessageId: event.data.messageId,
-          content: event.data.deltaContent,
-        }));
+        emitMapped(() => mapSdkAssistantMessageDelta(event));
       }));
 
       // Final assistant message
       unsubs.push(session.on('assistant.message', (event) => {
-        guard(() => {
-          if (event.data.content) {
-            emit({
-              type: 'message_final',
-              sdkMessageId: event.data.messageId,
-              content: event.data.content,
-            });
-          }
-        });
+        emitMapped(() => mapSdkAssistantMessage(event));
       }));
 
       // Reasoning
       unsubs.push(session.on('assistant.reasoning_delta', (event) => {
-        guard(() => emit({
-          type: 'reasoning',
-          reasoningId: event.data.reasoningId,
-          content: event.data.deltaContent,
-        }));
+        emitMapped(() => mapSdkAssistantReasoningDelta(event));
       }));
 
       // Tool execution
       unsubs.push(session.on('tool.execution_start', (event) => {
-        guard(() => emit({
-          type: 'tool_start',
-          toolCallId: event.data.toolCallId,
-          toolName: event.data.toolName,
-          args: event.data.arguments as Record<string, unknown> | undefined,
-          parentToolCallId: event.data.parentToolCallId,
-        }));
+        emitMapped(() => mapSdkToolExecutionStart(event));
       }));
 
       unsubs.push(session.on('tool.execution_progress', (event) => {
-        guard(() => emit({
-          type: 'tool_progress',
-          toolCallId: event.data.toolCallId,
-          message: event.data.progressMessage,
-        }));
+        emitMapped(() => mapSdkToolExecutionProgress(event));
       }));
 
       unsubs.push(session.on('tool.execution_partial_result', (event) => {
-        guard(() => emit({
-          type: 'tool_output',
-          toolCallId: event.data.toolCallId,
-          output: event.data.partialOutput,
-        }));
+        emitMapped(() => mapSdkToolExecutionPartialResult(event));
       }));
 
       unsubs.push(session.on('tool.execution_complete', (event) => {
-        guard(() => emit({
-          type: 'tool_done',
-          toolCallId: event.data.toolCallId,
-          success: event.data.success,
-          result: event.data.result?.content,
-          error: event.data.error?.message,
-        }));
+        emitMapped(() => mapSdkToolExecutionComplete(event));
       }));
 
       // Set up idle/error listeners BEFORE send to avoid missing events
@@ -150,7 +147,12 @@ export class ChatService {
         const unsubError = session.on('session.error', (event) => {
           if (turnDoneTimerId) clearTimeout(turnDoneTimerId);
           unsubError();
-          reject(new Error(event.data.message));
+          try {
+            reject(new Error(getSdkSessionErrorMessage(event)));
+          } catch (error) {
+            failSdkContract(error);
+            resolve();
+          }
         });
         unsubs.push(unsubError);
 

--- a/packages/services/src/sdk/sdkChatEventMapper.test.ts
+++ b/packages/services/src/sdk/sdkChatEventMapper.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SdkChatEventContractError,
+  getSdkSessionErrorMessage,
+  mapSdkAssistantMessage,
+  mapSdkAssistantMessageDelta,
+  mapSdkAssistantReasoningDelta,
+  mapSdkToolExecutionComplete,
+  mapSdkToolExecutionPartialResult,
+  mapSdkToolExecutionProgress,
+  mapSdkToolExecutionStart,
+} from './sdkChatEventMapper';
+
+describe('sdkChatEventMapper', () => {
+  it('maps the SDK event shapes ChatService consumes into Chamber chat events', () => {
+    expect(mapSdkAssistantMessageDelta({
+      data: { messageId: 'sdk-message-1', deltaContent: 'hello', extra: true },
+    })).toEqual({ type: 'chunk', sdkMessageId: 'sdk-message-1', content: 'hello' });
+
+    expect(mapSdkAssistantMessage({
+      data: { messageId: 'sdk-message-1', content: 'hello world' },
+    })).toEqual({ type: 'message_final', sdkMessageId: 'sdk-message-1', content: 'hello world' });
+
+    expect(mapSdkAssistantReasoningDelta({
+      data: { reasoningId: 'reasoning-1', deltaContent: 'thinking' },
+    })).toEqual({ type: 'reasoning', reasoningId: 'reasoning-1', content: 'thinking' });
+
+    expect(mapSdkToolExecutionStart({
+      data: {
+        toolCallId: 'tool-1',
+        toolName: 'read_file',
+        arguments: { path: 'README.md' },
+        parentToolCallId: 'parent-tool-1',
+      },
+    })).toEqual({
+      type: 'tool_start',
+      toolCallId: 'tool-1',
+      toolName: 'read_file',
+      args: { path: 'README.md' },
+      parentToolCallId: 'parent-tool-1',
+    });
+
+    expect(mapSdkToolExecutionProgress({
+      data: { toolCallId: 'tool-1', progressMessage: 'Reading README.md' },
+    })).toEqual({ type: 'tool_progress', toolCallId: 'tool-1', message: 'Reading README.md' });
+
+    expect(mapSdkToolExecutionPartialResult({
+      data: { toolCallId: 'tool-1', partialOutput: 'partial output' },
+    })).toEqual({ type: 'tool_output', toolCallId: 'tool-1', output: 'partial output' });
+
+    expect(mapSdkToolExecutionComplete({
+      data: {
+        toolCallId: 'tool-1',
+        success: true,
+        result: { content: 'complete output', extra: true },
+      },
+    })).toEqual({
+      type: 'tool_done',
+      toolCallId: 'tool-1',
+      success: true,
+      result: 'complete output',
+      error: undefined,
+    });
+
+    expect(getSdkSessionErrorMessage({ data: { message: 'SDK session failed' } })).toBe('SDK session failed');
+  });
+
+  it('rejects SDK event drift that would break chat streaming assumptions', () => {
+    expect(() => mapSdkAssistantMessageDelta({
+      data: { id: 'sdk-message-1', text: 'hello' },
+    })).toThrow(SdkChatEventContractError);
+
+    expect(() => mapSdkToolExecutionComplete({
+      data: { toolCallId: 'tool-1', success: 'yes' },
+    })).toThrow('SDK contract mismatch for tool.execution_complete');
+
+    expect(() => getSdkSessionErrorMessage({
+      data: { error: 'SDK session failed' },
+    })).toThrow('SDK contract mismatch for session.error');
+  });
+});
+

--- a/packages/services/src/sdk/sdkChatEventMapper.ts
+++ b/packages/services/src/sdk/sdkChatEventMapper.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+import type { ChatEvent } from '@chamber/shared/types';
+
+const sdkEvent = <Shape extends z.ZodRawShape>(shape: Shape) =>
+  z.object({ data: z.object(shape).passthrough() }).passthrough();
+
+export class SdkChatEventContractError extends Error {
+  constructor(
+    readonly eventName: string,
+    cause: unknown,
+  ) {
+    super(`SDK contract mismatch for ${eventName}`, { cause });
+    this.name = 'SdkChatEventContractError';
+  }
+}
+
+const sdkAssistantMessageDeltaEvent = sdkEvent({
+  messageId: z.string(),
+  deltaContent: z.string(),
+});
+
+const sdkAssistantMessageEvent = sdkEvent({
+  messageId: z.string(),
+  content: z.string().optional(),
+});
+
+const sdkAssistantReasoningDeltaEvent = sdkEvent({
+  reasoningId: z.string(),
+  deltaContent: z.string(),
+});
+
+const sdkToolExecutionStartEvent = sdkEvent({
+  toolCallId: z.string(),
+  toolName: z.string(),
+  arguments: z.record(z.string(), z.unknown()).optional(),
+  parentToolCallId: z.string().optional(),
+});
+
+const sdkToolExecutionProgressEvent = sdkEvent({
+  toolCallId: z.string(),
+  progressMessage: z.string(),
+});
+
+const sdkToolExecutionPartialResultEvent = sdkEvent({
+  toolCallId: z.string(),
+  partialOutput: z.string(),
+});
+
+const sdkToolExecutionCompleteEvent = sdkEvent({
+  toolCallId: z.string(),
+  success: z.boolean(),
+  result: z.object({ content: z.string().optional() }).passthrough().optional(),
+  error: z.object({ message: z.string().optional() }).passthrough().optional(),
+});
+
+const sdkSessionErrorEvent = sdkEvent({
+  message: z.string(),
+});
+
+function parseSdkEvent<Schema extends z.ZodTypeAny>(
+  eventName: string,
+  schema: Schema,
+  event: unknown,
+): z.output<Schema> {
+  const parsed = schema.safeParse(event);
+  if (!parsed.success) {
+    throw new SdkChatEventContractError(eventName, parsed.error);
+  }
+  return parsed.data;
+}
+
+export function mapSdkAssistantMessageDelta(event: unknown): Extract<ChatEvent, { type: 'chunk' }> {
+  const parsed = parseSdkEvent('assistant.message_delta', sdkAssistantMessageDeltaEvent, event);
+  return {
+    type: 'chunk',
+    sdkMessageId: parsed.data.messageId,
+    content: parsed.data.deltaContent,
+  };
+}
+
+export function mapSdkAssistantMessage(event: unknown): Extract<ChatEvent, { type: 'message_final' }> | null {
+  const parsed = parseSdkEvent('assistant.message', sdkAssistantMessageEvent, event);
+  if (!parsed.data.content) return null;
+  return {
+    type: 'message_final',
+    sdkMessageId: parsed.data.messageId,
+    content: parsed.data.content,
+  };
+}
+
+export function mapSdkAssistantReasoningDelta(event: unknown): Extract<ChatEvent, { type: 'reasoning' }> {
+  const parsed = parseSdkEvent('assistant.reasoning_delta', sdkAssistantReasoningDeltaEvent, event);
+  return {
+    type: 'reasoning',
+    reasoningId: parsed.data.reasoningId,
+    content: parsed.data.deltaContent,
+  };
+}
+
+export function mapSdkToolExecutionStart(event: unknown): Extract<ChatEvent, { type: 'tool_start' }> {
+  const parsed = parseSdkEvent('tool.execution_start', sdkToolExecutionStartEvent, event);
+  return {
+    type: 'tool_start',
+    toolCallId: parsed.data.toolCallId,
+    toolName: parsed.data.toolName,
+    args: parsed.data.arguments,
+    parentToolCallId: parsed.data.parentToolCallId,
+  };
+}
+
+export function mapSdkToolExecutionProgress(event: unknown): Extract<ChatEvent, { type: 'tool_progress' }> {
+  const parsed = parseSdkEvent('tool.execution_progress', sdkToolExecutionProgressEvent, event);
+  return {
+    type: 'tool_progress',
+    toolCallId: parsed.data.toolCallId,
+    message: parsed.data.progressMessage,
+  };
+}
+
+export function mapSdkToolExecutionPartialResult(event: unknown): Extract<ChatEvent, { type: 'tool_output' }> {
+  const parsed = parseSdkEvent('tool.execution_partial_result', sdkToolExecutionPartialResultEvent, event);
+  return {
+    type: 'tool_output',
+    toolCallId: parsed.data.toolCallId,
+    output: parsed.data.partialOutput,
+  };
+}
+
+export function mapSdkToolExecutionComplete(event: unknown): Extract<ChatEvent, { type: 'tool_done' }> {
+  const parsed = parseSdkEvent('tool.execution_complete', sdkToolExecutionCompleteEvent, event);
+  return {
+    type: 'tool_done',
+    toolCallId: parsed.data.toolCallId,
+    success: parsed.data.success,
+    result: parsed.data.result?.content,
+    error: parsed.data.error?.message,
+  };
+}
+
+export function getSdkSessionErrorMessage(event: unknown): string {
+  const parsed = parseSdkEvent('session.error', sdkSessionErrorEvent, event);
+  return parsed.data.message;
+}
+


### PR DESCRIPTION
## Summary
- Adds Zod-backed SDK chat event mappers at the SDK-to-Chamber chat boundary.
- Validates only the SDK event fields Chamber consumes and allows additive SDK fields through.
- Emits clear chat errors when SDK event drift would otherwise produce broken streamed output.
- Adds mapper and ChatService regression coverage.
- Bumps Chamber to v0.39.5.

Follow-up: #194

## Validation
- `npx vitest run --config config/vitest.config.ts packages/services/src/sdk/sdkChatEventMapper.test.ts packages/services/src/chat/ChatService.test.ts`
- `npm run lint`
- `npm test`
- `npm run test:sdk-smoke`
- `npx playwright test --config config/playwright.config.ts --project=electron --workers=1 tests/e2e/electron/monica-open-existing.spec.ts`