### PR TITLE
feat(chatroom): surface agent turn timeouts as a distinguishable event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.43.4 (2026-05-07)
+
+### Chatroom
+
+- **Surface agent turn timeouts as a distinguishable event** - `streamAgentTurn` now emits `{ type: 'timeout', timeoutMs }` when an agent turn rejects with `TurnTimeoutError`, instead of a generic `error` event. The renderer reducer renders an "Agent timed out after `<s>`s" message and clears the streaming/active-speaker state, so the chatroom no longer goes silent when the 5-minute send timer fires. (#53)
+
 ## v0.43.3 (2026-05-07)
 
 ### Performance

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -176,6 +176,18 @@ describe('handleChatEvent', () => {
     });
   });
 
+  describe('timeout', () => {
+    it('adds a timeout text block, sets isStreaming false, and reports the timeout in seconds', () => {
+      const initial = [makeMessage([], { id: 'msg-1', isStreaming: true })];
+      const msgs = handleChatEvent(initial, 'msg-1', makeChatEvent('timeout', { timeoutMs: 30_000 }));
+      expect(msgs[0].isStreaming).toBe(false);
+      const last = msgs[0].blocks[msgs[0].blocks.length - 1];
+      expect(last).toMatchObject({ type: 'text' });
+      expect(last.type === 'text' && last.content).toContain('timed out');
+      expect(last.type === 'text' && last.content).toContain('30s');
+    });
+  });
+
   it('ignores events for unknown messageId', () => {
     const initial = assistantMsg();
     const msgs = handleChatEvent(initial, 'wrong-id', makeChatEvent('chunk', { content: 'x' }));
@@ -832,6 +844,27 @@ describe('appReducer — chatroom actions', () => {
     expect(state.chatroomMessages[0].isStreaming).toBe(false);
     const textBlocks = state.chatroomMessages[0].blocks.filter(b => b.type === 'text');
     expect(textBlocks.some(b => b.type === 'text' && b.content.includes('boom'))).toBe(true);
+  });
+
+  it('CHATROOM_EVENT timeout sets streaming false, clears active speaker, and surfaces a timeout message', () => {
+    const base: AppState = {
+      ...initialState,
+      chatroomMessages: [
+        makeChatroomMessage({ id: 'a1', role: 'assistant', blocks: [], isStreaming: true, sender: { mindId: 'mind-1', name: 'Agent A' } }),
+      ],
+      chatroomStreamingByMind: { 'mind-1': true },
+      chatroomActiveSpeaker: { mindId: 'mind-1', mindName: 'Agent A', phase: 'speaking' },
+    };
+    const state = appReducer(base, {
+      type: 'CHATROOM_EVENT',
+      payload: { mindId: 'mind-1', mindName: 'Agent A', messageId: 'a1', roundId: 'r1', event: { type: 'timeout', timeoutMs: 5_000 } },
+    });
+    expect(state.chatroomStreamingByMind['mind-1']).toBe(false);
+    expect(state.chatroomActiveSpeaker).toBeNull();
+    expect(state.chatroomMessages[0].isStreaming).toBe(false);
+    const textBlocks = state.chatroomMessages[0].blocks.filter(b => b.type === 'text');
+    expect(textBlocks.some(b => b.type === 'text' && b.content.includes('timed out'))).toBe(true);
+    expect(textBlocks.some(b => b.type === 'text' && b.content.includes('5s'))).toBe(true);
   });
 
   it('multi-agent interleave — two agents streaming simultaneously, events update correct messages', () => {

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -126,6 +126,12 @@ export function handleChatEvent<T extends ChatMessage>(messages: T[], messageId:
           blocks: [...blocks, { type: 'text' as const, content: `Error: ${event.message}` }],
         });
 
+      case 'timeout':
+        return updateChatMessage(m, {
+          isStreaming: false,
+          blocks: [...blocks, { type: 'text' as const, content: `Agent timed out after ${Math.round(event.timeoutMs / 1000)}s` }],
+        });
+
       default:
         return m;
     }
@@ -177,7 +183,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const { mindId, messageId, event } = action.payload;
       const mindMsgs = state.messagesByMind[mindId] ?? [];
       const newMessages = handleChatEvent(mindMsgs, messageId, event);
-      const isDone = event.type === 'done' || event.type === 'error';
+      const isDone = event.type === 'done' || event.type === 'error' || event.type === 'timeout';
       const newStreamingByMind = isDone
         ? { ...state.streamingByMind, [mindId]: false }
         : state.streamingByMind;
@@ -574,7 +580,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       }
 
       const newMessages = handleChatEvent(messages, messageId, chatEvent);
-      const isDone = chatEvent.type === 'done' || chatEvent.type === 'error';
+      const isDone = chatEvent.type === 'done' || chatEvent.type === 'error' || chatEvent.type === 'timeout';
       return {
         ...state,
         chatroomMessages: newMessages,

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -74,6 +74,7 @@ export function makeChatEvent<T extends ChatEvent['type']>(
     reasoning: { reasoningId: 'r-1', content: 'thinking' },
     message_final: { sdkMessageId: 'sdk-1', content: 'final' },
     done: {},
+    timeout: { timeoutMs: 30_000 },
     error: { message: 'something went wrong' },
   };
   return { type, ...defaults[type], ...overrides } as Extract<ChatEvent, { type: T }>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.43.3",
+  "version": "0.43.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.43.3",
+  "version": "0.43.4",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chatroom/orchestration/stream-agent.test.ts
+++ b/packages/services/src/chatroom/orchestration/stream-agent.test.ts
@@ -307,7 +307,7 @@ describe('streamAgentTurn', () => {
     expect(errorEvents[0].messageId).not.toBe('');
   });
 
-  it('emits error event on turn timeout so renderer clears streaming state', async () => {
+  it('emits distinguishable timeout event on turn timeout so renderer can show timeout-specific UI', async () => {
     vi.useFakeTimers();
     const sess = createMockSession();
     const ctx = createContext(sessions);
@@ -325,12 +325,15 @@ describe('streamAgentTurn', () => {
     const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
       (c) => c[0] as ChatroomStreamEvent,
     );
-    const errorEvents = events.filter((e) => e.event.type === 'error');
-    expect(errorEvents).toHaveLength(1);
-    expect(errorEvents[0].event).toMatchObject({
-      type: 'error',
-      message: expect.stringContaining('timed out'),
+    const timeoutEvents = events.filter((e) => e.event.type === 'timeout');
+    expect(timeoutEvents).toHaveLength(1);
+    expect(timeoutEvents[0].event).toMatchObject({
+      type: 'timeout',
+      timeoutMs: 5_000,
     });
+    // No generic error event for timeouts — the renderer needs to distinguish them
+    expect(events.filter((e) => e.event.type === 'error')).toHaveLength(0);
+    expect(timeoutEvents[0].messageId).not.toBe('');
 
     process.removeListener('unhandledRejection', swallow);
   });

--- a/packages/services/src/chatroom/orchestration/stream-agent.ts
+++ b/packages/services/src/chatroom/orchestration/stream-agent.ts
@@ -184,12 +184,16 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
   }
 
   await turnDone.catch((err) => {
-    // Emit error event so the renderer clears the streaming state / active
-    // speaker for the auto-created message placeholder.
-    emitEvent({
-      type: 'error',
-      message: err instanceof Error ? err.message : String(err),
-    });
+    // Emit a discriminated event so the renderer clears the streaming state and
+    // can render timeout-specific UI without parsing error messages.
+    if (err instanceof TurnTimeoutError) {
+      emitEvent({ type: 'timeout', timeoutMs: err.timeoutMs });
+    } else {
+      emitEvent({
+        type: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
     throw err;
   });
 

--- a/packages/shared/src/chatroom-types.test.ts
+++ b/packages/shared/src/chatroom-types.test.ts
@@ -105,6 +105,7 @@ describe('chatroom-types', () => {
       { type: 'chunk', content: 'hello' },
       { type: 'done' },
       { type: 'error', message: 'fail' },
+      { type: 'timeout', timeoutMs: 30_000 },
       { type: 'reconnecting' },
       { type: 'tool_start', toolCallId: 't1', toolName: 'read' },
       { type: 'reasoning', reasoningId: 'r1', content: 'thinking' },

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -55,6 +55,7 @@ export type ChatEvent =
   | { type: 'message_final'; sdkMessageId: string; content: string }
   | { type: 'reconnecting' }
   | { type: 'done' }
+  | { type: 'timeout'; timeoutMs: number }
   | { type: 'error'; message: string };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When `streamAgentTurn` rejects with `TurnTimeoutError` (default 5-minute per-turn timer), emit a discriminated `{ type: 'timeout', timeoutMs }` event instead of folding it into a generic `{ type: 'error' }`. The renderer reducer surfaces "Agent timed out after Xs", clears the streaming/active-speaker state, and treats it as terminal for streaming-by-mind. The previous behavior left the chatroom silent on timeout with no UI signal beyond a generic error.

Closes #53

## Stack

This PR sits on top of #206 → #205 → #204. Merge in stack order; GitHub will retarget after each parent merges.

## Changes

- `packages/shared/src/types.ts` — added `{ type: 'timeout'; timeoutMs: number }` to the `ChatEvent` discriminated union.
- `packages/services/src/chatroom/orchestration/stream-agent.ts` — `turnDone.catch` branches on `err instanceof TurnTimeoutError` and emits the new event; non-timeout errors continue to emit `error`.
- `apps/web/src/renderer/lib/store/reducer.ts` — new `case 'timeout'` in `handleChatEvent` (renders seconds, matches the convention in `MagenticStrategy`); both `CHAT_EVENT` and `CHATROOM_EVENT` `isDone` checks now include `'timeout'`.
- Tests: stream-agent timeout test asserts the new event shape and absence of generic error; reducer tests cover the chat handler and `CHATROOM_EVENT` (clears active speaker, sets streaming false, surfaces text); `chatroom-types.test.ts` enumeration and `test/helpers.ts` `makeChatEvent` defaults updated to keep the union exhaustive.

## Out of scope (follow-up)

Uncle Bob review surfaced that the single-mind `ChatService` path *resolves* its turn timer instead of rejecting, so the new `timeout` event is currently emitted only by the chatroom orchestrator. The reducer's `case 'timeout'` is reachable on the chat path once `ChatService` is aligned. Tracked as **#208**.

## Verification

- `npm test` — 1076 tests pass (113 files).
- `npm run lint` — clean.
- Skipped packaging smoke (no runtime/Forge surface).