### PR TITLE
fix(chatroom): align renderer and service roundIds across IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.43.2 (2026-05-07)
+
+### Chatroom
+
+- **Align renderer and service roundIds** - The `chatroom:send` IPC handler now accepts an optional `roundId` and forwards it to `ChatroomService.broadcast`, which uses it for the persisted user message and emitted stream events. The renderer's optimistic `roundId` and the service-side identifier therefore agree, eliminating duplicate-round drift in the chatroom UI. (#50)
+
 ## v0.43.1 (2026-05-06)
 
 ### Security

--- a/apps/desktop/src/main/ipc/chatroom.test.ts
+++ b/apps/desktop/src/main/ipc/chatroom.test.ts
@@ -47,13 +47,25 @@ describe('Chatroom IPC', () => {
   it('chatroom:send invokes broadcast with message and model', async () => {
     const handler = getHandler('chatroom:send');
     await handler(EVT, 'Hello agents', 'gpt-4');
-    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', 'gpt-4');
+    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', 'gpt-4', undefined);
   });
 
   it('chatroom:send works without model', async () => {
     const handler = getHandler('chatroom:send');
     await handler(EVT, 'Hello agents');
-    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', undefined);
+    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', undefined, undefined);
+  });
+
+  it('chatroom:send forwards renderer-supplied roundId to the service', async () => {
+    const handler = getHandler('chatroom:send');
+    await handler(EVT, 'Hello agents', 'gpt-4', 'renderer-round-1');
+    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', 'gpt-4', 'renderer-round-1');
+  });
+
+  it('chatroom:send accepts roundId without a model', async () => {
+    const handler = getHandler('chatroom:send');
+    await handler(EVT, 'Hello agents', undefined, 'renderer-round-2');
+    expect(mockService.broadcast).toHaveBeenCalledWith('Hello agents', undefined, 'renderer-round-2');
   });
 
   describe('chatroom:send input validation', () => {
@@ -97,7 +109,36 @@ describe('Chatroom IPC', () => {
     it('accepts undefined model', async () => {
       const handler = getHandler('chatroom:send');
       await handler(EVT, 'hello', undefined);
-      expect(mockService.broadcast).toHaveBeenCalledWith('hello', undefined);
+      expect(mockService.broadcast).toHaveBeenCalledWith('hello', undefined, undefined);
+    });
+
+    const invalidRoundIds: Array<[string, unknown]> = [
+      ['number', 9],
+      ['null', null],
+      ['object', { id: 'r' }],
+      ['empty string', ''],
+    ];
+
+    for (const [label, value] of invalidRoundIds) {
+      it(`rejects ${label} roundId without invoking broadcast`, async () => {
+        const handler = getHandler('chatroom:send');
+        await expect(handler(EVT, 'hello', undefined, value)).rejects.toThrow(TypeError);
+        expect(mockService.broadcast).not.toHaveBeenCalled();
+      });
+    }
+
+    it('rejects roundId longer than 128 characters', async () => {
+      const handler = getHandler('chatroom:send');
+      const tooLong = 'x'.repeat(129);
+      await expect(handler(EVT, 'hello', undefined, tooLong)).rejects.toThrow(TypeError);
+      expect(mockService.broadcast).not.toHaveBeenCalled();
+    });
+
+    it('accepts roundId exactly 128 characters', async () => {
+      const handler = getHandler('chatroom:send');
+      const exact = 'x'.repeat(128);
+      await handler(EVT, 'hello', undefined, exact);
+      expect(mockService.broadcast).toHaveBeenCalledWith('hello', undefined, exact);
     });
   });
 

--- a/apps/desktop/src/main/ipc/chatroom.ts
+++ b/apps/desktop/src/main/ipc/chatroom.ts
@@ -2,30 +2,39 @@ import { ipcMain, BrowserWindow } from 'electron';
 import type { ChatroomService } from '@chamber/services';
 import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig } from '@chamber/shared/chatroom-types';
 
-function assertSendArgs(
-  message: unknown,
-  model: unknown,
-): asserts message is string {
+interface ChatroomSendArgs {
+  message: string;
+  model: string | undefined;
+  roundId: string | undefined;
+}
+
+const MAX_ROUND_ID_LENGTH = 128;
+
+function parseSendArgs(message: unknown, model: unknown, roundId: unknown): ChatroomSendArgs {
   if (typeof message !== 'string') {
     throw new TypeError(`chatroom:send: 'message' must be a string, got ${typeof message}`);
   }
   if (message.length === 0) {
     throw new TypeError(`chatroom:send: 'message' must be a non-empty string`);
   }
-  assertModel(model);
-}
-
-function assertModel(model: unknown): asserts model is string | undefined {
   if (model !== undefined && typeof model !== 'string') {
     throw new TypeError(`chatroom:send: 'model' must be a string or undefined, got ${typeof model}`);
   }
+  if (roundId !== undefined) {
+    if (typeof roundId !== 'string' || roundId.length === 0) {
+      throw new TypeError(`chatroom:send: 'roundId' must be a non-empty string or undefined`);
+    }
+    if (roundId.length > MAX_ROUND_ID_LENGTH) {
+      throw new TypeError(`chatroom:send: 'roundId' exceeds ${MAX_ROUND_ID_LENGTH} characters`);
+    }
+  }
+  return { message, model, roundId };
 }
 
 export function setupChatroomIPC(chatroomService: ChatroomService): void {
-  ipcMain.handle('chatroom:send', async (_event, message: unknown, model?: unknown) => {
-    assertSendArgs(message, model);
-    assertModel(model);
-    await chatroomService.broadcast(message, model);
+  ipcMain.handle('chatroom:send', async (_event, message: unknown, model?: unknown, roundId?: unknown) => {
+    const args = parseSendArgs(message, model, roundId);
+    await chatroomService.broadcast(args.message, args.model, args.roundId);
   });
 
   ipcMain.handle('chatroom:history', async () => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -64,7 +64,7 @@ const electronAPI: ElectronAPI = {
     removeGenesisRegistry: (id) => ipcRenderer.invoke('marketplace:removeGenesisRegistry', id),
   },
   chatroom: {
-    send: (message: string, model?: string) => ipcRenderer.invoke('chatroom:send', message, model),
+    send: (message: string, model?: string, roundId?: string) => ipcRenderer.invoke('chatroom:send', message, model, roundId),
     history: () => ipcRenderer.invoke('chatroom:history'),
     taskLedger: () => ipcRenderer.invoke('chatroom:task-ledger'),
     clear: () => ipcRenderer.invoke('chatroom:clear'),

--- a/apps/web/src/renderer/components/chatroom/ChatroomPanel.test.tsx
+++ b/apps/web/src/renderer/components/chatroom/ChatroomPanel.test.tsx
@@ -115,7 +115,7 @@ describe('ChatroomPanel', () => {
       fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
     });
 
-    expect(api.chatroom.send).toHaveBeenCalledWith('hello all', undefined);
+    expect(api.chatroom.send).toHaveBeenCalledWith('hello all', undefined, expect.any(String));
   });
 
   // 7. Disabled when no agents

--- a/apps/web/src/renderer/components/chatroom/ChatroomPanel.tsx
+++ b/apps/web/src/renderer/components/chatroom/ChatroomPanel.tsx
@@ -487,7 +487,7 @@ export function ChatroomPanel() {
         roundId,
       },
     });
-    await window.electronAPI.chatroom.send(content, selectedModel ?? undefined);
+    await window.electronAPI.chatroom.send(content, selectedModel ?? undefined, roundId);
   }, [dispatch, selectedModel]);
 
   const handleStop = useCallback(async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chatroom/ChatroomService.test.ts
+++ b/packages/services/src/chatroom/ChatroomService.test.ts
@@ -630,6 +630,68 @@ describe('ChatroomService', () => {
       expect(chunkEvent.roundId).toBeTruthy();
       expect(chunkEvent.messageId).toBeTruthy();
     });
+
+    it('honors the caller-supplied roundId so renderer and service agree', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+
+      const events: ChatroomStreamEvent[] = [];
+      svc.on('chatroom:event', (event: ChatroomStreamEvent) => events.push(event));
+
+      sess.send.mockImplementation(async () => {
+        setTimeout(() => {
+          sess._emit('assistant.message_delta', {
+            data: { messageId: 'sdk-1', deltaContent: 'Hi' },
+          });
+          sess._emit('session.idle', {});
+        }, 0);
+      });
+
+      const supplied = 'renderer-round-12345';
+      await svc.broadcast('Hi', undefined, supplied);
+
+      const persisted = svc.getHistory();
+      const userMsg = persisted.find((m) => m.role === 'user');
+      expect(userMsg?.roundId).toBe(supplied);
+
+      const chunkEvent = events.find((e) => e.event.type === 'chunk');
+      expect(chunkEvent?.roundId).toBe(supplied);
+    });
+
+    it('falls back to a generated roundId when caller omits one', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+      autoIdle(sess);
+
+      await svc.broadcast('Hi');
+
+      const persisted = svc.getHistory();
+      const userMsg = persisted.find((m) => m.role === 'user');
+      expect(userMsg?.roundId).toBeTruthy();
+      expect(typeof userMsg?.roundId).toBe('string');
+    });
+
+    it('regenerates roundId when caller supplies a duplicate', async () => {
+      const sess = createMockSession();
+      sessions.set('dude', sess);
+      minds.length = 0;
+      minds.push(makeMind('dude', 'The Dude'));
+      autoIdle(sess);
+
+      const dup = 'renderer-dup-id';
+      await svc.broadcast('first', undefined, dup);
+      await svc.broadcast('second', undefined, dup);
+
+      const userMsgs = svc.getHistory().filter((m) => m.role === 'user');
+      expect(userMsgs).toHaveLength(2);
+      expect(userMsgs[0].roundId).toBe(dup);
+      expect(userMsgs[1].roundId).not.toBe(dup);
+      expect(userMsgs[1].roundId).toBeTruthy();
+    });
   });
 
   describe('approval gate', () => {

--- a/packages/services/src/chatroom/ChatroomService.ts
+++ b/packages/services/src/chatroom/ChatroomService.ts
@@ -92,7 +92,7 @@ export class ChatroomService extends EventEmitter {
   // Public API
   // -------------------------------------------------------------------------
 
-  async broadcast(userMessage: string, _model?: string): Promise<void> {
+  async broadcast(userMessage: string, _model?: string, suppliedRoundId?: string): Promise<void> {
     void _model;
     // Cancel any in-flight agents from previous round
     this.stopAll();
@@ -105,7 +105,7 @@ export class ChatroomService extends EventEmitter {
     // (persisted alongside user message below)
     this.lastLedger = [];
 
-    const roundId = randomUUID();
+    const roundId = this.resolveRoundId(suppliedRoundId);
 
     // Snapshot participants (only ready minds)
     const participants = this.sessionFactory
@@ -303,6 +303,15 @@ export class ChatroomService extends EventEmitter {
       sender: { mindId: 'user', name: 'You' },
       roundId,
     };
+  }
+
+  private resolveRoundId(supplied: string | undefined): string {
+    if (supplied === undefined) return randomUUID();
+    if (this.messages.some((m) => m.roundId === supplied)) {
+      log.warn(`broadcast received duplicate roundId "${supplied}"; generating a fresh id`);
+      return randomUUID();
+    }
+    return supplied;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/shared/src/chatroom-types.ts
+++ b/packages/shared/src/chatroom-types.ts
@@ -156,7 +156,7 @@ export interface ChatroomStreamEvent {
 // ---------------------------------------------------------------------------
 
 export interface ChatroomAPI {
-  send: (message: string, model?: string) => Promise<void>;
+  send: (message: string, model?: string, roundId?: string) => Promise<void>;
   history: () => Promise<ChatroomMessage[]>;
   taskLedger: () => Promise<TaskLedgerItem[]>;
   clear: () => Promise<void>;


### PR DESCRIPTION
## Summary

Thread the renderer's optimistic `roundId` through the `chatroom:send` IPC into `ChatroomService.broadcast` so the persisted user message and emitted stream events share the identifier the renderer used for the optimistic user bubble.

Closes #50

## Stack

This PR sits on top of #204 (`fix/chatroom-ipc-input-validation-51`). Merge #204 first; GitHub will retarget this PR to `master` once the parent branch is deleted.

## Changes

- `apps/desktop/src/main/ipc/chatroom.ts` — replaced the assertion functions with a single `parseSendArgs` that validates and narrows `message`, `model`, and `roundId` in one pass; added a 128-character cap on `roundId`.
- `packages/services/src/chatroom/ChatroomService.ts` — `broadcast(userMessage, _model?, suppliedRoundId?)` uses `resolveRoundId` to honor the caller-supplied id, fall back to `randomUUID()` when omitted, and regenerate (with a logged warning) when a duplicate is detected. This protects `getLastNRounds` and history-grouping invariants against renderer bugs.
- `apps/desktop/src/preload.ts` and `packages/shared/src/chatroom-types.ts` — `ChatroomAPI.send` widened to `(message, model?, roundId?)` (additive).
- `apps/web/src/renderer/components/chatroom/ChatroomPanel.tsx` — call site forwards the local `roundId` it already generated for the optimistic user message.
- Tests cover supplied-roundId honoring, duplicate-roundId regeneration, omitted-roundId fallback, length-cap rejection, and IPC pass-through.

## Uncle Bob review

Adopted: defensive duplicate handling in the service, length cap on `roundId`, and consolidated the validation into a single `parseSendArgs` function so both narrowing and runtime checks happen in one place.

## Verification

- `npm test` — 1074 tests pass (113 files).
- `npm run lint` — clean.
- Packaging smoke skipped: no packaging/runtime/Forge surface changed.