### PR TITLE
Persist per-agent chat context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.40.0 (2026-05-05)
+
+### Chat
+
+- **Persist model choices per agent** - Agent chat now stores each mind's selected model in its config and recreates the SDK session with that model so switching minds no longer shares one global picker value. (#46)
+- **Inject local datetime context** - SDK prompts now include the current local datetime and timezone across chat, A2A tasks, chatroom orchestration, Genesis, and background prompt sends. (#32)
+
 ## v0.39.9 (2026-05-05)
 
 ### Desktop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@
 ### macOS
 
 - **Add macOS build support** — Chamber can now build macOS dmg/zip artifacts with platform-aware builder resources, optional signing/notarization settings, a macOS tray fallback icon path, and a draggable hidden-inset titlebar strip. (#177)
-- **Refresh the packaged Copilot CLI pin** — the development and committed desktop runtimes now pin `@github/copilot@1.0.41-0` so package smoke checks match the CLI binary shipped by the npm package.
+- **Refresh the packaged Copilot CLI pin** — the development and committed desktop runtimes now pin `@github/copilot@1.0.41-1` so package smoke checks match the CLI binary shipped by the npm package.
 
 ### Genesis
 

--- a/apps/desktop/src/main/ipc/mind.ts
+++ b/apps/desktop/src/main/ipc/mind.ts
@@ -39,6 +39,10 @@ export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): v
     mindManager.setActiveMind(mindId);
   });
 
+  ipcMain.handle('mind:setModel', async (_event, mindId: string, model: string | null) => {
+    return mindManager.setMindModel(mindId, model);
+  });
+
   ipcMain.handle('mind:selectDirectory', async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return null;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -11,7 +11,7 @@ const electronAPI: ElectronAPI = {
       ipcRenderer.invoke('chat:stop', mindId, messageId),
     newConversation: (mindId) =>
       ipcRenderer.invoke('chat:newConversation', mindId),
-    listModels: () => ipcRenderer.invoke('chat:listModels'),
+    listModels: (mindId?) => ipcRenderer.invoke('chat:listModels', mindId),
     onEvent: (callback) => createIpcListener(ipcRenderer, 'chat:event', callback),
   },
   mind: {
@@ -19,6 +19,7 @@ const electronAPI: ElectronAPI = {
     remove: (mindId) => ipcRenderer.invoke('mind:remove', mindId),
     list: () => ipcRenderer.invoke('mind:list'),
     setActive: (mindId) => ipcRenderer.invoke('mind:setActive', mindId),
+    setModel: (mindId, model) => ipcRenderer.invoke('mind:setModel', mindId, model),
     selectDirectory: () => ipcRenderer.invoke('mind:selectDirectory'),
     openWindow: (mindId) => ipcRenderer.invoke('mind:openWindow', mindId),
     onMindChanged: (callback) => createIpcListener(ipcRenderer, 'mind:changed', callback),

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -147,6 +147,7 @@ export function installBrowserApi(): void {
       remove: async () => unavailable('mind removal'),
       list: () => client.listMinds() as Promise<MindContext[]>,
       setActive: async () => unavailable('active mind changes'),
+      setModel: async () => null,
       selectDirectory: async () => window.prompt('Enter a local agent folder path on this computer:')?.trim() || null,
       openWindow: async (mindId) => {
         window.open(`/?mindId=${encodeURIComponent(mindId)}`, '_blank', 'noopener,noreferrer');

--- a/apps/web/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/web/src/renderer/components/chat/ChatPanel.tsx
@@ -30,7 +30,10 @@ export function ChatPanel() {
         disabled={!connected}
         availableModels={availableModels}
         selectedModel={selectedModel}
-        onModelChange={(model) => dispatch({ type: 'SET_SELECTED_MODEL', payload: model })}
+        onModelChange={(model) => {
+          if (activeMindId) void window.electronAPI.mind.setModel(activeMindId, model);
+          dispatch({ type: 'SET_SELECTED_MODEL', payload: model });
+        }}
       />
     </div>
   );

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.ts
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.ts
@@ -42,14 +42,13 @@ export function useAppSubscriptions() {
 
     const loadModels = async () => {
       try {
-        const models = await window.electronAPI.chat.listModels();
+        const models = await window.electronAPI.chat.listModels(activeMindId ?? undefined);
         dispatch({ type: 'SET_AVAILABLE_MODELS', payload: models });
 
-        const persisted = localStorage.getItem('chamber:selectedModel');
-        const valid = persisted && models.some(m => m.id === persisted);
-        if (!valid && models.length > 0) {
-          dispatch({ type: 'SET_SELECTED_MODEL', payload: models[0].id });
-        }
+        const activeMind = activeMindId ? minds.find((mind) => mind.mindId === activeMindId) : undefined;
+        const selected = activeMind?.selectedModel;
+        const valid = selected && models.some(m => m.id === selected);
+        dispatch({ type: 'SET_SELECTED_MODEL', payload: valid ? selected : models[0]?.id ?? null });
       } catch (err) {
         log.error('Failed to load models:', err);
       }

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.ts
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.ts
@@ -44,11 +44,6 @@ export function useAppSubscriptions() {
       try {
         const models = await window.electronAPI.chat.listModels(activeMindId ?? undefined);
         dispatch({ type: 'SET_AVAILABLE_MODELS', payload: models });
-
-        const activeMind = activeMindId ? minds.find((mind) => mind.mindId === activeMindId) : undefined;
-        const selected = activeMind?.selectedModel;
-        const valid = selected && models.some(m => m.id === selected);
-        dispatch({ type: 'SET_SELECTED_MODEL', payload: valid ? selected : models[0]?.id ?? null });
       } catch (err) {
         log.error('Failed to load models:', err);
       }

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -263,9 +263,36 @@ describe('appReducer', () => {
     expect(state.minds).toEqual(minds);
   });
 
+  it('SET_MINDS syncs the selected model for the active mind', () => {
+    const state = appReducer({
+      ...withActiveMind,
+      availableModels: [makeModelInfo('model-1', 'Model 1'), makeModelInfo('model-2', 'Model 2')],
+      selectedModel: 'model-1',
+    }, {
+      type: 'SET_MINDS',
+      payload: [{ ...withActiveMind.minds[0], selectedModel: 'model-2' }],
+    });
+
+    expect(state.selectedModel).toBe('model-2');
+  });
+
   it('SET_ACTIVE_MIND switches active mind', () => {
     const state = appReducer(withActiveMind, { type: 'SET_ACTIVE_MIND', payload: 'other-mind' });
     expect(state.activeMindId).toBe('other-mind');
+  });
+
+  it('SET_ACTIVE_MIND selects that mind persisted model', () => {
+    const state = appReducer({
+      ...withActiveMind,
+      availableModels: [makeModelInfo('model-1', 'Model 1'), makeModelInfo('model-2', 'Model 2')],
+      minds: [
+        { ...withActiveMind.minds[0], selectedModel: 'model-1' },
+        { mindId: 'other-mind', mindPath: '/other', identity: { name: 'Other', systemMessage: '' }, status: 'ready', selectedModel: 'model-2' },
+      ],
+      selectedModel: 'model-1',
+    }, { type: 'SET_ACTIVE_MIND', payload: 'other-mind' });
+
+    expect(state.selectedModel).toBe('model-2');
   });
 
   it('SET_ACTIVE_MIND preserves the selected mind streaming state', () => {
@@ -315,6 +342,16 @@ describe('appReducer', () => {
     const models = [makeModelInfo('m1', 'Model 1'), makeModelInfo('m2', 'Model 2')];
     const state = appReducer(initialState, { type: 'SET_AVAILABLE_MODELS', payload: models });
     expect(state.availableModels).toEqual(models);
+  });
+
+  it('SET_AVAILABLE_MODELS falls back when the active mind model is unavailable', () => {
+    const models = [makeModelInfo('model-1', 'Model 1'), makeModelInfo('model-2', 'Model 2')];
+    const state = appReducer({
+      ...withActiveMind,
+      minds: [{ ...withActiveMind.minds[0], selectedModel: 'missing-model' }],
+    }, { type: 'SET_AVAILABLE_MODELS', payload: models });
+
+    expect(state.selectedModel).toBe('model-1');
   });
 
   it('SET_SELECTED_MODEL updates selection for the active mind', () => {

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -317,17 +317,19 @@ describe('appReducer', () => {
     expect(state.availableModels).toEqual(models);
   });
 
-  it('SET_SELECTED_MODEL updates selection and persists to localStorage', () => {
-    const state = appReducer(initialState, { type: 'SET_SELECTED_MODEL', payload: 'model-1' });
+  it('SET_SELECTED_MODEL updates selection for the active mind', () => {
+    const state = appReducer(withActiveMind, { type: 'SET_SELECTED_MODEL', payload: 'model-1' });
     expect(state.selectedModel).toBe('model-1');
-    expect(localStorage.getItem('chamber:selectedModel')).toBe('model-1');
+    expect(state.minds[0].selectedModel).toBe('model-1');
   });
 
   it('SET_SELECTED_MODEL with null clears selection', () => {
-    localStorage.setItem('chamber:selectedModel', 'old');
-    const state = appReducer(initialState, { type: 'SET_SELECTED_MODEL', payload: null });
+    const state = appReducer({
+      ...withActiveMind,
+      minds: [{ ...withActiveMind.minds[0], selectedModel: 'old' }],
+    }, { type: 'SET_SELECTED_MODEL', payload: null });
     expect(state.selectedModel).toBeNull();
-    expect(localStorage.getItem('chamber:selectedModel')).toBeNull();
+    expect(state.minds[0].selectedModel).toBeUndefined();
   });
 
   it('SET_ACTIVE_VIEW updates activeView', () => {

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -233,12 +233,21 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, availableModels: action.payload };
 
     case 'SET_SELECTED_MODEL':
-      if (action.payload) {
-        localStorage.setItem('chamber:selectedModel', action.payload);
-      } else {
-        localStorage.removeItem('chamber:selectedModel');
+      if (
+        state.selectedModel === action.payload
+        && (!state.activeMindId || state.minds.find((mind) => mind.mindId === state.activeMindId)?.selectedModel === (action.payload ?? undefined))
+      ) {
+        return state;
       }
-      return { ...state, selectedModel: action.payload };
+      return {
+        ...state,
+        selectedModel: action.payload,
+        minds: state.activeMindId
+          ? state.minds.map((mind) => mind.mindId === state.activeMindId
+            ? { ...mind, selectedModel: action.payload ?? undefined }
+            : mind)
+          : state.minds,
+      };
 
     case 'SET_ACTIVE_VIEW':
       return { ...state, activeView: action.payload };

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -23,6 +23,15 @@ function updateChatMessage<T extends ChatMessage>(
   return { ...message, ...updates };
 }
 
+function selectedModelForActiveMind(state: AppState, activeMindId: string | null, minds = state.minds): string | null {
+  if (!activeMindId) return null;
+  const selectedModel = minds.find((mind) => mind.mindId === activeMindId)?.selectedModel;
+  if (selectedModel && (state.availableModels.length === 0 || state.availableModels.some((model) => model.id === selectedModel))) {
+    return selectedModel;
+  }
+  return state.availableModels[0]?.id ?? null;
+}
+
 export function handleChatEvent<T extends ChatMessage>(messages: T[], messageId: string, event: ChatEvent): T[] {
   return messages.map((m) => {
     if (m.id !== messageId) return m;
@@ -193,12 +202,17 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     }
 
     case 'SET_MINDS':
-      return { ...state, minds: action.payload };
+      return {
+        ...state,
+        minds: action.payload,
+        selectedModel: selectedModelForActiveMind(state, state.activeMindId, action.payload),
+      };
 
     case 'SET_ACTIVE_MIND':
       return {
         ...state,
         activeMindId: action.payload,
+        selectedModel: selectedModelForActiveMind(state, action.payload),
         isStreaming: action.payload ? Boolean(state.streamingByMind[action.payload]) : false,
         streamingByMind: state.streamingByMind,
       };
@@ -229,8 +243,13 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       };
     }
 
-    case 'SET_AVAILABLE_MODELS':
-      return { ...state, availableModels: action.payload };
+    case 'SET_AVAILABLE_MODELS': {
+      const nextState = { ...state, availableModels: action.payload };
+      return {
+        ...nextState,
+        selectedModel: selectedModelForActiveMind(nextState, nextState.activeMindId),
+      };
+    }
 
     case 'SET_SELECTED_MODEL':
       if (

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -78,7 +78,7 @@ export const initialState: AppState = {
   isStreaming: false,
   streamingByMind: {},
   availableModels: [],
-  selectedModel: localStorage.getItem('chamber:selectedModel'),
+  selectedModel: null,
   activeView: 'chat',
   discoveredViews: [],
   showLanding: false,

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -120,6 +120,7 @@ export function mockElectronAPI(): ElectronAPI {
       remove: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue([]),
       setActive: vi.fn().mockResolvedValue(undefined),
+      setModel: vi.fn().mockResolvedValue(null),
       selectDirectory: vi.fn().mockResolvedValue(null),
       openWindow: vi.fn().mockResolvedValue(undefined),
       onMindChanged: vi.fn().mockReturnValue(vi.fn()),

--- a/chamber-copilot-runtime/package-lock.json
+++ b/chamber-copilot-runtime/package-lock.json
@@ -8,31 +8,31 @@
       "name": "chamber-copilot-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "1.0.41-0",
+        "@github/copilot": "1.0.41-1",
         "@github/copilot-sdk": "0.3.0"
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-0.tgz",
-      "integrity": "sha512-gLyCadBZdJeJtHJI3XdN8wAmLMEUdXfCa3EcVnbdbV1NHZDAJhr7h41l7a49pqRAmJyLUKlk1Lokk7U+OD3tgw==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-1.tgz",
+      "integrity": "sha512-95Qxeds7SAi96b4bK91PAdB13M39ZKpZDfWf69yJg6362RTCFNa24QvflLG+3f4Vojh8GD4h8EvxAYwgq4zdMQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.41-0",
-        "@github/copilot-darwin-x64": "1.0.41-0",
-        "@github/copilot-linux-arm64": "1.0.41-0",
-        "@github/copilot-linux-x64": "1.0.41-0",
-        "@github/copilot-win32-arm64": "1.0.41-0",
-        "@github/copilot-win32-x64": "1.0.41-0"
+        "@github/copilot-darwin-arm64": "1.0.41-1",
+        "@github/copilot-darwin-x64": "1.0.41-1",
+        "@github/copilot-linux-arm64": "1.0.41-1",
+        "@github/copilot-linux-x64": "1.0.41-1",
+        "@github/copilot-win32-arm64": "1.0.41-1",
+        "@github/copilot-win32-x64": "1.0.41-1"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-0.tgz",
-      "integrity": "sha512-lrrH1oMbTOF1W/YxH6rvoEHOymxmXaMx4aDzm190hU0Yh6Cuu0BJGFvgG8nE9bqcv5O8W7eEBr26jDlGtnZiwg==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-1.tgz",
+      "integrity": "sha512-9ExZaLv3/yi7Be9GnjhxJgmuklQhqT59014BsqsWt1lpTA1khJs8VyC5B+iP8TEOkFKvD/UXJNSP9PCE6n5inQ==",
       "cpu": [
         "arm64"
       ],
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-0.tgz",
-      "integrity": "sha512-4418VtSSkEgn4BcwCFg+0UDhGCfQgGTx16r/PiWbuUOgIBzts3FfVzWMWTuXyxk7kl2Ib8k7KSd/7rNpjcrzBw==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-1.tgz",
+      "integrity": "sha512-6ZretUFTcCPajzcZyQZixn2unVlN+sbtC6hULBYT6FLHrqSrjK4QN52eCtTYOz/kPbBUO4lj9YjT/v1gkgMDwQ==",
       "cpu": [
         "x64"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-0.tgz",
-      "integrity": "sha512-5xjgp3Ak5QJ68byNbsgBpdK1V6T5t8EGu0pUwEJMNMMXxqvL9f7gPcnCGdTtV2DS4Q3adkziV/gpBSSQ5HY8hg==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-1.tgz",
+      "integrity": "sha512-iP/VbjvGMQvo0fudLHBpmp31nAmtGvq1tZWC+YEQ43D58n2miOXkiDR61Tn9PSPGTkNbrnTecE0mgBO2oePYPw==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-0.tgz",
-      "integrity": "sha512-oWPkj0bSjBjtAqonMEZD7EuSByBNXwtceMw8y7uGOfs6jQXfhDGzCCB6NGb+lcftVNtWDKFCUtx+x8Fbt4O37w==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-1.tgz",
+      "integrity": "sha512-DAVCL7pMxeRRHcVOcbpllDBn87zVgskHNqfWrdFPEcgfslx0bw7GkErO35jx/SLnehcwpdwHquqfkyDpnfRAqg==",
       "cpu": [
         "x64"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-0.tgz",
-      "integrity": "sha512-MaPg4tFWTiRuyv+j0ymJbZp8UPK+RIXNMpekR7FRf8/Uz+NiJgTTxTDjFi4ytRJU5UNrUezkVAk5Xduq/CaIew==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-1.tgz",
+      "integrity": "sha512-m+un4+m1MQlTbiaA6d+/1Aa0SBI85O+De6P/8RdrVCEaoLE0Uy10wZbiHk6GK+YN74B/9WGwW8YANVVaBXsDDw==",
       "cpu": [
         "arm64"
       ],
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-0.tgz",
-      "integrity": "sha512-ykRuDWjJEgSywMFJl1yaefssaklCVSVhprx2NcSVh6tIGupvvzVAM6nL6Mj6nyKpG6FKGHanedBeL6SJc935cw==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-1.tgz",
+      "integrity": "sha512-9Yl56T/4Eo7etQ+98XxsYTIzPdkuN5SAD0mZN2SHjdK5h0mBJFXpEmsminSelFgUbTsMHb+srfSmvx5nFe0m0A==",
       "cpu": [
         "x64"
       ],

--- a/chamber-copilot-runtime/package.json
+++ b/chamber-copilot-runtime/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Pinned packaged runtime for Chamber Copilot SDK + CLI",
   "dependencies": {
-    "@github/copilot": "1.0.41-0",
+    "@github/copilot": "1.0.41-1",
     "@github/copilot-sdk": "0.3.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.39.9",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.39.9",
+      "version": "0.40.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
-        "@github/copilot": "1.0.41-0",
+        "@github/copilot": "1.0.41-1",
         "@github/copilot-sdk": "0.3.0",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1511,27 +1511,27 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-0.tgz",
-      "integrity": "sha512-gLyCadBZdJeJtHJI3XdN8wAmLMEUdXfCa3EcVnbdbV1NHZDAJhr7h41l7a49pqRAmJyLUKlk1Lokk7U+OD3tgw==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-1.tgz",
+      "integrity": "sha512-95Qxeds7SAi96b4bK91PAdB13M39ZKpZDfWf69yJg6362RTCFNa24QvflLG+3f4Vojh8GD4h8EvxAYwgq4zdMQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.41-0",
-        "@github/copilot-darwin-x64": "1.0.41-0",
-        "@github/copilot-linux-arm64": "1.0.41-0",
-        "@github/copilot-linux-x64": "1.0.41-0",
-        "@github/copilot-win32-arm64": "1.0.41-0",
-        "@github/copilot-win32-x64": "1.0.41-0"
+        "@github/copilot-darwin-arm64": "1.0.41-1",
+        "@github/copilot-darwin-x64": "1.0.41-1",
+        "@github/copilot-linux-arm64": "1.0.41-1",
+        "@github/copilot-linux-x64": "1.0.41-1",
+        "@github/copilot-win32-arm64": "1.0.41-1",
+        "@github/copilot-win32-x64": "1.0.41-1"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-0.tgz",
-      "integrity": "sha512-lrrH1oMbTOF1W/YxH6rvoEHOymxmXaMx4aDzm190hU0Yh6Cuu0BJGFvgG8nE9bqcv5O8W7eEBr26jDlGtnZiwg==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-1.tgz",
+      "integrity": "sha512-9ExZaLv3/yi7Be9GnjhxJgmuklQhqT59014BsqsWt1lpTA1khJs8VyC5B+iP8TEOkFKvD/UXJNSP9PCE6n5inQ==",
       "cpu": [
         "arm64"
       ],
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-0.tgz",
-      "integrity": "sha512-4418VtSSkEgn4BcwCFg+0UDhGCfQgGTx16r/PiWbuUOgIBzts3FfVzWMWTuXyxk7kl2Ib8k7KSd/7rNpjcrzBw==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-1.tgz",
+      "integrity": "sha512-6ZretUFTcCPajzcZyQZixn2unVlN+sbtC6hULBYT6FLHrqSrjK4QN52eCtTYOz/kPbBUO4lj9YjT/v1gkgMDwQ==",
       "cpu": [
         "x64"
       ],
@@ -1563,9 +1563,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-0.tgz",
-      "integrity": "sha512-5xjgp3Ak5QJ68byNbsgBpdK1V6T5t8EGu0pUwEJMNMMXxqvL9f7gPcnCGdTtV2DS4Q3adkziV/gpBSSQ5HY8hg==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-1.tgz",
+      "integrity": "sha512-iP/VbjvGMQvo0fudLHBpmp31nAmtGvq1tZWC+YEQ43D58n2miOXkiDR61Tn9PSPGTkNbrnTecE0mgBO2oePYPw==",
       "cpu": [
         "arm64"
       ],
@@ -1580,9 +1580,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-0.tgz",
-      "integrity": "sha512-oWPkj0bSjBjtAqonMEZD7EuSByBNXwtceMw8y7uGOfs6jQXfhDGzCCB6NGb+lcftVNtWDKFCUtx+x8Fbt4O37w==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-1.tgz",
+      "integrity": "sha512-DAVCL7pMxeRRHcVOcbpllDBn87zVgskHNqfWrdFPEcgfslx0bw7GkErO35jx/SLnehcwpdwHquqfkyDpnfRAqg==",
       "cpu": [
         "x64"
       ],
@@ -1732,9 +1732,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-0.tgz",
-      "integrity": "sha512-MaPg4tFWTiRuyv+j0ymJbZp8UPK+RIXNMpekR7FRf8/Uz+NiJgTTxTDjFi4ytRJU5UNrUezkVAk5Xduq/CaIew==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-1.tgz",
+      "integrity": "sha512-m+un4+m1MQlTbiaA6d+/1Aa0SBI85O+De6P/8RdrVCEaoLE0Uy10wZbiHk6GK+YN74B/9WGwW8YANVVaBXsDDw==",
       "cpu": [
         "arm64"
       ],
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.41-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-0.tgz",
-      "integrity": "sha512-ykRuDWjJEgSywMFJl1yaefssaklCVSVhprx2NcSVh6tIGupvvzVAM6nL6Mj6nyKpG6FKGHanedBeL6SJc935cw==",
+      "version": "1.0.41-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-1.tgz",
+      "integrity": "sha512-9Yl56T/4Eo7etQ+98XxsYTIzPdkuN5SAD0mZN2SHjdK5h0mBJFXpEmsminSelFgUbTsMHb+srfSmvx5nFe0m0A==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.39.9",
+  "version": "0.40.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "@github/copilot": "1.0.41-0",
+    "@github/copilot": "1.0.41-1",
     "@github/copilot-sdk": "0.3.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/packages/services/src/a2a/TaskManager.test.ts
+++ b/packages/services/src/a2a/TaskManager.test.ts
@@ -257,6 +257,16 @@ describe('TaskManager', () => {
     );
   });
 
+  it('sendTask() injects current datetime context into the task prompt', async () => {
+    await tm.sendTask(makeRequest('target-1', 'hello'));
+    await flushPromises();
+
+    const sentPrompt = latestMockSession.send.mock.calls[0]?.[0]?.prompt;
+    expect(sentPrompt).toEqual(expect.stringContaining('<current_datetime>'));
+    expect(sentPrompt).toEqual(expect.stringContaining('<timezone>'));
+    expect(sentPrompt).toEqual(expect.stringContaining('hello'));
+  });
+
 
   it('getTask() returns current task state', async () => {
     const task = await tm.sendTask(makeRequest('target-1', 'hello'));

--- a/packages/services/src/a2a/TaskManager.ts
+++ b/packages/services/src/a2a/TaskManager.ts
@@ -12,6 +12,7 @@ import type {
   Message,
 } from './types';
 import { isStaleSessionError } from '@chamber/shared/sessionErrors';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
 
 const log = Logger.create('TaskManager');
 
@@ -216,6 +217,7 @@ export class TaskManager extends EventEmitter {
     // c. Serialize message
     const deliveryMessage: Message = { ...message, contextId: task.contextId, taskId: task.id };
     const xmlPrompt = serializeMessageToXml(deliveryMessage);
+    const prompt = injectCurrentDateTimeContext(xmlPrompt, getCurrentDateTimeContext());
 
     let session = await this.sessionFactory.createTaskSession(targetMindId, task.id, onUserInputRequest);
     this.sessions.set(task.id, session);
@@ -225,7 +227,7 @@ export class TaskManager extends EventEmitter {
 
     // e. Send prompt, with stale-session retry
     try {
-      await session.send({ prompt: xmlPrompt });
+      await session.send({ prompt });
     } catch (err) {
       if (!isStaleSessionError(err)) throw err;
 
@@ -234,7 +236,7 @@ export class TaskManager extends EventEmitter {
       session = await this.sessionFactory.createTaskSession(targetMindId, task.id, onUserInputRequest);
       this.sessions.set(task.id, session);
       this.bindTaskSessionListeners(session, task, targetMindId);
-      await session.send({ prompt: xmlPrompt });
+      await session.send({ prompt });
     }
   }
 

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -27,6 +27,7 @@ const mockMindManager = {
     return undefined;
   }),
   recreateSession: vi.fn(),
+  setMindModel: vi.fn(async () => null),
 };
 
 describe('ChatService', () => {
@@ -37,7 +38,10 @@ describe('ChatService', () => {
     vi.clearAllMocks();
     validModelClient.modelsCache = {};
     turnQueue = new TurnQueue();
-    svc = new ChatService(mockMindManager as unknown as MindManager, turnQueue);
+    svc = new ChatService(mockMindManager as unknown as MindManager, turnQueue, () => ({
+      currentDateTime: '2026-05-05T15:37:12.065Z',
+      timezone: 'America/New_York',
+    }));
   });
 
   describe('sendMessage', () => {
@@ -54,8 +58,26 @@ describe('ChatService', () => {
       await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
 
       expect(mockMindManager.getMind).toHaveBeenCalledWith('valid-mind');
-      expect(mockSession.send).toHaveBeenCalledWith({ prompt: 'hello' });
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
+      });
       expect(emit).toHaveBeenCalledWith({ type: 'done' });
+    });
+
+    it('persists model selection before sending with the mind session', async () => {
+      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          setTimeout(() => cb(), 0);
+        }
+        return vi.fn();
+      });
+      const emit = vi.fn();
+      await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit, 'gpt-5.4');
+
+      expect(mockMindManager.setMindModel).toHaveBeenCalledWith('valid-mind', 'gpt-5.4');
+      expect(mockSession.send).toHaveBeenCalledWith(expect.objectContaining({
+        prompt: expect.stringContaining('hello'),
+      }));
     });
 
     it('throws for invalid mindId', async () => {
@@ -155,7 +177,9 @@ describe('ChatService', () => {
 
       expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
       expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
-      expect(freshSession.send).toHaveBeenCalledWith({ prompt: 'hello' });
+      expect(freshSession.send).toHaveBeenCalledWith({
+        prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
+      });
       expect(emit).toHaveBeenCalledWith({ type: 'done' });
     });
 
@@ -258,7 +282,9 @@ describe('ChatService', () => {
 
         expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
         expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
-        expect(freshSession.send).toHaveBeenCalledWith({ prompt: 'hello' });
+        expect(freshSession.send).toHaveBeenCalledWith({
+          prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
+        });
       } finally {
         vi.useRealTimers();
         // Restore default impl so subsequent tests aren't left with a hung send.
@@ -303,14 +329,16 @@ describe('ChatService', () => {
 
       // Let microtasks settle so first send starts
       await new Promise((r) => setTimeout(r, 10));
-      expect(order).toEqual(['send-first']);
+      expect(order).toHaveLength(1);
+      expect(order[0]).toContain('\n\nfirst');
 
       // Complete first message
       idleCallbacks.shift()?.();
       await new Promise((r) => setTimeout(r, 10));
 
       // Now second should have started
-      expect(order).toEqual(['send-first', 'send-second']);
+      expect(order).toHaveLength(2);
+      expect(order[1]).toContain('\n\nsecond');
 
       // Complete second message
       idleCallbacks.shift()?.();

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -19,6 +19,7 @@ import {
 } from '../sdk/sdkChatEventMapper';
 import { clearCopilotModelsCache } from '../sdk/modelCacheCompat';
 import { TurnQueue } from './TurnQueue';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext, type DateTimeContextProvider } from './currentDateTimeContext';
 
 const log = Logger.create('ChatService');
 
@@ -28,6 +29,7 @@ export class ChatService {
   constructor(
     private readonly mindManager: MindManager,
     private readonly turnQueue: TurnQueue,
+    private readonly dateTimeContextProvider: DateTimeContextProvider = getCurrentDateTimeContext,
   ) {}
 
   async sendMessage(
@@ -35,10 +37,9 @@ export class ChatService {
     prompt: string,
     messageId: string,
     emit: (event: ChatEvent) => void,
-    _model?: string,
+    model?: string,
     attachments?: ChatImageAttachment[],
   ): Promise<void> {
-    void _model;
     return this.turnQueue.enqueue(mindId, async () => {
       const abortController = new AbortController();
       this.abortControllers.set(mindId, abortController);
@@ -50,7 +51,10 @@ export class ChatService {
         }
 
         try {
-          await this.streamTurn(context.session, prompt, abortController, emit, attachments);
+          const session = model ? await this.mindManager.setMindModel(mindId, model) : null;
+          const currentSession = session ? this.mindManager.getMind(mindId)?.session : context.session;
+          if (!currentSession) throw new Error(`Mind ${mindId} not found or has no session`);
+          await this.streamTurn(currentSession, prompt, abortController, emit, attachments);
         } catch (err) {
           if (abortController.signal.aborted) return;
           if (!isStaleSessionError(err)) throw err;
@@ -177,7 +181,8 @@ export class ChatService {
           mimeType: a.mimeType,
           displayName: a.name,
         }));
-        await Promise.race([session.send(sdkAttachments ? { prompt, attachments: sdkAttachments } : { prompt }), sendTimeout]);
+        const promptWithDateTime = injectCurrentDateTimeContext(prompt, this.dateTimeContextProvider());
+        await Promise.race([session.send(sdkAttachments ? { prompt: promptWithDateTime, attachments: sdkAttachments } : { prompt: promptWithDateTime }), sendTimeout]);
       } finally {
         if (sendTimerId) clearTimeout(sendTimerId);
       }

--- a/packages/services/src/chat/currentDateTimeContext.test.ts
+++ b/packages/services/src/chat/currentDateTimeContext.test.ts
@@ -15,4 +15,11 @@ describe('currentDateTimeContext', () => {
       timezone: 'America/New_York',
     })).toBe('<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello');
   });
+
+  it('keeps A2A agent-message prompts as a single XML root', () => {
+    expect(injectCurrentDateTimeContext('<agent-message role="user">\n  <content>hello</content>\n</agent-message>', {
+      currentDateTime: '2026-05-05T15:37:12.065Z',
+      timezone: 'America/New_York',
+    })).toBe('<agent-message role="user">\n  <current_datetime>2026-05-05T15:37:12.065Z</current_datetime>\n  <timezone>America/New_York</timezone>\n  <content>hello</content>\n</agent-message>');
+  });
 });

--- a/packages/services/src/chat/currentDateTimeContext.test.ts
+++ b/packages/services/src/chat/currentDateTimeContext.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from './currentDateTimeContext';
+
+describe('currentDateTimeContext', () => {
+  it('formats the current datetime as ISO with the local timezone name', () => {
+    const context = getCurrentDateTimeContext(new Date('2026-05-05T15:37:12.065Z'));
+
+    expect(context.currentDateTime).toBe('2026-05-05T15:37:12.065Z');
+    expect(context.timezone.length).toBeGreaterThan(0);
+  });
+
+  it('injects datetime context before the user prompt', () => {
+    expect(injectCurrentDateTimeContext('hello', {
+      currentDateTime: '2026-05-05T15:37:12.065Z',
+      timezone: 'America/New_York',
+    })).toBe('<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello');
+  });
+});

--- a/packages/services/src/chat/currentDateTimeContext.ts
+++ b/packages/services/src/chat/currentDateTimeContext.ts
@@ -13,6 +13,19 @@ export function getCurrentDateTimeContext(date = new Date()): CurrentDateTimeCon
 }
 
 export function injectCurrentDateTimeContext(prompt: string, context: CurrentDateTimeContext): string {
+  const agentMessageOpening = /^<agent-message\b[^>]*>/.exec(prompt)?.[0];
+  if (agentMessageOpening) {
+    return `${agentMessageOpening}
+  <current_datetime>${escapeXml(context.currentDateTime)}</current_datetime>
+  <timezone>${escapeXml(context.timezone)}</timezone>${prompt.slice(agentMessageOpening.length)}`;
+  }
+
   return `<current_datetime>\n${context.currentDateTime}\n</current_datetime>\n<timezone>\n${context.timezone}\n</timezone>\n\n${prompt}`;
 }
 
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/packages/services/src/chat/currentDateTimeContext.ts
+++ b/packages/services/src/chat/currentDateTimeContext.ts
@@ -1,0 +1,18 @@
+export interface CurrentDateTimeContext {
+  currentDateTime: string;
+  timezone: string;
+}
+
+export type DateTimeContextProvider = () => CurrentDateTimeContext;
+
+export function getCurrentDateTimeContext(date = new Date()): CurrentDateTimeContext {
+  return {
+    currentDateTime: date.toISOString(),
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  };
+}
+
+export function injectCurrentDateTimeContext(prompt: string, context: CurrentDateTimeContext): string {
+  return `<current_datetime>\n${context.currentDateTime}\n</current_datetime>\n<timezone>\n${context.timezone}\n</timezone>\n\n${prompt}`;
+}
+

--- a/packages/services/src/chatroom/orchestration/stream-agent.test.ts
+++ b/packages/services/src/chatroom/orchestration/stream-agent.test.ts
@@ -458,6 +458,10 @@ describe('sendToAgentWithRetry', () => {
 
     expect(ctx.getOrCreateSession).toHaveBeenCalledWith('dude');
     expect(sess.send).toHaveBeenCalledTimes(1);
+    const sentPrompt = sess.send.mock.calls[0]?.[0]?.prompt;
+    expect(sentPrompt).toEqual(expect.stringContaining('<current_datetime>'));
+    expect(sentPrompt).toEqual(expect.stringContaining('<timezone>'));
+    expect(sentPrompt).toEqual(expect.stringContaining('Hello'));
     expect(ctx.persistMessage).toHaveBeenCalledTimes(1);
     expect(result.message).not.toBeNull();
     expect(result.message!.role).toBe('assistant');

--- a/packages/services/src/chatroom/orchestration/stream-agent.ts
+++ b/packages/services/src/chatroom/orchestration/stream-agent.ts
@@ -4,6 +4,7 @@ import type { ChatroomStreamEvent, OrchestrationMode, ChatroomMessage } from '@c
 import type { OrchestrationContext } from './types';
 import type { CopilotSession } from '../../mind';
 import { isStaleSessionError, SEND_TIMEOUT_MS, DEFAULT_TURN_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../../chat/currentDateTimeContext';
 
 // ---------------------------------------------------------------------------
 // TurnTimeoutError — distinguishable timeout for callers
@@ -173,7 +174,7 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
     sendTimerId = setTimeout(() => reject(sendTimeoutError()), SEND_TIMEOUT_MS);
   });
   try {
-    await Promise.race([session.send({ prompt }), sendTimeout]);
+    await Promise.race([session.send({ prompt: injectCurrentDateTimeContext(prompt, getCurrentDateTimeContext()) }), sendTimeout]);
   } catch (err) {
     // Send failed (e.g. 30s timeout) — clear the turnDone timer to prevent leak
     clearTimeout(turnDoneTimeoutId);

--- a/packages/services/src/config/ConfigService.ts
+++ b/packages/services/src/config/ConfigService.ts
@@ -63,7 +63,9 @@ export class ConfigService {
     const theme = raw.theme === 'light' || raw.theme === 'dark' || raw.theme === 'system'
       ? raw.theme
       : 'dark';
-    const minds = Array.isArray(raw.minds) ? raw.minds as MindRecord[] : [];
+    const minds = Array.isArray(raw.minds)
+      ? raw.minds.map(normalizeMindRecord).filter((record): record is MindRecord => record !== null)
+      : [];
     return this.deduplicateMinds({
       version: 2,
       minds,
@@ -102,11 +104,24 @@ export class ConfigService {
     for (const mind of config.minds) {
       if (!seen.has(mind.path)) {
         seen.add(mind.path);
-        deduped.push(mind);
+        deduped.push({ ...mind });
       }
     }
     return { ...config, minds: deduped };
   }
+}
+
+function normalizeMindRecord(value: unknown): MindRecord | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== 'string' || typeof record.path !== 'string') return null;
+  return {
+    id: record.id,
+    path: record.path,
+    ...(typeof record.selectedModel === 'string' && record.selectedModel.trim().length > 0
+      ? { selectedModel: record.selectedModel.trim() }
+      : {}),
+  };
 }
 
 function isMarketplaceRegistry(value: unknown): value is MarketplaceRegistry {

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.test.ts
@@ -92,6 +92,20 @@ describe('GenesisMindTemplateInstaller', () => {
     expect(installer.clientFactory.createClient).not.toHaveBeenCalled();
   });
 
+  it('still installs the template when git is unavailable', async () => {
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw new Error('git not found');
+    });
+    const installer = new GenesisMindTemplateInstaller(registryClient);
+
+    const mindPath = await installer.install({ templateId: 'lucy', basePath });
+
+    expect(mindPath).toBe(path.join(basePath, 'lucy'));
+    expect(readFileSync(path.join(mindPath, 'SOUL.md'), 'utf8')).toBe('# Lucy\n');
+    expect(execSync).toHaveBeenCalledWith('git init', { cwd: mindPath, stdio: 'ignore' });
+    expect(execSync).not.toHaveBeenCalledWith('git add -A', { cwd: mindPath, stdio: 'ignore' });
+  });
+
   it('installs the selected marketplace when template ids overlap', async () => {
     seedMarketplace(registryClient, {
       owner: 'ianphil',

--- a/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateInstaller.ts
@@ -7,10 +7,12 @@ import { GenesisMindTemplateMarketplaceCatalog } from './GenesisMindTemplateMark
 import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
 import { MindScaffold } from './MindScaffold';
 import type { GenesisMindTemplate, GenesisMindTemplateMarketplaceSource } from './templateTypes';
+import { Logger } from '../logger';
 
 const IDEA_FOLDERS = ['inbox', 'domains', 'expertise', 'initiatives', 'Archive'];
 const WORKING_MEMORY_FILES = ['memory.md', 'rules.md', 'log.md'];
 const MAX_TEMPLATE_INSTALL_BYTES = 50 * 1024 * 1024;
+const log = Logger.create('GenesisMindTemplateInstaller');
 
 interface RegistryClient {
   fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]>;
@@ -99,9 +101,13 @@ export class GenesisMindTemplateInstaller {
   }
 
   private initGit(mindPath: string): void {
-    execSync('git init', { cwd: mindPath, stdio: 'ignore' });
-    execSync('git add -A', { cwd: mindPath, stdio: 'ignore' });
-    execSync('git commit -m "Genesis template install"', { cwd: mindPath, stdio: 'ignore' });
+    try {
+      execSync('git init', { cwd: mindPath, stdio: 'ignore' });
+      execSync('git add -A', { cwd: mindPath, stdio: 'ignore' });
+      execSync('git commit -m "Genesis template install"', { cwd: mindPath, stdio: 'ignore' });
+    } catch (error) {
+      log.warn('Git init failed for Genesis template install (non-fatal):', error);
+    }
   }
 
   private async listTemplates(): Promise<GenesisMindTemplate[]> {

--- a/packages/services/src/genesis/MindScaffold.test.ts
+++ b/packages/services/src/genesis/MindScaffold.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MindScaffold } from './MindScaffold';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -71,6 +71,44 @@ describe('MindScaffold.create', () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it('injects current datetime context into the genesis prompt', async () => {
+    const session = {
+      send: vi.fn<(_: { prompt: string }) => Promise<void>>(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+      on: vi.fn((event: string, callback: () => void) => {
+        if (event === 'session.idle') setTimeout(callback, 0);
+        return vi.fn();
+      }),
+      rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
+    };
+    const client = { createSession: vi.fn(async () => session) };
+    const clientFactory = {
+      createClient: vi.fn(async () => client),
+      destroyClient: vi.fn(async () => undefined),
+    } as unknown as CopilotClientFactory;
+    const scaffold = new MindScaffold(
+      {} as unknown as GitHubRegistryClient,
+      clientFactory,
+    );
+
+    const generateSoul = scaffold as unknown as {
+      generateSoul(mindPath: string, config: Parameters<MindScaffold['create']>[0], slug: string): Promise<void>;
+    };
+    const promise = generateSoul.generateSoul('/tmp/minds/bob', {
+      name: 'Bob',
+      role: 'reviewer',
+      voice: 'direct',
+      voiceDescription: 'direct',
+      basePath: '/tmp/minds',
+    }, 'bob');
+    await promise;
+
+    const sentPrompt = session.send.mock.calls[0]?.[0]?.prompt;
+    expect(sentPrompt).toEqual(expect.stringContaining('<current_datetime>'));
+    expect(sentPrompt).toEqual(expect.stringContaining('<timezone>'));
+    expect(sentPrompt).toEqual(expect.stringContaining('Bob'));
   });
 });
 

--- a/packages/services/src/genesis/MindScaffold.ts
+++ b/packages/services/src/genesis/MindScaffold.ts
@@ -7,6 +7,7 @@ import { execSync } from 'child_process';
 import { Logger } from '../logger';
 import { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import { approveAllCompat } from '../sdk/approveAllCompat';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
 import { buildGenesisPrompt } from './genesisPrompt';
 import { GitHubRegistryClient } from './GitHubRegistryClient';
 
@@ -163,7 +164,7 @@ export class MindScaffold {
     await session.rpc.permissions.setApproveAll({ enabled: true });
 
     try {
-      await session.send({ prompt });
+      await session.send({ prompt: injectCurrentDateTimeContext(prompt, getCurrentDateTimeContext()) });
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(resolve, 180_000);

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -28,6 +28,7 @@ const mockCreateSession = vi.fn((_config: Record<string, unknown>) => ({
   sendAndWait: vi.fn(),
   on: vi.fn(),
   off: vi.fn(),
+  disconnect: vi.fn(async () => undefined),
   rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
 }));
 
@@ -144,6 +145,47 @@ describe('MindManager', () => {
         '/tmp/agents/q',
       );
       expect(mockConfigService.save).toHaveBeenCalled();
+    });
+
+    it('injects current datetime context into background prompts', async () => {
+      await manager.loadMind('/tmp/agents/q');
+      const session = mockCreateSession.mock.results.at(-1)?.value;
+      session.on.mockImplementation((event: string, callback: () => void) => {
+        if (event === 'session.idle') setTimeout(callback, 0);
+        return vi.fn();
+      });
+      await manager.sendBackgroundPrompt('/tmp/agents/q', 'do background work');
+
+      const sentPrompt = session.send.mock.calls[0]?.[0]?.prompt;
+      expect(sentPrompt).toEqual(expect.stringContaining('<current_datetime>'));
+      expect(sentPrompt).toEqual(expect.stringContaining('<timezone>'));
+      expect(sentPrompt).toEqual(expect.stringContaining('do background work'));
+    });
+
+    it('uses a persisted per-mind model when creating the session', async () => {
+      currentConfig = {
+        version: 2,
+        minds: [{ id: 'q-a1b2', path: '/tmp/agents/q', selectedModel: 'gpt-5.4' }],
+        activeMindId: 'q-a1b2',
+        activeLogin: null,
+        theme: 'dark',
+      };
+
+      await manager.restoreFromConfig();
+
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
+      expect(manager.listMinds()[0].selectedModel).toBe('gpt-5.4');
+    });
+
+    it('persists a per-mind model and recreates the session with it', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      mockCreateSession.mockClear();
+
+      const updated = await manager.setMindModel(mind.mindId, 'claude-opus');
+
+      expect(updated?.selectedModel).toBe('claude-opus');
+      expect(lastSavedConfig().minds[0].selectedModel).toBe('claude-opus');
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-opus' }));
     });
 
     it('starts Lens watching and emits view changes after watcher rescans', async () => {

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -22,15 +22,19 @@ import * as fs from 'fs';
 
 const mockStart = vi.fn();
 const mockStop = vi.fn();
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockCreateSession = vi.fn((_config: Record<string, unknown>) => ({
+function createSessionStub() {
+  return {
   send: vi.fn(),
   sendAndWait: vi.fn(),
   on: vi.fn(),
   off: vi.fn(),
   disconnect: vi.fn(async () => undefined),
   rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
-}));
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockCreateSession = vi.fn((_config: Record<string, unknown>) => createSessionStub());
 
 function makeMockClient() {
   return {
@@ -186,6 +190,53 @@ describe('MindManager', () => {
       expect(updated?.selectedModel).toBe('claude-opus');
       expect(lastSavedConfig().minds[0].selectedModel).toBe('claude-opus');
       expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-opus' }));
+    });
+
+    it('serializes concurrent per-mind model changes', async () => {
+      const originalSession = createSessionStub();
+      const firstModelSession = createSessionStub();
+      const secondModelSession = createSessionStub();
+      let resolveFirstModelSession: (() => void) | undefined;
+      const createSession = vi.fn((config: Record<string, unknown>) => {
+        if (config.model === 'model-a') {
+          return new Promise((resolve) => {
+            resolveFirstModelSession = () => resolve(firstModelSession);
+          });
+        }
+        if (config.model === 'model-b') return Promise.resolve(secondModelSession);
+        return Promise.resolve(originalSession);
+      });
+      const clientFactory = {
+        createClient: vi.fn(async () => ({ start: vi.fn(), stop: vi.fn(), createSession })),
+        destroyClient: vi.fn(),
+      };
+      const localManager = new MindManager(
+        clientFactory as unknown as CopilotClientFactory,
+        mockIdentityLoader as unknown as IdentityLoader,
+        mockConfigService as unknown as ConfigService,
+        mockViewDiscovery as unknown as ViewDiscovery,
+      );
+
+      const mind = await localManager.loadMind('/tmp/agents/q');
+      createSession.mockClear();
+
+      const firstChange = localManager.setMindModel(mind.mindId, 'model-a');
+      const secondChange = localManager.setMindModel(mind.mindId, 'model-b');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(createSession).toHaveBeenCalledTimes(1);
+      expect(createSession).toHaveBeenCalledWith(expect.objectContaining({ model: 'model-a' }));
+
+      resolveFirstModelSession?.();
+      await Promise.all([firstChange, secondChange]);
+
+      expect(createSession).toHaveBeenCalledTimes(2);
+      expect(createSession).toHaveBeenLastCalledWith(expect.objectContaining({ model: 'model-b' }));
+      expect(localManager.getMind(mind.mindId)?.selectedModel).toBe('model-b');
+      expect(localManager.getMind(mind.mindId)?.session).toBe(secondModelSession);
+      expect(originalSession.disconnect).toHaveBeenCalledTimes(1);
+      expect(firstModelSession.disconnect).toHaveBeenCalledTimes(1);
     });
 
     it('starts Lens watching and emits view changes after watcher rescans', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -14,6 +14,7 @@ import { generateMindId } from './generateMindId';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import { approveAllCompat } from '../sdk/approveAllCompat';
 import type { IdentityLoader } from '../chat/IdentityLoader';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
 import type { ChamberToolProvider } from '../chamberTools';
 import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
@@ -85,14 +86,26 @@ export class MindManager extends EventEmitter {
 
     const sessionTools = this.getSessionTools(id, resolvedMindPath);
 
+    const selectedModel = this.knownMindRecords.get(id)?.selectedModel;
+
     // Create session
-    const session = await this.createSessionForMind(client, resolvedMindPath, identity.systemMessage, sessionTools);
+    const session = await this.createSessionForMind(
+      client,
+      resolvedMindPath,
+      identity.systemMessage,
+      sessionTools,
+      undefined,
+      approveAllCompat,
+      true,
+      selectedModel,
+    );
 
     const context: InternalMindContext = {
       mindId: id,
       mindPath: resolvedMindPath,
       identity,
       status: 'ready',
+      selectedModel,
       client,
       session,
     };
@@ -117,7 +130,7 @@ export class MindManager extends EventEmitter {
       throw err;
     }
 
-    this.knownMindRecords.set(id, { id, path: resolvedMindPath });
+    this.knownMindRecords.set(id, { id, path: resolvedMindPath, ...(selectedModel ? { selectedModel } : {}) });
 
     // Persist
     this.persistConfig();
@@ -192,9 +205,62 @@ export class MindManager extends EventEmitter {
 
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
     context.session = await this.createSessionForMind(
-      context.client, context.mindPath, context.identity.systemMessage, sessionTools,
+      context.client,
+      context.mindPath,
+      context.identity.systemMessage,
+      sessionTools,
+      undefined,
+      approveAllCompat,
+      true,
+      context.selectedModel,
     );
     return context.session;
+  }
+
+  async setMindModel(mindId: string, model: string | null): Promise<MindContext | null> {
+    const context = this.minds.get(mindId);
+    const selectedModel = model && model.trim().length > 0 ? model.trim() : undefined;
+
+    if (!context) {
+      const existingRecord = this.knownMindRecords.get(mindId);
+      if (!existingRecord) return null;
+      this.knownMindRecords.set(mindId, {
+        id: existingRecord.id,
+        path: existingRecord.path,
+        ...(selectedModel ? { selectedModel } : {}),
+      });
+      this.persistConfig();
+      return null;
+    }
+
+    if (context.selectedModel === selectedModel) return this.toExternalContext(context);
+
+    const previousSession = context.session;
+    const sessionTools = this.getSessionTools(mindId, context.mindPath);
+    const nextSession = await this.createSessionForMind(
+      context.client,
+      context.mindPath,
+      context.identity.systemMessage,
+      sessionTools,
+      undefined,
+      approveAllCompat,
+      true,
+      selectedModel,
+    );
+
+    context.selectedModel = selectedModel;
+    context.session = nextSession;
+    this.knownMindRecords.set(mindId, {
+      id: mindId,
+      path: context.mindPath,
+      ...(selectedModel ? { selectedModel } : {}),
+    });
+    this.persistConfig();
+    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
+
+    const external = this.toExternalContext(context);
+    this.emit('mind:loaded', external);
+    return external;
   }
 
   awaitRestore(): Promise<void> {
@@ -307,6 +373,7 @@ export class MindManager extends EventEmitter {
       identity: ctx.identity,
       status: ctx.status,
       error: ctx.error,
+      selectedModel: ctx.selectedModel,
       windowed: false,
     };
   }
@@ -367,6 +434,7 @@ export class MindManager extends EventEmitter {
     onUserInputRequest?: UserInputHandler,
     onPermissionRequest: PermissionHandler = approveAllCompat,
     approveAll = true,
+    model?: string,
   ): Promise<CopilotSession> {
     const sessionConfig: SessionConfig = {
       workingDirectory: mindPath,
@@ -380,6 +448,7 @@ export class MindManager extends EventEmitter {
         },
       },
       onPermissionRequest,
+      ...(model ? { model } : {}),
       ...(onUserInputRequest ? { onUserInputRequest } : {}),
     };
     const session = await client.createSession(sessionConfig);
@@ -398,7 +467,7 @@ export class MindManager extends EventEmitter {
     const context = this.minds.get(mind.mindId);
     if (!context?.session) return;
 
-    await context.session.send({ prompt });
+    await context.session.send({ prompt: injectCurrentDateTimeContext(prompt, getCurrentDateTimeContext()) });
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(resolve, 120_000);
       const unsub = context.session?.on('session.idle', () => {
@@ -428,6 +497,7 @@ export class MindManager extends EventEmitter {
       records.set(mind.mindId, {
         id: mind.mindId,
         path: mind.mindPath,
+        ...(mind.selectedModel ? { selectedModel: mind.selectedModel } : {}),
       });
     }
     return Array.from(records.values());

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -29,6 +29,7 @@ export class MindManager extends EventEmitter {
   private restorePromise: Promise<void> | null = null;
   private reloading = false;
   private providers: ChamberToolProvider[] = [];
+  private modelUpdates = new Map<string, Promise<void>>();
 
   constructor(
     private readonly clientFactory: CopilotClientFactory,
@@ -218,6 +219,26 @@ export class MindManager extends EventEmitter {
   }
 
   async setMindModel(mindId: string, model: string | null): Promise<MindContext | null> {
+    const previousUpdate = this.modelUpdates.get(mindId) ?? Promise.resolve();
+    let releaseUpdate: () => void;
+    const currentUpdate = new Promise<void>((resolve) => {
+      releaseUpdate = resolve;
+    });
+    const queuedUpdate = previousUpdate.then(() => currentUpdate, () => currentUpdate);
+    this.modelUpdates.set(mindId, queuedUpdate);
+    await previousUpdate.catch(() => { /* previous caller observes its own failure */ });
+
+    try {
+      return await this.setMindModelUnlocked(mindId, model);
+    } finally {
+      releaseUpdate!();
+      if (this.modelUpdates.get(mindId) === queuedUpdate) {
+        this.modelUpdates.delete(mindId);
+      }
+    }
+  }
+
+  private async setMindModelUnlocked(mindId: string, model: string | null): Promise<MindContext | null> {
     const context = this.minds.get(mindId);
     const selectedModel = model && model.trim().length > 0 ? model.trim() : undefined;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -88,6 +88,7 @@ export interface MindContext {
   readonly identity: MindIdentity;
   readonly status: MindStatus;
   readonly error?: string;
+  selectedModel?: string;
   readonly windowed?: boolean;
 }
 
@@ -95,6 +96,7 @@ export interface MindContext {
 export interface MindRecord {
   id: string;
   path: string;
+  selectedModel?: string;
 }
 
 export interface MarketplaceRegistry {
@@ -192,7 +194,7 @@ export interface ElectronAPI {
     send: (mindId: string, message: string, messageId: string, model?: string, attachments?: ChatImageAttachment[]) => Promise<void>;
     stop: (mindId: string, messageId: string) => Promise<void>;
     newConversation: (mindId: string) => Promise<void>;
-    listModels: () => Promise<ModelInfo[]>;
+    listModels: (mindId?: string) => Promise<ModelInfo[]>;
     onEvent: (callback: (mindId: string, messageId: string, event: ChatEvent) => void) => () => void;
   };
   mind: {
@@ -200,6 +202,7 @@ export interface ElectronAPI {
     remove: (mindId: string) => Promise<void>;
     list: () => Promise<MindContext[]>;
     setActive: (mindId: string) => Promise<void>;
+    setModel: (mindId: string, model: string | null) => Promise<MindContext | null>;
     selectDirectory: () => Promise<string | null>;
     openWindow: (mindId: string) => Promise<void>;
     onMindChanged: (callback: (minds: MindContext[]) => void) => () => void;

--- a/tests/e2e/electron/genesis-lucy-cos-chat.spec.ts
+++ b/tests/e2e/electron/genesis-lucy-cos-chat.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_LUCY_COS_CDP_PORT ?? 9344);
+const expectedReply = 'CHAMBER_LUCY_COS_READY_ACK';
+const lucyName = 'Lucy';
+const memoryInstruction = `When asked for the Lucy Chief of Staff smoke acknowledgement, answer exactly ${expectedReply} and no other text.`;
+
+// This spec drives a real Copilot SDK turn end-to-end. It is opt-in because:
+//   - It requires a logged-in Copilot account in the Electron app.
+//   - It takes several minutes (model latency + wizard navigation).
+// Set CHAMBER_E2E_LIVE_GENESIS=1 to enable. Defaults skip in CI and locally.
+const liveGenesisEnabled = process.env.CHAMBER_E2E_LIVE_GENESIS === '1';
+
+test.describe('electron Genesis Lucy Chief of Staff chat smoke', () => {
+  test.skip(!liveGenesisEnabled, 'Set CHAMBER_E2E_LIVE_GENESIS=1 to run the live Copilot Genesis Lucy CoS smoke.');
+  test.setTimeout(360_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let userDataPath = '';
+  let genesisBasePath = '';
+  let lucyPath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-genesis-lucy-cos-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    genesisBasePath = path.join(root, 'agents');
+    lucyPath = path.join(genesisBasePath, 'lucy');
+    tempRoots.push(root);
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+        CHAMBER_E2E_GENESIS_BASE_PATH: genesisBasePath,
+        CHAMBER_E2E_GENESIS_MEMORY_APPEND: memoryInstruction,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('creates Lucy as Chief of Staff through Genesis and uses working memory on the first chat turn', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('button', { name: /New Agent/i }).click();
+    await page.getByRole('button', { name: 'Begin' }).click();
+    await expect(page.getByRole('button', { name: /Lucy Chief of Staff/i })).toBeVisible({ timeout: 60_000 });
+    await page.getByRole('button', { name: /Lucy Chief of Staff/i }).click();
+
+    await expect(page.getByText('How can I help you today?')).toBeVisible({ timeout: 300_000 });
+    await expect(page.getByText(lucyName)).toBeVisible();
+    await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
+
+    expect(fs.existsSync(path.join(lucyPath, 'SOUL.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(lucyPath, 'SOUL.md'), 'utf-8')).toContain('I am Lucy, a calm and practical Chief of Staff.');
+    expect(fs.readFileSync(path.join(lucyPath, '.working-memory', 'memory.md'), 'utf-8')).toContain(memoryInstruction);
+
+    const result = await page.evaluate(async ({ expected, name }) => {
+      const minds = await window.electronAPI.mind.list();
+      const mind = minds.find((candidate) => candidate.identity.name === name);
+      if (!mind) throw new Error(`Created mind ${name} was not loaded.`);
+
+      const messageId = `genesis-lucy-cos-smoke-${Date.now()}`;
+      const events: Array<{ type: string; content?: string; message?: string }> = [];
+      let assistantText = '';
+      let errorMessage = '';
+      let resolveTerminal: () => void = () => undefined;
+      const terminal = new Promise<void>((resolve) => {
+        resolveTerminal = resolve;
+      });
+      const unsubscribe = window.electronAPI.chat.onEvent((mindId, receivedMessageId, event) => {
+        if (mindId !== mind.mindId || receivedMessageId !== messageId) return;
+        events.push(event);
+        if (event.type === 'chunk' || event.type === 'message_final') {
+          assistantText += event.content;
+        }
+        if (event.type === 'error') {
+          errorMessage = event.message;
+          resolveTerminal();
+        }
+        if (event.type === 'done') {
+          resolveTerminal();
+        }
+      });
+
+      try {
+        const send = window.electronAPI.chat.send(
+          mind.mindId,
+          `This is a live Chamber Lucy Chief of Staff smoke test. Reply with exactly ${expected} and no other text.`,
+          messageId,
+        );
+        const timeout = new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('Timed out waiting for Lucy Chief of Staff smoke response.')), 180_000);
+        });
+        await Promise.race([Promise.all([send, terminal]), timeout]);
+        return { mindName: mind.identity.name, assistantText, errorMessage, events };
+      } finally {
+        unsubscribe();
+      }
+    }, { expected: expectedReply, name: lucyName });
+
+    expect(result.mindName).toBe(lucyName);
+    expect(result.errorMessage).toBe('');
+    expect(result.assistantText).toContain(expectedReply);
+    expect(result.events.some((event) => event.type === 'done')).toBe(true);
+  });
+});
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[genesis-lucy-cos-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}

--- a/tests/e2e/electron/per-agent-model-persistence.spec.ts
+++ b/tests/e2e/electron/per-agent-model-persistence.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+import type { ModelInfo } from '@chamber/shared/types';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_PER_AGENT_MODEL_CDP_PORT ?? 9343);
+
+test.describe('electron per-agent model persistence smoke', () => {
+  test.setTimeout(180_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let userDataPath = '';
+  let alphaMindPath = '';
+  let betaMindPath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-per-agent-model-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    alphaMindPath = path.join(root, 'alpha-mind');
+    betaMindPath = path.join(root, 'beta-mind');
+    tempRoots.push(root);
+    seedMind(alphaMindPath, 'Alpha Mind');
+    seedMind(betaMindPath, 'Beta Mind');
+
+    app = await startApp(userDataPath);
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('restores each mind-specific model selection after restart', async () => {
+    let page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    const alpha = await loadMind(page, alphaMindPath, 'Alpha Mind');
+    const beta = await loadMind(page, betaMindPath, 'Beta Mind');
+    const models = await loadModels(page, alpha.mindId);
+    test.skip(models.length < 2, 'Per-agent model smoke requires at least two SDK models.');
+    const alphaModel = models[0];
+    const betaModel = models[1];
+
+    await selectMind(page, 'Alpha Mind');
+    await selectModel(page, betaModel.name);
+    await expectMindModel(page, alpha.mindId, betaModel.id);
+    await selectModel(page, alphaModel.name);
+    await expectMindModel(page, alpha.mindId, alphaModel.id);
+
+    await selectMind(page, 'Beta Mind');
+    await selectModel(page, betaModel.name);
+    await expectMindModel(page, beta.mindId, betaModel.id);
+
+    await selectMind(page, 'Alpha Mind');
+    await expectSelectedModel(page, alphaModel.name);
+
+    await app?.close();
+    app = undefined;
+    await delay(1_000);
+    app = await startApp(userDataPath);
+
+    page = await findRendererPage(app.browser, app.logs);
+    await page.waitForLoadState('domcontentloaded');
+    await expect.poll(
+      () => page.evaluate(() => window.electronAPI.mind.list().then((minds) => minds.map((mind) => mind.identity.name).sort())),
+      { timeout: 30_000 },
+    ).toEqual(['Alpha Mind', 'Beta Mind']);
+
+    await selectMind(page, 'Alpha Mind');
+    await expectSelectedModel(page, alphaModel.name);
+    await selectMind(page, 'Beta Mind');
+    await expectSelectedModel(page, betaModel.name);
+  });
+});
+
+async function startApp(userDataPath: string): Promise<LaunchedElectronApp> {
+  return launchElectronApp({
+    cdpPort,
+    env: {
+      CHAMBER_E2E_USER_DATA: userDataPath,
+    },
+  });
+}
+
+async function loadMind(page: Page, mindPath: string, name: string) {
+  const mind = await page.evaluate(async (pathToMind) => {
+    const loaded = await window.electronAPI.mind.add(pathToMind);
+    await window.electronAPI.mind.setActive(loaded.mindId);
+    return loaded;
+  }, mindPath);
+  await selectMind(page, name);
+  return mind;
+}
+
+async function loadModels(page: Page, mindId: string): Promise<ModelInfo[]> {
+  return page.evaluate((id) => window.electronAPI.chat.listModels(id), mindId);
+}
+
+async function selectMind(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name }).first().click();
+  await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
+}
+
+async function selectModel(page: Page, name: string): Promise<void> {
+  const picker = page.getByRole('combobox').first();
+  await expect(picker).toBeVisible();
+  await picker.click();
+  await page.getByRole('option', { name }).click();
+  await expect(picker).toContainText(name);
+}
+
+async function expectSelectedModel(page: Page, name: string): Promise<void> {
+  await expect(page.getByRole('combobox').first()).toContainText(name);
+}
+
+async function expectMindModel(page: Page, mindId: string, selectedModel: string): Promise<void> {
+  await expect.poll(
+    () => page.evaluate(
+      ({ mindId }) => window.electronAPI.mind.list().then((minds) => minds.find((mind) => mind.mindId === mindId)?.selectedModel),
+      { mindId },
+    ),
+    { timeout: 10_000 },
+  ).toBe(selectedModel);
+}
+
+function seedMind(root: string, name: string): void {
+  fs.mkdirSync(path.join(root, '.github', 'agents'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'SOUL.md'),
+    [
+      `# ${name}`,
+      '',
+      'A deterministic mind used by Electron per-agent model smoke tests.',
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(root, '.github', 'agents', `${slugify(name)}.agent.md`),
+    [
+      '---',
+      `name: ${name}`,
+      'description: Per-agent model smoke-test persona',
+      '---',
+      '',
+      `# ${name}`,
+      '',
+    ].join('\n'),
+  );
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[per-agent-model-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Persist each mind's selected chat model in Chamber config and recreate SDK sessions with the selected model.
- Inject current datetime and timezone context into SDK prompt sends across chat, A2A tasks, chatroom orchestration, Genesis, and background prompts.
- Harden follow-up review findings: preserve A2A XML root shape, serialize per-mind model session updates, and keep multi-window selected-model state reducer-owned.

## Notable changes
- Adds `selectedModel` to mind records/contexts and exposes `mind:setModel` over desktop preload IPC.
- Removes the global `localStorage` model selection in favor of per-active-mind state.
- Adds `v0.40.0` release metadata and changelog entries.

Closes #46
Closes #32

## Validation
- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npm run smoke:web`
- Uncle Bob review: no remaining material blockers on HEAD `5ceee9d`

## Smoke not run
- `npm run smoke:desktop` skipped; this change does not alter desktop navigation/windowing behavior beyond thin IPC/preload plumbing.
- Packaging smoke skipped per issue-slate default; packaged runtime/installer paths were not changed.