### PR TITLE
Fix cron create payload contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.42.0 (2026-05-05)
+
+### Cron
+
+- **Fix cron job creation guidance** - `cron_create` now exposes a visible required payload shape, returns a specific missing-payload validation error, and has Electron smoke coverage for the create/list/run/history/remove lifecycle. (#210)
+
 ## v0.41.0 (2026-05-05)
 
 ### Lens

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/cron/CronService.test.ts
+++ b/packages/services/src/cron/CronService.test.ts
@@ -125,6 +125,24 @@ describe('CronService', () => {
     ).toThrow('notification job payload requires a non-empty "title" string');
   });
 
+  it('rejects jobs missing payload with a specific cron_create error', () => {
+    const taskManager = new MockTaskManager();
+    const mindPath = makeMindPath();
+    const service = new CronService({
+      getTaskManager: () => taskManager as unknown as TaskManager,
+      showMind: vi.fn(),
+      notifier,
+    });
+
+    expect(() =>
+      service.createJob('mind-1', mindPath, {
+        name: 'Bad notification',
+        schedule: '0 9 * * *',
+        type: 'notification',
+      } as unknown as Parameters<CronService['createJob']>[2]),
+    ).toThrow('cron_create requires payload for notification jobs');
+  });
+
   it('rejects prompt jobs missing required prompt field', () => {
     const taskManager = new MockTaskManager();
     const mindPath = makeMindPath();

--- a/packages/services/src/cron/CronService.ts
+++ b/packages/services/src/cron/CronService.ts
@@ -18,8 +18,15 @@ function requireString(payload: Record<string, unknown>, field: string, jobType:
   }
 }
 
+function requirePayload(type: CronJobType, payload: CronJobPayload): Record<string, unknown> {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error(`cron_create requires payload for ${type} jobs`);
+  }
+  return payload as unknown as Record<string, unknown>;
+}
+
 function validatePayload(type: CronJobType, payload: CronJobPayload): void {
-  const p = payload as unknown as Record<string, unknown>;
+  const p = requirePayload(type, payload);
   switch (type) {
     case 'prompt':
       requireString(p, 'prompt', 'prompt');

--- a/packages/services/src/cron/tools.test.ts
+++ b/packages/services/src/cron/tools.test.ts
@@ -41,6 +41,23 @@ describe('buildCronTools', () => {
     expect(mockService.createJob).toHaveBeenCalledWith('mind-1', '/path', input);
   });
 
+  it('cron_create documents and requires the payload object with visible payload fields', () => {
+    const tools = buildCronTools('mind-1', '/path', mockService as unknown as CronService);
+    const create = tools.find((t) => t.name === 'cron_create')!;
+    const parameters = create.parameters as {
+      required?: string[];
+      properties: Record<string, { description?: string; properties?: Record<string, unknown> }>;
+    };
+
+    expect(create.description).toContain('Always include a payload object');
+    expect(parameters.properties.payload.description).toContain('notification use { "title": string, "body": string }');
+    expect(parameters.properties.payload.properties).toMatchObject({
+      title: { type: 'string', description: 'Notification title.' },
+      body: { description: 'Notification body string or webhook JSON body.' },
+    });
+    expect(parameters.required).toEqual(['name', 'schedule', 'type', 'payload']);
+  });
+
   it('cron_list dispatches to cronService.listJobs', async () => {
     const tools = buildCronTools('mind-1', '/path', mockService as unknown as CronService);
     const list = tools.find((t) => t.name === 'cron_list')!;

--- a/packages/services/src/cron/tools.ts
+++ b/packages/services/src/cron/tools.ts
@@ -10,7 +10,8 @@ export function buildCronTools(
   return [
     {
       name: 'cron_create',
-      description: 'Create a scheduled cron job for this mind. Prompt jobs can optionally target another agent by recipient.',
+      description:
+        'Create a scheduled cron job for this mind. Always include a payload object. Payload examples: prompt { "prompt": "Summarize today", "recipient": "optional-mind-id" }; shell { "command": "node", "args": ["script.js"] }; webhook { "url": "https://example.com/hook", "body": {} }; notification { "title": "Reminder", "body": "Standup starts now." }.',
       parameters: {
         type: 'object',
         properties: {
@@ -21,7 +22,21 @@ export function buildCronTools(
             enum: ['prompt', 'shell', 'webhook', 'notification'],
             description: 'The job type to run.',
           },
-          payload: { type: 'object', description: 'Type-specific job payload.' },
+          payload: {
+            type: 'object',
+            properties: {
+              prompt: { type: 'string', description: 'Prompt job text.' },
+              recipient: { type: 'string', description: 'Optional target mind id for prompt jobs.' },
+              command: { type: 'string', description: 'Shell job executable.' },
+              args: { type: 'array', items: { type: 'string' }, description: 'Optional shell job arguments.' },
+              url: { type: 'string', description: 'Webhook job URL.' },
+              headers: { type: 'object', description: 'Optional webhook headers.' },
+              title: { type: 'string', description: 'Notification title.' },
+              body: { description: 'Notification body string or webhook JSON body.' },
+            },
+            description:
+              'Required type-specific payload. For prompt use { "prompt": string, "recipient"?: string }; shell use { "command": string, "args"?: string[] }; webhook use { "url": string, "body"?: unknown, "headers"?: object }; notification use { "title": string, "body": string }.',
+          },
           enabled: { type: 'boolean', description: 'Whether the job starts enabled. Defaults to true.' },
           timeoutMs: { type: 'number', description: 'Optional timeout for prompt, shell, or webhook jobs.' },
         },

--- a/tests/e2e/electron/cron-tools-smoke.spec.ts
+++ b/tests/e2e/electron/cron-tools-smoke.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_CRON_CDP_PORT ?? 9340);
+const expectedReply = 'CRON_SMOKE_OK';
+const cronInstruction = [
+  'When asked to run the cron lifecycle smoke, use Chamber cron tools to:',
+  '1. create a disabled notification cron job with the exact requested name, schedule, title, and body;',
+  '2. list cron jobs and confirm the job exists;',
+  '3. run the job immediately;',
+  '4. inspect cron history for the job;',
+  '5. remove the job;',
+  `6. verify it is gone, then answer exactly ${expectedReply} and no other text.`,
+].join(' ');
+
+test.describe('electron Monica cron tools smoke', () => {
+  test.setTimeout(240_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let mindPath = '';
+  let userDataPath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-cron-tools-smoke-'));
+    mindPath = path.join(root, 'monica');
+    userDataPath = path.join(root, 'user-data');
+    tempRoots.push(root);
+    seedMonicaMind(mindPath);
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('creates, runs, lists, histories, and removes a cron notification job through chat tools', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#root')).not.toBeEmpty();
+
+    const mind = await page.evaluate(async (pathToMind) => {
+      const mind = await window.electronAPI.mind.add(pathToMind);
+      await window.electronAPI.mind.setActive(mind.mindId);
+      return mind;
+    }, mindPath);
+
+    await expect.poll(
+      () => page.evaluate(() => window.electronAPI.mind.list().then((minds) => minds.map((item) => item.identity.name))),
+    ).toEqual(['Monica']);
+
+    await page.getByRole('button', { name: 'Monica' }).first().click();
+    await expect(page.getByText('How can I help you today?')).toBeVisible();
+
+    const uniqueSuffix = Date.now();
+    const jobName = `Cron Smoke ${uniqueSuffix}`;
+    const result = await page.evaluate(async ({ expected, mindId, name }) => {
+      const messageId = `cron-smoke-${Date.now()}`;
+      const events: Array<{ type: string; content?: string; message?: string; toolName?: string; success?: boolean; error?: string }> = [];
+      let assistantText = '';
+      let errorMessage = '';
+      let resolveTerminal: () => void = () => undefined;
+      const terminal = new Promise<void>((resolve) => {
+        resolveTerminal = resolve;
+      });
+      const unsubscribe = window.electronAPI.chat.onEvent((receivedMindId, receivedMessageId, event) => {
+        if (receivedMindId !== mindId || receivedMessageId !== messageId) return;
+        events.push(event);
+        if (event.type === 'chunk' || event.type === 'message_final') {
+          assistantText += event.content;
+        }
+        if (event.type === 'error') {
+          errorMessage = event.message;
+          resolveTerminal();
+        }
+        if (event.type === 'done') {
+          resolveTerminal();
+        }
+      });
+
+      try {
+        const send = window.electronAPI.chat.send(
+          mindId,
+          [
+            'Run the cron lifecycle smoke now using your cron tools.',
+            `Create a disabled notification job named "${name}" with schedule "0 9 * * *".`,
+            `The cron_create call must include payload: {"title":"${name}","body":"Cron scheduler smoke test fired."}.`,
+            'List jobs to confirm it exists, run it now, inspect its history, remove it, and list again to verify it is gone.',
+            `After verifying removal, reply exactly ${expected} and no other text.`,
+          ].join(' '),
+          messageId,
+        );
+        const timeout = new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('Timed out waiting for cron smoke response.')), 240_000);
+        });
+        await Promise.race([Promise.all([send, terminal]), timeout]);
+        return { assistantText, errorMessage, events };
+      } finally {
+        unsubscribe();
+      }
+    }, { expected: expectedReply, mindId: mind.mindId, name: jobName });
+
+    expect(result.errorMessage).toBe('');
+    expect(result.assistantText).toContain(expectedReply);
+    expect(result.events.filter((event) => event.type === 'tool_done' && event.success === false)).toEqual([]);
+    expect(result.events.filter((event) => event.type === 'tool_start').map((event) => event.toolName)).toEqual(
+      expect.arrayContaining(['cron_create', 'cron_list', 'cron_run_now', 'cron_history', 'cron_remove']),
+    );
+
+    const jobs = readCronJobs(mindPath);
+    expect(jobs.some((job) => job.name === jobName)).toBe(false);
+  });
+});
+
+function seedMonicaMind(targetMindPath: string): void {
+  fs.mkdirSync(path.join(targetMindPath, '.github', 'agents'), { recursive: true });
+  fs.mkdirSync(path.join(targetMindPath, '.working-memory'), { recursive: true });
+  fs.writeFileSync(
+    path.join(targetMindPath, 'SOUL.md'),
+    [
+      '# Monica',
+      '',
+      'You are Monica, Chamber\'s meticulous, upbeat, systems-minded organizer.',
+      cronInstruction,
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(targetMindPath, '.github', 'agents', 'monica.agent.md'),
+    [
+      '---',
+      'name: Monica',
+      'description: Chamber cron smoke-test organizer persona',
+      '---',
+      '',
+      '# Monica Agent',
+      '',
+      'Use Chamber tools carefully and finish deterministic smoke tests with the requested exact token.',
+      '',
+    ].join('\n'),
+  );
+  for (const file of ['memory.md', 'rules.md', 'log.md']) {
+    fs.writeFileSync(
+      path.join(targetMindPath, '.working-memory', file),
+      file === 'memory.md' ? `${cronInstruction}\n` : '',
+    );
+  }
+}
+
+function readCronJobs(targetMindPath: string): Array<{ name?: string }> {
+  const jobsPath = path.join(targetMindPath, '.chamber', 'cron.json');
+  if (!fs.existsSync(jobsPath)) return [];
+  const parsed = JSON.parse(fs.readFileSync(jobsPath, 'utf-8')) as { jobs?: Array<{ name?: string }> };
+  return parsed.jobs ?? [];
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[cron-tools-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the `cron_create` tool contract so required payload fields are visible to agents.
- Adds a specific missing-payload validation error for cron job creation.
- Adds a live Electron Monica cron smoke covering create/list/run/history/remove through the real chat tool path.
- Bumps Chamber to v0.42.0 and documents the release change.

## Notable changes
- Expands the `cron_create` schema with nested payload fields for prompt, shell, webhook, and notification jobs.
- Keeps `payload` required in the tool schema while making its shape visible enough for the model to include it.
- Verifies missing payloads produce `cron_create requires payload for <type> jobs` at the service boundary.

Closes #210

## Test evidence
- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npx playwright test --config config/playwright.config.ts --project=electron tests/e2e/electron/cron-tools-smoke.spec.ts --workers=1`

## Skipped smoke
- Packaging smoke skipped: this does not touch packaging, installer, runtime layout, Forge config, or first-launch behavior.