### PR TITLE
fix(ipc): validate chatroom:send arguments at IPC boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.43.1 (2026-05-06)
+
+### Security
+
+- **Validate `chatroom:send` IPC arguments** - The `chatroom:send` handler now rejects non-string `message` and non-string-or-undefined `model` payloads with a `TypeError` before reaching `ChatroomService.broadcast`, closing the IPC contract against renderer-side type drift. (#51)
+
 ## v0.43.0 (2026-05-05)
 
 ### Chat

--- a/apps/desktop/src/main/ipc/chatroom.test.ts
+++ b/apps/desktop/src/main/ipc/chatroom.test.ts
@@ -56,6 +56,51 @@ describe('Chatroom IPC', () => {
     expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', undefined);
   });
 
+  describe('chatroom:send input validation', () => {
+    const invalidMessages: Array<[string, unknown]> = [
+      ['number', 42],
+      ['null', null],
+      ['undefined', undefined],
+      ['object', { text: 'hi' }],
+      ['array', ['hi']],
+      ['boolean', true],
+    ];
+
+    for (const [label, value] of invalidMessages) {
+      it(`rejects ${label} message without invoking broadcast`, async () => {
+        const handler = getHandler('chatroom:send');
+        await expect(handler(EVT, value)).rejects.toThrow(TypeError);
+        expect(mockService.broadcast).not.toHaveBeenCalled();
+      });
+    }
+
+    it('rejects empty-string message without invoking broadcast', async () => {
+      const handler = getHandler('chatroom:send');
+      await expect(handler(EVT, '')).rejects.toThrow(TypeError);
+      expect(mockService.broadcast).not.toHaveBeenCalled();
+    });
+
+    const invalidModels: Array<[string, unknown]> = [
+      ['number', 7],
+      ['null', null],
+      ['object', {}],
+    ];
+
+    for (const [label, value] of invalidModels) {
+      it(`rejects ${label} model without invoking broadcast`, async () => {
+        const handler = getHandler('chatroom:send');
+        await expect(handler(EVT, 'hello', value)).rejects.toThrow(TypeError);
+        expect(mockService.broadcast).not.toHaveBeenCalled();
+      });
+    }
+
+    it('accepts undefined model', async () => {
+      const handler = getHandler('chatroom:send');
+      await handler(EVT, 'hello', undefined);
+      expect(mockService.broadcast).toHaveBeenCalledWith('hello', undefined);
+    });
+  });
+
   it('chatroom:history returns result from getHistory', async () => {
     const messages = [{ id: 'msg-1', role: 'user', blocks: [], timestamp: 1 }];
     mockService.getHistory.mockReturnValue(messages);

--- a/apps/desktop/src/main/ipc/chatroom.ts
+++ b/apps/desktop/src/main/ipc/chatroom.ts
@@ -2,8 +2,29 @@ import { ipcMain, BrowserWindow } from 'electron';
 import type { ChatroomService } from '@chamber/services';
 import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig } from '@chamber/shared/chatroom-types';
 
+function assertSendArgs(
+  message: unknown,
+  model: unknown,
+): asserts message is string {
+  if (typeof message !== 'string') {
+    throw new TypeError(`chatroom:send: 'message' must be a string, got ${typeof message}`);
+  }
+  if (message.length === 0) {
+    throw new TypeError(`chatroom:send: 'message' must be a non-empty string`);
+  }
+  assertModel(model);
+}
+
+function assertModel(model: unknown): asserts model is string | undefined {
+  if (model !== undefined && typeof model !== 'string') {
+    throw new TypeError(`chatroom:send: 'model' must be a string or undefined, got ${typeof model}`);
+  }
+}
+
 export function setupChatroomIPC(chatroomService: ChatroomService): void {
-  ipcMain.handle('chatroom:send', async (_event, message: string, model?: string) => {
+  ipcMain.handle('chatroom:send', async (_event, message: unknown, model?: unknown) => {
+    assertSendArgs(message, model);
+    assertModel(model);
     await chatroomService.broadcast(message, model);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary

Add runtime type guards to the `chatroom:send` IPC handler so the renderer cannot smuggle non-string payloads to `ChatroomService.broadcast`.

Closes #51

## Changes

- `apps/desktop/src/main/ipc/chatroom.ts` — `assertSendArgs` rejects non-string `message` (including empty strings) and `assertModel` rejects non-string-or-undefined `model`. Both throw `TypeError` before the service is invoked. Assertions narrow the parameter types so the cast at the call site is gone.
- `apps/desktop/src/main/ipc/chatroom.test.ts` — table-driven tests cover number / null / undefined / object / array / boolean message variants, empty-string message, invalid model variants, and the happy `undefined` model path. 18 tests, all passing.

## Out of scope (follow-up)

Uncle Bob review surfaced that `chatroom:set-orchestration` has the same class of bug against a higher-impact channel (orchestration mode changes affect multi-agent safety properties). Tracked as **#203** rather than expanding this PR.

## Verification

- `npm test` — 1063 tests pass (113 files).
- `npm run lint` — clean (`tsc --noEmit && eslint . && deps:check`).
- Packaging smoke skipped: no packaging/runtime/Forge surface changed.