### PR TITLE
Add resumable conversation history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.43.0 (2026-05-05)
+
+### Chat
+
+- **Add resumable conversation history** - Chamber now creates named Copilot SDK sessions per mind, shows them in a right-side history pane, supports metadata-only rename, and resumes selected sessions so follow-up prompts continue the prior conversation. (#55)
+
+### Testing
+
+- **Smoke conversation history flows** - Electron smoke coverage now drives Monica and Lucy through history-pane create, rename, per-mind isolation, and restart restore flows. (#55)
+
 ## v0.42.0 (2026-05-05)
 
 ### Cron

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -52,6 +52,7 @@ import { setupMarketplaceIPC } from './main/ipc/marketplace';
 import { setupAuthIPC } from './main/ipc/auth';
 import { setupA2AIPC } from './main/ipc/a2a';
 import { setupChatroomIPC } from './main/ipc/chatroom';
+import { setupConversationHistoryIPC } from './main/ipc/conversationHistory';
 import { setupUpdaterIPC } from './main/ipc/updater';
 
 import { EventEmitter } from 'events';
@@ -450,6 +451,7 @@ app.on('ready', async () => {
 
   // --- IPC adapters (thin, parameter-injected) ---
   setupChatIPC(chatService, mindManager);
+  setupConversationHistoryIPC(chatService);
   setupMindIPC(mindManager, {
     preloadPath: path.join(__dirname, 'preload.js'),
     devServerUrl: MAIN_WINDOW_VITE_DEV_SERVER_URL || undefined,

--- a/apps/desktop/src/main/ipc/chat.ts
+++ b/apps/desktop/src/main/ipc/chat.ts
@@ -26,6 +26,6 @@ export function setupChatIPC(chatService: ChatService, mindManager: MindManager)
   });
 
   ipcMain.handle('chat:newConversation', async (_event, mindId: string) => {
-    await chatService.newConversation(mindId);
+    return chatService.newConversation(mindId);
   });
 }

--- a/apps/desktop/src/main/ipc/conversationHistory.ts
+++ b/apps/desktop/src/main/ipc/conversationHistory.ts
@@ -1,0 +1,13 @@
+import { ipcMain } from 'electron';
+import type { ChatService } from '@chamber/services';
+
+export function setupConversationHistoryIPC(chatService: ChatService): void {
+  ipcMain.handle('conversationHistory:list', async (_event, mindId: string) =>
+    chatService.listConversationHistory(mindId));
+
+  ipcMain.handle('conversationHistory:resume', async (_event, mindId: string, sessionId: string) =>
+    chatService.resumeConversation(mindId, sessionId));
+
+  ipcMain.handle('conversationHistory:rename', async (_event, mindId: string, sessionId: string, title: string) =>
+    chatService.renameConversation(mindId, sessionId, title));
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -14,6 +14,11 @@ const electronAPI: ElectronAPI = {
     listModels: (mindId?) => ipcRenderer.invoke('chat:listModels', mindId),
     onEvent: (callback) => createIpcListener(ipcRenderer, 'chat:event', callback),
   },
+  conversationHistory: {
+    list: (mindId) => ipcRenderer.invoke('conversationHistory:list', mindId),
+    resume: (mindId, sessionId) => ipcRenderer.invoke('conversationHistory:resume', mindId, sessionId),
+    rename: (mindId, sessionId, title) => ipcRenderer.invoke('conversationHistory:rename', mindId, sessionId, title),
+  },
   mind: {
     add: (mindPath) => ipcRenderer.invoke('mind:add', mindPath),
     remove: (mindId) => ipcRenderer.invoke('mind:remove', mindId),

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -48,7 +48,7 @@ export interface ChamberCtx {
   saveAttachment?: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
   cancelChat?: (mindId: string, messageId: string) => Promise<void> | void;
   sendChat?: (request: SendChatRequest) => Promise<void> | void;
-  newConversation?: (mindId: string) => Promise<void> | void;
+  newConversation?: (mindId: string) => Promise<unknown> | unknown;
   listModels?: (mindId?: string) => ModelDto[] | Promise<ModelDto[]>;
   shutdown?: () => void;
   handlePrivilegedRequest?: (request: PrivilegedRequest) => Promise<PrivilegedResponse>;

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -132,6 +132,7 @@ export function installBrowserApi(): void {
       },
       newConversation: async (mindId) => {
         await client.startNewConversation(mindId);
+        return { sessionId: '', messages: [], conversations: [] };
       },
       listModels: (): Promise<ModelInfo[]> => client.listModels(),
       onEvent: (callback) => {
@@ -141,6 +142,11 @@ export function installBrowserApi(): void {
           chatEventHandlers.delete(callback);
         };
       },
+    },
+    conversationHistory: {
+      list: async () => [],
+      resume: async () => ({ sessionId: '', messages: [], conversations: [] }),
+      rename: async () => [],
     },
     mind: {
       add: (mindPath): Promise<MindContext> => client.addMind(mindPath) as Promise<MindContext>,

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -1,0 +1,200 @@
+import { MoreHorizontal, Pencil, Plus } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ConversationSummary } from '@chamber/shared/types';
+import { useAppDispatch, useAppState } from '../../lib/store';
+import { Logger } from '../../lib/logger';
+import { cn } from '../../lib/utils';
+
+const log = Logger.create('ConversationHistoryPanel');
+
+export function ConversationHistoryPanel() {
+  const { activeMindId, conversationHistoryByMind, activeConversationByMind, messagesByMind, streamingByMind } = useAppState();
+  const dispatch = useAppDispatch();
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const conversations = useMemo(() => {
+    if (!activeMindId) return [];
+    return conversationHistoryByMind[activeMindId] ?? [];
+  }, [activeMindId, conversationHistoryByMind]);
+  const selectedConversationId = activeMindId ? activeConversationByMind[activeMindId] : undefined;
+  const activeMessageCount = activeMindId ? (messagesByMind[activeMindId]?.length ?? 0) : 0;
+  const isActiveMindStreaming = activeMindId ? Boolean(streamingByMind[activeMindId]) : false;
+
+  const applyResumeResult = useCallback((mindId: string, result: Awaited<ReturnType<typeof window.electronAPI.conversationHistory.resume>>) => {
+    dispatch({
+      type: 'RESUME_CONVERSATION',
+      payload: {
+        mindId,
+        sessionId: result.sessionId,
+        messages: result.messages,
+        conversations: result.conversations,
+      },
+    });
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!activeMindId) return;
+    let cancelled = false;
+    window.electronAPI.conversationHistory.list(activeMindId).then((history) => {
+      if (cancelled) return;
+      dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId: activeMindId, conversations: history } });
+      const activeConversation = history.find((conversation) => conversation.active);
+      if (activeConversation && activeMessageCount === 0 && !isActiveMindStreaming) {
+        window.electronAPI.conversationHistory.resume(activeMindId, activeConversation.sessionId).then((result) => {
+          if (cancelled) return;
+          applyResumeResult(activeMindId, result);
+        }).catch((error: unknown) => {
+          log.warn('Failed to hydrate active conversation:', error);
+        });
+      }
+    }).catch((error: unknown) => {
+      log.warn('Failed to load conversation history:', error);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeMessageCount, activeMindId, applyResumeResult, dispatch, isActiveMindStreaming]);
+
+  useEffect(() => {
+    if (renamingId) {
+      setTimeout(() => renameInputRef.current?.select(), 0);
+    }
+  }, [renamingId]);
+
+  const startRename = (conversation: ConversationSummary) => {
+    setRenamingId(conversation.sessionId);
+    setRenameValue(conversation.title);
+  };
+
+  const completeRename = async (sessionId: string, title: string | null) => {
+    if (title && activeMindId) {
+      const history = await window.electronAPI.conversationHistory.rename(activeMindId, sessionId, title);
+      dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId: activeMindId, conversations: history } });
+    }
+
+    setRenamingId(null);
+  };
+
+  const handleRenameKeyDown = (event: React.KeyboardEvent<HTMLInputElement>, id: string) => {
+    if (event.key === 'Enter') {
+      void completeRename(id, renameValue.trim() || null);
+    } else if (event.key === 'Escape') {
+      setRenamingId(null);
+    }
+  };
+
+  const resumeConversation = async (sessionId: string) => {
+    if (!activeMindId || isActiveMindStreaming || (sessionId === selectedConversationId && activeMessageCount > 0)) return;
+    const result = await window.electronAPI.conversationHistory.resume(activeMindId, sessionId);
+    applyResumeResult(activeMindId, result);
+    dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  };
+
+  const startNewConversation = async () => {
+    if (!activeMindId || isActiveMindStreaming) return;
+    const result = await window.electronAPI.chat.newConversation(activeMindId);
+    await window.electronAPI.chatroom.clear();
+    dispatch({ type: 'NEW_CONVERSATION' });
+    applyResumeResult(activeMindId, result);
+    dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  };
+
+  return (
+    <aside aria-label="Conversation history" className="w-80 shrink-0 bg-card border border-border rounded-xl overflow-hidden flex flex-col">
+      <div className="h-10 border-b border-border px-3 flex items-center justify-between">
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          History
+        </span>
+        <button
+          type="button"
+          disabled={!activeMindId || isActiveMindStreaming}
+          onClick={() => { void startNewConversation(); }}
+          className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+          aria-label="New conversation"
+        >
+          <Plus size={15} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-2">
+        {conversations.length === 0 ? (
+          <p className="px-2 py-3 text-xs text-muted-foreground">No conversations yet</p>
+        ) : null}
+        {conversations.map((conversation) => {
+          const isSelected = conversation.sessionId === selectedConversationId || conversation.active;
+
+          return (
+            <div
+              key={conversation.sessionId}
+              className={cn(
+                'group flex items-center gap-2 rounded-lg border-l-2 px-2 py-2 transition-colors',
+                isSelected
+                  ? 'border-l-primary bg-accent text-foreground'
+                  : 'border-l-transparent text-muted-foreground hover:text-foreground hover:bg-accent/50'
+              )}
+            >
+              <button
+                type="button"
+                aria-label={`Resume ${conversation.title}`}
+                disabled={isActiveMindStreaming}
+                onClick={() => { void resumeConversation(conversation.sessionId); }}
+                className="min-w-0 flex-1 text-left disabled:cursor-not-allowed"
+              >
+                {renamingId === conversation.sessionId ? (
+                  <input
+                    ref={renameInputRef}
+                    value={renameValue}
+                    onChange={(event) => setRenameValue(event.target.value)}
+                    onKeyDown={(event) => handleRenameKeyDown(event, conversation.sessionId)}
+                    onBlur={() => { void completeRename(conversation.sessionId, renameValue.trim() || null); }}
+                    className="w-full rounded border border-primary bg-background px-1.5 py-0.5 text-sm text-foreground outline-none"
+                  />
+                ) : (
+                  <>
+                    <div className="truncate text-sm font-medium">{conversation.title}</div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">
+                      {formatRelativeTime(conversation.updatedAt)}
+                      {conversation.active ? ' · Active' : ''}
+                    </div>
+                  </>
+                )}
+              </button>
+
+              <div className="flex items-center">
+                <button
+                  type="button"
+                  onClick={() => startRename(conversation)}
+                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-foreground hover:bg-accent group-hover:opacity-100 flex items-center justify-center"
+                  aria-label={`Rename ${conversation.title}`}
+                >
+                  <Pencil size={13} />
+                </button>
+                <button
+                  type="button"
+                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-foreground hover:bg-accent group-hover:opacity-100 flex items-center justify-center"
+                  aria-label={`${conversation.title} options`}
+                >
+                  <MoreHorizontal size={14} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+function formatRelativeTime(value: string): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return value;
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/apps/web/src/renderer/components/layout/AppShell.tsx
+++ b/apps/web/src/renderer/components/layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { useAppSubscriptions } from '../../hooks/useAppSubscriptions';
 import { useAppDispatch, useAppState } from '../../lib/store';
 import { TooltipProvider } from '../ui/tooltip';
 import { ActivityBar } from './ActivityBar';
+import { ConversationHistoryPanel } from '../history/ConversationHistoryPanel';
 import { MacTitlebarDrag } from './MacTitlebarDrag';
 import { MindSidebar } from './MindSidebar';
 import { ViewRouter } from './ViewRouter';
@@ -48,13 +49,14 @@ export function AppShell() {
     <TooltipProvider>
       <MacTitlebarDrag />
       <div className="flex flex-col h-screen w-screen bg-background text-foreground">
-        {/* Main layout: activity bar | mind sidebar | content */}
+        {/* Main layout: activity bar | mind sidebar | content | conversation history */}
         <div className="flex flex-1 min-h-0 gap-2 p-2">
           <ActivityBar />
           <MindSidebar />
           <main className="flex-1 flex flex-col min-w-0 bg-card border border-border rounded-xl overflow-hidden">
             <ViewRouter />
           </main>
+          <ConversationHistoryPanel />
         </div>
       </div>
     </TooltipProvider>

--- a/apps/web/src/renderer/components/layout/MindSidebar.tsx
+++ b/apps/web/src/renderer/components/layout/MindSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { cn } from '../../lib/utils';
-import { Plus, X, Bot, MessageSquarePlus, ExternalLink } from 'lucide-react';
+import { Plus, X, Bot, ExternalLink } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { MindContext } from '@chamber/shared/types';
 
@@ -152,21 +152,6 @@ export function MindSidebar() {
       </div>
 
       <div className="border-t border-border p-2 space-y-1">
-        <button
-          onClick={async () => {
-            if (activeMindId) {
-              await window.electronAPI.chat.newConversation(activeMindId);
-              await window.electronAPI.chatroom.clear();
-              dispatch({ type: 'NEW_CONVERSATION' });
-              dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
-            }
-          }}
-          disabled={!activeMindId}
-          className="w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded flex items-center gap-2 transition-colors disabled:opacity-50"
-        >
-          <MessageSquarePlus size={14} />
-          New Conversation
-        </button>
         <button
           onClick={handleAddMind}
           className="w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded flex items-center gap-2 transition-colors"

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -201,6 +201,41 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       };
     }
 
+    case 'SET_CONVERSATION_HISTORY':
+      return {
+        ...state,
+        conversationHistoryByMind: {
+          ...state.conversationHistoryByMind,
+          [action.payload.mindId]: action.payload.conversations,
+        },
+        activeConversationByMind: {
+          ...state.activeConversationByMind,
+          [action.payload.mindId]: action.payload.conversations.find((conversation) => conversation.active)?.sessionId,
+        },
+      };
+
+    case 'RESUME_CONVERSATION':
+      return {
+        ...state,
+        messagesByMind: {
+          ...state.messagesByMind,
+          [action.payload.mindId]: action.payload.messages,
+        },
+        conversationHistoryByMind: {
+          ...state.conversationHistoryByMind,
+          [action.payload.mindId]: action.payload.conversations,
+        },
+        activeConversationByMind: {
+          ...state.activeConversationByMind,
+          [action.payload.mindId]: action.payload.sessionId,
+        },
+        streamingByMind: {
+          ...state.streamingByMind,
+          [action.payload.mindId]: false,
+        },
+        isStreaming: state.activeMindId === action.payload.mindId ? false : state.isStreaming,
+      };
+
     case 'SET_MINDS':
       return {
         ...state,
@@ -230,7 +265,11 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     case 'REMOVE_MIND': {
       const newMinds = state.minds.filter(m => m.mindId !== action.payload);
       const newMsgsByMind = { ...state.messagesByMind };
+      const newConversationHistoryByMind = { ...state.conversationHistoryByMind };
+      const newActiveConversationByMind = { ...state.activeConversationByMind };
       delete newMsgsByMind[action.payload];
+      delete newConversationHistoryByMind[action.payload];
+      delete newActiveConversationByMind[action.payload];
       const newActive = state.activeMindId === action.payload
         ? (newMinds.length > 0 ? newMinds[0].mindId : null)
         : state.activeMindId;
@@ -239,6 +278,8 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         minds: newMinds,
         activeMindId: newActive,
         messagesByMind: newMsgsByMind,
+        conversationHistoryByMind: newConversationHistoryByMind,
+        activeConversationByMind: newActiveConversationByMind,
         showLanding: newMinds.length === 0,
       };
     }

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ChatEvent, ModelInfo, LensViewManifest, MindContext, ImageBlock } from '@chamber/shared/types';
+import type { ChatMessage, ChatEvent, ConversationSummary, ModelInfo, LensViewManifest, MindContext, ImageBlock } from '@chamber/shared/types';
 import type { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '@chamber/shared/a2a-types';
 import type { ChatroomMessage, ChatroomStreamEvent, OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig, TaskLedgerItem } from '@chamber/shared/chatroom-types';
 
@@ -10,6 +10,8 @@ export interface AppState {
   runtimePhase: 'ready' | 'switching-account';
   switchingAccountLogin: string | null;
   messagesByMind: Record<string, ChatMessage[]>;
+  conversationHistoryByMind: Record<string, ConversationSummary[]>;
+  activeConversationByMind: Record<string, string | undefined>;
   isStreaming: boolean;
   streamingByMind: Record<string, boolean>;
   availableModels: ModelInfo[];
@@ -38,6 +40,8 @@ export type AppAction =
   | { type: 'ADD_ASSISTANT_MESSAGE'; payload: { id: string; timestamp: number } }
   | { type: 'CHAT_EVENT'; payload: { mindId: string; messageId: string; event: ChatEvent } }
   | { type: 'HYDRATE_CHAT_STATE'; payload: { messagesByMind: Record<string, ChatMessage[]>; streamingByMind: Record<string, boolean> } }
+  | { type: 'SET_CONVERSATION_HISTORY'; payload: { mindId: string; conversations: ConversationSummary[] } }
+  | { type: 'RESUME_CONVERSATION'; payload: { mindId: string; sessionId: string; messages: ChatMessage[]; conversations: ConversationSummary[] } }
   | { type: 'SET_MINDS'; payload: MindContext[] }
   | { type: 'SET_ACTIVE_MIND'; payload: string | null }
   | { type: 'ADD_MIND'; payload: MindContext }
@@ -75,6 +79,8 @@ export const initialState: AppState = {
   runtimePhase: 'ready',
   switchingAccountLogin: null,
   messagesByMind: {},
+  conversationHistoryByMind: {},
+  activeConversationByMind: {},
   isStreaming: false,
   streamingByMind: {},
   availableModels: [],

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -111,9 +111,14 @@ export function mockElectronAPI(): ElectronAPI {
     chat: {
       send: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
-      newConversation: vi.fn().mockResolvedValue(undefined),
+      newConversation: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
       listModels: vi.fn().mockResolvedValue([]),
       onEvent: vi.fn().mockReturnValue(vi.fn()),
+    },
+    conversationHistory: {
+      list: vi.fn().mockResolvedValue([]),
+      resume: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
+      rename: vi.fn().mockResolvedValue([]),
     },
     mind: {
       add: vi.fn().mockResolvedValue({ mindId: 'test-1234', mindPath: 'C:\\test', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -27,6 +27,9 @@ const mockMindManager = {
     return undefined;
   }),
   recreateSession: vi.fn(),
+  listConversationHistory: vi.fn(() => []),
+  resumeConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
+  renameConversation: vi.fn(() => []),
   setMindModel: vi.fn(async () => null),
 };
 
@@ -130,6 +133,21 @@ describe('ChatService', () => {
     it('delegates to mindManager.recreateSession', async () => {
       await svc.newConversation('valid-mind');
       expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
+    });
+
+    it('rejects conversation switches while a message is streaming', async () => {
+      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+        void eventOrCb;
+        void cb;
+        return vi.fn();
+      });
+      const send = svc.sendMessage('valid-mind', 'hello', 'msg-1', vi.fn());
+      await Promise.resolve();
+
+      await expect(svc.newConversation('valid-mind')).rejects.toThrow('Cannot switch conversations');
+
+      await svc.cancelMessage('valid-mind', 'msg-1');
+      await send;
     });
   });
 

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -2,7 +2,7 @@
 // Gets sessions from MindManager, streams SDK events via callback.
 
 import type { MindManager } from '../mind';
-import type { ChatEvent, ChatImageAttachment, ModelInfo } from '@chamber/shared/types';
+import type { ChatEvent, ChatImageAttachment, ConversationResumeResult, ConversationSummary, ModelInfo } from '@chamber/shared/types';
 import type { CopilotSession } from '../mind/types';
 import { isStaleSessionError, SEND_TIMEOUT_MS, DEFAULT_TURN_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
 import { Logger } from '../logger';
@@ -210,8 +210,27 @@ export class ChatService {
     }
   }
 
-  async newConversation(mindId: string): Promise<void> {
+  async newConversation(mindId: string): Promise<ConversationResumeResult> {
+    this.assertCanSwitchConversation(mindId);
     await this.mindManager.recreateSession(mindId);
+    return {
+      sessionId: this.mindManager.getMind(mindId)?.activeSessionId ?? '',
+      messages: [],
+      conversations: this.mindManager.listConversationHistory(mindId),
+    };
+  }
+
+  listConversationHistory(mindId: string): ConversationSummary[] {
+    return this.mindManager.listConversationHistory(mindId);
+  }
+
+  async resumeConversation(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
+    this.assertCanSwitchConversation(mindId);
+    return this.mindManager.resumeConversation(mindId, sessionId);
+  }
+
+  renameConversation(mindId: string, sessionId: string, title: string): ConversationSummary[] {
+    return this.mindManager.renameConversation(mindId, sessionId, title);
   }
 
   async listModels(mindId: string): Promise<ModelInfo[]> {
@@ -222,5 +241,11 @@ export class ChatService {
     clearCopilotModelsCache(context.client);
     const models = await context.client.listModels();
     return models.map((m: { id: string; name: string }) => ({ id: m.id, name: m.name }));
+  }
+
+  private assertCanSwitchConversation(mindId: string): void {
+    if (this.abortControllers.has(mindId)) {
+      throw new Error('Cannot switch conversations while a message is still streaming.');
+    }
   }
 }

--- a/packages/services/src/config/ConfigService.test.ts
+++ b/packages/services/src/config/ConfigService.test.ts
@@ -86,6 +86,43 @@ describe('ConfigService', () => {
       });
     });
 
+    it('preserves per-mind conversation history metadata without transcript text', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [{
+          id: 'q-a1b2',
+          path: '/tmp/agents/q',
+          selectedModel: 'gpt-5.4',
+          activeSessionId: 'chamber-q-a1b2-conversation-1',
+          conversations: [{
+            sessionId: 'chamber-q-a1b2-conversation-1',
+            title: 'Launch plan',
+            createdAt: '2026-05-05T22:00:00.000Z',
+            updatedAt: '2026-05-05T22:15:00.000Z',
+            kind: 'chat',
+            messages: [{ role: 'user', content: 'do not persist me here' }],
+          }],
+        }],
+        activeMindId: 'q-a1b2',
+        activeLogin: null,
+        theme: 'dark',
+      }));
+
+      expect(svc.load().minds[0]).toEqual({
+        id: 'q-a1b2',
+        path: '/tmp/agents/q',
+        selectedModel: 'gpt-5.4',
+        activeSessionId: 'chamber-q-a1b2-conversation-1',
+        conversations: [{
+          sessionId: 'chamber-q-a1b2-conversation-1',
+          title: 'Launch plan',
+          createdAt: '2026-05-05T22:00:00.000Z',
+          updatedAt: '2026-05-05T22:15:00.000Z',
+          kind: 'chat',
+        }],
+      });
+    });
+
     it('preserves a saved disabled state for the default public marketplace', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         version: 2,

--- a/packages/services/src/config/ConfigService.ts
+++ b/packages/services/src/config/ConfigService.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { generateMindId } from '../mind';
-import type { AppConfig, AppConfigV1, MarketplaceRegistry, MindRecord } from '@chamber/shared/types';
+import type { AppConfig, AppConfigV1, ChamberConversationRecord, MarketplaceRegistry, MindRecord } from '@chamber/shared/types';
 
 const CONFIG_DIR = path.join(os.homedir(), '.chamber');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
@@ -121,6 +121,34 @@ function normalizeMindRecord(value: unknown): MindRecord | null {
     ...(typeof record.selectedModel === 'string' && record.selectedModel.trim().length > 0
       ? { selectedModel: record.selectedModel.trim() }
       : {}),
+    ...(typeof record.activeSessionId === 'string' && record.activeSessionId.trim().length > 0
+      ? { activeSessionId: record.activeSessionId.trim() }
+      : {}),
+    ...(Array.isArray(record.conversations)
+      ? { conversations: record.conversations.map(normalizeConversationRecord).filter((conversation): conversation is ChamberConversationRecord => conversation !== null) }
+      : {}),
+  };
+}
+
+function normalizeConversationRecord(value: unknown): ChamberConversationRecord | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const kind = record.kind === 'cron' || record.kind === 'task' ? record.kind : 'chat';
+  if (
+    typeof record.sessionId !== 'string'
+    || typeof record.createdAt !== 'string'
+    || typeof record.updatedAt !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    sessionId: record.sessionId,
+    ...(typeof record.title === 'string' && record.title.trim().length > 0
+      ? { title: record.title.trim() }
+      : {}),
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    kind,
   };
 }
 

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -31,6 +31,7 @@ function createSessionStub() {
   return {
   send: vi.fn(),
   sendAndWait: vi.fn(),
+  getMessages: vi.fn(async (): Promise<unknown[]> => []),
   on: vi.fn(),
   off: vi.fn(),
   disconnect: vi.fn(async () => undefined),
@@ -38,14 +39,22 @@ function createSessionStub() {
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockCreateSession = vi.fn((_config: Record<string, unknown>) => createSessionStub());
+const mockCreateSession = vi.fn((config: Record<string, unknown>) => {
+  void config;
+  return createSessionStub();
+});
+const mockResumeSession = vi.fn((sessionId: string, config: Record<string, unknown>) => {
+  void sessionId;
+  void config;
+  return createSessionStub();
+});
 
 function makeMockClient() {
   return {
     start: mockStart,
     stop: mockStop,
     createSession: mockCreateSession,
+    resumeSession: mockResumeSession,
   };
 }
 
@@ -130,6 +139,15 @@ describe('MindManager', () => {
       activeLogin: null,
       theme: 'dark',
     };
+    mockCreateSession.mockImplementation((config: Record<string, unknown>) => {
+      void config;
+      return createSessionStub();
+    });
+    mockResumeSession.mockImplementation((sessionId: string, config: Record<string, unknown>) => {
+      void sessionId;
+      void config;
+      return createSessionStub();
+    });
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
     vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => String(candidate));
@@ -154,6 +172,50 @@ describe('MindManager', () => {
         '/tmp/agents/q',
       );
       expect(mockConfigService.save).toHaveBeenCalled();
+    });
+
+    it('creates a named chamber session and persists conversation metadata', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const sessionConfig = mockCreateSession.mock.calls[0][0] as { sessionId?: string };
+
+      expect(sessionConfig.sessionId).toMatch(new RegExp(`^chamber-${mind.mindId}-`));
+      expect(lastSavedConfig().minds[0]).toMatchObject({
+        id: mind.mindId,
+        activeSessionId: sessionConfig.sessionId,
+        conversations: [expect.objectContaining({
+          sessionId: sessionConfig.sessionId,
+          kind: 'chat',
+        })],
+      });
+    });
+
+    it('resumes a persisted active conversation when restoring a mind', async () => {
+      currentConfig = {
+        version: 2,
+        minds: [{
+          id: 'q-a1b2',
+          path: '/tmp/agents/q',
+          activeSessionId: 'chamber-q-a1b2-existing',
+          conversations: [{
+            sessionId: 'chamber-q-a1b2-existing',
+            title: 'Existing chat',
+            createdAt: '2026-05-05T22:00:00.000Z',
+            updatedAt: '2026-05-05T22:00:00.000Z',
+            kind: 'chat',
+          }],
+        }],
+        activeMindId: 'q-a1b2',
+        activeLogin: null,
+        theme: 'dark',
+      };
+
+      await manager.restoreFromConfig();
+
+      expect(mockResumeSession).toHaveBeenCalledWith(
+        'chamber-q-a1b2-existing',
+        expect.objectContaining({ workingDirectory: '/tmp/agents/q' }),
+      );
+      expect(manager.listMinds()[0].activeSessionId).toBe('chamber-q-a1b2-existing');
     });
 
     it('injects current datetime context into background prompts', async () => {
@@ -186,15 +248,20 @@ describe('MindManager', () => {
       expect(manager.listMinds()[0].selectedModel).toBe('gpt-5.4');
     });
 
-    it('persists a per-mind model and recreates the session with it', async () => {
+    it('persists a per-mind model and resumes the active session with it', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       mockCreateSession.mockClear();
+      mockResumeSession.mockClear();
 
       const updated = await manager.setMindModel(mind.mindId, 'claude-opus');
 
       expect(updated?.selectedModel).toBe('claude-opus');
       expect(lastSavedConfig().minds[0].selectedModel).toBe('claude-opus');
-      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-opus' }));
+      expect(mockCreateSession).not.toHaveBeenCalled();
+      expect(mockResumeSession).toHaveBeenCalledWith(
+        mind.activeSessionId,
+        expect.objectContaining({ model: 'claude-opus' }),
+      );
     });
 
     it('serializes concurrent per-mind model changes', async () => {
@@ -202,7 +269,8 @@ describe('MindManager', () => {
       const firstModelSession = createSessionStub();
       const secondModelSession = createSessionStub();
       let resolveFirstModelSession: (() => void) | undefined;
-      const createSession = vi.fn((config: Record<string, unknown>) => {
+      const createSession = vi.fn(() => Promise.resolve(originalSession));
+      const resumeSession = vi.fn((_sessionId: string, config: Record<string, unknown>) => {
         if (config.model === 'model-a') {
           return new Promise((resolve) => {
             resolveFirstModelSession = () => resolve(firstModelSession);
@@ -212,7 +280,7 @@ describe('MindManager', () => {
         return Promise.resolve(originalSession);
       });
       const clientFactory = {
-        createClient: vi.fn(async () => ({ start: vi.fn(), stop: vi.fn(), createSession })),
+        createClient: vi.fn(async () => ({ start: vi.fn(), stop: vi.fn(), createSession, resumeSession })),
         destroyClient: vi.fn(),
       };
       const localManager = new MindManager(
@@ -224,20 +292,22 @@ describe('MindManager', () => {
 
       const mind = await localManager.loadMind('/tmp/agents/q');
       createSession.mockClear();
+      resumeSession.mockClear();
 
       const firstChange = localManager.setMindModel(mind.mindId, 'model-a');
       const secondChange = localManager.setMindModel(mind.mindId, 'model-b');
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(createSession).toHaveBeenCalledTimes(1);
-      expect(createSession).toHaveBeenCalledWith(expect.objectContaining({ model: 'model-a' }));
+      expect(resumeSession).toHaveBeenCalledTimes(1);
+      expect(resumeSession).toHaveBeenCalledWith(mind.activeSessionId, expect.objectContaining({ model: 'model-a' }));
 
       resolveFirstModelSession?.();
       await Promise.all([firstChange, secondChange]);
 
-      expect(createSession).toHaveBeenCalledTimes(2);
-      expect(createSession).toHaveBeenLastCalledWith(expect.objectContaining({ model: 'model-b' }));
+      expect(createSession).not.toHaveBeenCalled();
+      expect(resumeSession).toHaveBeenCalledTimes(2);
+      expect(resumeSession).toHaveBeenLastCalledWith(mind.activeSessionId, expect.objectContaining({ model: 'model-b' }));
       expect(localManager.getMind(mind.mindId)?.selectedModel).toBe('model-b');
       expect(localManager.getMind(mind.mindId)?.session).toBe(secondModelSession);
       expect(originalSession.disconnect).toHaveBeenCalledTimes(1);
@@ -448,10 +518,70 @@ describe('MindManager', () => {
       const newSession = newCtx.session;
       expect(newSession).toBeDefined();
       expect(mockCreateSession).toHaveBeenCalledTimes(2);
+      expect(manager.listConversationHistory(mind.mindId)).toHaveLength(2);
+      expect(manager.listConversationHistory(mind.mindId)[0].active).toBe(true);
     });
 
     it('throws for non-existent mind', async () => {
       await expect(manager.recreateSession('nonexistent')).rejects.toThrow();
+    });
+  });
+
+  describe('conversation history', () => {
+    it('resumes a selected conversation and hydrates messages from the SDK session', async () => {
+      const resumedSession = createSessionStub();
+      resumedSession.getMessages.mockResolvedValue([
+        {
+          type: 'user.message',
+          timestamp: '2026-05-05T22:00:00.000Z',
+          data: { messageId: 'u1', content: 'hello Monica' },
+        },
+        {
+          type: 'assistant.message',
+          timestamp: '2026-05-05T22:00:01.000Z',
+          data: { messageId: 'a1', content: 'hello human' },
+        },
+      ]);
+      mockResumeSession.mockResolvedValueOnce(resumedSession);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      await manager.recreateSession(mind.mindId);
+      const target = manager.listConversationHistory(mind.mindId)[1];
+
+      const result = await manager.resumeConversation(mind.mindId, target.sessionId);
+
+      expect(mockResumeSession).toHaveBeenCalledWith(
+        target.sessionId,
+        expect.objectContaining({ workingDirectory: '/tmp/agents/q' }),
+      );
+      expect(result.sessionId).toBe(target.sessionId);
+      expect(result.messages).toEqual([
+        {
+          id: 'u1',
+          role: 'user',
+          blocks: [{ type: 'text', content: 'hello Monica' }],
+          timestamp: Date.parse('2026-05-05T22:00:00.000Z'),
+        },
+        {
+          id: 'a1',
+          role: 'assistant',
+          blocks: [{ type: 'text', content: 'hello human' }],
+          timestamp: Date.parse('2026-05-05T22:00:01.000Z'),
+        },
+      ]);
+      expect(result.conversations.find((conversation) => conversation.sessionId === target.sessionId)?.active).toBe(true);
+    });
+
+    it('renames only Chamber-owned conversation metadata', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const sessionId = manager.listConversationHistory(mind.mindId)[0].sessionId;
+
+      const history = manager.renameConversation(mind.mindId, sessionId, 'Better title');
+
+      expect(history[0]).toMatchObject({ sessionId, title: 'Better title' });
+      expect(lastSavedConfig().minds[0].conversations?.[0]).toMatchObject({
+        sessionId,
+        title: 'Better title',
+      });
     });
   });
 

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -2,13 +2,14 @@
 // Owns Map<mindId, InternalMindContext>, lifecycle, persistence.
 
 import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { PermissionHandler, SessionConfig } from '@github/copilot-sdk';
+import type { PermissionHandler, ResumeSessionConfig, SessionConfig } from '@github/copilot-sdk';
 import { Logger } from '../logger';
 
 const log = Logger.create('MindManager');
-import type { MindContext, AppConfig, MindRecord } from '@chamber/shared/types';
+import type { AppConfig, ChamberConversationRecord, ChatMessage, ConversationResumeResult, ConversationSummary, MindContext, MindRecord } from '@chamber/shared/types';
 import type { InternalMindContext, CopilotClient, CopilotSession, Tool, UserInputHandler } from './types';
 import { generateMindId } from './generateMindId';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
@@ -94,10 +95,34 @@ export class MindManager extends EventEmitter {
 
     const sessionTools = this.getSessionTools(id, resolvedMindPath);
 
-    const selectedModel = this.knownMindRecords.get(id)?.selectedModel;
+    const knownRecord = this.knownMindRecords.get(id);
+    const selectedModel = knownRecord?.selectedModel;
+    const activeSessionId = knownRecord?.activeSessionId ?? this.createConversationRecord(id).sessionId;
+    const conversationRecord = this.ensureConversationRecord(id, activeSessionId, knownRecord?.conversations);
 
-    // Create session
-    const session = await this.createSessionForMind(
+    const session = knownRecord?.activeSessionId
+      ? await this.resumeSessionForMind(
+        client,
+        activeSessionId,
+        resolvedMindPath,
+        identity.systemMessage,
+        sessionTools,
+        undefined,
+        approveAllCompat,
+        true,
+        selectedModel,
+      ).catch(() => this.createSessionForMind(
+        client,
+        resolvedMindPath,
+        identity.systemMessage,
+        sessionTools,
+        undefined,
+        approveAllCompat,
+        true,
+        selectedModel,
+        activeSessionId,
+      ))
+      : await this.createSessionForMind(
       client,
       resolvedMindPath,
       identity.systemMessage,
@@ -106,6 +131,7 @@ export class MindManager extends EventEmitter {
       approveAllCompat,
       true,
       selectedModel,
+      activeSessionId,
     );
 
     const context: InternalMindContext = {
@@ -114,6 +140,7 @@ export class MindManager extends EventEmitter {
       identity,
       status: 'ready',
       selectedModel,
+      activeSessionId,
       client,
       session,
     };
@@ -138,7 +165,16 @@ export class MindManager extends EventEmitter {
       throw err;
     }
 
-    this.knownMindRecords.set(id, { id, path: resolvedMindPath, ...(selectedModel ? { selectedModel } : {}) });
+    this.knownMindRecords.set(id, {
+      id,
+      path: resolvedMindPath,
+      ...(selectedModel ? { selectedModel } : {}),
+      activeSessionId,
+      conversations: [
+        conversationRecord,
+        ...(knownRecord?.conversations ?? []).filter((conversation) => conversation.sessionId !== activeSessionId),
+      ],
+    });
 
     // Persist
     this.persistConfig();
@@ -211,8 +247,10 @@ export class MindManager extends EventEmitter {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
 
+    const conversation = this.createConversationRecord(mindId);
+    const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    context.session = await this.createSessionForMind(
+    const nextSession = await this.createSessionForMind(
       context.client,
       context.mindPath,
       context.identity.systemMessage,
@@ -221,8 +259,82 @@ export class MindManager extends EventEmitter {
       approveAllCompat,
       true,
       context.selectedModel,
+      conversation.sessionId,
     );
+    context.session = nextSession;
+    context.activeSessionId = conversation.sessionId;
+    this.upsertConversationRecord(mindId, conversation);
+    this.persistConfig();
+    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
     return context.session;
+  }
+
+  async resumeConversation(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+    const record = this.knownMindRecords.get(mindId);
+    if (!record?.conversations?.some((conversation) => conversation.sessionId === sessionId)) {
+      throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
+    }
+
+    const previousSession = context.session;
+    const sessionTools = this.getSessionTools(mindId, context.mindPath);
+    const nextSession = await this.resumeSessionForMind(
+      context.client,
+      sessionId,
+      context.mindPath,
+      context.identity.systemMessage,
+      sessionTools,
+      undefined,
+      approveAllCompat,
+      true,
+      context.selectedModel,
+    );
+    context.session = nextSession;
+    context.activeSessionId = sessionId;
+    this.touchConversationRecord(mindId, sessionId);
+    this.persistConfig();
+    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
+
+    return {
+      sessionId,
+      messages: await this.getMessagesForSession(nextSession),
+      conversations: this.listConversationHistory(mindId),
+    };
+  }
+
+  listConversationHistory(mindId: string): ConversationSummary[] {
+    const context = this.minds.get(mindId);
+    const record = this.knownMindRecords.get(mindId);
+    const activeSessionId = context?.activeSessionId ?? record?.activeSessionId;
+    return [...(record?.conversations ?? [])]
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+      .map((conversation) => ({
+        sessionId: conversation.sessionId,
+        title: conversation.title ?? this.defaultConversationTitle(conversation),
+        createdAt: conversation.createdAt,
+        updatedAt: conversation.updatedAt,
+        kind: conversation.kind,
+        active: conversation.sessionId === activeSessionId,
+      }));
+  }
+
+  renameConversation(mindId: string, sessionId: string, title: string): ConversationSummary[] {
+    const record = this.knownMindRecords.get(mindId);
+    if (!record) throw new Error(`Mind ${mindId} not found`);
+    const conversations = record.conversations ?? [];
+    if (!conversations.some((conversation) => conversation.sessionId === sessionId)) {
+      throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
+    }
+    const updatedAt = new Date().toISOString();
+    this.knownMindRecords.set(mindId, {
+      ...record,
+      conversations: conversations.map((conversation) => conversation.sessionId === sessionId
+        ? { ...conversation, title: title.trim(), updatedAt }
+        : conversation),
+    });
+    this.persistConfig();
+    return this.listConversationHistory(mindId);
   }
 
   async setMindModel(mindId: string, model: string | null): Promise<MindContext | null> {
@@ -256,6 +368,8 @@ export class MindManager extends EventEmitter {
         id: existingRecord.id,
         path: existingRecord.path,
         ...(selectedModel ? { selectedModel } : {}),
+        ...(existingRecord.activeSessionId ? { activeSessionId: existingRecord.activeSessionId } : {}),
+        ...(existingRecord.conversations ? { conversations: existingRecord.conversations } : {}),
       });
       this.persistConfig();
       return null;
@@ -265,16 +379,28 @@ export class MindManager extends EventEmitter {
 
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const nextSession = await this.createSessionForMind(
-      context.client,
-      context.mindPath,
-      context.identity.systemMessage,
-      sessionTools,
-      undefined,
-      approveAllCompat,
-      true,
-      selectedModel,
-    );
+    const nextSession = context.activeSessionId
+      ? await this.resumeSessionForMind(
+        context.client,
+        context.activeSessionId,
+        context.mindPath,
+        context.identity.systemMessage,
+        sessionTools,
+        undefined,
+        approveAllCompat,
+        true,
+        selectedModel,
+      )
+      : await this.createSessionForMind(
+        context.client,
+        context.mindPath,
+        context.identity.systemMessage,
+        sessionTools,
+        undefined,
+        approveAllCompat,
+        true,
+        selectedModel,
+      );
 
     context.selectedModel = selectedModel;
     context.session = nextSession;
@@ -282,6 +408,8 @@ export class MindManager extends EventEmitter {
       id: mindId,
       path: context.mindPath,
       ...(selectedModel ? { selectedModel } : {}),
+      ...(context.activeSessionId ? { activeSessionId: context.activeSessionId } : {}),
+      ...(this.knownMindRecords.get(mindId)?.conversations ? { conversations: this.knownMindRecords.get(mindId)?.conversations } : {}),
     });
     this.persistConfig();
     await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
@@ -402,6 +530,7 @@ export class MindManager extends EventEmitter {
       status: ctx.status,
       error: ctx.error,
       selectedModel: ctx.selectedModel,
+      activeSessionId: ctx.activeSessionId,
       windowed: false,
     };
   }
@@ -463,8 +592,45 @@ export class MindManager extends EventEmitter {
     onPermissionRequest: PermissionHandler = approveAllCompat,
     approveAll = true,
     model?: string,
+    sessionId?: string,
   ): Promise<CopilotSession> {
     const sessionConfig: SessionConfig = {
+      workingDirectory: mindPath,
+      enableConfigDiscovery: true,
+      tools,
+      systemMessage: {
+        mode: 'customize',
+        sections: {
+          identity: { action: 'replace', content: systemMessage },
+          tone: { action: 'remove' },
+        },
+      },
+      onPermissionRequest,
+      ...(sessionId ? { sessionId } : {}),
+      ...(model ? { model } : {}),
+      ...(onUserInputRequest ? { onUserInputRequest } : {}),
+    };
+    const session = await client.createSession(sessionConfig);
+
+    if (approveAll) {
+      await session.rpc.permissions.setApproveAll({ enabled: true });
+    }
+
+    return session;
+  }
+
+  private async resumeSessionForMind(
+    client: CopilotClient,
+    sessionId: string,
+    mindPath: string,
+    systemMessage: string,
+    tools: Tool[],
+    onUserInputRequest?: UserInputHandler,
+    onPermissionRequest: PermissionHandler = approveAllCompat,
+    approveAll = true,
+    model?: string,
+  ): Promise<CopilotSession> {
+    const sessionConfig: ResumeSessionConfig = {
       workingDirectory: mindPath,
       enableConfigDiscovery: true,
       tools,
@@ -479,13 +645,57 @@ export class MindManager extends EventEmitter {
       ...(model ? { model } : {}),
       ...(onUserInputRequest ? { onUserInputRequest } : {}),
     };
-    const session = await client.createSession(sessionConfig);
-
+    const session = await client.resumeSession(sessionId, sessionConfig);
     if (approveAll) {
       await session.rpc.permissions.setApproveAll({ enabled: true });
     }
-
     return session;
+  }
+
+  private async getMessagesForSession(session: CopilotSession): Promise<ChatMessage[]> {
+    const events = await session.getMessages();
+    return events.flatMap((event, index) => this.mapSessionEventToChatMessage(event, index));
+  }
+
+  private mapSessionEventToChatMessage(event: unknown, index: number): ChatMessage[] {
+    if (typeof event !== 'object' || event === null) return [];
+    const record = event as Record<string, unknown>;
+    const data = typeof record.data === 'object' && record.data !== null
+      ? record.data as Record<string, unknown>
+      : {};
+    const content = this.extractMessageContent(data);
+    if (!content) return [];
+    const timestamp = typeof record.timestamp === 'number'
+      ? record.timestamp
+      : Date.parse(String(record.timestamp ?? '')) || Date.now();
+    const id = typeof data.messageId === 'string'
+      ? data.messageId
+      : `${String(record.type ?? 'session-event')}-${index}`;
+    if (record.type === 'user.message') {
+      return [{ id, role: 'user', blocks: [{ type: 'text', content }], timestamp }];
+    }
+    if (record.type === 'assistant.message') {
+      return [{ id, role: 'assistant', blocks: [{ type: 'text', content }], timestamp }];
+    }
+    return [];
+  }
+
+  private extractMessageContent(data: Record<string, unknown>): string | null {
+    const value = data.content ?? data.message ?? data.text ?? data.prompt;
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) {
+      const content = value
+        .map((item) => {
+          if (typeof item === 'string') return item;
+          if (typeof item !== 'object' || item === null) return '';
+          const block = item as Record<string, unknown>;
+          return typeof block.text === 'string' ? block.text : '';
+        })
+        .filter(Boolean)
+        .join('\n');
+      return content || null;
+    }
+    return null;
   }
 
   async sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void> {
@@ -526,9 +736,68 @@ export class MindManager extends EventEmitter {
         id: mind.mindId,
         path: mind.mindPath,
         ...(mind.selectedModel ? { selectedModel: mind.selectedModel } : {}),
+        ...(mind.activeSessionId ? { activeSessionId: mind.activeSessionId } : {}),
+        ...(this.knownMindRecords.get(mind.mindId)?.conversations ? { conversations: this.knownMindRecords.get(mind.mindId)?.conversations } : {}),
       });
     }
     return Array.from(records.values());
+  }
+
+  private createConversationRecord(mindId: string): ChamberConversationRecord {
+    const now = new Date().toISOString();
+    return {
+      sessionId: `chamber-${mindId}-${randomUUID()}`,
+      title: `New chat · ${new Date(now).toLocaleString()}`,
+      createdAt: now,
+      updatedAt: now,
+      kind: 'chat',
+    };
+  }
+
+  private ensureConversationRecord(
+    mindId: string,
+    sessionId: string,
+    conversations: ChamberConversationRecord[] = [],
+  ): ChamberConversationRecord {
+    return conversations.find((conversation) => conversation.sessionId === sessionId)
+      ?? {
+        sessionId,
+        title: `New chat · ${new Date().toLocaleString()}`,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        kind: 'chat',
+      };
+  }
+
+  private upsertConversationRecord(mindId: string, conversation: ChamberConversationRecord): void {
+    const record = this.knownMindRecords.get(mindId);
+    if (!record) return;
+    const conversations = record.conversations ?? [];
+    this.knownMindRecords.set(mindId, {
+      ...record,
+      activeSessionId: conversation.sessionId,
+      conversations: [
+        conversation,
+        ...conversations.filter((existing) => existing.sessionId !== conversation.sessionId),
+      ],
+    });
+  }
+
+  private touchConversationRecord(mindId: string, sessionId: string): void {
+    const record = this.knownMindRecords.get(mindId);
+    if (!record) return;
+    const updatedAt = new Date().toISOString();
+    this.knownMindRecords.set(mindId, {
+      ...record,
+      activeSessionId: sessionId,
+      conversations: (record.conversations ?? []).map((conversation) => conversation.sessionId === sessionId
+        ? { ...conversation, updatedAt }
+        : conversation),
+    });
+  }
+
+  private defaultConversationTitle(conversation: ChamberConversationRecord): string {
+    return `Chat · ${new Date(conversation.createdAt).toLocaleString()}`;
   }
 
   private getPersistedActiveMindId(): string | null {

--- a/packages/services/src/mind/types.ts
+++ b/packages/services/src/mind/types.ts
@@ -21,4 +21,5 @@ export type UserInputResponse = Awaited<ReturnType<UserInputHandler>>;
 export interface InternalMindContext extends MindContext {
   client: CopilotClient;
   session: CopilotSession | null;
+  activeSessionId?: string;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -89,6 +89,7 @@ export interface MindContext {
   readonly status: MindStatus;
   readonly error?: string;
   selectedModel?: string;
+  activeSessionId?: string;
   readonly windowed?: boolean;
 }
 
@@ -97,6 +98,33 @@ export interface MindRecord {
   id: string;
   path: string;
   selectedModel?: string;
+  activeSessionId?: string;
+  conversations?: ChamberConversationRecord[];
+}
+
+export type ChamberConversationKind = 'chat' | 'cron' | 'task';
+
+export interface ChamberConversationRecord {
+  sessionId: string;
+  title?: string;
+  createdAt: string;
+  updatedAt: string;
+  kind: ChamberConversationKind;
+}
+
+export interface ConversationSummary {
+  sessionId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  kind: ChamberConversationKind;
+  active: boolean;
+}
+
+export interface ConversationResumeResult {
+  sessionId: string;
+  messages: ChatMessage[];
+  conversations: ConversationSummary[];
 }
 
 export interface MarketplaceRegistry {
@@ -200,9 +228,14 @@ export interface ElectronAPI {
   chat: {
     send: (mindId: string, message: string, messageId: string, model?: string, attachments?: ChatImageAttachment[]) => Promise<void>;
     stop: (mindId: string, messageId: string) => Promise<void>;
-    newConversation: (mindId: string) => Promise<void>;
+    newConversation: (mindId: string) => Promise<ConversationResumeResult>;
     listModels: (mindId?: string) => Promise<ModelInfo[]>;
     onEvent: (callback: (mindId: string, messageId: string, event: ChatEvent) => void) => () => void;
+  };
+  conversationHistory: {
+    list: (mindId: string) => Promise<ConversationSummary[]>;
+    resume: (mindId: string, sessionId: string) => Promise<ConversationResumeResult>;
+    rename: (mindId: string, sessionId: string, title: string) => Promise<ConversationSummary[]>;
   };
   mind: {
     add: (mindPath: string) => Promise<MindContext>;

--- a/scripts/run-sdk-smoke-test.js
+++ b/scripts/run-sdk-smoke-test.js
@@ -53,11 +53,78 @@ async function main() {
     if (!response.includes('Chamber')) {
       throw new Error(`Unexpected SDK smoke response: ${response}`);
     }
+    await assertNamedSessionResume({ sdk, cliPath, mindPath, logDir });
     console.log('SDK smoke passed.');
   } finally {
     await session?.destroy().catch(() => undefined);
     await client.stop().catch(() => undefined);
     await cleanupMind(mindPath);
+  }
+}
+
+async function assertNamedSessionResume({ sdk, cliPath, mindPath, logDir }) {
+  const sessionId = `chamber-sdk-smoke-${Date.now()}`;
+  const firstClient = new sdk.CopilotClient({
+    cliPath,
+    cwd: mindPath,
+    logLevel: 'all',
+    cliArgs: [
+      '--log-dir', logDir,
+      '--allow-all-tools',
+      '--allow-all-paths',
+      '--allow-all-urls',
+    ],
+  });
+  const secondClient = new sdk.CopilotClient({
+    cliPath,
+    cwd: mindPath,
+    logLevel: 'all',
+    cliArgs: [
+      '--log-dir', logDir,
+      '--allow-all-tools',
+      '--allow-all-paths',
+      '--allow-all-urls',
+    ],
+  });
+  let firstSession;
+  let resumedSession;
+  try {
+    await firstClient.start();
+    firstSession = await firstClient.createSession({
+      sessionId,
+      streaming: true,
+      workingDirectory: mindPath,
+      onPermissionRequest: async () => ({ kind: 'allow' }),
+      onUserInputRequest: async () => ({ answer: 'Proceed.', wasFreeform: true }),
+    });
+    await firstSession.rpc.permissions.setApproveAll({ enabled: true });
+    await sendAndWaitForResponse(firstSession, 'Remember this exact token: chamber-resume-smoke');
+    await firstSession.disconnect();
+    firstSession = undefined;
+    await firstClient.stop();
+
+    await secondClient.start();
+    resumedSession = await secondClient.resumeSession(sessionId, {
+      streaming: true,
+      workingDirectory: mindPath,
+      onPermissionRequest: async () => ({ kind: 'allow' }),
+      onUserInputRequest: async () => ({ answer: 'Proceed.', wasFreeform: true }),
+    });
+    await resumedSession.rpc.permissions.setApproveAll({ enabled: true });
+    const messages = await resumedSession.getMessages();
+    if (!messages.some((event) => JSON.stringify(event).includes('chamber-resume-smoke'))) {
+      throw new Error('Named SDK session resume did not restore prior messages.');
+    }
+    const response = await sendAndWaitForResponse(resumedSession, 'What exact token did I ask you to remember?');
+    if (!response.includes('chamber-resume-smoke')) {
+      throw new Error(`Named SDK session did not continue prior context: ${response}`);
+    }
+  } finally {
+    await resumedSession?.disconnect().catch(() => undefined);
+    await firstSession?.disconnect().catch(() => undefined);
+    await secondClient.deleteSession?.(sessionId).catch(() => undefined);
+    await secondClient.stop().catch(() => undefined);
+    await firstClient.stop().catch(() => undefined);
   }
 }
 

--- a/tests/e2e/electron/conversation-history-smoke.spec.ts
+++ b/tests/e2e/electron/conversation-history-smoke.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+test.describe('electron conversation history smoke', () => {
+  test.setTimeout(180_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let root = '';
+  let userDataPath = '';
+
+  test.afterEach(async () => {
+    await app?.close();
+    app = undefined;
+    if (root) await removeTempRoot(root);
+  });
+
+  test('Monica can create, resume, and rename history entries from the right pane', async () => {
+    const paths = await launchWithMinds(9350, ['Monica']);
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await addMind(page, paths.Monica);
+
+    const history = page.getByLabel('Conversation history');
+    await expect(history).toBeVisible();
+    await expect(history.getByLabel(/Rename /).first()).toBeVisible();
+
+    await history.getByRole('button', { name: 'New conversation' }).click();
+    await expect.poll(
+      () => history.getByLabel(/Rename /).count(),
+      { timeout: 60_000 },
+    ).toBeGreaterThanOrEqual(2);
+
+    await renameFirstHistoryItem(page, 'Monica planning thread');
+
+    await history.getByRole('button', { name: /Resume / }).last().click();
+    await expect(history.getByText('Active')).toBeVisible();
+    await history.getByRole('button', { name: 'Resume Monica planning thread' }).click();
+    await expect(history.getByText('Monica planning thread')).toBeVisible();
+  });
+
+  test('Monica and Lucy histories stay isolated by active mind', async () => {
+    const paths = await launchWithMinds(9351, ['Monica', 'Lucy']);
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await addMind(page, paths.Monica);
+    await renameFirstHistoryItem(page, 'Monica only');
+    await addMind(page, paths.Lucy);
+    await renameFirstHistoryItem(page, 'Lucy only');
+
+    const history = page.getByLabel('Conversation history');
+    await page.getByRole('button', { name: 'Monica' }).first().click();
+    await expect(history.getByText('Monica only')).toBeVisible();
+    await expect(history.getByText('Lucy only')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Lucy' }).first().click();
+    await expect(history.getByText('Lucy only')).toBeVisible();
+    await expect(history.getByText('Monica only')).toHaveCount(0);
+  });
+
+  test('Lucy history reloads after an app restart', async () => {
+    const paths = await launchWithMinds(9352, ['Lucy']);
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await addMind(page, paths.Lucy);
+
+    await renameFirstHistoryItem(page, 'Lucy restart thread');
+
+    await app?.close();
+    app = await launchElectronApp({
+      cdpPort: 9353,
+      env: { CHAMBER_E2E_USER_DATA: userDataPath },
+    });
+    const restartedPage = await findRendererPage(app.browser, app.logs);
+    await expect(restartedPage.getByRole('button', { name: 'Lucy' }).first()).toBeVisible();
+    await expect(restartedPage.getByLabel('Conversation history').getByText('Lucy restart thread')).toBeVisible();
+  });
+
+  async function launchWithMinds(cdpPort: number, names: string[]): Promise<Record<string, string>> {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-history-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    const paths: Record<string, string> = {};
+    for (const name of names) {
+      paths[name] = path.join(root, name.toLowerCase());
+      seedMind(paths[name], name);
+    }
+    app = await launchElectronApp({
+      cdpPort,
+      env: { CHAMBER_E2E_USER_DATA: userDataPath },
+    });
+    return paths;
+  }
+});
+
+async function addMind(page: Page, mindPath: string) {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('#root')).not.toBeEmpty();
+  await expect.poll(() => page.evaluate(() => typeof window.electronAPI?.mind?.add)).toBe('function');
+  const mind = await page.evaluate(async (pathToMind) => {
+    const loaded = await window.electronAPI.mind.add(pathToMind);
+    await window.electronAPI.mind.setActive(loaded.mindId);
+    return loaded;
+  }, mindPath);
+  await page.getByRole('button', { name: mind.identity.name }).first().click();
+  await expect(page.getByLabel('Conversation history').getByLabel(/Rename /).first()).toBeVisible();
+  return mind;
+}
+
+async function renameFirstHistoryItem(page: Page, title: string): Promise<void> {
+  const history = page.getByLabel('Conversation history');
+  await history.getByLabel(/Rename /).first().click();
+  const input = history.locator('input').first();
+  await input.fill(title);
+  await input.press('Enter');
+  await expect(history.getByText(title)).toBeVisible();
+}
+
+function seedMind(targetMindPath: string, name: string): void {
+  fs.mkdirSync(path.join(targetMindPath, '.github', 'agents'), { recursive: true });
+  fs.writeFileSync(
+    path.join(targetMindPath, 'SOUL.md'),
+    [
+      `# ${name}`,
+      '',
+      `You are ${name}, a concise Chamber smoke-test assistant.`,
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(targetMindPath, '.github', 'agents', `${name.toLowerCase()}.agent.md`),
+    [
+      '---',
+      `name: ${name}`,
+      'description: Chamber conversation history smoke persona',
+      '---',
+      '',
+      `# ${name} Agent`,
+      '',
+    ].join('\n'),
+  );
+}
+
+async function removeTempRoot(targetRoot: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(targetRoot, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[conversation-history-smoke] Failed to remove temp root ${targetRoot}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds resumable per-mind conversation history backed by named Copilot SDK sessions.
- Adds a right-side History pane with resume, rename, and the sole new-conversation `+` action.
- Persists Chamber-owned conversation metadata only while hydrating/resuming transcripts from the SDK session source of truth.
- Restores active conversations after restart and guards conversation switches while a mind is streaming.

Closes #55

## Tests
- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npx playwright test --config config/playwright.config.ts --project=electron tests/e2e/electron/conversation-history-smoke.spec.ts --workers=1`

## Smoke notes
- Packaging smoke skipped because this does not touch packaging, Forge, installer, signing, or first-launch runtime wiring.