### PR TITLE
Add Canvas-backed Lens views

### DIFF
--- a/.github/skills/skill-creator/LICENSE.txt
+++ b/.github/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few test prompts and run claude-with-access-to-the-skill on them
+- Help the user evaluate the results both qualitatively and quantitatively
+  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
+  - Use the `eval-viewer/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
+- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
+- Repeat until you're satisfied
+- Expand the test set and try again at larger scale
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+
+Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" and "benchmark" are borderline, but OK
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+├── SKILL.md (workflow + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+Claude reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Cases
+
+After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+
+Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+
+## Running and evaluating test cases
+
+This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+
+### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+
+For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+
+**With-skill run:**
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+```
+
+**Baseline run** (same prompt, but the baseline depends on context):
+- **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
+- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
+
+Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "assertions": []
+}
+```
+
+### Step 2: While runs are in progress, draft assertions
+
+Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+
+Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
+
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+
+### Step 3: As runs complete, capture timing data
+
+When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+
+### Step 4: Grade, aggregate, and launch the viewer
+
+Once all runs are done:
+
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+
+2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+   ```bash
+   python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+   ```
+   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
+Put each with_skill version before its baseline counterpart.
+
+3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+
+4. **Launch the viewer** with both qualitative outputs and quantitative data:
+   ```bash
+   nohup python <skill-creator-path>/eval-viewer/generate_review.py \
+     <workspace>/iteration-N \
+     --skill-name "my-skill" \
+     --benchmark <workspace>/iteration-N/benchmark.json \
+     > /dev/null 2>&1 &
+   VIEWER_PID=$!
+   ```
+   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
+
+   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+
+Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
+
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+
+### What the user sees in the viewer
+
+The "Outputs" tab shows one test case at a time:
+- **Prompt**: the task that was given
+- **Output**: the files the skill produced, rendered inline where possible
+- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
+- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Feedback**: a textbox that auto-saves as they type
+- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
+
+The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
+
+Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
+
+### Step 5: Read the feedback
+
+When the user tells you they're done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
+    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
+    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+
+Kill the viewer server when you're done with it:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
+4. Wait for the user to review and tell you they're done
+5. Read the new feedback, improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Advanced: Blind comparison
+
+For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+
+This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+
+---
+
+## Description Optimization
+
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+
+### Step 1: Generate trigger eval queries
+
+Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with user
+
+Present the eval set to the user for review using the HTML template:
+
+1. Read the template from `assets/eval_review.html`
+2. Replace the placeholders:
+   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
+   - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
+   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
+3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
+4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
+5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+
+This step matters — bad eval queries lead to bad descriptions.
+
+### Step 3: Run the optimization loop
+
+Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
+
+Save the eval set to the workspace, then run in the background:
+
+```bash
+python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+
+While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+
+This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+
+This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
+
+### Step 4: Apply the result
+
+Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
+
+---
+
+### Package and Present (only if `present_files` tool is available)
+
+Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+
+```bash
+python -m scripts.package_skill <path/to/skill-folder>
+```
+
+After packaging, direct the user to the resulting `.skill` file path so they can install it.
+
+---
+
+## Claude.ai-specific instructions
+
+In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
+
+**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+
+**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+
+**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+
+**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+
+**Blind comparison**: Requires subagents. Skip it.
+
+**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+
+**Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+- **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
+- **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
+
+---
+
+## Cowork-Specific Instructions
+
+If you're in Cowork, the main things to know are:
+
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
+- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
+- Packaging works — `package_skill.py` just needs Python and a filesystem.
+- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+- **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. Follow the update guidance in the claude.ai section above.
+
+---
+
+## Reference files
+
+The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/grader.md` — How to evaluate assertions against outputs
+- `agents/comparator.md` — How to do blind A/B comparison between two outputs
+- `agents/analyzer.md` — How to analyze why one version beat another
+
+The references/ directory has additional documentation:
+- `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run claude-with-access-to-the-skill on test prompts
+- With the user, evaluate the outputs:
+  - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
+  - Run quantitative evals
+- Repeat until you and the user are satisfied
+- Package the final skill and return it to the user.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `eval-viewer/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
+
+Good luck!

--- a/.github/skills/skill-creator/agents/analyzer.md
+++ b/.github/skills/skill-creator/agents/analyzer.md
@@ -1,0 +1,274 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates

--- a/.github/skills/skill-creator/agents/comparator.md
+++ b/.github/skills/skill-creator/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/.github/skills/skill-creator/agents/grader.md
+++ b/.github/skills/skill-creator/agents/grader.md
@@ -1,0 +1,223 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial

--- a/.github/skills/skill-creator/assets/eval_review.html
+++ b/.github/skills/skill-creator/assets/eval_review.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Set Review - __SKILL_NAME_PLACEHOLDER__</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Lora', Georgia, serif; background: #faf9f5; padding: 2rem; color: #141413; }
+    h1 { font-family: 'Poppins', sans-serif; margin-bottom: 0.5rem; font-size: 1.5rem; }
+    .description { color: #b0aea5; margin-bottom: 1.5rem; font-style: italic; max-width: 900px; }
+    .controls { margin-bottom: 1rem; display: flex; gap: 0.5rem; }
+    .btn { font-family: 'Poppins', sans-serif; padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; font-weight: 500; }
+    .btn-add { background: #6a9bcc; color: white; }
+    .btn-add:hover { background: #5889b8; }
+    .btn-export { background: #d97757; color: white; }
+    .btn-export:hover { background: #c4613f; }
+    table { width: 100%; max-width: 1100px; border-collapse: collapse; background: white; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    th { font-family: 'Poppins', sans-serif; background: #141413; color: #faf9f5; padding: 0.75rem 1rem; text-align: left; font-size: 0.875rem; }
+    td { padding: 0.75rem 1rem; border-bottom: 1px solid #e8e6dc; vertical-align: top; }
+    tr:nth-child(even) td { background: #faf9f5; }
+    tr:hover td { background: #f3f1ea; }
+    .section-header td { background: #e8e6dc; font-family: 'Poppins', sans-serif; font-weight: 500; font-size: 0.8rem; color: #141413; text-transform: uppercase; letter-spacing: 0.05em; }
+    .query-input { width: 100%; padding: 0.4rem; border: 1px solid #e8e6dc; border-radius: 4px; font-size: 0.875rem; font-family: 'Lora', Georgia, serif; resize: vertical; min-height: 60px; }
+    .query-input:focus { outline: none; border-color: #d97757; box-shadow: 0 0 0 2px rgba(217,119,87,0.15); }
+    .toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+    .toggle input { opacity: 0; width: 0; height: 0; }
+    .toggle .slider { position: absolute; inset: 0; background: #b0aea5; border-radius: 24px; cursor: pointer; transition: 0.2s; }
+    .toggle .slider::before { content: ""; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: white; border-radius: 50%; transition: 0.2s; }
+    .toggle input:checked + .slider { background: #d97757; }
+    .toggle input:checked + .slider::before { transform: translateX(20px); }
+    .btn-delete { background: #c44; color: white; padding: 0.3rem 0.6rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.75rem; font-family: 'Poppins', sans-serif; }
+    .btn-delete:hover { background: #a33; }
+    .summary { margin-top: 1rem; color: #b0aea5; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <h1>Eval Set Review: <span id="skill-name">__SKILL_NAME_PLACEHOLDER__</span></h1>
+  <p class="description">Current description: <span id="skill-desc">__SKILL_DESCRIPTION_PLACEHOLDER__</span></p>
+
+  <div class="controls">
+    <button class="btn btn-add" onclick="addRow()">+ Add Query</button>
+    <button class="btn btn-export" onclick="exportEvalSet()">Export Eval Set</button>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th style="width:65%">Query</th>
+        <th style="width:18%">Should Trigger</th>
+        <th style="width:10%">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="eval-body"></tbody>
+  </table>
+
+  <p class="summary" id="summary"></p>
+
+  <script>
+    const EVAL_DATA = __EVAL_DATA_PLACEHOLDER__;
+
+    let evalItems = [...EVAL_DATA];
+
+    function render() {
+      const tbody = document.getElementById('eval-body');
+      tbody.innerHTML = '';
+
+      // Sort: should-trigger first, then should-not-trigger
+      const sorted = evalItems
+        .map((item, origIdx) => ({ ...item, origIdx }))
+        .sort((a, b) => (b.should_trigger ? 1 : 0) - (a.should_trigger ? 1 : 0));
+
+      let lastGroup = null;
+      sorted.forEach(item => {
+        const group = item.should_trigger ? 'trigger' : 'no-trigger';
+        if (group !== lastGroup) {
+          const headerRow = document.createElement('tr');
+          headerRow.className = 'section-header';
+          headerRow.innerHTML = `<td colspan="3">${item.should_trigger ? 'Should Trigger' : 'Should NOT Trigger'}</td>`;
+          tbody.appendChild(headerRow);
+          lastGroup = group;
+        }
+
+        const idx = item.origIdx;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><textarea class="query-input" onchange="updateQuery(${idx}, this.value)">${escapeHtml(item.query)}</textarea></td>
+          <td>
+            <label class="toggle">
+              <input type="checkbox" ${item.should_trigger ? 'checked' : ''} onchange="updateTrigger(${idx}, this.checked)">
+              <span class="slider"></span>
+            </label>
+            <span style="margin-left:8px;font-size:0.8rem;color:#b0aea5">${item.should_trigger ? 'Yes' : 'No'}</span>
+          </td>
+          <td><button class="btn-delete" onclick="deleteRow(${idx})">Delete</button></td>
+        `;
+        tbody.appendChild(tr);
+      });
+      updateSummary();
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function updateQuery(idx, value) { evalItems[idx].query = value; updateSummary(); }
+    function updateTrigger(idx, value) { evalItems[idx].should_trigger = value; render(); }
+    function deleteRow(idx) { evalItems.splice(idx, 1); render(); }
+
+    function addRow() {
+      evalItems.push({ query: '', should_trigger: true });
+      render();
+      const inputs = document.querySelectorAll('.query-input');
+      inputs[inputs.length - 1].focus();
+    }
+
+    function updateSummary() {
+      const trigger = evalItems.filter(i => i.should_trigger).length;
+      const noTrigger = evalItems.filter(i => !i.should_trigger).length;
+      document.getElementById('summary').textContent =
+        `${evalItems.length} queries total: ${trigger} should trigger, ${noTrigger} should not trigger`;
+    }
+
+    function exportEvalSet() {
+      const valid = evalItems.filter(i => i.query.trim() !== '');
+      const data = valid.map(i => ({ query: i.query.trim(), should_trigger: i.should_trigger }));
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'eval_set.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/.github/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.github/skills/skill-creator/eval-viewer/generate_review.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Generate and serve a review page for eval results.
+
+Reads the workspace directory, discovers runs (directories with outputs/),
+embeds all output data into a self-contained HTML page, and serves it via
+a tiny HTTP server. Feedback auto-saves to feedback.json in the workspace.
+
+Usage:
+    python generate_review.py <workspace-path> [--port PORT] [--skill-name NAME]
+    python generate_review.py <workspace-path> --previous-feedback /path/to/old/feedback.json
+
+No dependencies beyond the Python stdlib are required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+# Files to exclude from output listings
+METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
+
+# Extensions we render as inline text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".json", ".csv", ".py", ".js", ".ts", ".tsx", ".jsx",
+    ".yaml", ".yml", ".xml", ".html", ".css", ".sh", ".rb", ".go", ".rs",
+    ".java", ".c", ".cpp", ".h", ".hpp", ".sql", ".r", ".toml",
+}
+
+# Extensions we render as inline images
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# MIME type overrides for common types
+MIME_OVERRIDES = {
+    ".svg": "image/svg+xml",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def get_mime_type(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in MIME_OVERRIDES:
+        return MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+def find_runs(workspace: Path) -> list[dict]:
+    """Recursively find directories that contain an outputs/ subdirectory."""
+    runs: list[dict] = []
+    _find_runs_recursive(workspace, workspace, runs)
+    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    return runs
+
+
+def _find_runs_recursive(root: Path, current: Path, runs: list[dict]) -> None:
+    if not current.is_dir():
+        return
+
+    outputs_dir = current / "outputs"
+    if outputs_dir.is_dir():
+        run = build_run(root, current)
+        if run:
+            runs.append(run)
+        return
+
+    skip = {"node_modules", ".git", "__pycache__", "skill", "inputs"}
+    for child in sorted(current.iterdir()):
+        if child.is_dir() and child.name not in skip:
+            _find_runs_recursive(root, child, runs)
+
+
+def build_run(root: Path, run_dir: Path) -> dict | None:
+    """Build a run dict with prompt, outputs, and grading data."""
+    prompt = ""
+    eval_id = None
+
+    # Try eval_metadata.json
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+        if candidate.exists():
+            try:
+                metadata = json.loads(candidate.read_text())
+                prompt = metadata.get("prompt", "")
+                eval_id = metadata.get("eval_id")
+            except (json.JSONDecodeError, OSError):
+                pass
+            if prompt:
+                break
+
+    # Fall back to transcript.md
+    if not prompt:
+        for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
+            if candidate.exists():
+                try:
+                    text = candidate.read_text()
+                    match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
+                    if match:
+                        prompt = match.group(1).strip()
+                except OSError:
+                    pass
+                if prompt:
+                    break
+
+    if not prompt:
+        prompt = "(No prompt found)"
+
+    run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
+
+    # Collect output files
+    outputs_dir = run_dir / "outputs"
+    output_files: list[dict] = []
+    if outputs_dir.is_dir():
+        for f in sorted(outputs_dir.iterdir()):
+            if f.is_file() and f.name not in METADATA_FILES:
+                output_files.append(embed_file(f))
+
+    # Load grading if present
+    grading = None
+    for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
+        if candidate.exists():
+            try:
+                grading = json.loads(candidate.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+            if grading:
+                break
+
+    return {
+        "id": run_id,
+        "prompt": prompt,
+        "eval_id": eval_id,
+        "outputs": output_files,
+        "grading": grading,
+    }
+
+
+def embed_file(path: Path) -> dict:
+    """Read a file and return an embedded representation."""
+    ext = path.suffix.lower()
+    mime = get_mime_type(path)
+
+    if ext in TEXT_EXTENSIONS:
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            content = "(Error reading file)"
+        return {
+            "name": path.name,
+            "type": "text",
+            "content": content,
+        }
+    elif ext in IMAGE_EXTENSIONS:
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "image",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".pdf":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "pdf",
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".xlsx":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "xlsx",
+            "data_b64": b64,
+        }
+    else:
+        # Binary / unknown — base64 download link
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "binary",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+
+
+def load_previous_iteration(workspace: Path) -> dict[str, dict]:
+    """Load previous iteration's feedback and outputs.
+
+    Returns a map of run_id -> {"feedback": str, "outputs": list[dict]}.
+    """
+    result: dict[str, dict] = {}
+
+    # Load feedback
+    feedback_map: dict[str, str] = {}
+    feedback_path = workspace / "feedback.json"
+    if feedback_path.exists():
+        try:
+            data = json.loads(feedback_path.read_text())
+            feedback_map = {
+                r["run_id"]: r["feedback"]
+                for r in data.get("reviews", [])
+                if r.get("feedback", "").strip()
+            }
+        except (json.JSONDecodeError, OSError, KeyError):
+            pass
+
+    # Load runs (to get outputs)
+    prev_runs = find_runs(workspace)
+    for run in prev_runs:
+        result[run["id"]] = {
+            "feedback": feedback_map.get(run["id"], ""),
+            "outputs": run.get("outputs", []),
+        }
+
+    # Also add feedback for run_ids that had feedback but no matching run
+    for run_id, fb in feedback_map.items():
+        if run_id not in result:
+            result[run_id] = {"feedback": fb, "outputs": []}
+
+    return result
+
+
+def generate_html(
+    runs: list[dict],
+    skill_name: str,
+    previous: dict[str, dict] | None = None,
+    benchmark: dict | None = None,
+) -> str:
+    """Generate the complete standalone HTML page with embedded data."""
+    template_path = Path(__file__).parent / "viewer.html"
+    template = template_path.read_text()
+
+    # Build previous_feedback and previous_outputs maps for the template
+    previous_feedback: dict[str, str] = {}
+    previous_outputs: dict[str, list[dict]] = {}
+    if previous:
+        for run_id, data in previous.items():
+            if data.get("feedback"):
+                previous_feedback[run_id] = data["feedback"]
+            if data.get("outputs"):
+                previous_outputs[run_id] = data["outputs"]
+
+    embedded = {
+        "skill_name": skill_name,
+        "runs": runs,
+        "previous_feedback": previous_feedback,
+        "previous_outputs": previous_outputs,
+    }
+    if benchmark:
+        embedded["benchmark"] = benchmark
+
+    data_json = json.dumps(embedded)
+
+    return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server (stdlib only, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _kill_port(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for pid_str in result.stdout.strip().split("\n"):
+            if pid_str.strip():
+                try:
+                    os.kill(int(pid_str.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+        if result.stdout.strip():
+            time.sleep(0.5)
+    except subprocess.TimeoutExpired:
+        pass
+    except FileNotFoundError:
+        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
+
+class ReviewHandler(BaseHTTPRequestHandler):
+    """Serves the review HTML and handles feedback saves.
+
+    Regenerates the HTML on each page load so that refreshing the browser
+    picks up new eval outputs without restarting the server.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        skill_name: str,
+        feedback_path: Path,
+        previous: dict[str, dict],
+        benchmark_path: Path | None,
+        *args,
+        **kwargs,
+    ):
+        self.workspace = workspace
+        self.skill_name = skill_name
+        self.feedback_path = feedback_path
+        self.previous = previous
+        self.benchmark_path = benchmark_path
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/" or self.path == "/index.html":
+            # Regenerate HTML on each request (re-scans workspace for new outputs)
+            runs = find_runs(self.workspace)
+            benchmark = None
+            if self.benchmark_path and self.benchmark_path.exists():
+                try:
+                    benchmark = json.loads(self.benchmark_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            html = generate_html(runs, self.skill_name, self.previous, benchmark)
+            content = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        elif self.path == "/api/feedback":
+            data = b"{}"
+            if self.feedback_path.exists():
+                data = self.feedback_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path == "/api/feedback":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                if not isinstance(data, dict) or "reviews" not in data:
+                    raise ValueError("Expected JSON object with 'reviews' key")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                resp = b'{"ok":true}'
+                self.send_response(200)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
+                resp = json.dumps({"error": str(e)}).encode()
+                self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress request logging to keep terminal clean
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and serve eval review")
+    parser.add_argument("workspace", type=Path, help="Path to workspace directory")
+    parser.add_argument("--port", "-p", type=int, default=3117, help="Server port (default: 3117)")
+    parser.add_argument("--skill-name", "-n", type=str, default=None, help="Skill name for header")
+    parser.add_argument(
+        "--previous-workspace", type=Path, default=None,
+        help="Path to previous iteration's workspace (shows old outputs and feedback as context)",
+    )
+    parser.add_argument(
+        "--benchmark", type=Path, default=None,
+        help="Path to benchmark.json to show in the Benchmark tab",
+    )
+    parser.add_argument(
+        "--static", "-s", type=Path, default=None,
+        help="Write standalone HTML to this path instead of starting a server",
+    )
+    args = parser.parse_args()
+
+    workspace = args.workspace.resolve()
+    if not workspace.is_dir():
+        print(f"Error: {workspace} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    runs = find_runs(workspace)
+    if not runs:
+        print(f"No runs found in {workspace}", file=sys.stderr)
+        sys.exit(1)
+
+    skill_name = args.skill_name or workspace.name.replace("-workspace", "")
+    feedback_path = workspace / "feedback.json"
+
+    previous: dict[str, dict] = {}
+    if args.previous_workspace:
+        previous = load_previous_iteration(args.previous_workspace.resolve())
+
+    benchmark_path = args.benchmark.resolve() if args.benchmark else None
+    benchmark = None
+    if benchmark_path and benchmark_path.exists():
+        try:
+            benchmark = json.loads(benchmark_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if args.static:
+        html = generate_html(runs, skill_name, previous, benchmark)
+        args.static.parent.mkdir(parents=True, exist_ok=True)
+        args.static.write_text(html)
+        print(f"\n  Static viewer written to: {args.static}\n")
+        sys.exit(0)
+
+    # Kill any existing process on the target port
+    port = args.port
+    _kill_port(port)
+    handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
+    try:
+        server = HTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        # Port still in use after kill attempt — find a free one
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+
+    url = f"http://localhost:{port}"
+    print(f"\n  Eval Viewer")
+    print(f"  ─────────────────────────────────")
+    print(f"  URL:       {url}")
+    print(f"  Workspace: {workspace}")
+    print(f"  Feedback:  {feedback_path}")
+    if previous:
+        print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
+    if benchmark_path:
+        print(f"  Benchmark: {benchmark_path}")
+    print(f"\n  Press Ctrl+C to stop.\n")
+
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/eval-viewer/viewer.html
+++ b/.github/skills/skill-creator/eval-viewer/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    /*__EMBEDDED_DATA__*/
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/.github/skills/skill-creator/references/schemas.md
+++ b/.github/skills/skill-creator/references/schemas.md
@@ -1,0 +1,430 @@
+# JSON Schemas
+
+This document defines the JSON schemas used by skill-creator.
+
+---
+
+## evals.json
+
+Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample1.pdf"],
+      "expectations": [
+        "The output includes X",
+        "The skill used script Y"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Name matching the skill's frontmatter
+- `evals[].id`: Unique integer identifier
+- `evals[].prompt`: The task to execute
+- `evals[].expected_output`: Human-readable description of success
+- `evals[].files`: Optional list of input file paths (relative to skill root)
+- `evals[].expectations`: List of verifiable statements
+
+---
+
+## history.json
+
+Tracks version progression in Improve mode. Located at workspace root.
+
+```json
+{
+  "started_at": "2026-01-15T10:30:00Z",
+  "skill_name": "pdf",
+  "current_best": "v2",
+  "iterations": [
+    {
+      "version": "v0",
+      "parent": null,
+      "expectation_pass_rate": 0.65,
+      "grading_result": "baseline",
+      "is_current_best": false
+    },
+    {
+      "version": "v1",
+      "parent": "v0",
+      "expectation_pass_rate": 0.75,
+      "grading_result": "won",
+      "is_current_best": false
+    },
+    {
+      "version": "v2",
+      "parent": "v1",
+      "expectation_pass_rate": 0.85,
+      "grading_result": "won",
+      "is_current_best": true
+    }
+  ]
+}
+```
+
+**Fields:**
+- `started_at`: ISO timestamp of when improvement started
+- `skill_name`: Name of the skill being improved
+- `current_best`: Version identifier of the best performer
+- `iterations[].version`: Version identifier (v0, v1, ...)
+- `iterations[].parent`: Parent version this was derived from
+- `iterations[].expectation_pass_rate`: Pass rate from grading
+- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
+- `iterations[].is_current_best`: Whether this is the current best version
+
+---
+
+## grading.json
+
+Output from the grader agent. Located at `<run-dir>/grading.json`.
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness."
+  }
+}
+```
+
+**Fields:**
+- `expectations[]`: Graded expectations with evidence
+- `summary`: Aggregate pass/fail counts
+- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
+- `timing`: Wall clock timing (from timing.json)
+- `claims`: Extracted and verified claims from the output
+- `user_notes_summary`: Issues flagged by the executor
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+
+---
+
+## metrics.json
+
+Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+
+```json
+{
+  "tool_calls": {
+    "Read": 5,
+    "Write": 2,
+    "Bash": 8,
+    "Edit": 1,
+    "Glob": 2,
+    "Grep": 0
+  },
+  "total_tool_calls": 18,
+  "total_steps": 6,
+  "files_created": ["filled_form.pdf", "field_values.json"],
+  "errors_encountered": 0,
+  "output_chars": 12450,
+  "transcript_chars": 3200
+}
+```
+
+**Fields:**
+- `tool_calls`: Count per tool type
+- `total_tool_calls`: Sum of all tool calls
+- `total_steps`: Number of major execution steps
+- `files_created`: List of output files created
+- `errors_encountered`: Number of errors during execution
+- `output_chars`: Total character count of output files
+- `transcript_chars`: Character count of transcript
+
+---
+
+## timing.json
+
+Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+
+**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3,
+  "executor_start": "2026-01-15T10:30:00Z",
+  "executor_end": "2026-01-15T10:32:45Z",
+  "executor_duration_seconds": 165.0,
+  "grader_start": "2026-01-15T10:32:46Z",
+  "grader_end": "2026-01-15T10:33:12Z",
+  "grader_duration_seconds": 26.0
+}
+```
+
+---
+
+## benchmark.json
+
+Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+
+```json
+{
+  "metadata": {
+    "skill_name": "pdf",
+    "skill_path": "/path/to/pdf",
+    "executor_model": "claude-sonnet-4-20250514",
+    "analyzer_model": "most-capable-model",
+    "timestamp": "2026-01-15T10:30:00Z",
+    "evals_run": [1, 2, 3],
+    "runs_per_configuration": 3
+  },
+
+  "runs": [
+    {
+      "eval_id": 1,
+      "eval_name": "Ocean",
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.85,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 42.5,
+        "tokens": 3800,
+        "tool_calls": 18,
+        "errors": 0
+      },
+      "expectations": [
+        {"text": "...", "passed": true, "evidence": "..."}
+      ],
+      "notes": [
+        "Used 2023 data, may be stale",
+        "Fell back to text overlay for non-fillable fields"
+      ]
+    }
+  ],
+
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.85, "stddev": 0.05, "min": 0.80, "max": 0.90},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0, "min": 32.0, "max": 58.0},
+      "tokens": {"mean": 3800, "stddev": 400, "min": 3200, "max": 4100}
+    },
+    "without_skill": {
+      "pass_rate": {"mean": 0.35, "stddev": 0.08, "min": 0.28, "max": 0.45},
+      "time_seconds": {"mean": 32.0, "stddev": 8.0, "min": 24.0, "max": 42.0},
+      "tokens": {"mean": 2100, "stddev": 300, "min": 1800, "max": 2500}
+    },
+    "delta": {
+      "pass_rate": "+0.50",
+      "time_seconds": "+13.0",
+      "tokens": "+1700"
+    }
+  },
+
+  "notes": [
+    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
+    "Without-skill runs consistently fail on table extraction expectations",
+    "Skill adds 13s average execution time but improves pass rate by 50%"
+  ]
+}
+```
+
+**Fields:**
+- `metadata`: Information about the benchmark run
+  - `skill_name`: Name of the skill
+  - `timestamp`: When the benchmark was run
+  - `evals_run`: List of eval names or IDs
+  - `runs_per_configuration`: Number of runs per config (e.g. 3)
+- `runs[]`: Individual run results
+  - `eval_id`: Numeric eval identifier
+  - `eval_name`: Human-readable eval name (used as section header in the viewer)
+  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
+  - `run_number`: Integer run number (1, 2, 3...)
+  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
+- `run_summary`: Statistical aggregates per configuration
+  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
+  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
+- `notes`: Freeform observations from the analyzer
+
+**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+
+---
+
+## comparison.json
+
+Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## analysis.json
+
+Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": ["Minor: skipped optional logging step"]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+  }
+}
+```

--- a/.github/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.github/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Aggregate individual run results into benchmark summary statistics.
+
+Reads grading.json files from run directories and produces:
+- run_summary with mean, stddev, min, max for each metric
+- delta between with_skill and without_skill configurations
+
+Usage:
+    python aggregate_benchmark.py <benchmark_dir>
+
+Example:
+    python aggregate_benchmark.py benchmarks/2026-01-15T10-30-00/
+
+The script supports two directory layouts:
+
+    Workspace layout (from skill-creator iterations):
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/
+        │   ├── run-1/grading.json
+        │   └── run-2/grading.json
+        └── without_skill/
+            ├── run-1/grading.json
+            └── run-2/grading.json
+
+    Legacy layout (with runs/ subdirectory):
+    <benchmark_dir>/
+    └── runs/
+        └── eval-N/
+            ├── with_skill/
+            │   └── run-1/grading.json
+            └── without_skill/
+                └── run-1/grading.json
+"""
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def calculate_stats(values: list[float]) -> dict:
+    """Calculate mean, stddev, min, max for a list of values."""
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+
+    if n > 1:
+        variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
+
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4)
+    }
+
+
+def load_run_results(benchmark_dir: Path) -> dict:
+    """
+    Load all run results from a benchmark directory.
+
+    Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
+    or "new_skill"/"old_skill"), each containing a list of run results.
+    """
+    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    runs_dir = benchmark_dir / "runs"
+    if runs_dir.exists():
+        search_dir = runs_dir
+    elif list(benchmark_dir.glob("eval-*")):
+        search_dir = benchmark_dir
+    else:
+        print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
+        return {}
+
+    results: dict[str, list] = {}
+
+    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+        metadata_path = eval_dir / "eval_metadata.json"
+        if metadata_path.exists():
+            try:
+                with open(metadata_path) as mf:
+                    eval_id = json.load(mf).get("eval_id", eval_idx)
+            except (json.JSONDecodeError, OSError):
+                eval_id = eval_idx
+        else:
+            try:
+                eval_id = int(eval_dir.name.split("-")[1])
+            except ValueError:
+                eval_id = eval_idx
+
+        # Discover config directories dynamically rather than hardcoding names
+        for config_dir in sorted(eval_dir.iterdir()):
+            if not config_dir.is_dir():
+                continue
+            # Skip non-config directories (inputs, outputs, etc.)
+            if not list(config_dir.glob("run-*")):
+                continue
+            config = config_dir.name
+            if config not in results:
+                results[config] = []
+
+            for run_dir in sorted(config_dir.glob("run-*")):
+                run_number = int(run_dir.name.split("-")[1])
+                grading_file = run_dir / "grading.json"
+
+                if not grading_file.exists():
+                    print(f"Warning: grading.json not found in {run_dir}")
+                    continue
+
+                try:
+                    with open(grading_file) as f:
+                        grading = json.load(f)
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
+                    continue
+
+                # Extract metrics
+                result = {
+                    "eval_id": eval_id,
+                    "run_number": run_number,
+                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+                    "passed": grading.get("summary", {}).get("passed", 0),
+                    "failed": grading.get("summary", {}).get("failed", 0),
+                    "total": grading.get("summary", {}).get("total", 0),
+                }
+
+                # Extract timing — check grading.json first, then sibling timing.json
+                timing = grading.get("timing", {})
+                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+                timing_file = run_dir / "timing.json"
+                if result["time_seconds"] == 0.0 and timing_file.exists():
+                    try:
+                        with open(timing_file) as tf:
+                            timing_data = json.load(tf)
+                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+                        result["tokens"] = timing_data.get("total_tokens", 0)
+                    except json.JSONDecodeError:
+                        pass
+
+                # Extract metrics if available
+                metrics = grading.get("execution_metrics", {})
+                result["tool_calls"] = metrics.get("total_tool_calls", 0)
+                if not result.get("tokens"):
+                    result["tokens"] = metrics.get("output_chars", 0)
+                result["errors"] = metrics.get("errors_encountered", 0)
+
+                # Extract expectations — viewer requires fields: text, passed, evidence
+                raw_expectations = grading.get("expectations", [])
+                for exp in raw_expectations:
+                    if "text" not in exp or "passed" not in exp:
+                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+                result["expectations"] = raw_expectations
+
+                # Extract notes from user_notes_summary
+                notes_summary = grading.get("user_notes_summary", {})
+                notes = []
+                notes.extend(notes_summary.get("uncertainties", []))
+                notes.extend(notes_summary.get("needs_review", []))
+                notes.extend(notes_summary.get("workarounds", []))
+                result["notes"] = notes
+
+                results[config].append(result)
+
+    return results
+
+
+def aggregate_results(results: dict) -> dict:
+    """
+    Aggregate run results into summary statistics.
+
+    Returns run_summary with stats for each configuration and delta.
+    """
+    run_summary = {}
+    configs = list(results.keys())
+
+    for config in configs:
+        runs = results.get(config, [])
+
+        if not runs:
+            run_summary[config] = {
+                "pass_rate": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "time_seconds": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "tokens": {"mean": 0, "stddev": 0, "min": 0, "max": 0}
+            }
+            continue
+
+        pass_rates = [r["pass_rate"] for r in runs]
+        times = [r["time_seconds"] for r in runs]
+        tokens = [r.get("tokens", 0) for r in runs]
+
+        run_summary[config] = {
+            "pass_rate": calculate_stats(pass_rates),
+            "time_seconds": calculate_stats(times),
+            "tokens": calculate_stats(tokens)
+        }
+
+    # Calculate delta between the first two configs (if two exist)
+    if len(configs) >= 2:
+        primary = run_summary.get(configs[0], {})
+        baseline = run_summary.get(configs[1], {})
+    else:
+        primary = run_summary.get(configs[0], {}) if configs else {}
+        baseline = {}
+
+    delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
+    delta_time = primary.get("time_seconds", {}).get("mean", 0) - baseline.get("time_seconds", {}).get("mean", 0)
+    delta_tokens = primary.get("tokens", {}).get("mean", 0) - baseline.get("tokens", {}).get("mean", 0)
+
+    run_summary["delta"] = {
+        "pass_rate": f"{delta_pass_rate:+.2f}",
+        "time_seconds": f"{delta_time:+.1f}",
+        "tokens": f"{delta_tokens:+.0f}"
+    }
+
+    return run_summary
+
+
+def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: str = "") -> dict:
+    """
+    Generate complete benchmark.json from run results.
+    """
+    results = load_run_results(benchmark_dir)
+    run_summary = aggregate_results(results)
+
+    # Build runs array for benchmark.json
+    runs = []
+    for config in results:
+        for result in results[config]:
+            runs.append({
+                "eval_id": result["eval_id"],
+                "configuration": config,
+                "run_number": result["run_number"],
+                "result": {
+                    "pass_rate": result["pass_rate"],
+                    "passed": result["passed"],
+                    "failed": result["failed"],
+                    "total": result["total"],
+                    "time_seconds": result["time_seconds"],
+                    "tokens": result.get("tokens", 0),
+                    "tool_calls": result.get("tool_calls", 0),
+                    "errors": result.get("errors", 0)
+                },
+                "expectations": result["expectations"],
+                "notes": result["notes"]
+            })
+
+    # Determine eval IDs from results
+    eval_ids = sorted(set(
+        r["eval_id"]
+        for config in results.values()
+        for r in config
+    ))
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name or "<skill-name>",
+            "skill_path": skill_path or "<path/to/skill>",
+            "executor_model": "<model-name>",
+            "analyzer_model": "<model-name>",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "evals_run": eval_ids,
+            "runs_per_configuration": 3
+        },
+        "runs": runs,
+        "run_summary": run_summary,
+        "notes": []  # To be filled by analyzer
+    }
+
+    return benchmark
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate human-readable benchmark.md from benchmark data."""
+    metadata = benchmark["metadata"]
+    run_summary = benchmark["run_summary"]
+
+    # Determine config names (excluding "delta")
+    configs = [k for k in run_summary if k != "delta"]
+    config_a = configs[0] if len(configs) >= 1 else "config_a"
+    config_b = configs[1] if len(configs) >= 2 else "config_b"
+    label_a = config_a.replace("_", " ").title()
+    label_b = config_b.replace("_", " ").title()
+
+    lines = [
+        f"# Skill Benchmark: {metadata['skill_name']}",
+        "",
+        f"**Model**: {metadata['executor_model']}",
+        f"**Date**: {metadata['timestamp']}",
+        f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        "",
+        "## Summary",
+        "",
+        f"| Metric | {label_a} | {label_b} | Delta |",
+        "|--------|------------|---------------|-------|",
+    ]
+
+    a_summary = run_summary.get(config_a, {})
+    b_summary = run_summary.get(config_b, {})
+    delta = run_summary.get("delta", {})
+
+    # Format pass rate
+    a_pr = a_summary.get("pass_rate", {})
+    b_pr = b_summary.get("pass_rate", {})
+    lines.append(f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |")
+
+    # Format time
+    a_time = a_summary.get("time_seconds", {})
+    b_time = b_summary.get("time_seconds", {})
+    lines.append(f"| Time | {a_time.get('mean', 0):.1f}s ± {a_time.get('stddev', 0):.1f}s | {b_time.get('mean', 0):.1f}s ± {b_time.get('stddev', 0):.1f}s | {delta.get('time_seconds', '—')}s |")
+
+    # Format tokens
+    a_tokens = a_summary.get("tokens", {})
+    b_tokens = b_summary.get("tokens", {})
+    lines.append(f"| Tokens | {a_tokens.get('mean', 0):.0f} ± {a_tokens.get('stddev', 0):.0f} | {b_tokens.get('mean', 0):.0f} ± {b_tokens.get('stddev', 0):.0f} | {delta.get('tokens', '—')} |")
+
+    # Notes section
+    if benchmark.get("notes"):
+        lines.extend([
+            "",
+            "## Notes",
+            ""
+        ])
+        for note in benchmark["notes"]:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate benchmark run results into summary statistics"
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        type=Path,
+        help="Path to the benchmark directory"
+    )
+    parser.add_argument(
+        "--skill-name",
+        default="",
+        help="Name of the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--skill-path",
+        default="",
+        help="Path to the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output path for benchmark.json (default: <benchmark_dir>/benchmark.json)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.benchmark_dir.exists():
+        print(f"Directory not found: {args.benchmark_dir}")
+        sys.exit(1)
+
+    # Generate benchmark
+    benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # Determine output paths
+    output_json = args.output or (args.benchmark_dir / "benchmark.json")
+    output_md = output_json.with_suffix(".md")
+
+    # Write benchmark.json
+    with open(output_json, "w") as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"Generated: {output_json}")
+
+    # Write benchmark.md
+    markdown = generate_markdown(benchmark)
+    with open(output_md, "w") as f:
+        f.write(markdown)
+    print(f"Generated: {output_md}")
+
+    # Print summary
+    run_summary = benchmark["run_summary"]
+    configs = [k for k in run_summary if k != "delta"]
+    delta = run_summary.get("delta", {})
+
+    print(f"\nSummary:")
+    for config in configs:
+        pr = run_summary[config]["pass_rate"]["mean"]
+        label = config.replace("_", " ").title()
+        print(f"  {label}: {pr*100:.1f}% pass rate")
+    print(f"  Delta:         {delta.get('pass_rate', '—')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/generate_report.py
+++ b/.github/skills/skill-creator/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/improve_description.py
+++ b/.github/skills/skill-creator/scripts/improve_description.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
+uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run `claude -p` with the prompt on stdin and return the text response.
+
+    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
+    body and can easily exceed comfortable argv length.
+    """
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def improve_description(
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy. There is a hard limit of 1024 characters — descriptions over that will be truncated, so stay comfortably under it.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    text = _call_claude(prompt, model)
+
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # Safety net: the prompt already states the 1024-char hard limit, but if
+    # the model blew past it anyway, make one fresh single-turn call that
+    # quotes the too-long version and asks for a shorter rewrite. (The old
+    # SDK path did this as a true multi-turn; `claude -p` is one-shot, so we
+    # inline the prior output into the new prompt instead.)
+    if len(description) > 1024:
+        shorten_prompt = (
+            f"{prompt}\n\n"
+            f"---\n\n"
+            f"A previous attempt produced this description, which at "
+            f"{len(description)} characters is over the 1024-character hard limit:\n\n"
+            f'"{description}"\n\n'
+            f"Rewrite it to be under 1024 characters while keeping the most "
+            f"important trigger words and intent coverage. Respond with only "
+            f"the new description in <new_description> tags."
+        )
+        shorten_text = _call_claude(shorten_prompt, model)
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    new_description = improve_description(
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/package_skill.py
+++ b/.github/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import fnmatch
+import sys
+import zipfile
+from pathlib import Path
+from scripts.quick_validate import validate_skill
+
+# Patterns to exclude when packaging skills.
+EXCLUDE_DIRS = {"__pycache__", "node_modules"}
+EXCLUDE_GLOBS = {"*.pyc"}
+EXCLUDE_FILES = {".DS_Store"}
+# Directories excluded only at the skill root (not when nested deeper).
+ROOT_EXCLUDE_DIRS = {"evals"}
+
+
+def should_exclude(rel_path: Path) -> bool:
+    """Check if a path should be excluded from packaging."""
+    parts = rel_path.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    # rel_path is relative to skill_path.parent, so parts[0] is the skill
+    # folder name and parts[1] (if present) is the first subdir.
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
+        return True
+    name = rel_path.name
+    if name in EXCLUDE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pat) for pat in EXCLUDE_GLOBS)
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory, excluding build artifacts
+            for file_path in skill_path.rglob('*'):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(skill_path.parent)
+                if should_exclude(arcname):
+                    print(f"  Skipped: {arcname}")
+                    continue
+                zipf.write(file_path, arcname)
+                print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/quick_validate.py
+++ b/.github/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.github/skills/skill-creator/scripts/run_eval.py
+++ b/.github/skills/skill-creator/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/run_loop.py
+++ b/.github/skills/skill-creator/scripts/run_loop.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/utils.py
+++ b/.github/skills/skill-creator/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### SDK
 
 - **Accept string tool arguments** - SDK tool execution events now tolerate object, JSON-string, and raw-string argument payloads, preventing contract mismatch failures for tools such as apply-patch.
+- **Align the packaged Copilot runtime** - Chamber now pins `@github/copilot` to `1.0.42-0` so the packaged runtime smoke matches the CLI binary version bundled by npm.
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.41.0 (2026-05-05)
+
+### Lens
+
+- **Add Canvas-backed Lens views** - Lens manifests can now declare `view: "canvas"` with an HTML source that renders inside Chamber through the Canvas server, preserving Activity Bar discovery while enabling richer Chamber-native UI.
+- **Bridge Canvas Lens actions to minds** - Embedded Canvas Lens pages can call `window.canvas.sendAction(...)`, and Chamber routes token-gated actions back to the owning mind without exposing Electron or SDK access to generated HTML.
+- **Upgrade the managed Lens skill** - Chamber now installs and upgrades the mind-local Lens skill to the Canvas Lens contract, clobbering exact old bundled skills while preserving locally edited managed or legacy-looking copies.
+
+### SDK
+
+- **Accept string tool arguments** - SDK tool execution events now tolerate object, JSON-string, and raw-string argument payloads, preventing contract mismatch failures for tools such as apply-patch.
+
+### Testing
+
+- **Smoke Canvas Lens rendering and actions** - Electron Lens smoke coverage now verifies Canvas Lens discovery, in-app rendering, and the iframe action bridge.
+
 ## v0.40.0 (2026-05-05)
 
 ### Chat

--- a/ai-docs/managed-mind-skills.md
+++ b/ai-docs/managed-mind-skills.md
@@ -1,0 +1,169 @@
+# Managed Mind Skills
+
+Chamber can equip minds with managed skills at runtime. A managed skill is a Chamber-owned capability guide that is installed into each mind under `.github/skills/<name>/`, versioned with Chamber metadata, and upgraded as Chamber learns better ways to use that capability.
+
+Use this pattern when Chamber needs to teach minds a workflow, product contract, or taste layer without permanently expanding the always-loaded tool surface.
+
+## When to create a managed skill
+
+Create a managed skill when the capability is mostly about **how** the mind should think, write, or operate:
+
+- product workflows, such as creating Chamber Lens views;
+- UI and brand guidance;
+- file layout conventions;
+- examples, checklists, and anti-patterns;
+- progressive instructions that should load only when relevant.
+
+Prefer a runtime tool when Chamber must enforce a hard boundary:
+
+- credential access;
+- filesystem safety beyond the mind workspace;
+- privileged operations;
+- deterministic validation or side effects;
+- operations that must not depend on model judgment.
+
+The Lens split is the reference model: Lens discovery and Canvas rendering enforce service-level safety, while the Lens skill teaches the mind how to create useful, Chamber-branded views.
+
+## Repository layout
+
+Bundled managed skills live under desktop assets:
+
+```text
+apps/desktop/src/main/assets/<skill-name>-skill/
+  SKILL.md
+  references/      # optional, for deeper docs
+  scripts/         # optional, for deterministic helpers
+  assets/          # optional, templates or static files
+```
+
+The current Lens skill lives at:
+
+```text
+apps/desktop/src/main/assets/lens-skill/SKILL.md
+```
+
+Contributor-facing skills used while developing Chamber can live under:
+
+```text
+.github/skills/<skill-name>/
+```
+
+For example, Chamber vendors Anthropic's `skill-creator` skill in `.github/skills/skill-creator/` so contributors can use it to design and improve future managed skills.
+
+## Skill file structure
+
+Follow the progressive-disclosure model used by Anthropic skills:
+
+1. **Metadata**: `name` and `description` are always visible to the model and drive triggering.
+2. **`SKILL.md` body**: loaded when the skill triggers; keep it concise and operational.
+3. **Bundled resources**: references, scripts, and assets loaded only when needed.
+
+The frontmatter description should be pushy enough to trigger in real user language. Include synonyms and debugging contexts.
+
+```markdown
+---
+name: lens
+version: 2.0.0
+description: Create, inspect, fix, and manage Chamber Lens views. Use this skill whenever the user mentions Lens, lenses, Chamber views, dashboards, panels, reports, forms, command centers, app-like screens, self-modifying UI, or says a Lens icon/view is missing. Always use this skill before creating or editing files under .github/lens.
+---
+```
+
+Put non-negotiable contracts in the first screenful of `SKILL.md`. If a mind only skims the top of the file, it should still see the required schema, file names, and anti-patterns.
+
+## Authoring checklist
+
+When creating or updating a managed skill:
+
+1. Define the exact user phrases and contexts that should trigger the skill.
+2. Put those triggers in the frontmatter `description`.
+3. Put required contracts before explanation or examples.
+4. Include at least one valid minimal example.
+5. Include common invalid examples or forbidden field names when mistakes are likely.
+6. Add a mechanical completion checklist the mind can run before reporting success.
+7. Keep subjective quality guidance in the skill, not in permanent tools.
+8. Keep hard safety enforcement in services, IPC, or runtime tools.
+9. Add install/upgrade tests for missing, managed, legacy, and locally edited skills.
+10. Test with a real mind conversation when the skill affects agent behavior.
+
+## Installation and upgrades
+
+Managed skills are installed by Chamber bootstrap code, not by Genesis templates. This lets Chamber progressively equip existing and newly created minds.
+
+The bootstrap path should be idempotent and safe to call from:
+
+- existing-agent import;
+- mind load/session creation;
+- Genesis scaffold activation;
+- Genesis template activation.
+
+Use a shared helper, such as `bootstrapMindCapabilities(mindPath)`, when multiple capability seeds must run together.
+
+For each managed skill, write metadata next to the installed skill:
+
+```text
+.github/skills/<skill-name>/
+  SKILL.md
+  .chamber-skill.json
+```
+
+Example metadata:
+
+```json
+{
+  "name": "lens",
+  "version": "2.0.0",
+  "managedBy": "chamber",
+  "contentSha256": "<sha256 of installed SKILL.md>",
+  "capabilities": ["lens-json", "canvas-lens", "chamber-theme-v1"]
+}
+```
+
+Upgrade policy:
+
+- Install when missing.
+- Upgrade managed skills when metadata says Chamber owns the file and the checksum still matches.
+- Preserve locally edited managed skills and log a warning.
+- For old unversioned Chamber-shaped skills, back up the previous file and install the managed version.
+- Preserve unmanaged skills that do not look like the Chamber-owned skill.
+
+Backups should stay beside the skill:
+
+```text
+SKILL.legacy-backup.md
+SKILL.legacy-backup-1.md
+```
+
+## Packaging
+
+If a managed skill must be available in packaged Chamber builds, include its asset directory in packaging resources. The Lens skill is copied through the desktop packaging config so packaged minds can be upgraded without needing source files.
+
+When introducing another managed skill, verify both development and packaged asset lookup paths.
+
+## Testing expectations
+
+Add focused tests for:
+
+- installing the skill when missing;
+- reading the skill from packaged resources;
+- upgrading managed unmodified skills;
+- preserving locally edited managed skills;
+- migrating legacy unversioned Chamber-owned skills with a backup;
+- preserving unrelated unmanaged skills;
+- calling the bootstrap path before SDK session creation.
+
+For behavior-sensitive skills, also run a manual mind conversation. Ask a realistic prompt and inspect the resulting files. If the mind misses the contract, improve the skill before adding tools.
+
+## Lessons from Lens
+
+The Lens skill originally put the Canvas manifest shape below general workflow prose. A mind manually inspected only the top of the file and created an invalid manifest using `title` and `renderer`. Chamber correctly ignored the view because discovery requires `name`, `icon`, `view`, and `source`.
+
+The fix was not a Lens-specific creation tool. The better skill design was:
+
+- make the trigger description include missing-icon and view-debugging scenarios;
+- move the required manifest schema to the top;
+- explicitly forbid likely wrong fields;
+- add a final validation checklist;
+- keep UI brand guidance in the skill;
+- keep runtime validation in Lens discovery and Canvas services.
+
+Use that pattern for future Chamber-managed skills.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -154,7 +154,28 @@ chatroomApprovalGate.setApprovalHandler(async (request) => ({
   reason: 'Chatroom approval UI is not wired yet; side-effect tools are blocked.',
 }));
 const chatroomService = new ChatroomService(mindManager, appPaths, chatroomApprovalGate);
-const canvasService = new CanvasService({ openExternal: { open: (url) => shell.openExternal(url) } });
+const canvasService = new CanvasService({
+  onAction: (action) => {
+    if (!action.lensViewId) {
+      log.info('Canvas action received:', action);
+      return;
+    }
+
+    const mindPath = mindManager.getMind(action.mindId)?.mindPath;
+    if (!mindPath) {
+      log.warn(`Canvas Lens action for unknown mind: ${action.mindId}`);
+      return;
+    }
+
+    void viewDiscovery.sendCanvasAction(action.lensViewId, {
+      action: action.action,
+      data: action.data,
+    }, mindPath).catch((error: unknown) => {
+      log.warn('Canvas Lens action failed:', error);
+    });
+  },
+  openExternal: { open: (url) => shell.openExternal(url) },
+});
 const cronService = new CronService({
   getTaskManager: () => taskManager,
   showMind: (mindId) => {
@@ -165,7 +186,7 @@ const cronService = new CronService({
 });
 const a2aToolProvider = new A2aToolProvider(messageRouter, agentCardRegistry, taskManager);
 
-mindManager.setProviders([cronService, canvasService, a2aToolProvider]);
+mindManager.setProviders([cronService, canvasService, viewDiscovery, a2aToolProvider]);
 
 wireLifecycleEvents({ mindManager, agentCardRegistry, taskManager, a2aEventBus });
 
@@ -435,7 +456,7 @@ app.on('ready', async () => {
     rendererPath: MAIN_WINDOW_VITE_DEV_SERVER_URL ? undefined : path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`),
     windowIcon,
   });
-  setupLensIPC(viewDiscovery, mindManager);
+  setupLensIPC(viewDiscovery, mindManager, canvasService);
   setupGenesisIPC(
     mindManager,
     scaffold,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -186,7 +186,7 @@ const cronService = new CronService({
 });
 const a2aToolProvider = new A2aToolProvider(messageRouter, agentCardRegistry, taskManager);
 
-mindManager.setProviders([cronService, canvasService, viewDiscovery, a2aToolProvider]);
+mindManager.setProviders([cronService, canvasService, a2aToolProvider]);
 
 wireLifecycleEvents({ mindManager, agentCardRegistry, taskManager, a2aEventBus });
 

--- a/apps/desktop/src/main/assets/lens-skill/SKILL.md
+++ b/apps/desktop/src/main/assets/lens-skill/SKILL.md
@@ -1,151 +1,167 @@
 ---
 name: lens
-description: Create and manage Lens views — declarative UI panels that appear in the Chamber activity bar. Use when the user asks to "create a view", "show me X in the UI", "add a dashboard", "make a panel for", or wants to visualize data, config, or status in the desktop app.
+version: 2.0.0
+description: Create and manage Chamber Lens views, including structured JSON views and rich Canvas-backed Chamber-native UI. Use when the user asks to create a view, dashboard, panel, report, form, command center, or app-like screen inside Chamber.
 ---
 
-# Lens — Declarative UI Views
+# Lens — Chamber Views
 
-Create `view.json` manifests in `.github/lens/<view-name>/` to add views to the Chamber activity bar.
+Create views in `.github/lens/<view-name>/` to add panels to the Chamber activity bar. Lens is the navigation and discovery model. Use the right renderer for the job:
 
-## Creating a View
+- Use classic JSON Lens views for simple structured data.
+- Use Canvas Lens views for rich dashboards, workflows, reports, forms, and app-like UI.
 
-1. Create `.github/lens/<view-name>/view.json`
-2. The UI discovers it automatically — a new icon appears
-3. For prompt-driven views, you write the data file when the user clicks Refresh
+## Creating Views
 
-## view.json Reference
+Prefer the `lens_create` tool whenever it is available. It creates the Lens directory, `view.json`, and source file in one operation, so you do not need shell access or a separate mkdir step.
+
+Example Canvas Lens creation:
+
+```json
+{
+  "viewId": "cron-jobs",
+  "name": "Cron Jobs",
+  "icon": "clock",
+  "view": "canvas",
+  "source": "index.html",
+  "content": "<!doctype html><html><body class=\"ch-page\"><section class=\"ch-card\"><h1>Cron Jobs</h1></section></body></html>"
+}
+```
+
+Example classic JSON Lens creation:
+
+```json
+{
+  "viewId": "cron-table",
+  "name": "Cron Table",
+  "icon": "clock",
+  "view": "table",
+  "source": "data.json",
+  "content": [{ "name": "Daily smoke", "status": "enabled" }]
+}
+```
+
+Only fall back to direct file creation when `lens_create` is not available and the parent directory already exists.
+
+## Canvas Lens Views
+
+Canvas Lens is the preferred renderer for expressive UI. Create an HTML file and a `view.json` manifest:
+
+```json
+{
+  "name": "Command Center",
+  "icon": "layout",
+  "view": "canvas",
+  "source": "index.html",
+  "prompt": "Build a Chamber-native dashboard for the user's current priorities.",
+  "refreshOn": "click"
+}
+```
+
+`source` must be an HTML file inside the same view folder. Chamber renders it in-app inside a sandboxed frame, injects Chamber theme styles, and provides a bridge at `window.canvas`.
+
+### Chamber Design Kit
+
+Use the injected classes so your UI feels native:
+
+- `ch-page` — full page wrapper
+- `ch-grid` — responsive card grid
+- `ch-card` — Chamber card surface
+- `ch-button` — primary button
+- `ch-button-secondary` — secondary button
+- `ch-input` — text/input control
+- `ch-table` — table styling
+- `ch-badge` — compact status badge
+- `ch-muted` — muted text
+
+Use CSS variables when custom styling is needed:
+
+```css
+color: var(--ch-foreground);
+background: var(--ch-card);
+border-color: var(--ch-border);
+accent-color: var(--ch-genesis);
+```
+
+Do not hard-code a separate visual theme unless the user explicitly asks. Default to dark Chamber-native UI.
+
+### Canvas Actions
+
+Canvas HTML does not get direct SDK access. Send user intent back to Chamber:
+
+```html
+<button class="ch-button" onclick="window.canvas.sendAction('approve', { id: 'task-123' })">
+  Approve
+</button>
+```
+
+Chamber routes actions to the active mind. Use your normal tools and context to satisfy the action, then update the HTML source file if the UI should change.
+
+## Classic JSON Lens Views
+
+Classic views still work well for simple structured data.
 
 ```json
 {
   "name": "Display Name",
-  "icon": "lucide-icon-name",
-  "view": "form | table | briefing",
+  "icon": "layout",
+  "view": "form | table | briefing | detail | status-board | timeline | editor",
   "source": "data.json",
   "prompt": "Optional: what to gather when user clicks Refresh",
   "refreshOn": "click"
 }
 ```
 
-### Fields
+When `prompt` is set, Chamber sends it to you with an output path appended. For classic JSON views, write only valid JSON to that path.
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Display name in tooltip and header |
-| `icon` | Yes | Lucide icon: `zap`, `newspaper`, `users`, `clock`, `settings`, `layout` |
-| `view` | Yes | `form` (key-value), `table` (rows), or `briefing` (card grid) |
-| `source` | Yes | Data filename, relative to view folder |
-| `prompt` | No | Prompt sent to you on Refresh. Describe what data to gather. |
-| `refreshOn` | No | `"click"` — manual refresh only |
-| `schema` | No | JSON Schema for field/column labels |
+### View Types
 
-## View Types
-
-### `form` — Key-Value Pairs
-Data: flat JSON object. Each key becomes a row.
-```json
-{ "agent": "Q", "status": "Online", "extensions": 5 }
-```
-
-### `briefing` — Card Grid  
-Data: flat JSON object. Numbers render large, strings render normal.
-```json
-{ "inbox_items": 12, "initiatives": 3, "top_priority": "Ship Lens" }
-```
-
-### `table` — Data Table
-Data: JSON array of objects. Each object is a row.
-```json
-[
-  { "name": "Kent", "role": "PM" },
-  { "name": "Michael", "role": "SWE" }
-]
-```
-
-For table column headers, use `schema.items.properties`:
-```json
-{
-  "schema": {
-    "items": {
-      "properties": {
-        "name": { "type": "string", "title": "Name" },
-        "role": { "type": "string", "title": "Role" }
-      }
-    }
-  }
-}
-```
-
-### `detail` — Single Item Detail Card
-Data: flat JSON object. `name`/`title` becomes heading, `description` becomes body, `status` becomes badge.
-```json
-{ "name": "Lens Framework", "status": "Active", "description": "Declarative UI views", "phase": 4 }
-```
-
-### `status-board` — Status Cards with Indicators
-Data: JSON array with `name` and `status` fields. Shows 🟢🟡🔴 based on status text (ok/running = green, error/fail = red, warn/pending = yellow).
-```json
-[
-  { "name": "daily-report", "status": "ok", "last_run": "2h ago" },
-  { "name": "sync-contacts", "status": "error", "last_run": "failed" }
-]
-```
-
-### `timeline` — Chronological Feed
-Data: JSON array. Auto-extracts `title`, `time`/`timestamp`, `description`.
-```json
-[
-  { "title": "Deployed v0.8.0", "time": "3:25 AM", "description": "Lens Phase 4 shipped" },
-  { "title": "Created newspaper view", "time": "3:12 AM" }
-]
-```
-
-### `editor` — Editable Form
-Data: flat JSON object. Schema `properties` define field types. Supports `string`, `number`, `boolean`, and `enum` (dropdown). Save button sends changes back through the agent.
-```json
-{
-  "schema": {
-    "properties": {
-      "name": { "type": "string", "title": "Name" },
-      "enabled": { "type": "boolean", "title": "Enabled" },
-      "level": { "type": "string", "title": "Level", "enum": ["low", "medium", "high"] }
-    }
-  }
-}
-```
-
-## Prompt-Driven Views
-
-When `prompt` is set, the UI sends the prompt to you with the output path appended. You gather data and write ONLY valid JSON to that path. No markdown, no explanation — just the JSON.
-
-## Static Views
-
-When `prompt` is not set, the `source` file must already exist. Create it alongside the `view.json`. The UI re-reads it when the file changes on disk.
-
-## Deleting a View
-
-Delete the folder from `.github/lens/`. The UI removes the icon automatically.
+- `form` — flat JSON object as key/value rows.
+- `briefing` — flat JSON object as card grid.
+- `table` — JSON array of objects.
+- `detail` — single object detail card.
+- `status-board` — array of status objects.
+- `timeline` — chronological array.
+- `editor` — editable flat object with schema-driven fields.
 
 ## Examples
 
-Quick status view:
+Canvas dashboard:
+
+```html
+<!doctype html>
+<html>
+  <body class="ch-page">
+    <section class="ch-grid">
+      <article class="ch-card">
+        <p class="ch-muted">Top priority</p>
+        <h1>Ship Canvas Lens</h1>
+        <button class="ch-button" onclick="window.canvas.sendAction('start', { item: 'canvas-lens' })">
+          Start
+        </button>
+      </article>
+    </section>
+  </body>
+</html>
+```
+
+Classic briefing:
+
 ```json
 {
-  "name": "Status",
-  "icon": "zap",
-  "view": "form",
-  "source": "data.json",
-  "prompt": "Report your name, mind path, extension count, and model. Write as flat JSON.",
+  "name": "Newspaper",
+  "icon": "newspaper",
+  "view": "briefing",
+  "source": "briefing.json",
+  "prompt": "Generate a morning briefing. Write a flat JSON object.",
   "refreshOn": "click"
 }
 ```
 
-Contacts table (static):
-```json
-{
-  "name": "Contacts",
-  "icon": "users",
-  "view": "table",
-  "source": "contacts.json",
-  "schema": { "items": { "properties": { "name": { "title": "Name" }, "url": { "title": "URL" } } } }
-}
-```
+## Rules
+
+- Keep all Lens files inside `.github/lens/<view-name>/`.
+- Never write credentials into Lens files.
+- Canvas UI sends intent; the mind uses SDK tools through Chamber.
+- Prefer Canvas Lens for rich UI, but keep simple data views as classic JSON Lens.
+- Delete the view folder to remove a view from Chamber.

--- a/apps/desktop/src/main/assets/lens-skill/SKILL.md
+++ b/apps/desktop/src/main/assets/lens-skill/SKILL.md
@@ -8,14 +8,13 @@ description: Create, inspect, fix, and manage Chamber Lens views. Use this skill
 
 Create views in `.github/lens/<view-name>/` to add panels to the Chamber activity bar. Lens is the navigation and discovery model.
 
-- Use classic JSON Lens views for simple structured data.
-- Use Canvas Lens views for rich dashboards, workflows, reports, forms, and app-like UI.
+Create new Lens views as Canvas Lens views. Classic JSON Lens views are legacy: inspect, refresh, and maintain existing ones, but do not create new classic JSON Lens views unless the user explicitly asks to modify an existing legacy Lens.
 
 ## Non-Negotiable Discovery Contract
 
 Chamber discovers only folders under `.github/lens/` that contain a valid `view.json`.
 
-For a Canvas Lens, `view.json` must use this exact shape:
+For every new Lens, `view.json` must use this Canvas shape:
 
 ```json
 {
@@ -28,32 +27,20 @@ For a Canvas Lens, `view.json` must use this exact shape:
 }
 ```
 
-For a classic JSON Lens, `view.json` must use this exact shape:
+Never create new `form`, `table`, `briefing`, `detail`, `status-board`, `timeline`, or `editor` Lens views. Those are legacy view types for existing views only.
 
-```json
-{
-  "name": "Cron Jobs",
-  "icon": "clock",
-  "view": "table",
-  "source": "data.json",
-  "prompt": "Optional refresh prompt.",
-  "refreshOn": "click"
-}
-```
-
-Never use `title`, `renderer`, `type`, `component`, `template`, or `file` in `view.json`. Chamber ignores those fields. The required fields are `name`, `icon`, `view`, and `source`.
+Never use `title`, `renderer`, `type`, `component`, `template`, or `file` in `view.json`. Chamber ignores those fields. The required fields for new views are `name`, `icon`, `view: "canvas"`, and `source: "index.html"`.
 
 Before finishing any Lens task, inspect the files and verify:
 
 - `.github/lens/<view-name>/view.json` exists.
 - `view.json` has `name`, `icon`, `view`, and `source`.
 - Canvas Lens uses `"view": "canvas"` and `"source": "index.html"`.
-- Classic JSON Lens uses a supported JSON view and a `.json` source file.
-- The source file named by `source` exists in the same folder.
+- `.github/lens/<view-name>/index.html` exists.
 
 ## Creating Views
 
-Create each Lens as a folder with exactly the files Chamber expects:
+Create each new Lens as a Canvas Lens folder with exactly the files Chamber expects:
 
 ```text
 .github/lens/<view-name>/
@@ -61,31 +48,18 @@ Create each Lens as a folder with exactly the files Chamber expects:
   index.html     # Canvas Lens
 ```
 
-or:
-
-```text
-.github/lens/<view-name>/
-  view.json
-  data.json      # classic JSON Lens
-```
-
 Use a short, stable, lowercase folder name like `cron-jobs`, `daily-briefing`, or `release-command-center`. Keep all Lens files inside that folder. If the folder does not exist, create it before writing files. Do not place Lens files at the root of `.github/lens/`; Chamber discovers only folders that contain a `view.json`.
 
-For rich UI, write both:
+Write both:
 
 1. `.github/lens/<view-name>/view.json`
 2. `.github/lens/<view-name>/index.html`
-
-For simple structured UI, write both:
-
-1. `.github/lens/<view-name>/view.json`
-2. `.github/lens/<view-name>/data.json`
 
 Before you finish, re-open or inspect the files you wrote and make sure `view.json` points to the source file you actually created.
 
 ## Canvas Lens Views
 
-Canvas Lens is the preferred renderer for expressive UI. Create an HTML file and a `view.json` manifest:
+Canvas Lens is the required renderer for new Lens views. Create an HTML file and a `view.json` manifest:
 
 ```json
 {
@@ -160,9 +134,9 @@ Canvas HTML does not get direct SDK access. Send user intent back to Chamber:
 
 Chamber routes actions to the active mind. Use your normal tools and context to satisfy the action, then update the HTML source file if the UI should change.
 
-## Classic JSON Lens Views
+## Legacy JSON Lens Views
 
-Classic views still work well for simple structured data.
+Classic JSON Lens views still render for backwards compatibility. Maintain or refresh them when they already exist, but do not create new ones.
 
 ```json
 {
@@ -208,7 +182,7 @@ Canvas dashboard:
 </html>
 ```
 
-Classic briefing:
+Legacy briefing shape:
 
 ```json
 {
@@ -226,5 +200,6 @@ Classic briefing:
 - Keep all Lens files inside `.github/lens/<view-name>/`.
 - Never write credentials into Lens files.
 - Canvas UI sends intent; the mind uses SDK tools through Chamber.
-- Prefer Canvas Lens for rich UI, but keep simple data views as classic JSON Lens.
+- Create new Lens views as Canvas Lens views only.
+- Use classic JSON Lens types only when maintaining an existing legacy Lens.
 - Delete the view folder to remove a view from Chamber.

--- a/apps/desktop/src/main/assets/lens-skill/SKILL.md
+++ b/apps/desktop/src/main/assets/lens-skill/SKILL.md
@@ -1,47 +1,87 @@
 ---
 name: lens
 version: 2.0.0
-description: Create and manage Chamber Lens views, including structured JSON views and rich Canvas-backed Chamber-native UI. Use when the user asks to create a view, dashboard, panel, report, form, command center, or app-like screen inside Chamber.
+description: Create, inspect, fix, and manage Chamber Lens views. Use this skill whenever the user mentions Lens, lenses, Chamber views, dashboards, panels, reports, forms, command centers, app-like screens, self-modifying UI, or says a Lens icon/view is missing. Always use this skill before creating or editing files under .github/lens.
 ---
 
 # Lens — Chamber Views
 
-Create views in `.github/lens/<view-name>/` to add panels to the Chamber activity bar. Lens is the navigation and discovery model. Use the right renderer for the job:
+Create views in `.github/lens/<view-name>/` to add panels to the Chamber activity bar. Lens is the navigation and discovery model.
 
 - Use classic JSON Lens views for simple structured data.
 - Use Canvas Lens views for rich dashboards, workflows, reports, forms, and app-like UI.
 
-## Creating Views
+## Non-Negotiable Discovery Contract
 
-Prefer the `lens_create` tool whenever it is available. It creates the Lens directory, `view.json`, and source file in one operation, so you do not need shell access or a separate mkdir step.
+Chamber discovers only folders under `.github/lens/` that contain a valid `view.json`.
 
-Example Canvas Lens creation:
+For a Canvas Lens, `view.json` must use this exact shape:
 
 ```json
 {
-  "viewId": "cron-jobs",
   "name": "Cron Jobs",
   "icon": "clock",
   "view": "canvas",
   "source": "index.html",
-  "content": "<!doctype html><html><body class=\"ch-page\"><section class=\"ch-card\"><h1>Cron Jobs</h1></section></body></html>"
+  "prompt": "Optional refresh prompt.",
+  "refreshOn": "click"
 }
 ```
 
-Example classic JSON Lens creation:
+For a classic JSON Lens, `view.json` must use this exact shape:
 
 ```json
 {
-  "viewId": "cron-table",
-  "name": "Cron Table",
+  "name": "Cron Jobs",
   "icon": "clock",
   "view": "table",
   "source": "data.json",
-  "content": [{ "name": "Daily smoke", "status": "enabled" }]
+  "prompt": "Optional refresh prompt.",
+  "refreshOn": "click"
 }
 ```
 
-Only fall back to direct file creation when `lens_create` is not available and the parent directory already exists.
+Never use `title`, `renderer`, `type`, `component`, `template`, or `file` in `view.json`. Chamber ignores those fields. The required fields are `name`, `icon`, `view`, and `source`.
+
+Before finishing any Lens task, inspect the files and verify:
+
+- `.github/lens/<view-name>/view.json` exists.
+- `view.json` has `name`, `icon`, `view`, and `source`.
+- Canvas Lens uses `"view": "canvas"` and `"source": "index.html"`.
+- Classic JSON Lens uses a supported JSON view and a `.json` source file.
+- The source file named by `source` exists in the same folder.
+
+## Creating Views
+
+Create each Lens as a folder with exactly the files Chamber expects:
+
+```text
+.github/lens/<view-name>/
+  view.json
+  index.html     # Canvas Lens
+```
+
+or:
+
+```text
+.github/lens/<view-name>/
+  view.json
+  data.json      # classic JSON Lens
+```
+
+Use a short, stable, lowercase folder name like `cron-jobs`, `daily-briefing`, or `release-command-center`. Keep all Lens files inside that folder. If the folder does not exist, create it before writing files. Do not place Lens files at the root of `.github/lens/`; Chamber discovers only folders that contain a `view.json`.
+
+For rich UI, write both:
+
+1. `.github/lens/<view-name>/view.json`
+2. `.github/lens/<view-name>/index.html`
+
+For simple structured UI, write both:
+
+1. `.github/lens/<view-name>/view.json`
+2. `.github/lens/<view-name>/data.json`
+
+Before you finish, re-open or inspect the files you wrote and make sure `view.json` points to the source file you actually created.
 
 ## Canvas Lens Views
 
@@ -84,6 +124,29 @@ accent-color: var(--ch-genesis);
 ```
 
 Do not hard-code a separate visual theme unless the user explicitly asks. Default to dark Chamber-native UI.
+
+### Chamber UI Rubric
+
+Before writing Canvas HTML, design the view like a native Chamber screen:
+
+- Start with `<body class="ch-page">`; never leave raw browser-default body styling.
+- Use `ch-grid` for responsive layout and `ch-card` for every major content group.
+- Put the primary insight or action in the first card. Do not start with a generic title-only page.
+- Use `ch-muted` for labels, timestamps, and secondary explanation.
+- Use `ch-badge` for status values such as enabled, blocked, passing, stale, or needs attention.
+- Use `ch-button` for the main action and `ch-button-secondary` for lower-priority actions.
+- Prefer concise cards, status rows, and action clusters over long unstyled paragraphs.
+- Keep spacing generous, dark, and calm. Avoid rainbow colors, default blue links, raw tables without `ch-table`, and unstyled form controls.
+- If the user asked for operational data, show summary cards first, then details.
+- If the view has actions, wire buttons through `window.canvas.sendAction(...)`; do not fake interactivity.
+
+Self-check before saving:
+
+- Does the page use Chamber classes rather than raw default HTML?
+- Is the most useful information visible without scrolling?
+- Are statuses visually scannable?
+- Are actions explicit and routed through `window.canvas.sendAction(...)`?
+- Would this look plausible as a built-in Chamber pane?
 
 ### Canvas Actions
 

--- a/apps/desktop/src/main/ipc/genesis.test.ts
+++ b/apps/desktop/src/main/ipc/genesis.test.ts
@@ -10,15 +10,14 @@ vi.mock('@chamber/services', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@chamber/services')>();
   return {
     ...actual,
-    seedLensDefaults: vi.fn(),
-    installLensSkill: vi.fn(),
+    bootstrapMindCapabilities: vi.fn(),
   };
 });
 
 import { ipcMain, BrowserWindow } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron';
 import { setupGenesisIPC } from './genesis';
-import type { GenesisMindTemplate, MindManager, MindScaffold } from '@chamber/services';
+import { bootstrapMindCapabilities, type GenesisMindTemplate, type MindManager, type MindScaffold } from '@chamber/services';
 
 type InvokeHandler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
 
@@ -80,6 +79,7 @@ describe('setupGenesisIPC', () => {
     });
 
     expect(installer.install).toHaveBeenCalledWith({ templateId: 'lucy', basePath: 'C:\\agents' });
+    expect(bootstrapMindCapabilities).toHaveBeenCalledWith('C:\\agents\\lucy');
     expect(mindManager.loadMind).toHaveBeenCalledWith('C:\\agents\\lucy');
     expect(mindManager.setActiveMind).toHaveBeenCalledWith('lucy-1234');
     expect(mockSend).toHaveBeenCalledWith('genesis:progress', { step: 'complete', detail: 'Genesis template install complete.' });

--- a/apps/desktop/src/main/ipc/genesis.ts
+++ b/apps/desktop/src/main/ipc/genesis.ts
@@ -5,8 +5,7 @@ import * as path from 'node:path';
 import {
   MindManager,
   MindScaffold,
-  installLensSkill,
-  seedLensDefaults,
+  bootstrapMindCapabilities,
   type GenesisConfig,
   type GenesisMindTemplate,
   type GenesisMindTemplateInstallRequest,
@@ -85,8 +84,7 @@ export function setupGenesisIPC(
 
 async function activateCreatedMind(mindManager: MindManager, mindPath: string): Promise<{ success: true; mindId: string; mindPath: string }> {
   appendE2EGenesisMemory(mindPath);
-  seedLensDefaults(mindPath);
-  installLensSkill(mindPath);
+  bootstrapMindCapabilities(mindPath);
 
   const mind = await mindManager.loadMind(mindPath);
   mindManager.setActiveMind(mind.mindId);

--- a/apps/desktop/src/main/ipc/lens.ts
+++ b/apps/desktop/src/main/ipc/lens.ts
@@ -1,12 +1,17 @@
 // Lens IPC handlers — thin adapters for ViewDiscovery
 import { BrowserWindow, ipcMain } from 'electron';
-import type { MindManager, ViewDiscovery } from '@chamber/services';
+import type { CanvasService, MindManager, ViewDiscovery } from '@chamber/services';
 import type { LensViewManifest } from '@chamber/shared/types';
 
-export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindManager): void {
+export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindManager, canvasService: CanvasService): void {
   const resolveMindPath = (mindId?: string): string | undefined => {
     const id = mindId ?? mindManager.getActiveMindId() ?? undefined;
     return id ? mindManager.getMind(id)?.mindPath : undefined;
+  };
+
+  const resolveMind = (mindId?: string) => {
+    const id = mindId ?? mindManager.getActiveMindId() ?? undefined;
+    return id ? mindManager.getMind(id) : undefined;
   };
 
   ipcMain.handle('lens:getViews', async (_event, mindId?: string) => {
@@ -27,6 +32,14 @@ export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindMana
     const mindPath = resolveMindPath(mindId);
     if (!mindPath) return null;
     return viewDiscovery.sendAction(viewId, action, mindPath);
+  });
+
+  ipcMain.handle('lens:getCanvasUrl', async (_event, viewId: string, mindId?: string) => {
+    const mind = resolveMind(mindId);
+    if (!mind) return null;
+    const sourcePath = viewDiscovery.getViewSourcePath(viewId, mind.mindPath);
+    if (!sourcePath) return null;
+    return canvasService.showLensCanvas(mind.mindId, mind.mindPath, viewId, sourcePath);
   });
 
   mindManager.on('lens:viewsChanged', (views: LensViewManifest[], mindId: string) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -29,6 +29,7 @@ const electronAPI: ElectronAPI = {
     getViewData: (viewId, mindId?) => ipcRenderer.invoke('lens:getViewData', viewId, mindId),
     refreshView: (viewId, mindId?) => ipcRenderer.invoke('lens:refreshView', viewId, mindId),
     sendAction: (viewId, action, mindId?) => ipcRenderer.invoke('lens:sendAction', viewId, action, mindId),
+    getCanvasUrl: (viewId, mindId?) => ipcRenderer.invoke('lens:getCanvasUrl', viewId, mindId),
     onViewsChanged: (callback) => createIpcListener(ipcRenderer, 'lens:viewsChanged', callback),
   },
   auth: {

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -159,6 +159,7 @@ export function installBrowserApi(): void {
       getViewData: async () => null,
       refreshView: async () => null,
       sendAction: async () => unavailable('Lens write actions'),
+      getCanvasUrl: async () => null,
       onViewsChanged: () => noopUnsubscribe,
     },
     auth: {

--- a/apps/web/src/renderer/components/layout/ViewRouter.tsx
+++ b/apps/web/src/renderer/components/layout/ViewRouter.tsx
@@ -22,7 +22,7 @@ export function ViewRouter() {
 
   const view = discoveredViews.find(v => v.id === activeView);
   if (view) {
-    return <LensViewRenderer key={view.id} view={view} />;
+    return <LensViewRenderer key={`${view.id}:${view.view}`} view={view} />;
   }
 
   // Fallback to chat if view not found

--- a/apps/web/src/renderer/components/views/CanvasLensView.test.tsx
+++ b/apps/web/src/renderer/components/views/CanvasLensView.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ElectronAPI } from '@chamber/shared/types';
+import { CanvasLensView } from './CanvasLensView';
+
+describe('CanvasLensView', () => {
+  beforeEach(() => {
+    window.electronAPI = {
+      lens: {
+        getCanvasUrl: vi.fn(async () => 'http://127.0.0.1:4312/mind-1/lens-abc.html'),
+        getViewData: vi.fn(),
+        getViews: vi.fn(),
+        onViewsChanged: vi.fn(),
+        refreshView: vi.fn(),
+        sendAction: vi.fn(),
+      },
+    } as unknown as ElectronAPI;
+  });
+
+  it('renders Canvas Lens content in a sandboxed iframe', async () => {
+    render(<CanvasLensView view={{
+      icon: 'layout',
+      id: 'command-center',
+      name: 'Command Center',
+      source: 'index.html',
+      view: 'canvas',
+    }} />);
+
+    const iframe = await screen.findByTitle('Command Center');
+
+    expect(iframe.getAttribute('src')).toBe('http://127.0.0.1:4312/mind-1/lens-abc.html');
+    expect(iframe.getAttribute('sandbox')).toBe('allow-forms allow-same-origin allow-scripts');
+  });
+
+  it('refreshes the view before reloading the iframe url', async () => {
+    render(<CanvasLensView view={{
+      icon: 'layout',
+      id: 'command-center',
+      name: 'Command Center',
+      prompt: 'Build the dashboard',
+      source: 'index.html',
+      view: 'canvas',
+    }} />);
+
+    await screen.findByTitle('Command Center');
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() => {
+      expect(window.electronAPI.lens.refreshView).toHaveBeenCalledWith('command-center');
+      expect(window.electronAPI.lens.getCanvasUrl).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/src/renderer/components/views/CanvasLensView.tsx
+++ b/apps/web/src/renderer/components/views/CanvasLensView.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import type { LensViewManifest } from '@chamber/shared/types';
+import { RefreshCw } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import { Logger } from '../../lib/logger';
+
+interface Props {
+  view: LensViewManifest;
+}
+
+const log = Logger.create('CanvasLensView');
+
+export function CanvasLensView({ view }: Props) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [frameKey, setFrameKey] = useState(0);
+
+  const loadCanvasUrl = useCallback(async () => {
+    const result = await window.electronAPI.lens.getCanvasUrl(view.id);
+    setUrl(result);
+    setFrameKey((key) => key + 1);
+  }, [view.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await window.electronAPI.lens.getCanvasUrl(view.id);
+        if (!cancelled) {
+          setUrl(result);
+          setFrameKey((key) => key + 1);
+        }
+      } catch (err) {
+        log.error(`Failed to load Canvas Lens ${view.id}:`, err);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load Canvas Lens');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [view.id]);
+
+  const handleRefresh = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await window.electronAPI.lens.refreshView(view.id);
+      await loadCanvasUrl();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Refresh failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [loadCanvasUrl, loading, view.id]);
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 bg-background">
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold">{view.name}</h2>
+          <p className="text-xs text-muted-foreground">Canvas Lens</p>
+        </div>
+        {view.prompt && (
+          <button
+            onClick={handleRefresh}
+            disabled={loading}
+            className={cn(
+              'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-colors',
+              'bg-secondary hover:bg-accent text-muted-foreground hover:text-foreground',
+              loading && 'opacity-50 cursor-not-allowed'
+            )}
+          >
+            <RefreshCw size={14} className={cn(loading && 'animate-spin')} />
+            {loading ? 'Refreshing...' : 'Refresh'}
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="m-4 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 p-3">
+        {url ? (
+          <iframe
+            key={frameKey}
+            title={view.name}
+            src={url}
+            sandbox="allow-forms allow-same-origin allow-scripts"
+            className="h-full w-full rounded-lg border border-border bg-background"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center rounded-lg border border-border bg-card text-sm text-muted-foreground">
+            {loading ? 'Loading Canvas Lens...' : 'Canvas Lens source not found.'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/views/LensViewRenderer.tsx
+++ b/apps/web/src/renderer/components/views/LensViewRenderer.tsx
@@ -10,6 +10,7 @@ import { LensStatusBoard } from './LensStatusBoard';
 import { LensTimeline } from './LensTimeline';
 import { LensEditor } from './LensEditor';
 import { LensForm } from './LensForm';
+import { CanvasLensView } from './CanvasLensView';
 
 interface Props {
   view: LensViewManifest;
@@ -34,6 +35,10 @@ function refreshLensView(viewId: string): Promise<Record<string, unknown> | null
 }
 
 export function LensViewRenderer({ view }: Props) {
+  if (view.view === 'canvas') {
+    return <CanvasLensView view={view} />;
+  }
+
   const [data, setData] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -130,6 +130,7 @@ export function mockElectronAPI(): ElectronAPI {
       getViewData: vi.fn().mockResolvedValue(null),
       refreshView: vi.fn().mockResolvedValue(null),
       sendAction: vi.fn().mockResolvedValue(null),
+      getCanvasUrl: vi.fn().mockResolvedValue(null),
       onViewsChanged: vi.fn().mockReturnValue(vi.fn()),
     },
     auth: {

--- a/chamber-copilot-runtime/package-lock.json
+++ b/chamber-copilot-runtime/package-lock.json
@@ -8,31 +8,31 @@
       "name": "chamber-copilot-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "1.0.41-1",
+        "@github/copilot": "1.0.42-0",
         "@github/copilot-sdk": "0.3.0"
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-1.tgz",
-      "integrity": "sha512-95Qxeds7SAi96b4bK91PAdB13M39ZKpZDfWf69yJg6362RTCFNa24QvflLG+3f4Vojh8GD4h8EvxAYwgq4zdMQ==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.42-0.tgz",
+      "integrity": "sha512-QF0mnYc4PeWCtaV5WSUrlVXt+2mzqyvo694B+1Wc2FdCtmoPsimbUEQFxGsf/bNXZ6ykZnXH3wnX58gUlkwNLQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.41-1",
-        "@github/copilot-darwin-x64": "1.0.41-1",
-        "@github/copilot-linux-arm64": "1.0.41-1",
-        "@github/copilot-linux-x64": "1.0.41-1",
-        "@github/copilot-win32-arm64": "1.0.41-1",
-        "@github/copilot-win32-x64": "1.0.41-1"
+        "@github/copilot-darwin-arm64": "1.0.42-0",
+        "@github/copilot-darwin-x64": "1.0.42-0",
+        "@github/copilot-linux-arm64": "1.0.42-0",
+        "@github/copilot-linux-x64": "1.0.42-0",
+        "@github/copilot-win32-arm64": "1.0.42-0",
+        "@github/copilot-win32-x64": "1.0.42-0"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-1.tgz",
-      "integrity": "sha512-9ExZaLv3/yi7Be9GnjhxJgmuklQhqT59014BsqsWt1lpTA1khJs8VyC5B+iP8TEOkFKvD/UXJNSP9PCE6n5inQ==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.42-0.tgz",
+      "integrity": "sha512-8t9oE0kCmMhKopRXHaOFZqx8IqG74XWggrB276z1ANBkxswH31kqq9+KYekfBZKLQemUC8shsu+PTmaQ9PPawA==",
       "cpu": [
         "arm64"
       ],
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-1.tgz",
-      "integrity": "sha512-6ZretUFTcCPajzcZyQZixn2unVlN+sbtC6hULBYT6FLHrqSrjK4QN52eCtTYOz/kPbBUO4lj9YjT/v1gkgMDwQ==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.42-0.tgz",
+      "integrity": "sha512-xKuku6fy0342cT2RY/rDTeOXD9rF6I43NxH0CZOglVNxneXOBbZRq162j19jtMnpopq37FciGw+Kn75zVxJFhA==",
       "cpu": [
         "x64"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-1.tgz",
-      "integrity": "sha512-iP/VbjvGMQvo0fudLHBpmp31nAmtGvq1tZWC+YEQ43D58n2miOXkiDR61Tn9PSPGTkNbrnTecE0mgBO2oePYPw==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.42-0.tgz",
+      "integrity": "sha512-+zvGqBHArDLreRKE6CGlkAPdqw2xGx50D0MBRIMLXoGCAB+s7o3iuuWvpK6Wh4b8WQMxyjXGnnhYhdtaLbcyvg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-1.tgz",
-      "integrity": "sha512-DAVCL7pMxeRRHcVOcbpllDBn87zVgskHNqfWrdFPEcgfslx0bw7GkErO35jx/SLnehcwpdwHquqfkyDpnfRAqg==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.42-0.tgz",
+      "integrity": "sha512-tyiiblErhUsL64xzn9b8m9/SAMRWwP+/1EcdA3kx/w9B2OuNVL8ixMVaGgCshI451tFQu2zQPoeEgOCDzHyXww==",
       "cpu": [
         "x64"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-1.tgz",
-      "integrity": "sha512-m+un4+m1MQlTbiaA6d+/1Aa0SBI85O+De6P/8RdrVCEaoLE0Uy10wZbiHk6GK+YN74B/9WGwW8YANVVaBXsDDw==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.42-0.tgz",
+      "integrity": "sha512-kEPlbqkZhZ0/jE4vpFH0hkl74cHcVAwZVEBjLLqVy0q/uQ4nyfIR2LUImE3nEjBn82mpUkCkyqetV2DN+NQ9lA==",
       "cpu": [
         "arm64"
       ],
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-1.tgz",
-      "integrity": "sha512-9Yl56T/4Eo7etQ+98XxsYTIzPdkuN5SAD0mZN2SHjdK5h0mBJFXpEmsminSelFgUbTsMHb+srfSmvx5nFe0m0A==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.42-0.tgz",
+      "integrity": "sha512-kGsjdpFALvsTuwCJh8ZQGNl14CNEhNQo+/vwh2nFDfeQb0dEYT9Ni9pbOPx9xhOThpxS1cle0KCI6Mn53h5yQA==",
       "cpu": [
         "x64"
       ],

--- a/chamber-copilot-runtime/package.json
+++ b/chamber-copilot-runtime/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Pinned packaged runtime for Chamber Copilot SDK + CLI",
   "dependencies": {
-    "@github/copilot": "1.0.41-1",
+    "@github/copilot": "1.0.42-0",
     "@github/copilot-sdk": "0.3.0"
   }
 }

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -42,7 +42,13 @@ const config: ForgeConfig = {
         schemes: ['chamber'],
       },
     ],
-    extraResource: ['./resources/node', './resources/copilot-runtime', './apps/server/dist', './node_modules/keytar'],
+    extraResource: [
+      './resources/node',
+      './resources/copilot-runtime',
+      './apps/server/dist',
+      './node_modules/keytar',
+      './apps/desktop/src/main/assets/lens-skill',
+    ],
   },
   publishers: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
-        "@github/copilot": "1.0.41-1",
+        "@github/copilot": "1.0.42-0",
         "@github/copilot-sdk": "0.3.0",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1511,27 +1511,27 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.41-1.tgz",
-      "integrity": "sha512-95Qxeds7SAi96b4bK91PAdB13M39ZKpZDfWf69yJg6362RTCFNa24QvflLG+3f4Vojh8GD4h8EvxAYwgq4zdMQ==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.42-0.tgz",
+      "integrity": "sha512-QF0mnYc4PeWCtaV5WSUrlVXt+2mzqyvo694B+1Wc2FdCtmoPsimbUEQFxGsf/bNXZ6ykZnXH3wnX58gUlkwNLQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.41-1",
-        "@github/copilot-darwin-x64": "1.0.41-1",
-        "@github/copilot-linux-arm64": "1.0.41-1",
-        "@github/copilot-linux-x64": "1.0.41-1",
-        "@github/copilot-win32-arm64": "1.0.41-1",
-        "@github/copilot-win32-x64": "1.0.41-1"
+        "@github/copilot-darwin-arm64": "1.0.42-0",
+        "@github/copilot-darwin-x64": "1.0.42-0",
+        "@github/copilot-linux-arm64": "1.0.42-0",
+        "@github/copilot-linux-x64": "1.0.42-0",
+        "@github/copilot-win32-arm64": "1.0.42-0",
+        "@github/copilot-win32-x64": "1.0.42-0"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-1.tgz",
-      "integrity": "sha512-9ExZaLv3/yi7Be9GnjhxJgmuklQhqT59014BsqsWt1lpTA1khJs8VyC5B+iP8TEOkFKvD/UXJNSP9PCE6n5inQ==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.42-0.tgz",
+      "integrity": "sha512-8t9oE0kCmMhKopRXHaOFZqx8IqG74XWggrB276z1ANBkxswH31kqq9+KYekfBZKLQemUC8shsu+PTmaQ9PPawA==",
       "cpu": [
         "arm64"
       ],
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-1.tgz",
-      "integrity": "sha512-6ZretUFTcCPajzcZyQZixn2unVlN+sbtC6hULBYT6FLHrqSrjK4QN52eCtTYOz/kPbBUO4lj9YjT/v1gkgMDwQ==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.42-0.tgz",
+      "integrity": "sha512-xKuku6fy0342cT2RY/rDTeOXD9rF6I43NxH0CZOglVNxneXOBbZRq162j19jtMnpopq37FciGw+Kn75zVxJFhA==",
       "cpu": [
         "x64"
       ],
@@ -1563,9 +1563,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-1.tgz",
-      "integrity": "sha512-iP/VbjvGMQvo0fudLHBpmp31nAmtGvq1tZWC+YEQ43D58n2miOXkiDR61Tn9PSPGTkNbrnTecE0mgBO2oePYPw==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.42-0.tgz",
+      "integrity": "sha512-+zvGqBHArDLreRKE6CGlkAPdqw2xGx50D0MBRIMLXoGCAB+s7o3iuuWvpK6Wh4b8WQMxyjXGnnhYhdtaLbcyvg==",
       "cpu": [
         "arm64"
       ],
@@ -1580,9 +1580,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-1.tgz",
-      "integrity": "sha512-DAVCL7pMxeRRHcVOcbpllDBn87zVgskHNqfWrdFPEcgfslx0bw7GkErO35jx/SLnehcwpdwHquqfkyDpnfRAqg==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.42-0.tgz",
+      "integrity": "sha512-tyiiblErhUsL64xzn9b8m9/SAMRWwP+/1EcdA3kx/w9B2OuNVL8ixMVaGgCshI451tFQu2zQPoeEgOCDzHyXww==",
       "cpu": [
         "x64"
       ],
@@ -1732,9 +1732,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-1.tgz",
-      "integrity": "sha512-m+un4+m1MQlTbiaA6d+/1Aa0SBI85O+De6P/8RdrVCEaoLE0Uy10wZbiHk6GK+YN74B/9WGwW8YANVVaBXsDDw==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.42-0.tgz",
+      "integrity": "sha512-kEPlbqkZhZ0/jE4vpFH0hkl74cHcVAwZVEBjLLqVy0q/uQ4nyfIR2LUImE3nEjBn82mpUkCkyqetV2DN+NQ9lA==",
       "cpu": [
         "arm64"
       ],
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.41-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-1.tgz",
-      "integrity": "sha512-9Yl56T/4Eo7etQ+98XxsYTIzPdkuN5SAD0mZN2SHjdK5h0mBJFXpEmsminSelFgUbTsMHb+srfSmvx5nFe0m0A==",
+      "version": "1.0.42-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.42-0.tgz",
+      "integrity": "sha512-kGsjdpFALvsTuwCJh8ZQGNl14CNEhNQo+/vwh2nFDfeQb0dEYT9Ni9pbOPx9xhOThpxS1cle0KCI6Mn53h5yQA==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "@github/copilot": "1.0.41-1",
+    "@github/copilot": "1.0.42-0",
     "@github/copilot-sdk": "0.3.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/canvas/CanvasServer.test.ts
+++ b/packages/services/src/canvas/CanvasServer.test.ts
@@ -25,14 +25,17 @@ async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Promi
 describe('CanvasServer', () => {
   let server: CanvasServer;
   const mindDirs = new Map<string, string>();
+  const tokens = new Map<string, string>();
   const onAction = vi.fn();
 
   beforeEach(() => {
     mindDirs.clear();
+    tokens.clear();
     onAction.mockReset();
     server = new CanvasServer({
       resolveContentDir: (mindId) => mindDirs.get(mindId) ?? null,
       onAction,
+      authorizeRequest: (mindId, filename, token) => tokens.get(`${mindId}:${filename}`) === token,
     });
   });
 
@@ -54,23 +57,28 @@ describe('CanvasServer', () => {
       '<!DOCTYPE html><html><body><h1>Hello</h1></body></html>',
       'utf8',
     );
+    tokens.set('mind-1:report.html', 'secret-token');
 
     const port = await server.start();
-    const response = await fetch(`http://127.0.0.1:${port}/mind-1/report.html`);
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/report.html?token=secret-token`);
     const html = await response.text();
 
     expect(response.status).toBe(200);
-    expect(html).toContain("new EventSource('_sse?canvas=' + encodeURIComponent(canvasFile))");
-    expect(html).toContain("fetch('_action?canvas=' + encodeURIComponent(canvasFile)");
+    expect(html).toContain('--ch-background');
+    expect(html).toContain('.ch-card');
+    expect(html).toContain("new URLSearchParams(location.search).get('token')");
+    expect(html).toContain("new EventSource('_sse?canvas=' + encodeURIComponent(canvasFile) + '&token='");
+    expect(html).toContain("fetch('_action?canvas=' + encodeURIComponent(canvasFile) + '&token='");
   });
 
   it('supports targeted reload and close events over SSE', async () => {
     const mindDir = makeMindDir();
     mindDirs.set('mind-1', mindDir);
+    tokens.set('mind-1:report.html', 'secret-token');
     fs.writeFileSync(path.join(mindDir, 'report.html'), '<html><body>Hi</body></html>', 'utf8');
 
     const port = await server.start();
-    const response = await fetch(`http://127.0.0.1:${port}/mind-1/_sse?canvas=report.html`);
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/_sse?canvas=report.html&token=secret-token`);
     const reader = response.body?.getReader();
     if (!reader) {
       throw new Error('Expected SSE response body');
@@ -94,9 +102,10 @@ describe('CanvasServer', () => {
   it('routes browser actions back to the callback', async () => {
     const mindDir = makeMindDir();
     mindDirs.set('mind-1', mindDir);
+    tokens.set('mind-1:report.html', 'secret-token');
 
     const port = await server.start();
-    const response = await fetch(`http://127.0.0.1:${port}/mind-1/_action?canvas=report.html`, {
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/_action?canvas=report.html&token=secret-token`, {
       body: JSON.stringify({
         action: 'button-clicked',
         data: { id: 'approve' },
@@ -117,6 +126,24 @@ describe('CanvasServer', () => {
       mindId: 'mind-1',
       timestamp: 123,
     });
+  });
+
+  it('rejects Canvas actions without the canvas token', async () => {
+    const mindDir = makeMindDir();
+    mindDirs.set('mind-1', mindDir);
+    tokens.set('mind-1:report.html', 'secret-token');
+
+    const port = await server.start();
+    const response = await fetch(`http://127.0.0.1:${port}/mind-1/_action?canvas=report.html`, {
+      body: JSON.stringify({ action: 'button-clicked' }),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(403);
+    expect(onAction).not.toHaveBeenCalled();
   });
 
   it('rejects path traversal outside the mind content directory', async () => {

--- a/packages/services/src/canvas/CanvasServer.ts
+++ b/packages/services/src/canvas/CanvasServer.ts
@@ -19,16 +19,69 @@ const MIME_TYPES: Record<string, string> = {
 interface CanvasServerOptions {
   resolveContentDir: (mindId: string) => string | null;
   onAction: (action: CanvasAction) => void;
+  authorizeRequest: (mindId: string, filename: string, token: string | null) => boolean;
 }
 
 type CanvasClient = ServerResponse<IncomingMessage>;
+
+const CHAMBER_CANVAS_STYLE = `
+<style>
+:root {
+  color-scheme: dark;
+  --ch-background: oklch(0.145 0.008 260);
+  --ch-foreground: oklch(0.985 0 0);
+  --ch-card: oklch(0.195 0.015 260);
+  --ch-border: oklch(0.25 0.012 260);
+  --ch-muted: oklch(0.255 0.015 260);
+  --ch-muted-foreground: oklch(0.708 0.01 260);
+  --ch-accent: oklch(0.255 0.015 260);
+  --ch-genesis: oklch(0.72 0.15 160);
+  --ch-radius: 0.75rem;
+  --ch-font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --ch-font-mono: "JetBrains Mono", ui-monospace, monospace;
+}
+* { box-sizing: border-box; }
+html, body { min-height: 100%; }
+body {
+  margin: 0;
+  background: var(--ch-background);
+  color: var(--ch-foreground);
+  font-family: var(--ch-font-sans);
+}
+.ch-page { min-height: 100vh; padding: 1.5rem; background: var(--ch-background); color: var(--ch-foreground); }
+.ch-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); gap: 1rem; }
+.ch-card { border: 1px solid var(--ch-border); border-radius: var(--ch-radius); background: var(--ch-card); padding: 1rem; }
+.ch-muted { color: var(--ch-muted-foreground); }
+.ch-button, .ch-button-secondary {
+  border: 0;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.5rem 0.75rem;
+}
+.ch-button { background: var(--ch-foreground); color: var(--ch-background); }
+.ch-button-secondary { background: var(--ch-muted); color: var(--ch-foreground); }
+.ch-input {
+  width: 100%;
+  border: 1px solid var(--ch-border);
+  border-radius: 0.5rem;
+  background: var(--ch-muted);
+  color: var(--ch-foreground);
+  font: inherit;
+  padding: 0.5rem 0.75rem;
+}
+.ch-table { width: 100%; border-collapse: collapse; }
+.ch-table th, .ch-table td { border-bottom: 1px solid var(--ch-border); padding: 0.625rem; text-align: left; }
+.ch-badge { border: 1px solid var(--ch-border); border-radius: 999px; display: inline-flex; padding: 0.125rem 0.5rem; color: var(--ch-muted-foreground); }
+</style>`;
 
 function buildBridgeScript(filename: string): string {
   return `
 <script>
 (function() {
   var canvasFile = ${JSON.stringify(filename)};
-  var es = new EventSource('_sse?canvas=' + encodeURIComponent(canvasFile));
+  var canvasToken = new URLSearchParams(location.search).get('token') || '';
+  var es = new EventSource('_sse?canvas=' + encodeURIComponent(canvasFile) + '&token=' + encodeURIComponent(canvasToken));
   es.onmessage = function(e) {
     if (e.data === 'reload') { location.reload(); }
     if (e.data === 'close') { window.close(); }
@@ -36,7 +89,7 @@ function buildBridgeScript(filename: string): string {
 
   window.canvas = {
     sendAction: function(name, data) {
-      return fetch('_action?canvas=' + encodeURIComponent(canvasFile), {
+      return fetch('_action?canvas=' + encodeURIComponent(canvasFile) + '&token=' + encodeURIComponent(canvasToken), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: name, data: data || {}, timestamp: Date.now() })
@@ -49,13 +102,21 @@ function buildBridgeScript(filename: string): string {
 
 function injectBridge(html: string, filename: string): string {
   const bridgeScript = buildBridgeScript(filename);
+  const additions = `${CHAMBER_CANVAS_STYLE}\n${bridgeScript}`;
+  if (html.includes('</head>')) {
+    const withStyle = html.replace('</head>', `${CHAMBER_CANVAS_STYLE}\n</head>`);
+    if (withStyle.includes('</body>')) {
+      return withStyle.replace('</body>', `${bridgeScript}\n</body>`);
+    }
+    return `${withStyle}${bridgeScript}`;
+  }
   if (html.includes('</body>')) {
-    return html.replace('</body>', `${bridgeScript}\n</body>`);
+    return html.replace('</body>', `${additions}\n</body>`);
   }
   if (html.includes('</html>')) {
-    return html.replace('</html>', `${bridgeScript}\n</html>`);
+    return html.replace('</html>', `${additions}\n</html>`);
   }
-  return `${html}${bridgeScript}`;
+  return `${html}${additions}`;
 }
 
 function normalizePath(value: string): string {
@@ -69,11 +130,18 @@ function isPathInside(parent: string, child: string): boolean {
   return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}${path.sep}`);
 }
 
-function readRequestBody(req: IncomingMessage): Promise<string> {
+function readRequestBody(req: IncomingMessage, maxBytes = 64 * 1024): Promise<string> {
   return new Promise((resolve, reject) => {
     let body = '';
+    let bytes = 0;
     req.setEncoding('utf8');
     req.on('data', (chunk) => {
+      bytes += Buffer.byteLength(chunk, 'utf8');
+      if (bytes > maxBytes) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
       body += chunk;
     });
     req.on('end', () => resolve(body));
@@ -177,27 +245,31 @@ export class CanvasServer implements CanvasServerLike {
     }
 
     if (rest.length === 1 && rest[0] === '_sse') {
-      this.handleSse(req, res, mindId, requestUrl.searchParams.get('canvas'));
+      this.handleSse(req, res, mindId, requestUrl.searchParams.get('canvas'), requestUrl.searchParams.get('token'));
       return;
     }
 
     if (rest.length === 1 && rest[0] === '_action') {
-      await this.handleAction(req, res, mindId, requestUrl.searchParams.get('canvas'));
+      await this.handleAction(req, res, mindId, requestUrl.searchParams.get('canvas'), requestUrl.searchParams.get('token'));
       return;
     }
 
-    this.handleStaticFile(res, mindId, rest);
+    this.handleStaticFile(res, mindId, rest, requestUrl.searchParams.get('token'));
   }
 
-  private handleSse(req: IncomingMessage, res: ServerResponse, mindId: string, filename: string | null): void {
+  private handleSse(req: IncomingMessage, res: ServerResponse, mindId: string, filename: string | null, token: string | null): void {
     if (!filename) {
       res.writeHead(400);
       res.end('Missing canvas query parameter');
       return;
     }
+    if (!this.options.authorizeRequest(mindId, filename, token)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
 
     res.writeHead(200, {
-      'Access-Control-Allow-Origin': '*',
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
       'Content-Type': 'text/event-stream',
@@ -210,10 +282,25 @@ export class CanvasServer implements CanvasServerLike {
     });
   }
 
-  private async handleAction(req: IncomingMessage, res: ServerResponse, mindId: string, filename: string | null): Promise<void> {
+  private async handleAction(req: IncomingMessage, res: ServerResponse, mindId: string, filename: string | null, token: string | null): Promise<void> {
     if (!filename) {
       res.writeHead(400);
       res.end('{"error":"missing canvas"}');
+      return;
+    }
+    if (req.method !== 'POST') {
+      res.writeHead(405);
+      res.end('{"error":"method not allowed"}');
+      return;
+    }
+    if (!this.options.authorizeRequest(mindId, filename, token)) {
+      res.writeHead(403);
+      res.end('{"error":"forbidden"}');
+      return;
+    }
+    if (!String(req.headers['content-type'] ?? '').toLowerCase().includes('application/json')) {
+      res.writeHead(415);
+      res.end('{"error":"unsupported media type"}');
       return;
     }
 
@@ -228,7 +315,6 @@ export class CanvasServer implements CanvasServerLike {
         timestamp: typeof parsed.timestamp === 'number' ? parsed.timestamp : Date.now(),
       });
       res.writeHead(200, {
-        'Access-Control-Allow-Origin': '*',
         'Content-Type': 'application/json',
       });
       res.end('{"ok":true}');
@@ -238,7 +324,7 @@ export class CanvasServer implements CanvasServerLike {
     }
   }
 
-  private handleStaticFile(res: ServerResponse, mindId: string, segments: string[]): void {
+  private handleStaticFile(res: ServerResponse, mindId: string, segments: string[], token: string | null): void {
     const contentDir = this.options.resolveContentDir(mindId);
     if (!contentDir) {
       res.writeHead(404);
@@ -249,6 +335,12 @@ export class CanvasServer implements CanvasServerLike {
     const relativePath = segments.length === 0 ? 'index.html' : path.join(...segments);
     const fullPath = path.resolve(contentDir, relativePath);
     if (!isPathInside(contentDir, fullPath)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+    const normalizedRelativePath = relativePath.replace(/\\/g, '/');
+    if (!this.options.authorizeRequest(mindId, normalizedRelativePath, token)) {
       res.writeHead(403);
       res.end('Forbidden');
       return;
@@ -266,7 +358,7 @@ export class CanvasServer implements CanvasServerLike {
       const mimeType = MIME_TYPES[extension] ?? 'application/octet-stream';
 
       if (extension === '.html') {
-        content = injectBridge(content.toString('utf8'), relativePath.replace(/\\/g, '/'));
+        content = injectBridge(content.toString('utf8'), normalizedRelativePath);
       }
 
       res.writeHead(200, {

--- a/packages/services/src/canvas/CanvasService.test.ts
+++ b/packages/services/src/canvas/CanvasService.test.ts
@@ -77,7 +77,7 @@ describe('CanvasService', () => {
     const content = fs.readFileSync(contentPath, 'utf8');
 
     expect(server.start).toHaveBeenCalledOnce();
-    expect(openedUrls).toContain('http://127.0.0.1:4312/mind-1/daily-plan.html');
+    expect(openedUrls[0]).toMatch(/^http:\/\/127\.0\.0\.1:4312\/mind-1\/daily-plan\.html\?token=[A-Za-z0-9_-]+$/);
     expect(content).toContain('<!DOCTYPE html>');
     expect(content).toContain('<h1>Plan</h1>');
     expect(result).toContain('opened in browser');
@@ -98,7 +98,32 @@ describe('CanvasService', () => {
     const copied = fs.readFileSync(path.join(mindPath, '.chamber', 'canvas', 'copied.html'), 'utf8');
     expect(copied).toBe('<html><body>From file</body></html>');
     expect(openedUrls).toHaveLength(0);
-    expect(result).toContain('http://127.0.0.1:4312/mind-1/copied.html');
+    expect(result).toMatch(/http:\/\/127\.0\.0\.1:4312\/mind-1\/copied\.html\?token=[A-Za-z0-9_-]+/);
+  });
+
+  it('serves a Lens html source as an embedded canvas without opening the browser', async () => {
+    const mindPath = makeMindPath();
+    const sourceFile = path.join(mindPath, '.github', 'lens', 'command-center', 'index.html');
+    fs.mkdirSync(path.dirname(sourceFile), { recursive: true });
+    fs.writeFileSync(sourceFile, '<html><body>Command</body></html>', 'utf8');
+
+    const url = await service.showLensCanvas('mind-1', mindPath, 'command-center', sourceFile);
+
+    expect(server.start).toHaveBeenCalledOnce();
+    expect(openedUrls).toHaveLength(0);
+    const servedFilename = new URL(url).pathname.split('/').pop();
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:4312\/mind-1\/lens-[a-f0-9]{16}\.html\?token=[A-Za-z0-9_-]+$/);
+    expect(fs.readFileSync(path.join(mindPath, '.chamber', 'canvas', servedFilename ?? ''), 'utf8')).toContain('Command');
+    expect(server.reload).toHaveBeenCalledWith('mind-1', servedFilename);
+  });
+
+  it('rejects embedded Lens canvas sources outside the mind lens directory', async () => {
+    const mindPath = makeMindPath();
+    const sourceFile = path.join(mindPath, 'outside.html');
+    fs.writeFileSync(sourceFile, '<html><body>Outside</body></html>', 'utf8');
+
+    await expect(service.showLensCanvas('mind-1', mindPath, 'outside', sourceFile))
+      .rejects.toThrow('inside the mind .github/lens directory');
   });
 
   it('updates an existing canvas and triggers targeted reload', async () => {

--- a/packages/services/src/canvas/CanvasService.ts
+++ b/packages/services/src/canvas/CanvasService.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { createHash, randomBytes } from 'node:crypto';
 import { Logger } from '../logger';
 import type { ChamberToolProvider } from '../chamberTools';
 
@@ -36,6 +37,17 @@ function validateCanvasName(name: string): void {
   }
 }
 
+function normalizePath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const normalizedParent = normalizePath(parent);
+  const normalizedChild = normalizePath(child);
+  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}${path.sep}`);
+}
+
 function wrapHtml(name: string, html: string, title?: string): string {
   const lowerCaseHtml = html.toLowerCase();
   if (!lowerCaseHtml.includes('<!doctype') && !lowerCaseHtml.includes('<html')) {
@@ -63,17 +75,20 @@ ${html}
 export class CanvasService implements ChamberToolProvider {
   private readonly mindPaths = new Map<string, string>();
   private readonly canvases = new Map<string, Map<string, CanvasEntry>>();
+  private readonly lensViewIdsByCanvas = new Map<string, Map<string, string>>();
   private readonly server: CanvasServerLike;
   private readonly openExternal: ExternalOpener;
+  private readonly onAction: (action: CanvasAction) => void;
 
   constructor(options: CanvasServiceOptions = {}) {
-    const onAction = options.onAction ?? ((action: CanvasAction) => {
+    this.onAction = options.onAction ?? ((action: CanvasAction) => {
       log.info('Action received:', action);
     });
 
     this.server = options.server ?? new CanvasServer({
       resolveContentDir: (mindId) => this.getContentDirForMind(mindId),
-      onAction,
+      onAction: (action) => this.onAction(this.decorateCanvasAction(action)),
+      authorizeRequest: (mindId, filename, token) => this.isAuthorizedCanvasRequest(mindId, filename, token),
     });
     this.openExternal = options.openExternal ?? {
       open: () => {
@@ -93,6 +108,7 @@ export class CanvasService implements ChamberToolProvider {
   async releaseMind(mindId: string): Promise<void> {
     this.server.closeClients(mindId);
     this.canvases.delete(mindId);
+    this.lensViewIdsByCanvas.delete(mindId);
     this.mindPaths.delete(mindId);
     await this.stopServerIfIdle();
   }
@@ -120,11 +136,13 @@ export class CanvasService implements ChamberToolProvider {
     }
 
     const port = await this.server.start();
-    const url = this.buildCanvasUrl(mindId, filename, port);
+    const token = this.getExistingToken(mindId, input.name) ?? createCanvasToken();
+    const url = this.buildCanvasUrl(mindId, filename, port, token);
     this.upsertCanvas(mindId, {
       filename,
       name: input.name,
       url,
+      token,
     });
 
     if (input.open_browser !== false) {
@@ -133,6 +151,41 @@ export class CanvasService implements ChamberToolProvider {
     }
 
     return `Canvas **${input.name}** is live at ${url}`;
+  }
+
+  async showLensCanvas(mindId: string, mindPath: string, viewId: string, sourcePath: string): Promise<string> {
+    if (!path.isAbsolute(sourcePath)) {
+      throw new Error('Canvas Lens source path must be absolute');
+    }
+    const lensDir = path.join(mindPath, '.github', 'lens');
+    if (!isPathInside(lensDir, sourcePath)) {
+      throw new Error('Canvas Lens source path must be inside the mind .github/lens directory');
+    }
+    if (!fs.existsSync(sourcePath)) {
+      throw new Error(`Canvas Lens source file not found: ${sourcePath}`);
+    }
+
+    const contentDir = this.ensureMind(mindId, mindPath);
+    const name = this.getLensCanvasName(viewId);
+    const filename = `${name}.html`;
+    fs.copyFileSync(sourcePath, path.join(contentDir, filename));
+
+    const port = await this.server.start();
+    const token = this.getExistingToken(mindId, name) ?? createCanvasToken();
+    const url = this.buildCanvasUrl(mindId, filename, port, token);
+    this.upsertCanvas(mindId, {
+      filename,
+      name,
+      url,
+      token,
+    });
+
+    const lensViews = this.lensViewIdsByCanvas.get(mindId) ?? new Map<string, string>();
+    lensViews.set(filename, viewId);
+    this.lensViewIdsByCanvas.set(mindId, lensViews);
+    this.server.reload(mindId, filename);
+
+    return url;
   }
 
   updateCanvas(mindId: string, mindPath: string, input: CanvasUpdateInput): string {
@@ -160,6 +213,7 @@ export class CanvasService implements ChamberToolProvider {
 
     const canvases = this.canvases.get(mindId);
     canvases?.delete(input.name);
+    this.removeLensCanvasMapping(mindId, existing.filename);
     if (canvases && canvases.size === 0) {
       this.canvases.delete(mindId);
     }
@@ -202,6 +256,7 @@ export class CanvasService implements ChamberToolProvider {
     const count = canvases.size;
     for (const entry of canvases.values()) {
       this.deleteCanvasFile(mindId, entry.filename);
+      this.removeLensCanvasMapping(mindId, entry.filename);
     }
     this.canvases.delete(mindId);
 
@@ -240,8 +295,43 @@ export class CanvasService implements ChamberToolProvider {
     this.canvases.set(mindId, canvases);
   }
 
-  private buildCanvasUrl(mindId: string, filename: string, port: number): string {
-    return `http://127.0.0.1:${port}/${encodeURIComponent(mindId)}/${encodeURIComponent(filename)}`;
+  private buildCanvasUrl(mindId: string, filename: string, port: number, token: string): string {
+    return `http://127.0.0.1:${port}/${encodeURIComponent(mindId)}/${encodeURIComponent(filename)}?token=${encodeURIComponent(token)}`;
+  }
+
+  private getLensCanvasName(viewId: string): string {
+    const digest = createHash('sha256').update(viewId).digest('hex').slice(0, 16);
+    return `lens-${digest}`;
+  }
+
+  private decorateCanvasAction(action: CanvasAction): CanvasAction {
+    const lensViewId = this.lensViewIdsByCanvas.get(action.mindId)?.get(action.canvas);
+    return lensViewId ? { ...action, lensViewId } : action;
+  }
+
+  private getExistingToken(mindId: string, name: string): string | null {
+    return this.canvases.get(mindId)?.get(name)?.token ?? null;
+  }
+
+  private isAuthorizedCanvasRequest(mindId: string, filename: string, token: string | null): boolean {
+    if (!token) return false;
+    const canvases = this.canvases.get(mindId);
+    if (!canvases) return false;
+    const normalizedFilename = filename.replace(/\\/g, '/');
+    for (const canvas of canvases.values()) {
+      if (canvas.filename === normalizedFilename && canvas.token === token) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private removeLensCanvasMapping(mindId: string, filename: string): void {
+    const lensViews = this.lensViewIdsByCanvas.get(mindId);
+    lensViews?.delete(filename);
+    if (lensViews?.size === 0) {
+      this.lensViewIdsByCanvas.delete(mindId);
+    }
   }
 
   private deleteCanvasFile(mindId: string, filename: string): void {
@@ -266,4 +356,8 @@ export class CanvasService implements ChamberToolProvider {
       await this.server.stop();
     }
   }
+}
+
+function createCanvasToken(): string {
+  return randomBytes(32).toString('base64url');
 }

--- a/packages/services/src/canvas/types.ts
+++ b/packages/services/src/canvas/types.ts
@@ -4,12 +4,14 @@ export interface CanvasAction {
   action: string;
   data: unknown;
   timestamp: number;
+  lensViewId?: string;
 }
 
 export interface CanvasEntry {
   name: string;
   filename: string;
   url: string;
+  token: string;
 }
 
 export interface CanvasShowInput {

--- a/packages/services/src/lens/MindBootstrap.test.ts
+++ b/packages/services/src/lens/MindBootstrap.test.ts
@@ -8,7 +8,7 @@ vi.mock('fs', () => ({
 }));
 
 import * as fs from 'fs';
-import { seedLensDefaults } from './MindBootstrap';
+import { installLensSkill, seedLensDefaults } from './MindBootstrap';
 
 describe('seedLensDefaults', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -22,6 +22,134 @@ describe('seedLensDefaults', () => {
   it('skips when views exist', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     seedLensDefaults('C:\\test\\mind');
+    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+  });
+});
+
+describe('installLensSkill', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('installs the bundled Lens skill with managed metadata when missing', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => String(p).includes('assets\\lens-skill\\SKILL.md'));
+    vi.mocked(fs.readFileSync).mockReturnValue('---\nname: lens\nversion: 2.0.0\n---\n# Lens');
+
+    installLensSkill('C:\\test\\mind');
+
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('SKILL.md'),
+      expect.stringContaining('# Lens'),
+    );
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('.chamber-skill.json'),
+      expect.stringContaining('"version": "2.0.0"'),
+    );
+  });
+
+  it('installs the Lens skill from packaged Forge resources', () => {
+    const previousResourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: 'C:\\packed\\resources',
+    });
+    vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === 'C:\\packed\\resources\\lens-skill\\SKILL.md');
+    vi.mocked(fs.readFileSync).mockReturnValue('---\nname: lens\nversion: 2.0.0\n---\n# Packaged Lens');
+
+    try {
+      installLensSkill('C:\\test\\mind');
+    } finally {
+      Object.defineProperty(process, 'resourcesPath', {
+        configurable: true,
+        value: previousResourcesPath,
+      });
+    }
+
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('SKILL.md'),
+      expect.stringContaining('# Packaged Lens'),
+    );
+  });
+
+  it('upgrades a managed unmodified Lens skill', () => {
+    const oldContent = 'old managed content';
+    const oldHash = '5b701009643e89a73dd2cbe5c2f56e819650c0aeac106ad1dfea77d60b526a22';
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync)
+      .mockReturnValueOnce('new bundled content')
+      .mockReturnValueOnce(oldContent)
+      .mockReturnValueOnce(JSON.stringify({
+        name: 'lens',
+        version: '1.0.0',
+        managedBy: 'chamber',
+        contentSha256: oldHash,
+        capabilities: ['lens-json'],
+      }));
+
+    installLensSkill('C:\\test\\mind');
+
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('SKILL.md'),
+      'new bundled content',
+    );
+  });
+
+  it('preserves edited legacy-looking Lens skills without metadata', () => {
+    const legacySkill = [
+      '---',
+      'name: lens',
+      'description: Create and manage Lens views',
+      '---',
+      '# Lens — Declarative UI Views',
+      'Create `view.json` manifests in `.github/lens/<view-name>/` to add views.',
+      '"view": "form | table | briefing"',
+      '',
+      'Local instruction: do not overwrite this customization.',
+    ].join('\n');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync)
+      .mockReturnValueOnce('new bundled content')
+      .mockReturnValueOnce(legacySkill);
+
+    installLensSkill('C:\\test\\mind');
+
+    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+  });
+
+  it('preserves compact edited legacy-looking Lens skills', () => {
+    const legacySkill = [
+      '---',
+      'name: lens',
+      'description: Create and manage Lens views',
+      '---',
+      '# Lens — Declarative UI Views',
+      'Views live under .github/lens/<view-name>/view.json.',
+      'The old contract supports form, table, and briefing panels.',
+      'Local instruction: prefer concise panels.',
+    ].join('\n');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync)
+      .mockReturnValueOnce('new bundled content')
+      .mockReturnValueOnce(legacySkill);
+
+    installLensSkill('C:\\test\\mind');
+
+    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+  });
+
+  it('preserves locally edited managed Lens skills', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync)
+      .mockReturnValueOnce('new bundled content')
+      .mockReturnValueOnce('locally edited content')
+      .mockReturnValueOnce(JSON.stringify({
+        name: 'lens',
+        version: '1.0.0',
+        managedBy: 'chamber',
+        contentSha256: 'different',
+        capabilities: ['lens-json'],
+      }));
+
+    installLensSkill('C:\\test\\mind');
+
     expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
   });
 });

--- a/packages/services/src/lens/MindBootstrap.test.ts
+++ b/packages/services/src/lens/MindBootstrap.test.ts
@@ -8,7 +8,7 @@ vi.mock('fs', () => ({
 }));
 
 import * as fs from 'fs';
-import { installLensSkill, seedLensDefaults } from './MindBootstrap';
+import { bootstrapMindCapabilities, installLensSkill, seedLensDefaults } from './MindBootstrap';
 
 describe('seedLensDefaults', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -23,6 +23,26 @@ describe('seedLensDefaults', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     seedLensDefaults('C:\\test\\mind');
     expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+  });
+});
+
+describe('bootstrapMindCapabilities', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('seeds default lenses and installs the managed Lens skill', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => String(p).includes('assets\\lens-skill\\SKILL.md'));
+    vi.mocked(fs.readFileSync).mockReturnValue('---\nname: lens\nversion: 2.0.0\n---\n# Lens');
+
+    bootstrapMindCapabilities('C:\\test\\mind');
+
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('hello-world'),
+      expect.any(String),
+    );
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('SKILL.md'),
+      expect.stringContaining('# Lens'),
+    );
   });
 });
 
@@ -92,7 +112,7 @@ describe('installLensSkill', () => {
     );
   });
 
-  it('preserves edited legacy-looking Lens skills without metadata', () => {
+  it('upgrades legacy-looking unversioned Lens skills with a backup', () => {
     const legacySkill = [
       '---',
       'name: lens',
@@ -104,17 +124,24 @@ describe('installLensSkill', () => {
       '',
       'Local instruction: do not overwrite this customization.',
     ].join('\n');
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockImplementation((p) => !String(p).includes('legacy-backup'));
     vi.mocked(fs.readFileSync)
       .mockReturnValueOnce('new bundled content')
       .mockReturnValueOnce(legacySkill);
 
     installLensSkill('C:\\test\\mind');
 
-    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('SKILL.legacy-backup.md'),
+      legacySkill,
+    );
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('SKILL.md'),
+      'new bundled content',
+    );
   });
 
-  it('preserves compact edited legacy-looking Lens skills', () => {
+  it('upgrades compact legacy-looking unversioned Lens skills', () => {
     const legacySkill = [
       '---',
       'name: lens',
@@ -125,14 +152,17 @@ describe('installLensSkill', () => {
       'The old contract supports form, table, and briefing panels.',
       'Local instruction: prefer concise panels.',
     ].join('\n');
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockImplementation((p) => !String(p).includes('legacy-backup'));
     vi.mocked(fs.readFileSync)
       .mockReturnValueOnce('new bundled content')
       .mockReturnValueOnce(legacySkill);
 
     installLensSkill('C:\\test\\mind');
 
-    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('SKILL.md'),
+      'new bundled content',
+    );
   });
 
   it('preserves locally edited managed Lens skills', () => {
@@ -147,6 +177,17 @@ describe('installLensSkill', () => {
         contentSha256: 'different',
         capabilities: ['lens-json'],
       }));
+
+    installLensSkill('C:\\test\\mind');
+
+    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+  });
+
+  it('preserves unmanaged non-Lens skills', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync)
+      .mockReturnValueOnce('new bundled content')
+      .mockReturnValueOnce('custom unrelated skill');
 
     installLensSkill('C:\\test\\mind');
 

--- a/packages/services/src/lens/MindBootstrap.ts
+++ b/packages/services/src/lens/MindBootstrap.ts
@@ -71,6 +71,11 @@ export function seedLensDefaults(mindPath: string): void {
   }
 }
 
+export function bootstrapMindCapabilities(mindPath: string): void {
+  seedLensDefaults(mindPath);
+  installLensSkill(mindPath);
+}
+
 export function installLensSkill(mindPath: string): void {
   const skillDir = path.join(mindPath, '.github', 'skills', 'lens');
   const skillPath = path.join(skillDir, 'SKILL.md');
@@ -113,11 +118,22 @@ export function installLensSkill(mindPath: string): void {
   }
 
   if (isLegacyBundledLensSkill(installedContent)) {
-    log.warn('Lens skill looks like an edited legacy skill; skipping install to preserve local edits');
+    log.info(`Upgrading legacy Lens skill to ${LENS_SKILL_VERSION}`);
+    backupLegacyLensSkill(skillDir, installedContent);
+    writeManagedLensSkill(skillDir, skillPath, metadataPath, content, contentSha256);
     return;
   }
 
   log.warn('Lens skill is unmanaged; skipping install to preserve local edits');
+}
+
+function backupLegacyLensSkill(skillDir: string, installedContent: string): void {
+  const baseBackupPath = path.join(skillDir, 'SKILL.legacy-backup.md');
+  let backupPath = baseBackupPath;
+  for (let index = 1; fs.existsSync(backupPath); index += 1) {
+    backupPath = path.join(skillDir, `SKILL.legacy-backup-${index}.md`);
+  }
+  fs.writeFileSync(backupPath, installedContent);
 }
 
 function readBundledLensSkill(): string | null {
@@ -145,7 +161,6 @@ function isLegacyBundledLensSkill(content: string): boolean {
   const normalized = content.toLowerCase();
   return content.includes('name: lens')
     && !content.includes('version:')
-    && content.includes('# Lens — Declarative UI Views')
     && normalized.includes('.github/lens')
     && normalized.includes('form')
     && normalized.includes('table')

--- a/packages/services/src/lens/MindBootstrap.ts
+++ b/packages/services/src/lens/MindBootstrap.ts
@@ -3,9 +3,16 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { createHash } from 'crypto';
 import { Logger } from '../logger';
 
 const log = Logger.create('MindBootstrap');
+const LENS_SKILL_VERSION = '2.0.0';
+const LENS_SKILL_METADATA = '.chamber-skill.json';
+const KNOWN_UNVERSIONED_LENS_SKILL_HASHES = new Set([
+  '1f263ca4285fef4c9b497ab42a286bd246ff2dfdbd0c3170101db9f2c92d23e3',
+  '716367d40a6fa9a5a6980437ac5a4bac25118e439ccf1b70e2b21d735c0d84da',
+]);
 
 export function seedLensDefaults(mindPath: string): void {
   const lensDir = path.join(mindPath, '.github', 'lens');
@@ -67,15 +74,60 @@ export function seedLensDefaults(mindPath: string): void {
 export function installLensSkill(mindPath: string): void {
   const skillDir = path.join(mindPath, '.github', 'skills', 'lens');
   const skillPath = path.join(skillDir, 'SKILL.md');
+  const metadataPath = path.join(skillDir, LENS_SKILL_METADATA);
+  const content = readBundledLensSkill();
 
-  if (fs.existsSync(skillPath)) return;
+  if (!content) {
+    log.warn('Lens skill asset not found, skipping install');
+    return;
+  }
 
-  // Read bundled SKILL.md — check packaged, built, and dev paths
+  const contentSha256 = sha256(content);
+  if (!fs.existsSync(skillPath)) {
+    log.info('Installing Lens skill into mind');
+    writeManagedLensSkill(skillDir, skillPath, metadataPath, content, contentSha256);
+    return;
+  }
+
+  const installedContent = fs.readFileSync(skillPath, 'utf-8');
+  const installedSha256 = sha256(installedContent);
+  const metadata = readLensSkillMetadata(metadataPath);
+
+  if (metadata?.managedBy === 'chamber') {
+    if (metadata.contentSha256 !== installedSha256) {
+      log.warn('Lens skill has local edits; skipping managed upgrade');
+      return;
+    }
+
+    if (compareVersions(metadata.version, LENS_SKILL_VERSION) < 0 || installedSha256 !== contentSha256) {
+      log.info(`Upgrading Lens skill from ${metadata.version} to ${LENS_SKILL_VERSION}`);
+      writeManagedLensSkill(skillDir, skillPath, metadataPath, content, contentSha256);
+    }
+    return;
+  }
+
+  if (KNOWN_UNVERSIONED_LENS_SKILL_HASHES.has(installedSha256)) {
+    log.info(`Migrating unversioned Lens skill to ${LENS_SKILL_VERSION}`);
+    writeManagedLensSkill(skillDir, skillPath, metadataPath, content, contentSha256);
+    return;
+  }
+
+  if (isLegacyBundledLensSkill(installedContent)) {
+    log.warn('Lens skill looks like an edited legacy skill; skipping install to preserve local edits');
+    return;
+  }
+
+  log.warn('Lens skill is unmanaged; skipping install to preserve local edits');
+}
+
+function readBundledLensSkill(): string | null {
   const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath ?? '';
   const candidates = [
     path.join(resourcesPath, 'assets', 'lens-skill', 'SKILL.md'),
+    path.join(resourcesPath, 'lens-skill', 'SKILL.md'),
     path.join(__dirname, '..', 'assets', 'lens-skill', 'SKILL.md'),
     path.join(__dirname, '..', '..', 'src', 'main', 'assets', 'lens-skill', 'SKILL.md'),
+    path.join(process.cwd(), 'apps', 'desktop', 'src', 'main', 'assets', 'lens-skill', 'SKILL.md'),
   ];
 
   let content: string | null = null;
@@ -86,12 +138,76 @@ export function installLensSkill(mindPath: string): void {
     }
   }
 
-  if (!content) {
-    log.warn('Lens skill asset not found, skipping install');
-    return;
-  }
+  return content;
+}
 
-  log.info('Installing Lens skill into mind');
+function isLegacyBundledLensSkill(content: string): boolean {
+  const normalized = content.toLowerCase();
+  return content.includes('name: lens')
+    && !content.includes('version:')
+    && content.includes('# Lens — Declarative UI Views')
+    && normalized.includes('.github/lens')
+    && normalized.includes('form')
+    && normalized.includes('table')
+    && normalized.includes('briefing')
+    && !normalized.includes('canvas lens');
+}
+
+interface LensSkillMetadata {
+  name: string;
+  version: string;
+  managedBy: 'chamber';
+  contentSha256: string;
+  capabilities: string[];
+}
+
+function readLensSkillMetadata(metadataPath: string): LensSkillMetadata | null {
+  if (!fs.existsSync(metadataPath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(metadataPath, 'utf-8')) as Partial<LensSkillMetadata>;
+    if (
+      parsed.name === 'lens'
+      && parsed.managedBy === 'chamber'
+      && typeof parsed.version === 'string'
+      && typeof parsed.contentSha256 === 'string'
+      && Array.isArray(parsed.capabilities)
+    ) {
+      return parsed as LensSkillMetadata;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function writeManagedLensSkill(
+  skillDir: string,
+  skillPath: string,
+  metadataPath: string,
+  content: string,
+  contentSha256: string,
+): void {
   fs.mkdirSync(skillDir, { recursive: true });
   fs.writeFileSync(skillPath, content);
+  fs.writeFileSync(metadataPath, JSON.stringify({
+    name: 'lens',
+    version: LENS_SKILL_VERSION,
+    managedBy: 'chamber',
+    contentSha256,
+    capabilities: ['lens-json', 'canvas-lens', 'chamber-theme-v1'],
+  }, null, 2) + '\n');
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (leftParts[index] || 0) - (rightParts[index] || 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
 }

--- a/packages/services/src/lens/ViewDiscovery.test.ts
+++ b/packages/services/src/lens/ViewDiscovery.test.ts
@@ -16,7 +16,6 @@ vi.mock('fs', () => ({
 
 import * as fs from 'fs';
 import { ViewDiscovery } from './ViewDiscovery';
-import type { LensViewManifest } from '@chamber/shared/types';
 
 const mockExistsSync = vi.mocked(fs.existsSync);
 const mockReaddirSync = vi.mocked(fs.readdirSync);
@@ -188,66 +187,6 @@ describe('ViewDiscovery', () => {
       await discovery.scan('/tmp/mind-b');
 
       expect(discovery.getViews()).toHaveLength(2);
-    });
-  });
-
-  describe('lens_create tool', () => {
-    it('creates the Lens directory, manifest, and Canvas source file', async () => {
-      mockExistsSync.mockReturnValue(false);
-      const tool = discovery.getToolsForMind('mind-1', 'C:\\test\\mind')
-        .find((candidate) => candidate.name === 'lens_create');
-      if (!tool) throw new Error('Expected lens_create tool');
-
-      const result = await tool.handler({
-        viewId: 'cron-jobs',
-        name: 'Cron Jobs',
-        icon: 'clock',
-        view: 'canvas',
-        source: 'index.html',
-        content: '<!doctype html><html><body class="ch-page">Cron</body></html>',
-      }, {} as never) as { ok: boolean; view: LensViewManifest };
-
-      expect(result.ok).toBe(true);
-      expect(result.view).toEqual(expect.objectContaining({
-        id: 'cron-jobs',
-        name: 'Cron Jobs',
-        view: 'canvas',
-        source: 'index.html',
-      }));
-      expect(fs.mkdirSync).toHaveBeenCalledWith(
-        path.join('C:\\test\\mind', '.github', 'lens', 'cron-jobs'),
-        { recursive: true },
-      );
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        path.join('C:\\test\\mind', '.github', 'lens', 'cron-jobs', 'view.json'),
-        expect.stringContaining('"view": "canvas"'),
-        'utf-8',
-      );
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        path.join('C:\\test\\mind', '.github', 'lens', 'cron-jobs', 'index.html'),
-        expect.stringContaining('Cron'),
-        'utf-8',
-      );
-    });
-
-    it('rejects unsafe Lens ids and Canvas sources', async () => {
-      await expect(discovery.createView('/tmp/mind', {
-        viewId: '../bad',
-        name: 'Bad',
-        icon: 'clock',
-        view: 'canvas',
-        source: 'index.html',
-        content: '<html></html>',
-      })).rejects.toThrow('viewId');
-
-      await expect(discovery.createView('/tmp/mind', {
-        viewId: 'bad-source',
-        name: 'Bad',
-        icon: 'clock',
-        view: 'canvas',
-        source: 'data.json',
-        content: '<html></html>',
-      })).rejects.toThrow('Canvas Lens sources must be .html files');
     });
   });
 

--- a/packages/services/src/lens/ViewDiscovery.test.ts
+++ b/packages/services/src/lens/ViewDiscovery.test.ts
@@ -16,6 +16,7 @@ vi.mock('fs', () => ({
 
 import * as fs from 'fs';
 import { ViewDiscovery } from './ViewDiscovery';
+import type { LensViewManifest } from '@chamber/shared/types';
 
 const mockExistsSync = vi.mocked(fs.existsSync);
 const mockReaddirSync = vi.mocked(fs.readdirSync);
@@ -108,6 +109,45 @@ describe('ViewDiscovery', () => {
       await expect(discovery.scan('/tmp/test/mind')).resolves.toEqual([]);
     });
 
+    it('accepts Canvas Lens manifests with html sources', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'command-center', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        name: 'Command Center',
+        icon: 'layout',
+        view: 'canvas',
+        source: 'index.html',
+      }));
+
+      const views = await discovery.scan('/tmp/test/mind');
+
+      expect(views).toEqual([
+        expect.objectContaining({
+          id: 'command-center',
+          name: 'Command Center',
+          view: 'canvas',
+          source: 'index.html',
+        }),
+      ]);
+    });
+
+    it('skips Canvas Lens manifests with non-html sources', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'bad-canvas', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        name: 'Bad Canvas',
+        icon: 'layout',
+        view: 'canvas',
+        source: 'data.json',
+      }));
+
+      await expect(discovery.scan('/tmp/test/mind')).resolves.toEqual([]);
+    });
+
     it('skips manifests with missing source', async () => {
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue([
@@ -151,6 +191,66 @@ describe('ViewDiscovery', () => {
     });
   });
 
+  describe('lens_create tool', () => {
+    it('creates the Lens directory, manifest, and Canvas source file', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const tool = discovery.getToolsForMind('mind-1', 'C:\\test\\mind')
+        .find((candidate) => candidate.name === 'lens_create');
+      if (!tool) throw new Error('Expected lens_create tool');
+
+      const result = await tool.handler({
+        viewId: 'cron-jobs',
+        name: 'Cron Jobs',
+        icon: 'clock',
+        view: 'canvas',
+        source: 'index.html',
+        content: '<!doctype html><html><body class="ch-page">Cron</body></html>',
+      }, {} as never) as { ok: boolean; view: LensViewManifest };
+
+      expect(result.ok).toBe(true);
+      expect(result.view).toEqual(expect.objectContaining({
+        id: 'cron-jobs',
+        name: 'Cron Jobs',
+        view: 'canvas',
+        source: 'index.html',
+      }));
+      expect(fs.mkdirSync).toHaveBeenCalledWith(
+        path.join('C:\\test\\mind', '.github', 'lens', 'cron-jobs'),
+        { recursive: true },
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        path.join('C:\\test\\mind', '.github', 'lens', 'cron-jobs', 'view.json'),
+        expect.stringContaining('"view": "canvas"'),
+        'utf-8',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        path.join('C:\\test\\mind', '.github', 'lens', 'cron-jobs', 'index.html'),
+        expect.stringContaining('Cron'),
+        'utf-8',
+      );
+    });
+
+    it('rejects unsafe Lens ids and Canvas sources', async () => {
+      await expect(discovery.createView('/tmp/mind', {
+        viewId: '../bad',
+        name: 'Bad',
+        icon: 'clock',
+        view: 'canvas',
+        source: 'index.html',
+        content: '<html></html>',
+      })).rejects.toThrow('viewId');
+
+      await expect(discovery.createView('/tmp/mind', {
+        viewId: 'bad-source',
+        name: 'Bad',
+        icon: 'clock',
+        view: 'canvas',
+        source: 'data.json',
+        content: '<html></html>',
+      })).rejects.toThrow('Canvas Lens sources must be .html files');
+    });
+  });
+
   describe('getViewData', () => {
     it('returns parsed data for valid view', async () => {
       mockExistsSync.mockReturnValue(true);
@@ -185,6 +285,23 @@ describe('ViewDiscovery', () => {
 
       mockReadFileSync.mockReturnValueOnce(JSON.stringify(['not', 'an', 'object']));
       expect(discovery.getViewData('test', '/tmp/test/mind')).toBeNull();
+    });
+
+    it('does not parse Canvas Lens html as JSON data', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'canvas', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      mockReadFileSync.mockReturnValueOnce(JSON.stringify({
+        name: 'Canvas',
+        icon: 'layout',
+        view: 'canvas',
+        source: 'index.html',
+      }));
+
+      await discovery.scan('/tmp/test/mind');
+
+      expect(discovery.getViewData('canvas', '/tmp/test/mind')).toBeNull();
     });
   });
 

--- a/packages/services/src/lens/ViewDiscovery.ts
+++ b/packages/services/src/lens/ViewDiscovery.ts
@@ -3,7 +3,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { LensViewManifest } from '@chamber/shared/types';
+import type { CanvasLensAction, LensViewManifest } from '@chamber/shared/types';
+import type { ChamberToolProvider } from '../chamberTools';
+import type { Tool } from '../mind/types';
 import { Logger } from '../logger';
 
 const log = Logger.create('ViewDiscovery');
@@ -18,13 +20,26 @@ const SUPPORTED_LENS_VIEWS = new Set<LensViewManifest['view']>([
   'detail',
   'timeline',
   'editor',
+  'canvas',
 ]);
 
 export interface ViewRefreshHandler {
   sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void>;
 }
 
-export class ViewDiscovery {
+interface CreateLensViewInput {
+  viewId: string;
+  name: string;
+  icon: string;
+  view: LensViewManifest['view'];
+  source: string;
+  content: unknown;
+  prompt?: string;
+  refreshOn?: 'click' | 'interval';
+  schema?: Record<string, unknown>;
+}
+
+export class ViewDiscovery implements ChamberToolProvider {
   private viewsByMind = new Map<string, LensViewManifest[]>();
   private watchersByMind = new Map<string, fs.FSWatcher[]>();
   private scanTimersByMind = new Map<string, ReturnType<typeof setTimeout>>();
@@ -36,6 +51,48 @@ export class ViewDiscovery {
 
   setRefreshHandler(handler: ViewRefreshHandler): void {
     this.refreshHandler = handler;
+  }
+
+  getToolsForMind(_mindId: string, mindPath: string): Tool[] {
+    return [{
+      name: 'lens_create',
+      description: 'Create or replace a Chamber Lens view. Creates the .github/lens/<viewId>/ directory, view.json manifest, and source file in one safe operation.',
+      parameters: {
+        type: 'object',
+        properties: {
+          viewId: {
+            type: 'string',
+            description: 'Directory id for the Lens view. Use lowercase letters, numbers, hyphens, or underscores.',
+          },
+          name: { type: 'string', description: 'Display name for the Activity Bar tooltip and view header.' },
+          icon: { type: 'string', description: 'Lucide icon name, for example layout, table, newspaper, clock, or zap.' },
+          view: {
+            type: 'string',
+            enum: [...SUPPORTED_LENS_VIEWS],
+            description: 'Lens renderer type. Use canvas for rich HTML UI.',
+          },
+          source: {
+            type: 'string',
+            description: 'Source filename inside the view folder. Canvas views must use an .html file such as index.html.',
+          },
+          content: {
+            description: 'Source file content. For canvas, provide HTML. For classic JSON views, provide a JSON object/array or a JSON string.',
+          },
+          prompt: { type: 'string', description: 'Optional refresh prompt.' },
+          refreshOn: { type: 'string', enum: ['click', 'interval'], description: 'Optional refresh behavior.' },
+          schema: { type: 'object', description: 'Optional JSON schema for classic Lens views.' },
+        },
+        required: ['viewId', 'name', 'icon', 'view', 'source', 'content'],
+      },
+      handler: async (args) => {
+        const view = await this.createView(mindPath, args as unknown as CreateLensViewInput);
+        return {
+          ok: true,
+          view,
+          message: `Created Lens view "${view.name}" at .github/lens/${view.id}/.`,
+        };
+      },
+    }] as Tool[];
   }
 
   async scan(mindPath: string): Promise<LensViewManifest[]> {
@@ -87,6 +144,7 @@ export class ViewDiscovery {
     const views = mindPath ? this.getViews(mindPath) : this.getViews();
     const view = views.find(v => v.id === viewId);
     if (!view || !view._basePath) return null;
+    if (view.view === 'canvas') return null;
 
     const dataPath = path.join(view._basePath, view.source);
     if (!fs.existsSync(dataPath)) return null;
@@ -99,13 +157,62 @@ export class ViewDiscovery {
     }
   }
 
+  getViewSourcePath(viewId: string, mindPath: string): string | null {
+    const view = this.getViews(mindPath).find(v => v.id === viewId);
+    if (!view || !view._basePath) return null;
+    return path.join(view._basePath, view.source);
+  }
+
+  async createView(mindPath: string, input: CreateLensViewInput): Promise<LensViewManifest> {
+    const viewId = parseViewId(input.viewId);
+    const source = parseSource(input.source, input.view);
+    if (typeof input.name !== 'string' || input.name.trim() === '') {
+      throw new Error('lens_create requires a non-empty name');
+    }
+    if (typeof input.icon !== 'string' || input.icon.trim() === '') {
+      throw new Error('lens_create requires a non-empty icon');
+    }
+    if (!isLensViewType(input.view)) {
+      throw new Error(`Unsupported Lens view type: ${String(input.view)}`);
+    }
+
+    const lensDir = path.join(mindPath, '.github', 'lens');
+    const viewDir = path.join(lensDir, viewId);
+    fs.mkdirSync(viewDir, { recursive: true });
+
+    const manifest = {
+      name: input.name,
+      icon: input.icon,
+      view: input.view,
+      source,
+      ...(input.prompt ? { prompt: input.prompt } : {}),
+      ...(input.refreshOn ? { refreshOn: input.refreshOn } : {}),
+      ...(input.schema ? { schema: input.schema } : {}),
+    };
+
+    fs.writeFileSync(path.join(viewDir, 'view.json'), JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+    fs.writeFileSync(path.join(viewDir, source), formatSourceContent(input.content, input.view), 'utf-8');
+
+    await this.scan(mindPath);
+    return this.getViews(mindPath).find(view => view.id === viewId)
+      ?? parseLensViewManifest(manifest, viewId, viewDir)
+      ?? {
+        ...manifest,
+        id: viewId,
+        _basePath: viewDir,
+      };
+  }
+
   async refreshView(viewId: string, mindPath: string): Promise<Record<string, unknown> | null> {
     const views = this.getViews(mindPath);
     const view = views.find(v => v.id === viewId);
     if (!view || !view.prompt || !view._basePath) return this.getViewData(viewId, mindPath);
 
     const dataPath = path.join(view._basePath, view.source);
-    const fullPrompt = `${view.prompt}\n\nWrite the JSON output to: ${dataPath}`;
+    const outputInstruction = view.view === 'canvas'
+      ? `Write the Chamber-branded HTML output to: ${dataPath}`
+      : `Write the JSON output to: ${dataPath}`;
+    const fullPrompt = `${view.prompt}\n\n${outputInstruction}`;
 
     try {
       await this.refreshHandler?.sendBackgroundPrompt(mindPath, fullPrompt);
@@ -129,6 +236,26 @@ export class ViewDiscovery {
     } catch {
       return this.getViewData(viewId, mindPath);
     }
+  }
+
+  async sendCanvasAction(viewId: string, action: CanvasLensAction, mindPath: string): Promise<void> {
+    const views = this.getViews(mindPath);
+    const view = views.find(v => v.id === viewId);
+    if (!view || view.view !== 'canvas' || !view._basePath) return;
+
+    const sourcePath = path.join(view._basePath, view.source);
+    const fullPrompt = [
+      `The user interacted with the Canvas Lens view "${view.name}" (source: ${sourcePath}).`,
+      '',
+      `Action: ${action.action}`,
+      action.intent ? `Intent: ${action.intent}` : null,
+      action.correlationId ? `Correlation ID: ${action.correlationId}` : null,
+      `Data: ${JSON.stringify(action.data ?? {})}`,
+      '',
+      'Use your normal Chamber tools and context to satisfy the action. If the UI should change, update the Canvas Lens HTML source file at the path above.',
+    ].filter((line): line is string => line !== null).join('\n');
+
+    await this.refreshHandler?.sendBackgroundPrompt(mindPath, fullPrompt);
   }
 
   startWatching(mindPath: string, onChanged: () => void): void {
@@ -209,6 +336,7 @@ function parseLensViewManifest(value: unknown, id: string, basePath: string): Le
   if (typeof value.name !== 'string' || typeof value.icon !== 'string') return null;
   if (!isLensViewType(value.view)) return null;
   if (!isSafeRelativeSource(value.source)) return null;
+  if (value.view === 'canvas' && !isHtmlSource(value.source)) return null;
 
   return {
     ...value,
@@ -229,6 +357,37 @@ function isSafeRelativeSource(value: unknown): value is string {
   if (typeof value !== 'string' || value.trim() === '') return false;
   if (path.isAbsolute(value) || path.win32.isAbsolute(value) || path.posix.isAbsolute(value)) return false;
   return !value.split(/[\\/]+/).includes('..');
+}
+
+function isHtmlSource(value: string): boolean {
+  return path.extname(value).toLowerCase() === '.html';
+}
+
+function parseViewId(value: unknown): string {
+  if (typeof value !== 'string' || !/^[a-z0-9][a-z0-9_-]*$/i.test(value)) {
+    throw new Error('lens_create viewId must use letters, numbers, hyphens, or underscores');
+  }
+  return value;
+}
+
+function parseSource(value: unknown, view: LensViewManifest['view']): string {
+  if (!isSafeRelativeSource(value)) {
+    throw new Error('lens_create source must be a safe relative filename');
+  }
+  if (view === 'canvas' && !isHtmlSource(value)) {
+    throw new Error('Canvas Lens sources must be .html files');
+  }
+  return value;
+}
+
+function formatSourceContent(content: unknown, view: LensViewManifest['view']): string {
+  if (typeof content === 'string') {
+    return content.endsWith('\n') ? content : `${content}\n`;
+  }
+  if (view === 'canvas') {
+    throw new Error('Canvas Lens content must be an HTML string');
+  }
+  return `${JSON.stringify(content, null, 2)}\n`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/services/src/lens/ViewDiscovery.ts
+++ b/packages/services/src/lens/ViewDiscovery.ts
@@ -4,8 +4,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { CanvasLensAction, LensViewManifest } from '@chamber/shared/types';
-import type { ChamberToolProvider } from '../chamberTools';
-import type { Tool } from '../mind/types';
 import { Logger } from '../logger';
 
 const log = Logger.create('ViewDiscovery');
@@ -27,19 +25,7 @@ export interface ViewRefreshHandler {
   sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void>;
 }
 
-interface CreateLensViewInput {
-  viewId: string;
-  name: string;
-  icon: string;
-  view: LensViewManifest['view'];
-  source: string;
-  content: unknown;
-  prompt?: string;
-  refreshOn?: 'click' | 'interval';
-  schema?: Record<string, unknown>;
-}
-
-export class ViewDiscovery implements ChamberToolProvider {
+export class ViewDiscovery {
   private viewsByMind = new Map<string, LensViewManifest[]>();
   private watchersByMind = new Map<string, fs.FSWatcher[]>();
   private scanTimersByMind = new Map<string, ReturnType<typeof setTimeout>>();
@@ -51,48 +37,6 @@ export class ViewDiscovery implements ChamberToolProvider {
 
   setRefreshHandler(handler: ViewRefreshHandler): void {
     this.refreshHandler = handler;
-  }
-
-  getToolsForMind(_mindId: string, mindPath: string): Tool[] {
-    return [{
-      name: 'lens_create',
-      description: 'Create or replace a Chamber Lens view. Creates the .github/lens/<viewId>/ directory, view.json manifest, and source file in one safe operation.',
-      parameters: {
-        type: 'object',
-        properties: {
-          viewId: {
-            type: 'string',
-            description: 'Directory id for the Lens view. Use lowercase letters, numbers, hyphens, or underscores.',
-          },
-          name: { type: 'string', description: 'Display name for the Activity Bar tooltip and view header.' },
-          icon: { type: 'string', description: 'Lucide icon name, for example layout, table, newspaper, clock, or zap.' },
-          view: {
-            type: 'string',
-            enum: [...SUPPORTED_LENS_VIEWS],
-            description: 'Lens renderer type. Use canvas for rich HTML UI.',
-          },
-          source: {
-            type: 'string',
-            description: 'Source filename inside the view folder. Canvas views must use an .html file such as index.html.',
-          },
-          content: {
-            description: 'Source file content. For canvas, provide HTML. For classic JSON views, provide a JSON object/array or a JSON string.',
-          },
-          prompt: { type: 'string', description: 'Optional refresh prompt.' },
-          refreshOn: { type: 'string', enum: ['click', 'interval'], description: 'Optional refresh behavior.' },
-          schema: { type: 'object', description: 'Optional JSON schema for classic Lens views.' },
-        },
-        required: ['viewId', 'name', 'icon', 'view', 'source', 'content'],
-      },
-      handler: async (args) => {
-        const view = await this.createView(mindPath, args as unknown as CreateLensViewInput);
-        return {
-          ok: true,
-          view,
-          message: `Created Lens view "${view.name}" at .github/lens/${view.id}/.`,
-        };
-      },
-    }] as Tool[];
   }
 
   async scan(mindPath: string): Promise<LensViewManifest[]> {
@@ -161,46 +105,6 @@ export class ViewDiscovery implements ChamberToolProvider {
     const view = this.getViews(mindPath).find(v => v.id === viewId);
     if (!view || !view._basePath) return null;
     return path.join(view._basePath, view.source);
-  }
-
-  async createView(mindPath: string, input: CreateLensViewInput): Promise<LensViewManifest> {
-    const viewId = parseViewId(input.viewId);
-    const source = parseSource(input.source, input.view);
-    if (typeof input.name !== 'string' || input.name.trim() === '') {
-      throw new Error('lens_create requires a non-empty name');
-    }
-    if (typeof input.icon !== 'string' || input.icon.trim() === '') {
-      throw new Error('lens_create requires a non-empty icon');
-    }
-    if (!isLensViewType(input.view)) {
-      throw new Error(`Unsupported Lens view type: ${String(input.view)}`);
-    }
-
-    const lensDir = path.join(mindPath, '.github', 'lens');
-    const viewDir = path.join(lensDir, viewId);
-    fs.mkdirSync(viewDir, { recursive: true });
-
-    const manifest = {
-      name: input.name,
-      icon: input.icon,
-      view: input.view,
-      source,
-      ...(input.prompt ? { prompt: input.prompt } : {}),
-      ...(input.refreshOn ? { refreshOn: input.refreshOn } : {}),
-      ...(input.schema ? { schema: input.schema } : {}),
-    };
-
-    fs.writeFileSync(path.join(viewDir, 'view.json'), JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
-    fs.writeFileSync(path.join(viewDir, source), formatSourceContent(input.content, input.view), 'utf-8');
-
-    await this.scan(mindPath);
-    return this.getViews(mindPath).find(view => view.id === viewId)
-      ?? parseLensViewManifest(manifest, viewId, viewDir)
-      ?? {
-        ...manifest,
-        id: viewId,
-        _basePath: viewDir,
-      };
   }
 
   async refreshView(viewId: string, mindPath: string): Promise<Record<string, unknown> | null> {
@@ -361,33 +265,6 @@ function isSafeRelativeSource(value: unknown): value is string {
 
 function isHtmlSource(value: string): boolean {
   return path.extname(value).toLowerCase() === '.html';
-}
-
-function parseViewId(value: unknown): string {
-  if (typeof value !== 'string' || !/^[a-z0-9][a-z0-9_-]*$/i.test(value)) {
-    throw new Error('lens_create viewId must use letters, numbers, hyphens, or underscores');
-  }
-  return value;
-}
-
-function parseSource(value: unknown, view: LensViewManifest['view']): string {
-  if (!isSafeRelativeSource(value)) {
-    throw new Error('lens_create source must be a safe relative filename');
-  }
-  if (view === 'canvas' && !isHtmlSource(value)) {
-    throw new Error('Canvas Lens sources must be .html files');
-  }
-  return value;
-}
-
-function formatSourceContent(content: unknown, view: LensViewManifest['view']): string {
-  if (typeof content === 'string') {
-    return content.endsWith('\n') ? content : `${content}\n`;
-  }
-  if (view === 'canvas') {
-    throw new Error('Canvas Lens content must be an HTML string');
-  }
-  return `${JSON.stringify(content, null, 2)}\n`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/services/src/lens/index.ts
+++ b/packages/services/src/lens/index.ts
@@ -1,2 +1,2 @@
 export { ViewDiscovery } from './ViewDiscovery';
-export { seedLensDefaults, installLensSkill } from './MindBootstrap';
+export { bootstrapMindCapabilities, seedLensDefaults, installLensSkill } from './MindBootstrap';

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -19,11 +19,11 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('../lens/MindBootstrap', () => ({
-  installLensSkill: vi.fn(),
+  bootstrapMindCapabilities: vi.fn(),
 }));
 
 import * as fs from 'fs';
-import { installLensSkill } from '../lens/MindBootstrap';
+import { bootstrapMindCapabilities } from '../lens/MindBootstrap';
 
 const mockStart = vi.fn();
 const mockStop = vi.fn();
@@ -244,17 +244,17 @@ describe('MindManager', () => {
       expect(firstModelSession.disconnect).toHaveBeenCalledTimes(1);
     });
 
-    it('installs or upgrades the managed Lens skill before creating the SDK session', async () => {
+    it('bootstraps managed mind capabilities before creating the SDK session', async () => {
       await manager.loadMind('/tmp/agents/q');
 
-      expect(installLensSkill).toHaveBeenCalledWith('/tmp/agents/q');
+      expect(bootstrapMindCapabilities).toHaveBeenCalledWith('/tmp/agents/q');
       expect(mockClientFactory.createClient).toHaveBeenCalledWith('/tmp/agents/q');
-      expect(vi.mocked(installLensSkill).mock.invocationCallOrder[0])
+      expect(vi.mocked(bootstrapMindCapabilities).mock.invocationCallOrder[0])
         .toBeLessThan(mockClientFactory.createClient.mock.invocationCallOrder[0]);
     });
 
-    it('continues loading when the managed Lens skill upgrade fails', async () => {
-      vi.mocked(installLensSkill).mockImplementationOnce(() => {
+    it('continues loading when managed mind capability bootstrap fails', async () => {
+      vi.mocked(bootstrapMindCapabilities).mockImplementationOnce(() => {
         throw new Error('skill asset missing');
       });
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(vi.fn());

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -18,7 +18,12 @@ vi.mock('fs', () => ({
   }),
 }));
 
+vi.mock('../lens/MindBootstrap', () => ({
+  installLensSkill: vi.fn(),
+}));
+
 import * as fs from 'fs';
+import { installLensSkill } from '../lens/MindBootstrap';
 
 const mockStart = vi.fn();
 const mockStop = vi.fn();
@@ -237,6 +242,28 @@ describe('MindManager', () => {
       expect(localManager.getMind(mind.mindId)?.session).toBe(secondModelSession);
       expect(originalSession.disconnect).toHaveBeenCalledTimes(1);
       expect(firstModelSession.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('installs or upgrades the managed Lens skill before creating the SDK session', async () => {
+      await manager.loadMind('/tmp/agents/q');
+
+      expect(installLensSkill).toHaveBeenCalledWith('/tmp/agents/q');
+      expect(mockClientFactory.createClient).toHaveBeenCalledWith('/tmp/agents/q');
+      expect(vi.mocked(installLensSkill).mock.invocationCallOrder[0])
+        .toBeLessThan(mockClientFactory.createClient.mock.invocationCallOrder[0]);
+    });
+
+    it('continues loading when the managed Lens skill upgrade fails', async () => {
+      vi.mocked(installLensSkill).mockImplementationOnce(() => {
+        throw new Error('skill asset missing');
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(vi.fn());
+
+      const mind = await manager.loadMind('/tmp/agents/q');
+
+      expect(mind.status).toBe('ready');
+      expect(mockClientFactory.createClient).toHaveBeenCalledWith('/tmp/agents/q');
+      warnSpy.mockRestore();
     });
 
     it('starts Lens watching and emits view changes after watcher rescans', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -18,6 +18,7 @@ import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat
 import type { ChamberToolProvider } from '../chamberTools';
 import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
+import { installLensSkill } from '../lens/MindBootstrap';
 
 export class MindManager extends EventEmitter {
   private minds = new Map<string, InternalMindContext>();
@@ -80,6 +81,12 @@ export class MindManager extends EventEmitter {
     const identity = this.identityLoader.load(resolvedMindPath);
     if (!identity) {
       throw new Error(`Failed to load identity from ${resolvedMindPath}`);
+    }
+
+    try {
+      installLensSkill(resolvedMindPath);
+    } catch (err) {
+      log.warn('Lens skill install/upgrade failed (non-fatal):', err);
     }
 
     // Create client

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -18,7 +18,7 @@ import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat
 import type { ChamberToolProvider } from '../chamberTools';
 import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
-import { installLensSkill } from '../lens/MindBootstrap';
+import { bootstrapMindCapabilities } from '../lens/MindBootstrap';
 
 export class MindManager extends EventEmitter {
   private minds = new Map<string, InternalMindContext>();
@@ -84,9 +84,9 @@ export class MindManager extends EventEmitter {
     }
 
     try {
-      installLensSkill(resolvedMindPath);
+      bootstrapMindCapabilities(resolvedMindPath);
     } catch (err) {
-      log.warn('Lens skill install/upgrade failed (non-fatal):', err);
+      log.warn('Mind capability bootstrap failed (non-fatal):', err);
     }
 
     // Create client

--- a/packages/services/src/sdk/sdkChatEventMapper.test.ts
+++ b/packages/services/src/sdk/sdkChatEventMapper.test.ts
@@ -65,6 +65,38 @@ describe('sdkChatEventMapper', () => {
     expect(getSdkSessionErrorMessage({ data: { message: 'SDK session failed' } })).toBe('SDK session failed');
   });
 
+  it('maps JSON-string tool arguments emitted by the SDK into Chamber argument records', () => {
+    expect(mapSdkToolExecutionStart({
+      data: {
+        toolCallId: 'tool-1',
+        toolName: 'powershell',
+        arguments: '{"command":"git status","description":"Check status"}',
+      },
+    })).toEqual({
+      type: 'tool_start',
+      toolCallId: 'tool-1',
+      toolName: 'powershell',
+      args: { command: 'git status', description: 'Check status' },
+      parentToolCallId: undefined,
+    });
+  });
+
+  it('preserves non-JSON string tool arguments without failing chat streaming', () => {
+    expect(mapSdkToolExecutionStart({
+      data: {
+        toolCallId: 'tool-1',
+        toolName: 'apply_patch',
+        arguments: '*** Begin Patch\n*** End Patch',
+      },
+    })).toEqual({
+      type: 'tool_start',
+      toolCallId: 'tool-1',
+      toolName: 'apply_patch',
+      args: { input: '*** Begin Patch\n*** End Patch' },
+      parentToolCallId: undefined,
+    });
+  });
+
   it('rejects SDK event drift that would break chat streaming assumptions', () => {
     expect(() => mapSdkAssistantMessageDelta({
       data: { id: 'sdk-message-1', text: 'hello' },
@@ -79,4 +111,3 @@ describe('sdkChatEventMapper', () => {
     })).toThrow('SDK contract mismatch for session.error');
   });
 });
-

--- a/packages/services/src/sdk/sdkChatEventMapper.ts
+++ b/packages/services/src/sdk/sdkChatEventMapper.ts
@@ -32,7 +32,7 @@ const sdkAssistantReasoningDeltaEvent = sdkEvent({
 const sdkToolExecutionStartEvent = sdkEvent({
   toolCallId: z.string(),
   toolName: z.string(),
-  arguments: z.record(z.string(), z.unknown()).optional(),
+  arguments: z.union([z.record(z.string(), z.unknown()), z.string()]).optional(),
   parentToolCallId: z.string().optional(),
 });
 
@@ -69,6 +69,22 @@ function parseSdkEvent<Schema extends z.ZodTypeAny>(
   return parsed.data;
 }
 
+function normalizeToolArguments(value: Record<string, unknown> | string | undefined): Record<string, unknown> | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') return value;
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return { input: value };
+  }
+
+  return { input: value };
+}
+
 export function mapSdkAssistantMessageDelta(event: unknown): Extract<ChatEvent, { type: 'chunk' }> {
   const parsed = parseSdkEvent('assistant.message_delta', sdkAssistantMessageDeltaEvent, event);
   return {
@@ -103,7 +119,7 @@ export function mapSdkToolExecutionStart(event: unknown): Extract<ChatEvent, { t
     type: 'tool_start',
     toolCallId: parsed.data.toolCallId,
     toolName: parsed.data.toolName,
-    args: parsed.data.arguments,
+    args: normalizeToolArguments(parsed.data.arguments),
     parentToolCallId: parsed.data.parentToolCallId,
   };
 }
@@ -141,4 +157,3 @@ export function getSdkSessionErrorMessage(event: unknown): string {
   const parsed = parseSdkEvent('session.error', sdkSessionErrorEvent, event);
   return parsed.data.message;
 }
-

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -139,13 +139,20 @@ export interface LensViewManifest {
   id: string;
   name: string;
   icon: string;
-  view: 'form' | 'table' | 'briefing' | 'status-board' | 'list' | 'monitor' | 'detail' | 'timeline' | 'editor';
+  view: 'form' | 'table' | 'briefing' | 'status-board' | 'list' | 'monitor' | 'detail' | 'timeline' | 'editor' | 'canvas';
   source: string;
   schema?: Record<string, unknown>;
   prompt?: string;
   refreshOn?: 'click' | 'interval';
   /** Resolved absolute path to the view.json directory */
   _basePath?: string;
+}
+
+export interface CanvasLensAction {
+  action: string;
+  data?: unknown;
+  intent?: string;
+  correlationId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +219,7 @@ export interface ElectronAPI {
     getViewData: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
     refreshView: (viewId: string, mindId?: string) => Promise<Record<string, unknown> | null>;
     sendAction: (viewId: string, action: string, mindId?: string) => Promise<Record<string, unknown> | null>;
+    getCanvasUrl: (viewId: string, mindId?: string) => Promise<string | null>;
     onViewsChanged: (callback: (views: LensViewManifest[], mindId?: string) => void) => () => void;
   };
   auth: {

--- a/tests/e2e/electron/lens-hotload.spec.ts
+++ b/tests/e2e/electron/lens-hotload.spec.ts
@@ -9,6 +9,7 @@ import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from '.
 const cdpPort = Number(process.env.CHAMBER_E2E_LENS_CDP_PORT ?? 9336);
 const smokeViewId = 'smoke-hotload';
 const refreshViewId = 'smoke-refresh-continuity';
+const canvasSmokeViewId = 'canvas-smoke';
 
 test.describe('electron Lens hot-load smoke', () => {
   test.setTimeout(180_000);
@@ -154,10 +155,67 @@ test.describe('electron Lens hot-load smoke', () => {
 
     await page.getByRole('button', { name: 'Smoke Refresh Continuity' }).click();
     await expect(page.getByRole('heading', { name: 'Smoke Refresh Continuity' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Refreshing…', exact: true })).toBeVisible();
 
     await expect(page.getByText('fresh', { exact: true })).toBeVisible();
     await expect(page.getByText('stale', { exact: true })).toHaveCount(0);
+  });
+
+  test('renders a Canvas Lens inside Chamber', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    const mind = await page.evaluate(async ({ pathToMind, pathToInactiveMind }) => {
+      const loaded = await window.electronAPI.mind.add(pathToMind);
+      await window.electronAPI.mind.add(pathToInactiveMind);
+      await window.electronAPI.mind.setActive(loaded.mindId);
+      return loaded;
+    }, { pathToMind: mindPath, pathToInactiveMind: inactiveMindPath });
+
+    writeCanvasLensView(mindPath);
+
+    await expect.poll(
+      () => page.evaluate(async ({ mindId, viewId }) => {
+        const views = await window.electronAPI.lens.getViews(mindId);
+        return views.some((view) => view.id === viewId && view.view === 'canvas');
+      }, { mindId: mind.mindId, viewId: canvasSmokeViewId }),
+      { timeout: 10_000 },
+    ).toBe(true);
+
+    await page.getByRole('button', { name: 'Canvas Smoke' }).click();
+
+    const frame = page.frameLocator('iframe[title="Canvas Smoke"]');
+    await expect(frame.getByRole('heading', { name: 'Chamber Canvas Smoke' })).toBeVisible();
+    await expect(frame.getByText('Rendered through Canvas Lens')).toBeVisible();
+  });
+
+  test('routes Canvas Lens actions through the Canvas bridge', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    const mind = await page.evaluate(async ({ pathToMind, pathToInactiveMind }) => {
+      const loaded = await window.electronAPI.mind.add(pathToMind);
+      await window.electronAPI.mind.add(pathToInactiveMind);
+      await window.electronAPI.mind.setActive(loaded.mindId);
+      return loaded;
+    }, { pathToMind: mindPath, pathToInactiveMind: inactiveMindPath });
+
+    writeCanvasLensView(mindPath);
+
+    await expect.poll(
+      () => page.evaluate(async ({ mindId, viewId }) => {
+        const views = await window.electronAPI.lens.getViews(mindId);
+        return views.some((view) => view.id === viewId && view.view === 'canvas');
+      }, { mindId: mind.mindId, viewId: canvasSmokeViewId }),
+      { timeout: 10_000 },
+    ).toBe(true);
+
+    await page.getByRole('button', { name: 'Canvas Smoke' }).click();
+
+    const frame = page.frameLocator('iframe[title="Canvas Smoke"]');
+    await frame.getByRole('button', { name: 'Send smoke action' }).click();
+
+    await expect(frame.getByText('Action bridge returned: ok')).toBeVisible();
+    expect((app?.logs ?? []).join('\n')).not.toContain('SDK contract mismatch for tool.execution_start');
   });
 });
 
@@ -193,6 +251,47 @@ function writeLensView(
   );
   const data = options.status ? { status: options.status } : { rows: [{ status: 'ok' }] };
   fs.writeFileSync(path.join(viewDir, 'data.json'), JSON.stringify(data, null, 2));
+}
+
+function writeCanvasLensView(root: string): void {
+  const viewDir = path.join(root, '.github', 'lens', canvasSmokeViewId);
+  fs.mkdirSync(viewDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(viewDir, 'view.json'),
+    JSON.stringify({
+      name: 'Canvas Smoke',
+      icon: 'layout',
+      view: 'canvas',
+      source: 'index.html',
+    }, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(viewDir, 'index.html'),
+    [
+      '<!DOCTYPE html>',
+      '<html lang="en">',
+      '<head><meta charset="utf-8"><title>Canvas Smoke</title></head>',
+      '<body>',
+      '  <main class="ch-page">',
+      '    <section class="ch-card">',
+      '      <p class="ch-badge">Rendered through Canvas Lens</p>',
+      '      <h1>Chamber Canvas Smoke</h1>',
+      '      <button class="ch-button" type="button" onclick="sendSmokeAction()">Send smoke action</button>',
+      '      <p id="action-result" class="ch-muted">Action pending</p>',
+      '    </section>',
+      '  </main>',
+      '  <script>',
+      '    async function sendSmokeAction() {',
+      '      const response = await window.canvas.sendAction("smoke-test-click", { ok: true });',
+      '      const result = await response.json();',
+      '      document.getElementById("action-result").textContent = result.ok ? "Action bridge returned: ok" : "Action bridge failed";',
+      '    }',
+      '  </script>',
+      '</body>',
+      '</html>',
+    ].join('\n'),
+    'utf8',
+  );
 }
 
 async function removeTempRoot(root: string): Promise<void> {


### PR DESCRIPTION
## Summary  Adds Canvas-backed Lens views so agents can build richer Chamber-native UI while Lens remains the discovered Activity Bar surface.  ## Notable changes  - Adds `view: "canvas"` Lens manifests with in-app sandboxed iframe rendering through Canvas. - Routes token-gated `window.canvas.sendAction(...)` events back to the owning mind without exposing Electron or SDK access to generated HTML. - Injects Chamber Canvas design-kit CSS into served HTML. - Updates the managed Lens skill to v2.0.0 and migrates exact old bundled skills while preserving local edits. - Accepts object, JSON-string, and raw-string SDK tool execution arguments to avoid contract mismatch failures. - Adds Canvas Lens renderer, service, migration, SDK mapper, and Electron smoke coverage. - Bumps Chamber to v0.41.0 and updates the changelog.  ## Tests  - `npm run lint` - `npm test` - `npm run smoke:sdk` - `npm run smoke:web` - `npx playwright test --config config\\playwright.config.ts --project=electron --workers=1 --grep "Lens|Canvas"`  ## Smoke notes  - `npm run make:sandbox`  No closing issue: exploratory feature work was not tied to a specific issue. 

Additional sandbox fix:
- Added a Chamber-native `lens_create` tool so packaged minds can create Lens view directories and files without shell access, and updated the bundled Lens skill to prefer it.