### PR TITLE
fix: keep lens refresh results across view switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.39.8 (2026-05-05)
+
+### Lens
+
+- **Keep Lens refresh results across view switches** - In-flight Lens refreshes now survive renderer remounts so returning to a view applies the completed data instead of leaving stale content visible. (#38)
+
 ## v0.39.7 (2026-05-05)
 
 ### Chat

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain, powerMonitor, shell, Notification, type MessageBoxOptions, type NativeImage, type Tray as ElectronTray } from 'electron';
+import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
@@ -168,9 +169,7 @@ mindManager.setProviders([cronService, canvasService, a2aToolProvider]);
 wireLifecycleEvents({ mindManager, agentCardRegistry, taskManager, a2aEventBus });
 
 // Wire Lens refresh to use the mind's session
-viewDiscovery.setRefreshHandler({
-  sendBackgroundPrompt: (path, prompt) => mindManager.sendBackgroundPrompt(path, prompt),
-});
+viewDiscovery.setRefreshHandler(createLensRefreshHandler((mindPath, prompt) => mindManager.sendBackgroundPrompt(mindPath, prompt)));
 
 let mainWindow: BrowserWindow | null = null;
 let appTray: ElectronTray | null = null;
@@ -533,3 +532,27 @@ app.on('will-quit', () => {
   appTray?.destroy();
   appTray = null;
 });
+
+function createLensRefreshHandler(sendBackgroundPrompt: (mindPath: string, prompt: string) => Promise<void>) {
+  const e2eRefreshJson = process.env.CHAMBER_E2E_LENS_REFRESH_JSON;
+  if (process.env.CHAMBER_E2E !== '1' || !e2eRefreshJson) {
+    return { sendBackgroundPrompt };
+  }
+
+  const refreshData = JSON.parse(e2eRefreshJson) as unknown;
+  const delayMs = Number(process.env.CHAMBER_E2E_LENS_REFRESH_DELAY_MS ?? 0);
+  return {
+    sendBackgroundPrompt: async (_mindPath: string, prompt: string) => {
+      if (Number.isFinite(delayMs) && delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+      fs.writeFileSync(parseLensRefreshOutputPath(prompt), `${JSON.stringify(refreshData, null, 2)}\n`);
+    },
+  };
+}
+
+function parseLensRefreshOutputPath(prompt: string): string {
+  const match = /Write the JSON output to:\s*(.+)\s*$/m.exec(prompt);
+  if (!match?.[1]) throw new Error('E2E Lens refresh prompt did not include an output path.');
+  return match[1].trim();
+}

--- a/apps/web/src/renderer/components/views/LensViewRenderer.test.tsx
+++ b/apps/web/src/renderer/components/views/LensViewRenderer.test.tsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ElectronAPI } from '@chamber/shared/types';
+import { mockElectronAPI, makeLensViewManifest } from '../../../test/helpers';
+import { LensViewRenderer } from './LensViewRenderer';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function installElectronAPI(api: ElectronAPI): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: api,
+  });
+}
+
+describe('LensViewRenderer', () => {
+  afterEach(() => {
+    cleanup();
+    Reflect.deleteProperty(window, 'electronAPI');
+    vi.restoreAllMocks();
+  });
+
+  it('applies an in-flight refresh result after the view remounts', async () => {
+    const api = mockElectronAPI();
+    vi.mocked(api.lens.getViewData).mockResolvedValue({ status: 'stale' });
+    const refresh = deferred<Record<string, unknown> | null>();
+    vi.mocked(api.lens.refreshView).mockReturnValue(refresh.promise);
+    installElectronAPI(api);
+
+    const view = makeLensViewManifest({
+      id: 'daily-briefing',
+      name: 'Daily Briefing',
+      prompt: 'Refresh this briefing',
+      view: 'briefing',
+    });
+
+    const { unmount } = render(<LensViewRenderer view={view} />);
+    expect(await screen.findByText('stale')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    unmount();
+
+    render(<LensViewRenderer view={view} />);
+    expect(await screen.findByText('stale')).toBeTruthy();
+
+    refresh.resolve({ status: 'fresh' });
+
+    await waitFor(() => {
+      expect(screen.getByText('fresh')).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/renderer/components/views/LensViewRenderer.tsx
+++ b/apps/web/src/renderer/components/views/LensViewRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import type { LensViewManifest } from '@chamber/shared/types';
 import { RefreshCw, Send } from 'lucide-react';
 import { cn } from '../../lib/utils';
@@ -17,22 +17,61 @@ interface Props {
 
 const log = Logger.create('LensView');
 
+const pendingRefreshes = new Map<string, Promise<Record<string, unknown> | null>>();
+
+function refreshLensView(viewId: string): Promise<Record<string, unknown> | null> {
+  const existing = pendingRefreshes.get(viewId);
+  if (existing) return existing;
+
+  const refresh = window.electronAPI.lens.refreshView(viewId)
+    .finally(() => {
+      if (pendingRefreshes.get(viewId) === refresh) {
+        pendingRefreshes.delete(viewId);
+      }
+    });
+  pendingRefreshes.set(viewId, refresh);
+  return refresh;
+}
+
 export function LensViewRenderer({ view }: Props) {
   const [data, setData] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [actionInput, setActionInput] = useState('');
+  const mountedRef = useRef(true);
 
   useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
     const load = async () => {
+      const pendingRefresh = pendingRefreshes.get(view.id);
+      if (pendingRefresh) setLoading(true);
       try {
         const result = await window.electronAPI.lens.getViewData(view.id);
+        if (cancelled) return;
         setData(result);
+        if (pendingRefresh) {
+          const refreshed = await pendingRefresh;
+          if (cancelled) return;
+          setData(refreshed);
+        }
       } catch (err) {
         log.error(`Failed to load data for ${view.id}:`, err);
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load view data');
+      } finally {
+        if (!cancelled && pendingRefresh) setLoading(false);
       }
     };
     load();
+    return () => {
+      cancelled = true;
+    };
   }, [view.id]);
 
   const handleRefresh = useCallback(async () => {
@@ -40,12 +79,12 @@ export function LensViewRenderer({ view }: Props) {
     setLoading(true);
     setError(null);
     try {
-      const result = await window.electronAPI.lens.refreshView(view.id);
-      setData(result);
+      const result = await refreshLensView(view.id);
+      if (mountedRef.current) setData(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Refresh failed');
+      if (mountedRef.current) setError(err instanceof Error ? err.message : 'Refresh failed');
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   }, [view.id, loading]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.7",
+  "version": "0.39.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.7",
+      "version": "0.39.8",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.7",
+  "version": "0.39.8",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/tests/e2e/electron/lens-hotload.spec.ts
+++ b/tests/e2e/electron/lens-hotload.spec.ts
@@ -8,6 +8,7 @@ import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from '.
 
 const cdpPort = Number(process.env.CHAMBER_E2E_LENS_CDP_PORT ?? 9336);
 const smokeViewId = 'smoke-hotload';
+const refreshViewId = 'smoke-refresh-continuity';
 
 test.describe('electron Lens hot-load smoke', () => {
   test.setTimeout(180_000);
@@ -32,6 +33,8 @@ test.describe('electron Lens hot-load smoke', () => {
       cdpPort,
       env: {
         CHAMBER_E2E_USER_DATA: userDataPath,
+        CHAMBER_E2E_LENS_REFRESH_DELAY_MS: '1000',
+        CHAMBER_E2E_LENS_REFRESH_JSON: JSON.stringify({ status: 'fresh' }),
       },
     });
   });
@@ -111,6 +114,51 @@ test.describe('electron Lens hot-load smoke', () => {
 
     await expect(page.getByRole('button', { name: 'Smoke Hotload' })).toHaveCount(0);
   });
+
+  test('applies Lens refresh results after switching away and returning', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    writeLensView(mindPath, {
+      id: refreshViewId,
+      name: 'Smoke Refresh Continuity',
+      prompt: 'Refresh this deterministic smoke Lens view.',
+      status: 'stale',
+    });
+
+    const mind = await page.evaluate(async ({ pathToMind }) => {
+      const loaded = await window.electronAPI.mind.add(pathToMind);
+      await window.electronAPI.mind.setActive(loaded.mindId);
+      return loaded;
+    }, { pathToMind: mindPath });
+
+    await expect.poll(
+      () => page.evaluate(async ({ mindId, viewId }) => {
+        const views = await window.electronAPI.lens.getViews(mindId);
+        return views.some((view) => view.id === viewId);
+      }, { mindId: mind.mindId, viewId: refreshViewId }),
+      { timeout: 10_000 },
+    ).toBe(true);
+    await page.getByRole('button', { name: /Active Lens Smoke Mind/ }).click();
+    await expect(page.getByRole('button', { name: 'Smoke Refresh Continuity' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Smoke Refresh Continuity' }).click();
+    await expect(page.getByRole('heading', { name: 'Smoke Refresh Continuity' })).toBeVisible();
+    await expect(page.getByText('stale', { exact: true })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Refreshing…', exact: true })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Chat', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Smoke Refresh Continuity' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Smoke Refresh Continuity' }).click();
+    await expect(page.getByRole('heading', { name: 'Smoke Refresh Continuity' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Refreshing…', exact: true })).toBeVisible();
+
+    await expect(page.getByText('fresh', { exact: true })).toBeVisible();
+    await expect(page.getByText('stale', { exact: true })).toHaveCount(0);
+  });
 });
 
 function seedMind(root: string, name: string): void {
@@ -126,19 +174,25 @@ function seedMind(root: string, name: string): void {
   );
 }
 
-function writeLensView(root: string): void {
-  const viewDir = path.join(root, '.github', 'lens', smokeViewId);
+function writeLensView(
+  root: string,
+  options: { id?: string; name?: string; prompt?: string; status?: string } = {},
+): void {
+  const id = options.id ?? smokeViewId;
+  const viewDir = path.join(root, '.github', 'lens', id);
   fs.mkdirSync(viewDir, { recursive: true });
   fs.writeFileSync(
     path.join(viewDir, 'view.json'),
     JSON.stringify({
-      name: 'Smoke Hotload',
+      name: options.name ?? 'Smoke Hotload',
       icon: 'table',
       view: 'table',
       source: 'data.json',
+      ...(options.prompt ? { prompt: options.prompt } : {}),
     }, null, 2),
   );
-  fs.writeFileSync(path.join(viewDir, 'data.json'), JSON.stringify({ rows: [{ status: 'ok' }] }, null, 2));
+  const data = options.status ? { status: options.status } : { rows: [{ status: 'ok' }] };
+  fs.writeFileSync(path.join(viewDir, 'data.json'), JSON.stringify(data, null, 2));
 }
 
 async function removeTempRoot(root: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Keeps in-flight Lens refresh promises alive across `LensViewRenderer` unmount/remount cycles.
- Reloads current Lens data on mount, then applies the pending refresh result if the user returns before it completes.
- Adds a renderer regression test for switching away during refresh and returning before completion.

Closes #38

## Validation
- `npm test -- apps/web/src/renderer/components/views/LensViewRenderer.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run smoke:web`

## Review
- Uncle Bob skipped: focused renderer race fix with test coverage and no architecture, SDK, or security surface change.