### PR TITLE
fix: preserve chatroom message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.39.7 (2026-05-05)
+
+### Chat
+
+- **Preserve chatroom message types** - Chat event reduction now keeps extended chatroom message fields without casts when streaming events update messages. (#49)
+
 ## v0.39.6 (2026-05-05)
 
 ### Code Health

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import { handleChatEvent, appReducer, initialState } from '.';
 import type { AppState, AppAction } from '.';
 import type { ChatMessage } from '@chamber/shared/types';
@@ -180,6 +180,20 @@ describe('handleChatEvent', () => {
     const initial = assistantMsg();
     const msgs = handleChatEvent(initial, 'wrong-id', makeChatEvent('chunk', { content: 'x' }));
     expect(msgs[0].blocks).toHaveLength(0);
+  });
+
+  it('preserves extended chat message types', () => {
+    const initial: ChatroomMessage[] = [{
+      ...makeMessage([], { id: 'msg-1', isStreaming: true }),
+      sender: { mindId: 'agent-1', name: 'Agent One' },
+      roundId: 'round-1',
+    }];
+
+    const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('done'));
+
+    expectTypeOf(msgs).toEqualTypeOf<ChatroomMessage[]>();
+    expect(msgs[0].sender).toEqual({ mindId: 'agent-1', name: 'Agent One' });
+    expect(msgs[0].roundId).toBe('round-1');
   });
 });
 

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -16,7 +16,14 @@ function nonEmptyString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
 }
 
-export function handleChatEvent(messages: ChatMessage[], messageId: string, event: ChatEvent): ChatMessage[] {
+function updateChatMessage<T extends ChatMessage>(
+  message: T,
+  updates: Partial<Pick<ChatMessage, 'blocks' | 'isStreaming'>>,
+): T {
+  return { ...message, ...updates };
+}
+
+export function handleChatEvent<T extends ChatMessage>(messages: T[], messageId: string, event: ChatEvent): T[] {
   return messages.map((m) => {
     if (m.id !== messageId) return m;
 
@@ -31,7 +38,7 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
         } else {
           blocks.push({ type: 'text', sdkMessageId: event.sdkMessageId, content: event.content });
         }
-        return { ...m, blocks };
+        return updateChatMessage(m, { blocks });
       }
 
       case 'tool_start': {
@@ -43,7 +50,7 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
           arguments: event.args,
           parentToolCallId: event.parentToolCallId,
         });
-        return { ...m, blocks };
+        return updateChatMessage(m, { blocks });
       }
 
       case 'tool_progress': {
@@ -52,7 +59,7 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
           const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
           blocks[idx] = { ...block, output: (block.output || '') + event.message + '\n' };
         }
-        return { ...m, blocks };
+        return updateChatMessage(m, { blocks });
       }
 
       case 'tool_output': {
@@ -61,7 +68,7 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
           const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
           blocks[idx] = { ...block, output: (block.output || '') + event.output };
         }
-        return { ...m, blocks };
+        return updateChatMessage(m, { blocks });
       }
 
       case 'tool_done': {
@@ -75,7 +82,7 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
             ...(event.error && { error: event.error }),
           };
         }
-        return { ...m, blocks };
+        return updateChatMessage(m, { blocks });
       }
 
       case 'reasoning': {
@@ -85,7 +92,7 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
         } else {
           blocks.push({ type: 'reasoning', reasoningId: event.reasoningId, content: event.content });
         }
-        return { ...m, blocks };
+        return updateChatMessage(m, { blocks });
       }
 
       case 'message_final': {
@@ -93,7 +100,7 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
         const hasThisMessage = blocks.some(b => b.type === 'text' && b.sdkMessageId === event.sdkMessageId);
         if (!hasThisMessage && event.content) {
           blocks.push({ type: 'text', sdkMessageId: event.sdkMessageId, content: event.content });
-          return { ...m, blocks };
+          return updateChatMessage(m, { blocks });
         }
         return m;
       }
@@ -102,14 +109,13 @@ export function handleChatEvent(messages: ChatMessage[], messageId: string, even
         return m; // No-op in blocks — UI uses isStreaming to show indicator
 
       case 'done':
-        return { ...m, isStreaming: false };
+        return updateChatMessage(m, { isStreaming: false });
 
       case 'error':
-        return {
-          ...m,
+        return updateChatMessage(m, {
           isStreaming: false,
           blocks: [...blocks, { type: 'text' as const, content: `Error: ${event.message}` }],
-        };
+        });
 
       default:
         return m;
@@ -485,7 +491,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const isDone = chatEvent.type === 'done' || chatEvent.type === 'error';
       return {
         ...state,
-        chatroomMessages: newMessages as ChatroomMessage[],
+        chatroomMessages: newMessages,
         chatroomStreamingByMind: isDone
           ? { ...state.chatroomStreamingByMind, [mindId]: false }
           : { ...state.chatroomStreamingByMind, [mindId]: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.6",
+  "version": "0.39.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.6",
+      "version": "0.39.7",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.6",
+  "version": "0.39.7",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary
- Makes `handleChatEvent` generic so extended `ChatMessage` subtypes keep their extra fields through streaming event updates.
- Removes the chatroom reducer cast from `ChatMessage[]` back to `ChatroomMessage[]`.
- Adds a reducer regression test that proves `ChatroomMessage[]` is preserved.

Closes #49

## Validation
- `npm run typecheck`
- `npm test -- apps/web/src/renderer/lib/store/reducer.test.ts`
- `npm run lint`
- `npm test`

## Smoke tests
- Not run: this is a type-safety reducer change with no runtime surface change beyond preserving the existing message object fields.

## Review
- Uncle Bob skipped: focused type-safety fix with no architecture, runtime, SDK, or security surface change.