### PR TITLE
perf(chatroom): use Set for round-id lookups in getLastNRounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.43.3 (2026-05-07)
+
+### Performance
+
+- **Use `Set` for round-id lookups in chatroom history** - `ChatroomService.getLastNRounds` now collects unique round ids with a `Set<string>` instead of `Array.includes`, replacing the O(n·r) inner loop with O(n+r) for chatrooms with deep history. (#54)
+
 ## v0.43.2 (2026-05-07)
 
 ### Chatroom

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chatroom/ChatroomService.ts
+++ b/packages/services/src/chatroom/ChatroomService.ts
@@ -357,11 +357,12 @@ export class ChatroomService extends EventEmitter {
   }
 
   private getLastNRounds(n: number): ChatroomMessage[] {
-    // Collect unique roundIds in reverse order, take last n
+    const seen = new Set<string>();
     const roundIds: string[] = [];
     for (let i = this.messages.length - 1; i >= 0; i--) {
       const rid = this.messages[i].roundId;
-      if (!roundIds.includes(rid)) {
+      if (!seen.has(rid)) {
+        seen.add(rid);
         roundIds.unshift(rid);
       }
     }
@@ -369,10 +370,11 @@ export class ChatroomService extends EventEmitter {
     // Exclude the current round (it's being built now — its user msg is already in this.messages)
     // The last roundId is the current round, so take n rounds before it
     const currentRoundId = roundIds[roundIds.length - 1];
-    const previousRoundIds = roundIds.filter((r) => r !== currentRoundId);
-    const targetRoundIds = previousRoundIds.slice(-n);
+    const targetRoundIds = new Set(
+      roundIds.filter((r) => r !== currentRoundId).slice(-n),
+    );
 
-    return this.messages.filter((m) => targetRoundIds.includes(m.roundId));
+    return this.messages.filter((m) => targetRoundIds.has(m.roundId));
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace the O(n*r) `Array.includes` membership checks in `ChatroomService.getLastNRounds` with `Set<string>` for both the unique round-id collection pass and the final round-id filter.

Closes #54

## Stack

This PR sits on top of #205 (`fix/chatroom-round-id-alignment-50`), which sits on top of #204. Merge in order; GitHub will retarget after each parent merges.

## Changes

- `packages/services/src/chatroom/ChatroomService.ts` — `getLastNRounds` now uses `Set` for unique-id collection and final filter membership. Behavior is preserved.

## Verification

- `npm test` — 1074 tests pass; the existing `context window` test still asserts the n=2 round window is honored.
- `npm run lint` — clean.
- Skipped Uncle Bob (focused, behavior-preserving perf refactor) and packaging smoke (no runtime/Forge surface).