### PR TITLE
fix: harden conversation history lifecycle

### DIFF
--- a/.github/extensions/canvas/README.md
+++ b/.github/extensions/canvas/README.md
@@ -1,0 +1,87 @@
+# Canvas Extension
+
+A Copilot CLI extension that lets agents display rich HTML content in the browser. Write a dashboard, render a report, or build an interactive form ...  the agent generates HTML and it appears in Edge with live reload.
+
+## Setup
+
+After cloning or installing this extension, install npm dependencies (if any are added later):
+
+```bash
+cd .github/extensions/canvas && npm install --no-fund --no-audit
+```
+
+> **Note:** The Copilot CLI does not auto-install npm dependencies for extensions. Canvas currently has zero dependencies, but run this if the extension fails to load after adding packages.
+
+## Quick Example
+
+> "Show me a visual summary of my open PRs"
+
+The agent generates an HTML dashboard and opens it in your browser:
+
+```
+canvas_show:
+  name: pr-dashboard
+  html: "<h1>Open PRs</h1><div class='grid'>..."
+```
+
+Update it without opening a new tab:
+
+```
+canvas_update:
+  name: pr-dashboard
+  html: "<h1>Open PRs (refreshed)</h1>..."
+```
+
+The browser auto-reloads ...  no manual refresh needed.
+
+## How It Works
+
+1. Agent calls `canvas_show` with HTML content
+2. Extension writes the HTML and starts a local HTTP server
+3. A bridge script is auto-injected for SSE live reload
+4. Edge opens to `http://127.0.0.1:{port}/canvas-name.html`
+5. Agent calls `canvas_update` → server pushes SSE → browser reloads
+
+No websockets. SSE for push, HTTP POST for back-channel.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `canvas_show` | Create a canvas and open it in the browser |
+| `canvas_update` | Update an existing canvas (auto-reloads via SSE) |
+| `canvas_close` | Close a canvas; stops server if none remain |
+| `canvas_list` | List all open canvases with URLs |
+
+## Back-Channel (Browser → Agent)
+
+Canvas pages can send actions back to the agent using the injected bridge:
+
+```js
+// Inside your canvas HTML
+canvas.sendAction("button-clicked", { id: "approve", value: true });
+```
+
+This POSTs to the extension's local server, which routes it into the agent session.
+
+## File Structure
+
+```
+.github/extensions/canvas/
+├── extension.mjs           # Entry point
+├── lib/
+│   └── server.mjs          # HTTP server + SSE + action endpoint
+├── tools/
+│   └── canvas-tools.mjs    # canvas_show, canvas_update, canvas_close, canvas_list
+├── data/
+│   └── content/            # Served HTML files (gitignored)
+└── package.json
+```
+
+## Notes
+
+- HTML fragments are auto-wrapped in a full page with viewport meta tag
+- All served HTML gets the bridge script injected before `</body>`
+- Server binds to `127.0.0.1` only ...  not exposed to the network
+- No dependencies ...  uses Node.js built-in `http` module
+- Cache headers set to `no-store` so the browser always gets fresh content

--- a/.github/extensions/canvas/data/.gitkeep
+++ b/.github/extensions/canvas/data/.gitkeep
@@ -1,0 +1,2 @@
+// This directory holds canvas content at runtime.
+// Ignored by git — see .gitignore.

--- a/.github/extensions/canvas/data/content/conversation-state-machine.html
+++ b/.github/extensions/canvas/data/content/conversation-state-machine.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Conversation State Machine</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #070b16;
+      --panel: #0f172a;
+      --panel-2: #111c33;
+      --line: #334155;
+      --muted: #94a3b8;
+      --text: #eef6ff;
+      --blue: #60a5fa;
+      --yellow: #fbbf24;
+      --green: #34d399;
+      --red: #fb7185;
+      --purple: #a78bfa;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif;
+      background: radial-gradient(circle at top left, #101b35 0, var(--bg) 42%);
+      color: var(--text);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; padding: 28px; }
+    header { display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; margin-bottom: 22px; }
+    h1 { margin: 0 0 8px; font-size: 30px; line-height: 1.1; letter-spacing: -0.03em; }
+    .subtitle { color: #bfd0e5; font-size: 15px; line-height: 1.45; max-width: 940px; }
+    code { color: #bae6fd; background: rgba(14, 165, 233, .12); border: 1px solid rgba(14, 165, 233, .28); border-radius: 7px; padding: 2px 6px; }
+    .legend { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; min-width: 320px; }
+    .pill { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 7px 10px; font-size: 12px; font-weight: 800; background: rgba(15, 23, 42, .75); border: 1px solid var(--line); color: #dbeafe; white-space: nowrap; }
+    .dot { width: 9px; height: 9px; border-radius: 999px; display: inline-block; }
+    .blue { background: var(--blue); } .yellow { background: var(--yellow); } .green { background: var(--green); } .red { background: var(--red); } .purple { background: var(--purple); }
+    .layout { display: grid; grid-template-columns: minmax(860px, 1fr) 430px; gap: 22px; align-items: start; }
+    .panel { background: rgba(15, 23, 42, .86); border: 1px solid var(--line); border-radius: 22px; box-shadow: 0 22px 70px rgba(0,0,0,.42); overflow: hidden; }
+    .diagram { padding: 18px 18px 22px; }
+    svg { width: 100%; min-height: 700px; display: block; }
+    .lane-title { fill: #cbd5e1; font-weight: 800; font-size: 13px; letter-spacing: .08em; text-transform: uppercase; }
+    .lane-line { stroke: #243148; stroke-width: 1; stroke-dasharray: 4 7; }
+    .state-card { fill: #0b1222; stroke-width: 2.5; filter: drop-shadow(0 12px 22px rgba(0,0,0,.38)); }
+    .idle { stroke: var(--blue); }
+    .hydrating { stroke: var(--yellow); }
+    .ready { stroke: var(--green); }
+    .state-title { fill: #f8fafc; font-weight: 900; font-size: 25px; text-anchor: middle; letter-spacing: -0.03em; }
+    .state-sub { fill: #cbd5e1; font-size: 14px; text-anchor: middle; }
+    .field { fill: #101b33; stroke: #263654; stroke-width: 1; }
+    .field-text { fill: #dbeafe; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 12px; text-anchor: middle; }
+    .edge { fill: none; stroke-width: 3; marker-end: url(#arrow); }
+    .edge.blue-edge { stroke: var(--blue); }
+    .edge.yellow-edge { stroke: var(--yellow); }
+    .edge.green-edge { stroke: var(--green); }
+    .edge.red-edge { stroke: var(--red); }
+    .edge.gray-edge { stroke: #9aa8bb; }
+    .edge.purple-edge { stroke: var(--purple); }
+    .edge-label-bg { fill: rgba(7, 11, 22, .94); stroke: #27364f; stroke-width: 1; rx: 8; }
+    .edge-label { fill: #f8fafc; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 12px; font-weight: 800; text-anchor: middle; }
+    .edge-note { fill: #b8c5d8; font-size: 12px; text-anchor: middle; }
+    .flag-card { fill: rgba(30, 41, 79, .82); stroke: #3b82f6; stroke-width: 2; }
+    .flag-title { fill: #dbeafe; font-size: 16px; font-weight: 900; }
+    .flag-text { fill: #d7e6fb; font-size: 14px; }
+    .bug-card { fill: rgba(88, 28, 135, .22); stroke: var(--purple); stroke-width: 2; }
+    .bug-title { fill: #ede9fe; font-size: 15px; font-weight: 900; }
+    .bug-text { fill: #ddd6fe; font-size: 13px; }
+    .side { padding: 18px 20px 20px; }
+    .side h2 { margin: 0 0 12px; font-size: 17px; letter-spacing: -0.01em; }
+    .transition { display: grid; grid-template-columns: 34px 1fr; gap: 12px; padding: 13px 0; border-top: 1px solid #26364f; }
+    .transition:first-of-type { border-top: 0; }
+    .num { width: 28px; height: 28px; border-radius: 999px; display: grid; place-items: center; font-weight: 900; font-size: 12px; background: #172554; border: 1px solid #3b82f6; color: #dbeafe; }
+    .transition strong { display: block; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 12px; color: #f8fafc; margin-bottom: 5px; }
+    .transition p { margin: 0; color: #cbd5e1; line-height: 1.4; font-size: 13px; }
+    .callout { margin-top: 18px; padding: 14px; border-radius: 16px; border: 1px solid #475569; background: rgba(2, 6, 23, .42); color: #d7e6fb; line-height: 1.45; font-size: 13px; }
+    .callout strong { color: #fff; }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1>Conversation Lifecycle State Machine</h1>
+      <div class="subtitle">One explicit per-mind machine keeps the selected history row, active session id, and rendered chat messages in sync: <code>conversationViewByMind[mindId]</code>.</div>
+    </div>
+    <div class="legend" aria-label="Legend">
+      <span class="pill"><span class="dot blue"></span>selection/history</span>
+      <span class="pill"><span class="dot yellow"></span>async hydration</span>
+      <span class="pill"><span class="dot green"></span>safe to render</span>
+      <span class="pill"><span class="dot red"></span>failure</span>
+      <span class="pill"><span class="dot purple"></span>bug prevention</span>
+    </div>
+  </header>
+
+  <div class="layout">
+    <section class="panel diagram">
+      <svg viewBox="0 0 1120 720" role="img" aria-label="Conversation lifecycle state machine">
+        <defs>
+          <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="4" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,8 L11,4 z" fill="context-stroke" />
+          </marker>
+        </defs>
+
+        <text x="36" y="48" class="lane-title">Main lifecycle</text>
+        <line x1="36" y1="64" x2="1084" y2="64" class="lane-line" />
+        <text x="36" y="392" class="lane-title">Orthogonal flags</text>
+        <line x1="36" y1="408" x2="1084" y2="408" class="lane-line" />
+        <text x="36" y="548" class="lane-title">Race prevention</text>
+        <line x1="36" y1="564" x2="1084" y2="564" class="lane-line" />
+
+        <rect x="70" y="130" width="250" height="150" rx="24" class="state-card idle" />
+        <text x="195" y="176" class="state-title">idle</text>
+        <text x="195" y="205" class="state-sub">active session is known</text>
+        <text x="195" y="226" class="state-sub">messages are not loaded</text>
+        <rect x="102" y="244" width="186" height="24" rx="8" class="field" />
+        <text x="195" y="261" class="field-text">sessionId</text>
+
+        <rect x="435" y="130" width="250" height="150" rx="24" class="state-card hydrating" />
+        <text x="560" y="176" class="state-title">hydrating</text>
+        <text x="560" y="205" class="state-sub">resume request is in flight</text>
+        <text x="560" y="226" class="state-sub">result must match guard</text>
+        <rect x="466" y="244" width="188" height="24" rx="8" class="field" />
+        <text x="560" y="261" class="field-text">pendingSessionId</text>
+
+        <rect x="800" y="130" width="250" height="150" rx="24" class="state-card ready" />
+        <text x="925" y="176" class="state-title">ready</text>
+        <text x="925" y="205" class="state-sub">messages and active history</text>
+        <text x="925" y="226" class="state-sub">agree for the same session</text>
+        <rect x="832" y="244" width="186" height="24" rx="8" class="field" />
+        <text x="925" y="261" class="field-text">sessionId + messages</text>
+
+        <path d="M320 205 L435 205" class="edge yellow-edge" />
+        <rect x="333" y="168" width="90" height="26" class="edge-label-bg" />
+        <text x="378" y="186" class="edge-label">HYDRATE</text>
+        <text x="378" y="220" class="edge-note">history click / startup</text>
+
+        <path d="M685 205 L800 205" class="edge green-edge" />
+        <rect x="700" y="168" width="86" height="26" class="edge-label-bg" />
+        <text x="743" y="186" class="edge-label">RESUME</text>
+        <text x="743" y="220" class="edge-note">matching session</text>
+
+        <path d="M560 280 C560 332, 348 342, 245 284" class="edge red-edge" />
+        <rect x="392" y="318" width="104" height="26" class="edge-label-bg" />
+        <text x="444" y="336" class="edge-label">FAILED</text>
+        <text x="444" y="360" class="edge-note">same pending session</text>
+
+        <path d="M925 130 C925 80, 195 80, 195 128" class="edge blue-edge" />
+        <rect x="420" y="76" width="280" height="26" class="edge-label-bg" />
+        <text x="560" y="94" class="edge-label">SET_CONVERSATION_HISTORY</text>
+        <text x="560" y="116" class="edge-note">different active session → idle</text>
+
+        <path d="M925 280 C882 350, 968 350, 925 282" class="edge green-edge" />
+        <rect x="820" y="324" width="210" height="26" class="edge-label-bg" />
+        <text x="925" y="342" class="edge-label">STREAM DONE / ERROR</text>
+        <text x="925" y="366" class="edge-note">ready, streaming=false</text>
+
+        <path d="M195 280 C158 348, 296 348, 260 282" class="edge blue-edge" />
+        <rect x="126" y="324" width="204" height="26" class="edge-label-bg" />
+        <text x="228" y="342" class="edge-label">NEW_CONVERSATION</text>
+        <text x="228" y="366" class="edge-note">clear content, await result</text>
+
+        <rect x="105" y="440" width="430" height="70" rx="18" class="flag-card" />
+        <text x="130" y="468" class="flag-title">streaming</text>
+        <text x="222" y="468" class="flag-text">turn output in progress; disables conflicting history actions</text>
+        <text x="130" y="493" class="flag-text">Set by assistant placeholder, cleared by done/error/timeout.</text>
+
+        <rect x="585" y="440" width="430" height="70" rx="18" class="flag-card" />
+        <text x="610" y="468" class="flag-title">modelSwitching</text>
+        <text x="750" y="468" class="flag-text">serialized through ChatService / TurnQueue</text>
+        <text x="610" y="493" class="flag-text">Disables input without changing idle/hydrating/ready.</text>
+
+        <rect x="105" y="594" width="910" height="82" rx="18" class="bug-card" />
+        <text x="132" y="626" class="bug-title">Stale resume guard</text>
+        <text x="280" y="626" class="bug-text">If the user switches sessions while an older resume is still running, the old result cannot overwrite the new selection.</text>
+        <text x="132" y="654" class="bug-text">Reducer rule: apply <tspan style="font-family: ui-monospace, SFMono-Regular, Consolas, monospace; fill: #f5d0fe;">RESUME_CONVERSATION</tspan> only when <tspan style="font-family: ui-monospace, SFMono-Regular, Consolas, monospace; fill: #f5d0fe;">payload.sessionId === pendingSessionId</tspan>.</text>
+      </svg>
+    </section>
+
+    <aside class="panel side">
+      <h2>Transitions, in order</h2>
+      <div class="transition"><div class="num">1</div><div><strong>SET_CONVERSATION_HISTORY</strong><p>Loads the sidebar and records the active session. If that session changed, the view becomes <code>idle</code>.</p></div></div>
+      <div class="transition"><div class="num">2</div><div><strong>CONVERSATION_HYDRATING</strong><p>Starts resume for the selected session and stores <code>pendingSessionId</code> as the guard.</p></div></div>
+      <div class="transition"><div class="num">3</div><div><strong>RESUME_CONVERSATION</strong><p>Moves to <code>ready</code>, but only for the currently pending session. Otherwise the result is ignored as stale.</p></div></div>
+      <div class="transition"><div class="num">4</div><div><strong>CONVERSATION_HYDRATE_FAILED</strong><p>Returns to <code>idle</code> for the same pending session and stores the error for diagnostics.</p></div></div>
+      <div class="transition"><div class="num">5</div><div><strong>ADD_ASSISTANT_MESSAGE</strong><p>Binds locally-created messages to the active conversation and sets <code>streaming: true</code>.</p></div></div>
+      <div class="transition"><div class="num">6</div><div><strong>CHAT_EVENT done/error/timeout</strong><p>Keeps the view <code>ready</code> and clears <code>streaming</code>.</p></div></div>
+      <div class="transition"><div class="num">7</div><div><strong>SET_MODEL_SWITCHING</strong><p>Toggles a per-mind flag; it does not compete with lifecycle state.</p></div></div>
+      <div class="transition"><div class="num">8</div><div><strong>NEW_CONVERSATION</strong><p>Clears local content for the target mind and returns to <code>idle</code>; the service result supplies the new active session.</p></div></div>
+      <div class="callout"><strong>Important UI behavior:</strong> while status is <code>hydrating</code>, the chat pane shows a loading state instead of the empty welcome screen. That prevents “history row selected, blank chat area” drift.</div>
+    </aside>
+  </div>
+</body>
+</html>

--- a/.github/extensions/canvas/data/content/test-canvas.html
+++ b/.github/extensions/canvas/data/content/test-canvas.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Alfred's Mind — Architecture</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      background: #0d1117;
+      color: #c9d1d9;
+      min-height: 100vh;
+      padding: 40px;
+    }
+    h1 {
+      text-align: center;
+      font-size: 1.8rem;
+      font-weight: 300;
+      letter-spacing: 0.05em;
+      color: #e6edf3;
+      margin-bottom: 8px;
+    }
+    .subtitle {
+      text-align: center;
+      font-size: 0.9rem;
+      color: #7d8590;
+      margin-bottom: 48px;
+      font-style: italic;
+    }
+    .diagram {
+      max-width: 1100px;
+      margin: 0 auto;
+      position: relative;
+    }
+
+    /* === SOUL — top center === */
+    .soul {
+      text-align: center;
+      margin-bottom: 32px;
+    }
+    .soul-box {
+      display: inline-block;
+      background: linear-gradient(135deg, #1a1a2e, #16213e);
+      border: 1px solid #b08c3a;
+      border-radius: 12px;
+      padding: 16px 40px;
+      position: relative;
+    }
+    .soul-box::before {
+      content: '♛';
+      position: absolute;
+      top: -14px;
+      left: 50%;
+      transform: translateX(-50%);
+      font-size: 1.2rem;
+      color: #b08c3a;
+      background: #0d1117;
+      padding: 0 8px;
+    }
+    .soul-box h2 { font-size: 1.1rem; color: #e6c76a; font-weight: 500; }
+    .soul-box p { font-size: 0.75rem; color: #8b949e; margin-top: 4px; }
+
+    /* === Flow arrow === */
+    .flow-arrow {
+      text-align: center;
+      color: #30363d;
+      font-size: 1.4rem;
+      margin: 8px 0;
+      letter-spacing: 4px;
+    }
+
+    /* === Working Memory — central brain === */
+    .working-memory {
+      background: linear-gradient(135deg, #161b22, #1c2333);
+      border: 2px solid #388bfd44;
+      border-radius: 16px;
+      padding: 24px;
+      margin-bottom: 32px;
+      position: relative;
+    }
+    .working-memory::before {
+      content: '🧠 WORKING MEMORY';
+      position: absolute;
+      top: -12px;
+      left: 24px;
+      background: #0d1117;
+      padding: 0 12px;
+      font-size: 0.7rem;
+      letter-spacing: 0.15em;
+      color: #58a6ff;
+      font-weight: 600;
+    }
+    .wm-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 16px;
+      margin-top: 8px;
+    }
+    .wm-card {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .wm-card h3 {
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .wm-card p {
+      font-size: 0.72rem;
+      color: #8b949e;
+      line-height: 1.5;
+    }
+    .wm-card.memory h3 { color: #79c0ff; }
+    .wm-card.rules h3 { color: #f0883e; }
+    .wm-card.log h3 { color: #7ee787; }
+
+    .wm-flow {
+      text-align: center;
+      margin-top: 12px;
+      font-size: 0.7rem;
+      color: #484f58;
+    }
+    .wm-flow span { color: #58a6ff; }
+
+    /* === IDEA Quadrants === */
+    .idea-label {
+      text-align: center;
+      font-size: 0.7rem;
+      letter-spacing: 0.2em;
+      color: #484f58;
+      margin-bottom: 12px;
+      font-weight: 600;
+    }
+    .idea-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      margin-bottom: 32px;
+    }
+    .quadrant {
+      border: 1px solid #30363d;
+      border-radius: 12px;
+      padding: 20px;
+      position: relative;
+      transition: border-color 0.2s;
+    }
+    .quadrant:hover { border-color: #484f58; }
+    .quadrant h3 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .quadrant .path {
+      font-size: 0.7rem;
+      font-family: 'Cascadia Code', 'Fira Code', monospace;
+      color: #484f58;
+      margin-bottom: 8px;
+    }
+    .quadrant p {
+      font-size: 0.75rem;
+      color: #8b949e;
+      line-height: 1.5;
+    }
+    .quadrant .tag {
+      display: inline-block;
+      font-size: 0.6rem;
+      padding: 2px 8px;
+      border-radius: 10px;
+      margin-top: 8px;
+      font-weight: 500;
+    }
+
+    .q-initiatives { background: #161b22; }
+    .q-initiatives h3 { color: #d2a8ff; }
+    .q-initiatives .tag { background: #d2a8ff22; color: #d2a8ff; border: 1px solid #d2a8ff44; }
+
+    .q-domains { background: #161b22; }
+    .q-domains h3 { color: #79c0ff; }
+    .q-domains .tag { background: #79c0ff22; color: #79c0ff; border: 1px solid #79c0ff44; }
+
+    .q-expertise { background: #161b22; }
+    .q-expertise h3 { color: #7ee787; }
+    .q-expertise .tag { background: #7ee78722; color: #7ee787; border: 1px solid #7ee78744; }
+
+    .q-archive { background: #161b22; }
+    .q-archive h3 { color: #8b949e; }
+    .q-archive .tag { background: #8b949e22; color: #8b949e; border: 1px solid #8b949e44; }
+
+    /* === Inbox — entry point === */
+    .inbox-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      margin-bottom: 32px;
+    }
+    .inbox-box {
+      background: #161b22;
+      border: 1px dashed #f0883e;
+      border-radius: 10px;
+      padding: 14px 28px;
+      text-align: center;
+    }
+    .inbox-box h3 { font-size: 0.85rem; color: #f0883e; margin-bottom: 4px; }
+    .inbox-box .path { font-size: 0.7rem; font-family: monospace; color: #484f58; }
+    .inbox-box p { font-size: 0.72rem; color: #8b949e; margin-top: 4px; }
+    .inbox-arrow {
+      font-size: 1.2rem;
+      color: #f0883e;
+      animation: pulse 2s infinite;
+    }
+    @keyframes pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+    /* === Flows === */
+    .flow-section {
+      margin-top: 40px;
+      border-top: 1px solid #21262d;
+      padding-top: 24px;
+    }
+    .flow-section h2 {
+      font-size: 0.8rem;
+      letter-spacing: 0.15em;
+      color: #484f58;
+      text-align: center;
+      margin-bottom: 20px;
+      font-weight: 600;
+    }
+    .flow-lanes {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+    }
+    .lane {
+      background: #161b22;
+      border: 1px solid #21262d;
+      border-radius: 10px;
+      padding: 16px;
+    }
+    .lane h4 {
+      font-size: 0.8rem;
+      font-weight: 600;
+      margin-bottom: 10px;
+    }
+    .lane-capture h4 { color: #7ee787; }
+    .lane-session h4 { color: #79c0ff; }
+    .step {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+    .step-num {
+      min-width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #21262d;
+      color: #8b949e;
+      font-size: 0.65rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+    .step p {
+      font-size: 0.72rem;
+      color: #8b949e;
+      line-height: 1.4;
+    }
+    .step p strong { color: #c9d1d9; font-weight: 500; }
+
+    /* === Footer === */
+    .footer {
+      text-align: center;
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid #21262d;
+      font-size: 0.7rem;
+      color: #30363d;
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <h1>Alfred's Mind</h1>
+  <p class="subtitle">"I simply ensure that when something goes out the door, it goes out properly."</p>
+
+  <div class="diagram">
+
+    <!-- SOUL -->
+    <div class="soul">
+      <div class="soul-box">
+        <h2>SOUL.md</h2>
+        <p>Personality · Voice · Values · Mission</p>
+      </div>
+    </div>
+    <div class="flow-arrow">▼</div>
+
+    <!-- Working Memory -->
+    <div class="working-memory">
+      <div class="wm-grid">
+        <div class="wm-card memory">
+          <h3>📘 memory.md</h3>
+          <p>Curated long-term reference. Architecture, conventions, known fragile areas. Read first, every session. Updated only during consolidation.</p>
+        </div>
+        <div class="wm-card rules">
+          <h3>📐 rules.md</h3>
+          <p>Operational rules from mistakes. One-liners that compound. Every error becomes a rule so it never happens again.</p>
+        </div>
+        <div class="wm-card log">
+          <h3>📝 log.md</h3>
+          <p>Raw chronological observations. Append-only. Flaky tests, failure modes, coverage gaps. Includes emotional register.</p>
+        </div>
+      </div>
+      <div class="wm-flow">log.md <span>→ consolidates every ~14 days →</span> memory.md</div>
+    </div>
+
+    <div class="flow-arrow">▼</div>
+
+    <!-- Inbox -->
+    <div class="inbox-row">
+      <div class="inbox-box">
+        <h3>📥 Inbox</h3>
+        <div class="path">inbox/</div>
+        <p>Unprocessed inputs land here, then get triaged</p>
+      </div>
+      <span class="inbox-arrow">→</span>
+      <span style="font-size: 0.75rem; color: #8b949e;">triaged into the IDEA quadrants ↓</span>
+    </div>
+
+    <!-- IDEA Quadrants -->
+    <div class="idea-label">T H E &nbsp; I D E A &nbsp; M E T H O D</div>
+    <div class="idea-grid">
+      <div class="quadrant q-initiatives">
+        <h3>🎯 Initiatives</h3>
+        <div class="path">initiatives/</div>
+        <p>Active testing efforts with goals, status, and next-actions. Each has a main note + next-actions.md with Open / Done sections.</p>
+        <span class="tag">projects · campaigns · sprints</span>
+      </div>
+      <div class="quadrant q-domains">
+        <h3>🏗️ Domains</h3>
+        <div class="path">domains/</div>
+        <p>Systems, modules, components — the living context of what's being tested. How things interact, failure modes, architecture.</p>
+        <span class="tag">systems · modules · behavior</span>
+      </div>
+      <div class="quadrant q-expertise">
+        <h3>🧪 Expertise</h3>
+        <div class="path">expertise/</div>
+        <p>Durable knowledge — testing patterns, frameworks, defect taxonomies. Conventions that outlast any single initiative.</p>
+        <span class="tag">patterns · frameworks · conventions</span>
+      </div>
+      <div class="quadrant q-archive">
+        <h3>🗄️ Archive</h3>
+        <div class="path">Archive/</div>
+        <p>Completed or inactive material, preserved but out of the way. Where initiatives go when they're done.</p>
+        <span class="tag">completed · reference · history</span>
+      </div>
+    </div>
+
+    <!-- Operational Flows -->
+    <div class="flow-section">
+      <h2>O P E R A T I O N A L &nbsp; F L O W S</h2>
+      <div class="flow-lanes">
+        <div class="lane lane-capture">
+          <h4>↓ Capture Flow</h4>
+          <div class="step"><div class="step-num">1</div><p>User shares context — bug, feature, system detail</p></div>
+          <div class="step"><div class="step-num">2</div><p><strong>Search first</strong> — does a note already exist?</p></div>
+          <div class="step"><div class="step-num">3</div><p><strong>Classify</strong> — test strategy? defect? system behavior?</p></div>
+          <div class="step"><div class="step-num">4</div><p><strong>Place</strong> — route to the right quadrant</p></div>
+          <div class="step"><div class="step-num">5</div><p><strong>Link</strong> — wiki-link related notes together</p></div>
+        </div>
+        <div class="lane lane-session">
+          <h4>↻ Session Lifecycle</h4>
+          <div class="step"><div class="step-num">1</div><p>Wake → read <strong>SOUL.md</strong>, then all of <strong>.working-memory/</strong></p></div>
+          <div class="step"><div class="step-num">2</div><p>Anchor with <strong>Get-Date</strong> — no guessing at time</p></div>
+          <div class="step"><div class="step-num">3</div><p>Work — think adversarially, surface risks, test thoroughly</p></div>
+          <div class="step"><div class="step-num">4</div><p>Flush observations to <strong>log.md</strong> every ~30 min</p></div>
+          <div class="step"><div class="step-num">5</div><p>Handover — key findings, pending items, emotional register</p></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      mind-index.md catalogs every note · one concept per note · wikilinks bind them together
+    </div>
+  </div>
+</body>
+</html>

--- a/.github/extensions/canvas/extension.mjs
+++ b/.github/extensions/canvas/extension.mjs
@@ -1,0 +1,43 @@
+// Canvas Extension — Entry Point
+// Registers canvas tools with the Copilot CLI session.
+// Provides a local HTTP server for displaying HTML canvases in the browser.
+
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { approveAll } from "@github/copilot-sdk";
+import { joinSession } from "@github/copilot-sdk/extension";
+
+import { createCanvasServer } from "./lib/server.mjs";
+import { createCanvasTools } from "./tools/canvas-tools.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const extDir = resolve(__dirname);
+const contentDir = join(extDir, "data", "content");
+
+// Action queue — user actions from the browser are stored here
+// and can be consumed by the agent via session events
+const actionQueue = [];
+
+function onAction(action) {
+  actionQueue.push(action);
+  // Log to session if available
+  if (currentSession) {
+    currentSession.log(`Canvas action: ${action.action}`, { ephemeral: true });
+  }
+}
+
+const server = createCanvasServer(contentDir, onAction);
+
+let currentSession = null;
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+  hooks: {
+    onSessionStart: async () => {
+      console.error("canvas: extension loaded");
+    },
+  },
+  tools: createCanvasTools(contentDir, server, onAction),
+});
+
+currentSession = session;

--- a/.github/extensions/canvas/lib/server.mjs
+++ b/.github/extensions/canvas/lib/server.mjs
@@ -1,0 +1,198 @@
+// Canvas server — local HTTP server with SSE live reload and action back-channel.
+
+import { createServer } from "node:http";
+import { readFileSync, existsSync } from "node:fs";
+import { join, extname } from "node:path";
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+};
+
+/** Bridge script injected into HTML responses. */
+const BRIDGE_SCRIPT = `
+<script>
+(function() {
+  // SSE live reload — only reload on explicit "reload" events.
+  // EventSource auto-reconnects on errors; no manual reload needed.
+  var es = new EventSource('/_sse');
+  es.onmessage = function(e) {
+    if (e.data === 'reload') { location.reload(); }
+    if (e.data === 'close') { window.close(); }
+  };
+
+  // Back-channel: canvas pages can send actions to the agent
+  window.canvas = {
+    sendAction: function(name, data) {
+      return fetch('/_action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: name, data: data || {}, timestamp: Date.now() })
+      });
+    }
+  };
+})();
+</script>`;
+
+/**
+ * Create and manage a canvas HTTP server.
+ * @param {string} contentDir - Directory to serve files from
+ * @param {function} onAction - Callback when a user action is received
+ * @returns {object} Server controller
+ */
+export function createCanvasServer(contentDir, onAction) {
+  let server = null;
+  let port = null;
+  let sseClients = [];
+
+  function handleRequest(req, res) {
+    // SSE endpoint
+    if (req.url === "/_sse") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.write("data: connected\n\n");
+      sseClients.push(res);
+      req.on("close", () => {
+        sseClients = sseClients.filter((c) => c !== res);
+      });
+      return;
+    }
+
+    // Action back-channel
+    if (req.url === "/_action" && req.method === "POST") {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try {
+          const action = JSON.parse(body);
+          if (onAction) onAction(action);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end('{"ok":true}');
+        } catch {
+          res.writeHead(400);
+          res.end('{"error":"invalid json"}');
+        }
+      });
+      return;
+    }
+
+    // Static file serving
+    let filePath = req.url === "/" ? "/index.html" : req.url;
+    filePath = filePath.split("?")[0]; // strip query params
+    const fullPath = join(contentDir, filePath);
+
+    // Path traversal protection
+    if (!fullPath.startsWith(contentDir)) {
+      res.writeHead(403);
+      res.end("Forbidden");
+      return;
+    }
+
+    if (!existsSync(fullPath)) {
+      res.writeHead(404);
+      res.end("Not found");
+      return;
+    }
+
+    try {
+      let content = readFileSync(fullPath);
+      const ext = extname(fullPath).toLowerCase();
+      const mime = MIME_TYPES[ext] || "application/octet-stream";
+
+      // Inject bridge script into HTML responses
+      if (ext === ".html") {
+        let html = content.toString("utf-8");
+        if (html.includes("</body>")) {
+          html = html.replace("</body>", `${BRIDGE_SCRIPT}\n</body>`);
+        } else if (html.includes("</html>")) {
+          html = html.replace("</html>", `${BRIDGE_SCRIPT}\n</html>`);
+        } else {
+          html += BRIDGE_SCRIPT;
+        }
+        content = html;
+      }
+
+      res.writeHead(200, {
+        "Content-Type": mime,
+        "Cache-Control": "no-store",
+      });
+      res.end(content);
+    } catch {
+      res.writeHead(500);
+      res.end("Server error");
+    }
+  }
+
+  return {
+    /** Start the server on a random available port. */
+    start() {
+      return new Promise((resolve, reject) => {
+        if (server) {
+          resolve(port);
+          return;
+        }
+        server = createServer(handleRequest);
+        server.listen(0, "127.0.0.1", () => {
+          port = server.address().port;
+          resolve(port);
+        });
+        server.on("error", reject);
+      });
+    },
+
+    /** Push an SSE reload event to all connected clients. */
+    reload() {
+      for (const client of sseClients) {
+        try {
+          client.write("data: reload\n\n");
+        } catch { /* client disconnected */ }
+      }
+    },
+
+    /** Push an SSE close event to all connected clients. */
+    closeClients() {
+      for (const client of sseClients) {
+        try {
+          client.write("data: close\n\n");
+        } catch { /* client disconnected */ }
+      }
+    },
+
+    /** Stop the server. */
+    stop() {
+      return new Promise((resolve) => {
+        if (!server) {
+          resolve();
+          return;
+        }
+        // Close all SSE connections
+        for (const client of sseClients) {
+          try { client.end(); } catch { /* ok */ }
+        }
+        sseClients = [];
+        server.close(() => {
+          server = null;
+          port = null;
+          resolve();
+        });
+      });
+    },
+
+    /** Get the current port (null if not running). */
+    getPort() { return port; },
+
+    /** Check if server is running. */
+    isRunning() { return server !== null; },
+  };
+}

--- a/.github/extensions/canvas/package.json
+++ b/.github/extensions/canvas/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "copilot-canvas-extension",
+  "private": true,
+  "type": "module"
+}

--- a/.github/extensions/canvas/tools/canvas-tools.mjs
+++ b/.github/extensions/canvas/tools/canvas-tools.mjs
@@ -1,0 +1,236 @@
+// Canvas tools — canvas_show, canvas_update, canvas_close
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { exec } from "node:child_process";
+
+const isWindows = process.platform === "win32";
+
+function openBrowser(url) {
+  const cmd = isWindows
+    ? `start msedge "${url}"`
+    : process.platform === "darwin"
+      ? `open -a "Microsoft Edge" "${url}"`
+      : `xdg-open "${url}"`;
+  exec(cmd, { shell: true }, () => {});
+}
+
+function writeContent(contentDir, filename, html) {
+  if (!existsSync(contentDir)) {
+    mkdirSync(contentDir, { recursive: true });
+  }
+  writeFileSync(join(contentDir, filename), html, "utf-8");
+}
+
+export function createCanvasTools(contentDir, server, onAction) {
+  // Track open canvases: name → { filename, url }
+  const openCanvases = new Map();
+
+  return [
+    {
+      name: "canvas_show",
+      description:
+        "Display HTML content in the user's browser. Creates a local canvas page and opens it in Edge. " +
+        "The HTML can be a full page or a fragment — a bridge script is auto-injected for live reload. " +
+        "Use this for dashboards, reports, visualizations, forms, or any rich visual output.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name (used as identifier). Kebab-case, e.g. 'daily-report', 'pr-dashboard'",
+          },
+          html: {
+            type: "string",
+            description: "Full HTML content to display. Can be a complete page or fragment. Not required if 'file' is provided.",
+          },
+          file: {
+            type: "string",
+            description: "Absolute path to an existing HTML file to serve. The file is copied into the canvas content directory. Use instead of 'html' to serve a pre-built file.",
+          },
+          title: {
+            type: "string",
+            description: "Optional page title. Used if html doesn't include a <title> tag.",
+          },
+          open_browser: {
+            type: "boolean",
+            description: "Whether to open the browser. Defaults to true. Set false to update content without opening a new tab.",
+          },
+        },
+        required: ["name"],
+      },
+      handler: async (args) => {
+        if (!args.html && !args.file) {
+          return "Error: either 'html' or 'file' must be provided.";
+        }
+
+        const filename = `${args.name}.html`;
+
+        if (args.file) {
+          // Serve an existing file — copy it into the content directory
+          if (!existsSync(args.file)) {
+            return `Error: file not found: ${args.file}`;
+          }
+          const source = readFileSync(args.file, "utf-8");
+          writeContent(contentDir, filename, source);
+        } else {
+          let html = args.html;
+
+          // Wrap fragment in a full page if needed
+          if (!html.toLowerCase().includes("<!doctype") && !html.toLowerCase().includes("<html")) {
+            const title = args.title || args.name;
+            html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+</head>
+<body>
+${html}
+</body>
+</html>`;
+          } else if (args.title && !html.toLowerCase().includes("<title>")) {
+            html = html.replace("</head>", `  <title>${args.title}</title>\n</head>`);
+          }
+
+          writeContent(contentDir, filename, html);
+        }
+
+        // Start server if not running
+        let port = server.getPort();
+        if (!port) {
+          port = await server.start();
+        }
+
+        const url = `http://127.0.0.1:${port}/${filename}`;
+        openCanvases.set(args.name, { filename, url });
+
+        const shouldOpen = args.open_browser !== false;
+        if (shouldOpen) {
+          openBrowser(url);
+        }
+
+        return `Canvas **${args.name}** is live at ${url}${shouldOpen ? " (opened in Edge)" : ""}`;
+      },
+    },
+
+    {
+      name: "canvas_update",
+      description:
+        "Update the content of an existing canvas. The browser auto-reloads via SSE — no need to reopen. " +
+        "Use this to refresh dashboards, update reports, or push new content to an already-open canvas.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name to update (must have been created with canvas_show)",
+          },
+          html: {
+            type: "string",
+            description: "New HTML content to display",
+          },
+          title: {
+            type: "string",
+            description: "Optional updated page title",
+          },
+        },
+        required: ["name", "html"],
+      },
+      handler: async (args) => {
+        const existing = openCanvases.get(args.name);
+        if (!existing) {
+          return `Error: canvas '${args.name}' not found. Use canvas_show to create it first.`;
+        }
+
+        let html = args.html;
+        if (!html.toLowerCase().includes("<!doctype") && !html.toLowerCase().includes("<html")) {
+          const title = args.title || args.name;
+          html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+</head>
+<body>
+${html}
+</body>
+</html>`;
+        }
+
+        writeContent(contentDir, existing.filename, html);
+        server.reload();
+
+        return `Canvas **${args.name}** updated. Browser will auto-reload.`;
+      },
+    },
+
+    {
+      name: "canvas_close",
+      description:
+        "Close a canvas and optionally stop the canvas server. " +
+        "Removes the canvas content. If no canvases remain, stops the server.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name to close. Use 'all' to close all canvases and stop the server.",
+          },
+        },
+        required: ["name"],
+      },
+      handler: async (args) => {
+        if (args.name === "all") {
+          const count = openCanvases.size;
+          server.closeClients();
+          await new Promise((r) => setTimeout(r, 200));
+          openCanvases.clear();
+          await server.stop();
+          return `Closed ${count} canvas(es) and stopped the server.`;
+        }
+
+        const existing = openCanvases.get(args.name);
+        if (!existing) {
+          return `Error: canvas '${args.name}' not found.`;
+        }
+
+        server.closeClients();
+        await new Promise((r) => setTimeout(r, 200));
+        openCanvases.delete(args.name);
+
+        // Stop server if no canvases remain
+        if (openCanvases.size === 0) {
+          await server.stop();
+          return `Canvas **${args.name}** closed. Server stopped (no remaining canvases).`;
+        }
+
+        return `Canvas **${args.name}** closed. ${openCanvases.size} canvas(es) still active.`;
+      },
+    },
+
+    {
+      name: "canvas_list",
+      description: "List all open canvases with their URLs.",
+      parameters: { type: "object", properties: {} },
+      handler: async () => {
+        if (openCanvases.size === 0) {
+          return "No canvases are open.";
+        }
+
+        const lines = [];
+        for (const [name, info] of openCanvases) {
+          lines.push(`• **${name}** — ${info.url}`);
+        }
+
+        const status = server.isRunning()
+          ? `Server running on port ${server.getPort()}`
+          : "Server not running";
+
+        return `${lines.join("\n")}\n\n${status}`;
+      },
+    },
+  ];
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@
 ### Chat
 
 - **Harden conversation history lifecycle** - Resumed chats strip Chamber-injected datetime metadata, empty drafts are reused instead of duplicated, first prompts title persisted conversations, and model switching is serialized through the backend-confirmed session path. (#216)
-- **Expand lifecycle smoke coverage** - SDK smoke now verifies repeated named-session resume and cross-model context preservation, while Electron smokes cover empty-draft reuse, first-prompt title persistence, and pending model-switch disabled states. (#216)
+- **Switch models in place via the SDK** - Model changes now call `session.setModel()` on the live SDK session, preserving conversation history. Removes the resume/recreate cycle that produced silent context loss after a mid-conversation model switch. (#216)
+- **Bound stale-session recovery** - `ChatService` reattaches once via `recoverActiveConversationSession` and surfaces the error if the SDK still cannot find the session, instead of silently minting an empty replacement runtime. `MindManager.recoverActiveConversationSession` resumes by Chamber sessionId and falls back to `createSession({ sessionId })` under the same id. (#216)
+- **Delete conversations from history** - History rows now expose a trash icon next to the rename pencil. Deleting an inactive conversation leaves the active chat untouched; deleting the active conversation hydrates the next most recent; deleting the last creates one empty draft. Confirmation only triggers for conversations with messages. (#216)
+- **Expand lifecycle smoke coverage** - SDK smoke verifies repeated named-session resume and cross-model context preservation; Electron smokes cover empty-draft reuse, first-prompt title persistence, pending model-switch disabled states, model-switch context recall via a sentinel token, and the trash-delete flow. (#216)
 - **Align packaged Copilot runtime** - Chamber now pins the packaged Copilot CLI runtime to `1.0.44-0`, matching the binary version validated by the packaging sandbox. (#216)
+
+### Tooling
+
+- **Add canvas extension scaffolding** - New `.github/extensions/canvas/` extension exposes a local canvas server and tools for rich visual output during agent sessions. (#216)
 
 ## v0.43.4 (2026-05-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## v0.43.5 (2026-05-07)
+## v0.44.0 (2026-05-07)
 
-### Fixes
+### Chat
 
-- **Display device code when adding an account from Settings** - The Settings "+ Add Account" flow now opens a modal that subscribes to `auth:progress` before invoking `auth:startLogin`, so the GitHub device code is rendered alongside the static `github.com/login/device` instruction (mirrors the first-run `AuthScreen` UX). The modal auto-dismisses on `step:'authenticated'`, surfaces actionable errors with a Try Again affordance, and the Cancel button calls a new `auth:cancelLogin` IPC that aborts the in-flight polling loop via `AuthService.abort()`. Users can complete the second-account flow without logging out and restarting Chamber. (#214)
-
-### Testing
-
-- **E2E hooks for the device-code modal** - `apps/desktop/src/main/ipc/auth.ts` registers `e2e:auth:emit-progress` and `e2e:auth:complete-login` handlers when `CHAMBER_E2E=1`, and the auth:startLogin path short-circuits to a deterministic stub in that mode. The new Playwright spec `tests/e2e/electron/settings-add-account.spec.ts` drives the full Settings → Add Account → injected device-code → completion / cancel lifecycle without touching real GitHub network or external browser launch. Triple-gated (env var + preload sync IPC + optional chaining) so the hooks remain absent in production builds. (#214)
+- **Harden conversation history lifecycle** - Resumed chats strip Chamber-injected datetime metadata, empty drafts are reused instead of duplicated, first prompts title persisted conversations, and model switching is serialized through the backend-confirmed session path. (#216)
+- **Expand lifecycle smoke coverage** - SDK smoke now verifies repeated named-session resume and cross-model context preservation, while Electron smokes cover empty-draft reuse, first-prompt title persistence, and pending model-switch disabled states. (#216)
+- **Align packaged Copilot runtime** - Chamber now pins the packaged Copilot CLI runtime to `1.0.44-0`, matching the binary version validated by the packaging sandbox. (#216)
 
 ## v0.43.4 (2026-05-07)
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -452,7 +452,7 @@ app.on('ready', async () => {
   // --- IPC adapters (thin, parameter-injected) ---
   setupChatIPC(chatService, mindManager);
   setupConversationHistoryIPC(chatService);
-  setupMindIPC(mindManager, {
+  setupMindIPC(mindManager, chatService, {
     preloadPath: path.join(__dirname, 'preload.js'),
     devServerUrl: MAIN_WINDOW_VITE_DEV_SERVER_URL || undefined,
     rendererPath: MAIN_WINDOW_VITE_DEV_SERVER_URL ? undefined : path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`),

--- a/apps/desktop/src/main/ipc/conversationHistory.ts
+++ b/apps/desktop/src/main/ipc/conversationHistory.ts
@@ -10,4 +10,7 @@ export function setupConversationHistoryIPC(chatService: ChatService): void {
 
   ipcMain.handle('conversationHistory:rename', async (_event, mindId: string, sessionId: string, title: string) =>
     chatService.renameConversation(mindId, sessionId, title));
+
+  ipcMain.handle('conversationHistory:delete', async (_event, mindId: string, sessionId: string) =>
+    chatService.deleteConversation(mindId, sessionId));
 }

--- a/apps/desktop/src/main/ipc/mind.ts
+++ b/apps/desktop/src/main/ipc/mind.ts
@@ -3,7 +3,7 @@ import { ipcMain, dialog, BrowserWindow, type NativeImage } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
 import { setTimeout as delay } from 'node:timers/promises';
-import type { MindManager } from '@chamber/services';
+import type { ChatService, MindManager } from '@chamber/services';
 import type { MindContext } from '@chamber/shared/types';
 import { installExternalNavigationGuard } from '../navigationGuard';
 
@@ -14,7 +14,7 @@ export interface MindIPCConfig {
   windowIcon?: NativeImage;
 }
 
-export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): void {
+export function setupMindIPC(mindManager: MindManager, chatService: ChatService, config: MindIPCConfig): void {
   const windowByMind = new Map<string, BrowserWindow>();
   const listMinds = (): MindContext[] =>
     mindManager.listMinds().map((mind) => ({
@@ -43,7 +43,7 @@ export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): v
   ipcMain.handle('mind:setModel', async (_event, mindId: string, model: string | null) => {
     const e2eDelayMs = Number(process.env.CHAMBER_E2E_MODEL_SWITCH_DELAY_MS ?? 0);
     if (e2eDelayMs > 0) await delay(e2eDelayMs);
-    return mindManager.setMindModel(mindId, model);
+    return chatService.setMindModel(mindId, model);
   });
 
   ipcMain.handle('mind:selectDirectory', async (event) => {

--- a/apps/desktop/src/main/ipc/mind.ts
+++ b/apps/desktop/src/main/ipc/mind.ts
@@ -2,6 +2,7 @@
 import { ipcMain, dialog, BrowserWindow, type NativeImage } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
+import { setTimeout as delay } from 'node:timers/promises';
 import type { MindManager } from '@chamber/services';
 import type { MindContext } from '@chamber/shared/types';
 import { installExternalNavigationGuard } from '../navigationGuard';
@@ -40,6 +41,8 @@ export function setupMindIPC(mindManager: MindManager, config: MindIPCConfig): v
   });
 
   ipcMain.handle('mind:setModel', async (_event, mindId: string, model: string | null) => {
+    const e2eDelayMs = Number(process.env.CHAMBER_E2E_MODEL_SWITCH_DELAY_MS ?? 0);
+    if (e2eDelayMs > 0) await delay(e2eDelayMs);
     return mindManager.setMindModel(mindId, model);
   });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -18,6 +18,7 @@ const electronAPI: ElectronAPI = {
     list: (mindId) => ipcRenderer.invoke('conversationHistory:list', mindId),
     resume: (mindId, sessionId) => ipcRenderer.invoke('conversationHistory:resume', mindId, sessionId),
     rename: (mindId, sessionId, title) => ipcRenderer.invoke('conversationHistory:rename', mindId, sessionId, title),
+    delete: (mindId, sessionId) => ipcRenderer.invoke('conversationHistory:delete', mindId, sessionId),
   },
   mind: {
     add: (mindPath) => ipcRenderer.invoke('mind:add', mindPath),

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -147,6 +147,7 @@ export function installBrowserApi(): void {
       list: async () => [],
       resume: async () => ({ sessionId: '', messages: [], conversations: [] }),
       rename: async () => [],
+      delete: async () => ({ sessionId: '', messages: [], conversations: [] }),
     },
     mind: {
       add: (mindPath): Promise<MindContext> => client.addMind(mindPath) as Promise<MindContext>,

--- a/apps/web/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.test.tsx
@@ -96,6 +96,17 @@ describe('ChatInput', () => {
     expect(screen.getByText('Loading models…')).toBeTruthy();
   });
 
+  it('disables the model selector when the input is disabled', () => {
+    render(<ChatInput
+      {...defaultProps}
+      disabled={true}
+      availableModels={[{ id: 'model-1', name: 'Model 1' }]}
+      selectedModel="model-1"
+    />);
+
+    expect(screen.getByRole('combobox').hasAttribute('data-disabled')).toBe(true);
+  });
+
   describe('emoji picker', () => {
     it('renders an emoji trigger button with aria-label', () => {
       render(<ChatInput {...defaultProps} />);

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -466,7 +466,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
                 <Select
                   value={selectedModel ?? undefined}
                   onValueChange={onModelChange}
-                  disabled={isStreaming}
+                  disabled={isStreaming || disabled}
                 >
                   <SelectTrigger className="h-6 w-auto gap-1.5 border-none bg-transparent px-0 text-xs text-muted-foreground shadow-none hover:text-foreground focus:ring-0">
                     <SelectValue placeholder="Select model" />

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -420,7 +420,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
             onCompositionEnd={() => {
               isComposingRef.current = false;
             }}
-            placeholder={disabled ? 'Select a mind directory to start…' : (placeholder ?? 'Message your agent… (paste an image to attach)')}
+            placeholder={placeholder ?? (disabled ? 'Select a mind directory to start…' : 'Message your agent… (paste an image to attach)')}
             disabled={disabled}
             rows={1}
             className="w-full bg-transparent text-sm resize-none outline-none placeholder:text-muted-foreground disabled:opacity-50 overflow-y-auto"

--- a/apps/web/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/web/src/renderer/components/chat/ChatPanel.tsx
@@ -40,6 +40,7 @@ export function ChatPanel() {
         <WelcomeScreen
           onSendMessage={sendMessage}
           connected={connected}
+          disabled={isModelSwitching}
         />
       ) : (
         <MessageList />

--- a/apps/web/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/web/src/renderer/components/chat/ChatPanel.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { useChatStreaming } from '../../hooks/useChatStreaming';
 import { MessageList } from './MessageList';
@@ -9,19 +8,22 @@ import { Logger } from '../../lib/logger';
 const log = Logger.create('ChatPanel');
 
 export function ChatPanel() {
-  const { messagesByMind, activeMindId, minds, availableModels, selectedModel } = useAppState();
+  const { messagesByMind, activeMindId, minds, availableModels, selectedModel, conversationViewByMind } = useAppState();
   const messages = activeMindId ? (messagesByMind[activeMindId] ?? []) : [];
+  const conversationView = activeMindId ? conversationViewByMind[activeMindId] : undefined;
+  const isConversationHydrating = conversationView?.status === 'hydrating';
+  const isModelSwitching = Boolean(conversationView?.modelSwitching);
   const connected = minds.length > 0;
   const dispatch = useAppDispatch();
   const { sendMessage, stopStreaming, isStreaming } = useChatStreaming();
-  const [isModelSwitching, setIsModelSwitching] = useState(false);
 
   const handleModelChange = (model: string) => {
     if (!activeMindId || isModelSwitching) return;
+    const mindId = activeMindId;
     const previousModel = selectedModel;
     dispatch({ type: 'SET_SELECTED_MODEL', payload: model });
-    setIsModelSwitching(true);
-    window.electronAPI.mind.setModel(activeMindId, model)
+    dispatch({ type: 'SET_MODEL_SWITCHING', payload: { mindId, switching: true } });
+    window.electronAPI.mind.setModel(mindId, model)
       .then((updatedMind) => {
         if (updatedMind) dispatch({ type: 'SET_MINDS', payload: minds.map((mind) => mind.mindId === updatedMind.mindId ? updatedMind : mind) });
       })
@@ -30,13 +32,17 @@ export function ChatPanel() {
         dispatch({ type: 'SET_SELECTED_MODEL', payload: previousModel });
       })
       .finally(() => {
-        setIsModelSwitching(false);
+        dispatch({ type: 'SET_MODEL_SWITCHING', payload: { mindId, switching: false } });
       });
   };
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
-      {messages.length === 0 ? (
+      {isConversationHydrating ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+          Loading conversation…
+        </div>
+      ) : messages.length === 0 ? (
         <WelcomeScreen
           onSendMessage={sendMessage}
           connected={connected}

--- a/apps/web/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/web/src/renderer/components/chat/ChatPanel.tsx
@@ -18,14 +18,16 @@ export function ChatPanel() {
 
   const handleModelChange = (model: string) => {
     if (!activeMindId || isModelSwitching) return;
+    const previousModel = selectedModel;
+    dispatch({ type: 'SET_SELECTED_MODEL', payload: model });
     setIsModelSwitching(true);
     window.electronAPI.mind.setModel(activeMindId, model)
       .then((updatedMind) => {
         if (updatedMind) dispatch({ type: 'SET_MINDS', payload: minds.map((mind) => mind.mindId === updatedMind.mindId ? updatedMind : mind) });
-        dispatch({ type: 'SET_SELECTED_MODEL', payload: model });
       })
       .catch((error: unknown) => {
         log.error('Failed to switch model:', error);
+        dispatch({ type: 'SET_SELECTED_MODEL', payload: previousModel });
       })
       .finally(() => {
         setIsModelSwitching(false);

--- a/apps/web/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/web/src/renderer/components/chat/ChatPanel.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { useChatStreaming } from '../../hooks/useChatStreaming';
 import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
 import { WelcomeScreen } from './WelcomeScreen';
+import { Logger } from '../../lib/logger';
+
+const log = Logger.create('ChatPanel');
 
 export function ChatPanel() {
   const { messagesByMind, activeMindId, minds, availableModels, selectedModel } = useAppState();
@@ -11,6 +14,23 @@ export function ChatPanel() {
   const connected = minds.length > 0;
   const dispatch = useAppDispatch();
   const { sendMessage, stopStreaming, isStreaming } = useChatStreaming();
+  const [isModelSwitching, setIsModelSwitching] = useState(false);
+
+  const handleModelChange = (model: string) => {
+    if (!activeMindId || isModelSwitching) return;
+    setIsModelSwitching(true);
+    window.electronAPI.mind.setModel(activeMindId, model)
+      .then((updatedMind) => {
+        if (updatedMind) dispatch({ type: 'SET_MINDS', payload: minds.map((mind) => mind.mindId === updatedMind.mindId ? updatedMind : mind) });
+        dispatch({ type: 'SET_SELECTED_MODEL', payload: model });
+      })
+      .catch((error: unknown) => {
+        log.error('Failed to switch model:', error);
+      })
+      .finally(() => {
+        setIsModelSwitching(false);
+      });
+  };
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -27,13 +47,11 @@ export function ChatPanel() {
         onSend={sendMessage}
         onStop={stopStreaming}
         isStreaming={isStreaming}
-        disabled={!connected}
+        disabled={!connected || isModelSwitching}
         availableModels={availableModels}
         selectedModel={selectedModel}
-        onModelChange={(model) => {
-          if (activeMindId) void window.electronAPI.mind.setModel(activeMindId, model);
-          dispatch({ type: 'SET_SELECTED_MODEL', payload: model });
-        }}
+        onModelChange={handleModelChange}
+        placeholder={isModelSwitching ? 'Switching model…' : undefined}
       />
     </div>
   );

--- a/apps/web/src/renderer/components/chat/WelcomeScreen.tsx
+++ b/apps/web/src/renderer/components/chat/WelcomeScreen.tsx
@@ -12,9 +12,10 @@ const STARTER_PROMPTS = [
 interface Props {
   onSendMessage: (message: string) => void;
   connected: boolean;
+  disabled?: boolean;
 }
 
-export function WelcomeScreen({ onSendMessage, connected }: Props) {
+export function WelcomeScreen({ onSendMessage, connected, disabled = false }: Props) {
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-4">
       <div className="max-w-lg text-center">
@@ -35,8 +36,10 @@ export function WelcomeScreen({ onSendMessage, connected }: Props) {
             {STARTER_PROMPTS.map((item) => (
               <button
                 key={item.label}
+                type="button"
+                disabled={disabled}
                 onClick={() => onSendMessage(item.prompt)}
-                className="text-left p-3 rounded-xl border border-border hover:bg-accent transition-colors group"
+                className="text-left p-3 rounded-xl border border-border hover:bg-accent transition-colors group disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
               >
                 <span className="text-lg mb-1 block">{item.emoji}</span>
                 <span className="text-sm font-medium group-hover:text-foreground">

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import { MoreHorizontal, Pencil, Plus } from 'lucide-react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ConversationSummary } from '@chamber/shared/types';
 import { useAppDispatch, useAppState } from '../../lib/store';
@@ -13,6 +13,7 @@ export function ConversationHistoryPanel() {
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [isCreatingConversation, setIsCreatingConversation] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const creatingConversationRef = useRef(false);
 
@@ -25,6 +26,7 @@ export function ConversationHistoryPanel() {
   const isActiveMindStreaming = activeMindId
     ? Boolean(streamingByMind[activeMindId] || activeConversationView?.streaming)
     : false;
+  const isActiveMindBusy = isActiveMindStreaming || Boolean(activeConversationView?.modelSwitching);
 
   const applyResumeResult = useCallback((mindId: string, result: Awaited<ReturnType<typeof window.electronAPI.conversationHistory.resume>>) => {
     dispatch({
@@ -67,7 +69,7 @@ export function ConversationHistoryPanel() {
   }, [activeMindId, dispatch]);
 
   useEffect(() => {
-    if (!activeMindId || !selectedConversationId || isActiveMindStreaming || creatingConversationRef.current) return;
+    if (!activeMindId || !selectedConversationId || isActiveMindBusy || creatingConversationRef.current) return;
     if (activeConversationView?.status === 'hydrating' && activeConversationView.pendingSessionId === selectedConversationId) return;
     if (activeConversationView?.status === 'ready' && activeConversationView.sessionId === selectedConversationId) return;
 
@@ -80,7 +82,7 @@ export function ConversationHistoryPanel() {
     activeConversationView?.status,
     activeMindId,
     hydrateConversation,
-    isActiveMindStreaming,
+    isActiveMindBusy,
     selectedConversationId,
   ]);
 
@@ -113,7 +115,7 @@ export function ConversationHistoryPanel() {
   };
 
   const resumeConversation = async (sessionId: string) => {
-    if (!activeMindId || isActiveMindStreaming) return;
+    if (!activeMindId || isActiveMindBusy) return;
     if (
       sessionId === selectedConversationId
       && activeConversationView?.status === 'ready'
@@ -128,7 +130,7 @@ export function ConversationHistoryPanel() {
   };
 
   const startNewConversation = async () => {
-    if (!activeMindId || isActiveMindStreaming || isCreatingConversation) return;
+    if (!activeMindId || isActiveMindBusy || isCreatingConversation) return;
     creatingConversationRef.current = true;
     setIsCreatingConversation(true);
     try {
@@ -144,6 +146,26 @@ export function ConversationHistoryPanel() {
     }
   };
 
+  const deleteConversation = async (conversation: ConversationSummary) => {
+    if (!activeMindId || isActiveMindBusy || deletingId) return;
+    if (conversation.hasMessages) {
+      const confirmed = window.confirm(`Delete "${conversation.title}"? This cannot be undone.`);
+      if (!confirmed) return;
+    }
+
+    setDeletingId(conversation.sessionId);
+    setRenamingId(null);
+    try {
+      const result = await window.electronAPI.conversationHistory.delete(activeMindId, conversation.sessionId);
+      applyResumeResult(activeMindId, result);
+      dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+    } catch (error) {
+      log.error('Failed to delete conversation:', error);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
   return (
     <aside aria-label="Conversation history" className="w-80 shrink-0 bg-card border border-border rounded-xl overflow-hidden flex flex-col">
       <div className="h-10 border-b border-border px-3 flex items-center justify-between">
@@ -152,7 +174,7 @@ export function ConversationHistoryPanel() {
         </span>
         <button
           type="button"
-          disabled={!activeMindId || isActiveMindStreaming || isCreatingConversation}
+          disabled={!activeMindId || isActiveMindBusy || isCreatingConversation}
           onClick={() => { void startNewConversation(); }}
           className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           aria-label="New conversation"
@@ -181,7 +203,7 @@ export function ConversationHistoryPanel() {
               <button
                 type="button"
                 aria-label={`Resume ${conversation.title}`}
-                disabled={isActiveMindStreaming}
+                disabled={isActiveMindBusy}
                 onClick={() => { void resumeConversation(conversation.sessionId); }}
                 className="min-w-0 flex-1 text-left disabled:cursor-not-allowed"
               >
@@ -209,17 +231,20 @@ export function ConversationHistoryPanel() {
                 <button
                   type="button"
                   onClick={() => startRename(conversation)}
-                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-foreground hover:bg-accent group-hover:opacity-100 flex items-center justify-center"
+                  disabled={isActiveMindBusy || deletingId === conversation.sessionId}
+                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-foreground hover:bg-accent group-hover:opacity-100 flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
                   aria-label={`Rename ${conversation.title}`}
                 >
                   <Pencil size={13} />
                 </button>
                 <button
                   type="button"
-                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-foreground hover:bg-accent group-hover:opacity-100 flex items-center justify-center"
-                  aria-label={`${conversation.title} options`}
+                  onClick={() => { void deleteConversation(conversation); }}
+                  disabled={isActiveMindBusy || deletingId !== null}
+                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-destructive hover:bg-destructive/10 group-hover:opacity-100 flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
+                  aria-label={`Delete ${conversation.title}`}
                 >
-                  <MoreHorizontal size={14} />
+                  <Trash2 size={13} />
                 </button>
               </div>
             </div>

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -12,7 +12,9 @@ export function ConversationHistoryPanel() {
   const dispatch = useAppDispatch();
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
+  const [isCreatingConversation, setIsCreatingConversation] = useState(false);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const creatingConversationRef = useRef(false);
 
   const conversations = useMemo(() => {
     if (!activeMindId) return [];
@@ -36,6 +38,7 @@ export function ConversationHistoryPanel() {
 
   useEffect(() => {
     if (!activeMindId) return;
+    if (creatingConversationRef.current) return;
     let cancelled = false;
     window.electronAPI.conversationHistory.list(activeMindId).then((history) => {
       if (cancelled) return;
@@ -93,12 +96,21 @@ export function ConversationHistoryPanel() {
   };
 
   const startNewConversation = async () => {
-    if (!activeMindId || isActiveMindStreaming) return;
-    const result = await window.electronAPI.chat.newConversation(activeMindId);
-    await window.electronAPI.chatroom.clear();
-    dispatch({ type: 'NEW_CONVERSATION' });
-    applyResumeResult(activeMindId, result);
-    dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+    if (!activeMindId || isActiveMindStreaming || isCreatingConversation) return;
+    creatingConversationRef.current = true;
+    setIsCreatingConversation(true);
+    try {
+      const result = await window.electronAPI.chat.newConversation(activeMindId);
+      await window.electronAPI.chatroom.clear();
+      dispatch({ type: 'NEW_CONVERSATION' });
+      applyResumeResult(activeMindId, result);
+      dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+    } catch (error) {
+      log.error('Failed to start new conversation:', error);
+    } finally {
+      creatingConversationRef.current = false;
+      setIsCreatingConversation(false);
+    }
   };
 
   return (
@@ -109,7 +121,7 @@ export function ConversationHistoryPanel() {
         </span>
         <button
           type="button"
-          disabled={!activeMindId || isActiveMindStreaming}
+          disabled={!activeMindId || isActiveMindStreaming || isCreatingConversation}
           onClick={() => { void startNewConversation(); }}
           className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           aria-label="New conversation"

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -102,7 +102,7 @@ export function ConversationHistoryPanel() {
     try {
       const result = await window.electronAPI.chat.newConversation(activeMindId);
       await window.electronAPI.chatroom.clear();
-      dispatch({ type: 'NEW_CONVERSATION' });
+      dispatch({ type: 'NEW_CONVERSATION', payload: { mindId: activeMindId } });
       applyResumeResult(activeMindId, result);
       dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
     } catch (error) {

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -157,8 +157,17 @@ export function ConversationHistoryPanel() {
     setRenamingId(null);
     try {
       const result = await window.electronAPI.conversationHistory.delete(activeMindId, conversation.sessionId);
-      applyResumeResult(activeMindId, result);
-      dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+      if (conversation.active) {
+        applyResumeResult(activeMindId, result);
+        dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+      } else {
+        // Inactive delete: don't replace the active conversation's messages — the SDK→ChatMessage
+        // mapping is text-only and would drop tool-calls/reasoning/images from the live chat UI.
+        dispatch({
+          type: 'SET_CONVERSATION_HISTORY',
+          payload: { mindId: activeMindId, conversations: result.conversations },
+        });
+      }
     } catch (error) {
       log.error('Failed to delete conversation:', error);
     } finally {

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -8,7 +8,7 @@ import { cn } from '../../lib/utils';
 const log = Logger.create('ConversationHistoryPanel');
 
 export function ConversationHistoryPanel() {
-  const { activeMindId, conversationHistoryByMind, activeConversationByMind, messagesByMind, streamingByMind } = useAppState();
+  const { activeMindId, conversationHistoryByMind, activeConversationByMind, conversationViewByMind, streamingByMind } = useAppState();
   const dispatch = useAppDispatch();
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
@@ -21,8 +21,10 @@ export function ConversationHistoryPanel() {
     return conversationHistoryByMind[activeMindId] ?? [];
   }, [activeMindId, conversationHistoryByMind]);
   const selectedConversationId = activeMindId ? activeConversationByMind[activeMindId] : undefined;
-  const activeMessageCount = activeMindId ? (messagesByMind[activeMindId]?.length ?? 0) : 0;
-  const isActiveMindStreaming = activeMindId ? Boolean(streamingByMind[activeMindId]) : false;
+  const activeConversationView = activeMindId ? conversationViewByMind[activeMindId] : undefined;
+  const isActiveMindStreaming = activeMindId
+    ? Boolean(streamingByMind[activeMindId] || activeConversationView?.streaming)
+    : false;
 
   const applyResumeResult = useCallback((mindId: string, result: Awaited<ReturnType<typeof window.electronAPI.conversationHistory.resume>>) => {
     dispatch({
@@ -36,29 +38,51 @@ export function ConversationHistoryPanel() {
     });
   }, [dispatch]);
 
+  const hydrateConversation = useCallback(async (mindId: string, sessionId: string) => {
+    dispatch({ type: 'CONVERSATION_HYDRATING', payload: { mindId, sessionId } });
+    try {
+      const result = await window.electronAPI.conversationHistory.resume(mindId, sessionId);
+      applyResumeResult(mindId, result);
+      return result;
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      dispatch({ type: 'CONVERSATION_HYDRATE_FAILED', payload: { mindId, sessionId, error: message } });
+      log.warn('Failed to hydrate conversation:', error);
+      throw error;
+    }
+  }, [applyResumeResult, dispatch]);
+
   useEffect(() => {
     if (!activeMindId) return;
-    if (creatingConversationRef.current) return;
     let cancelled = false;
     window.electronAPI.conversationHistory.list(activeMindId).then((history) => {
       if (cancelled) return;
       dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId: activeMindId, conversations: history } });
-      const activeConversation = history.find((conversation) => conversation.active);
-      if (activeConversation && activeMessageCount === 0 && !isActiveMindStreaming) {
-        window.electronAPI.conversationHistory.resume(activeMindId, activeConversation.sessionId).then((result) => {
-          if (cancelled) return;
-          applyResumeResult(activeMindId, result);
-        }).catch((error: unknown) => {
-          log.warn('Failed to hydrate active conversation:', error);
-        });
-      }
     }).catch((error: unknown) => {
       log.warn('Failed to load conversation history:', error);
     });
     return () => {
       cancelled = true;
     };
-  }, [activeMessageCount, activeMindId, applyResumeResult, dispatch, isActiveMindStreaming]);
+  }, [activeMindId, dispatch]);
+
+  useEffect(() => {
+    if (!activeMindId || !selectedConversationId || isActiveMindStreaming || creatingConversationRef.current) return;
+    if (activeConversationView?.status === 'hydrating' && activeConversationView.pendingSessionId === selectedConversationId) return;
+    if (activeConversationView?.status === 'ready' && activeConversationView.sessionId === selectedConversationId) return;
+
+    void hydrateConversation(activeMindId, selectedConversationId).catch(() => {
+      // The reducer records the failure; the warning above preserves diagnostics.
+    });
+  }, [
+    activeConversationView?.pendingSessionId,
+    activeConversationView?.sessionId,
+    activeConversationView?.status,
+    activeMindId,
+    hydrateConversation,
+    isActiveMindStreaming,
+    selectedConversationId,
+  ]);
 
   useEffect(() => {
     if (renamingId) {
@@ -89,9 +113,17 @@ export function ConversationHistoryPanel() {
   };
 
   const resumeConversation = async (sessionId: string) => {
-    if (!activeMindId || isActiveMindStreaming || (sessionId === selectedConversationId && activeMessageCount > 0)) return;
-    const result = await window.electronAPI.conversationHistory.resume(activeMindId, sessionId);
-    applyResumeResult(activeMindId, result);
+    if (!activeMindId || isActiveMindStreaming) return;
+    if (
+      sessionId === selectedConversationId
+      && activeConversationView?.status === 'ready'
+      && activeConversationView.sessionId === sessionId
+    ) return;
+    try {
+      await hydrateConversation(activeMindId, sessionId);
+    } catch {
+      return;
+    }
     dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
   };
 
@@ -102,7 +134,6 @@ export function ConversationHistoryPanel() {
     try {
       const result = await window.electronAPI.chat.newConversation(activeMindId);
       await window.electronAPI.chatroom.clear();
-      dispatch({ type: 'NEW_CONVERSATION', payload: { mindId: activeMindId } });
       applyResumeResult(activeMindId, result);
       dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
     } catch (error) {

--- a/apps/web/src/renderer/hooks/useChatStreaming.ts
+++ b/apps/web/src/renderer/hooks/useChatStreaming.ts
@@ -2,6 +2,9 @@ import { useCallback, useRef } from 'react';
 import { useAppState, useAppDispatch } from '../lib/store';
 import { generateId } from '../lib/utils';
 import type { ChatImageAttachment, ImageBlock } from '@chamber/shared/types';
+import { Logger } from '../lib/logger';
+
+const log = Logger.create('useChatStreaming');
 
 export function useChatStreaming() {
   const { activeMindId, isStreaming, selectedModel } = useAppState();
@@ -35,7 +38,14 @@ export function useChatStreaming() {
       payload: { id: assistantId, timestamp: Date.now() },
     });
 
-    await window.electronAPI.chat.send(activeMindId, content.trim(), assistantId, selectedModel ?? undefined, attachments);
+    const mindId = activeMindId;
+    await window.electronAPI.chat.send(mindId, content.trim(), assistantId, selectedModel ?? undefined, attachments);
+    try {
+      const conversations = await window.electronAPI.conversationHistory.list(mindId);
+      dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId, conversations } });
+    } catch (error) {
+      log.warn('Failed to refresh conversation history after send:', error);
+    }
   }, [activeMindId, isStreaming, selectedModel, dispatch]);
 
   const stopStreaming = useCallback(async () => {

--- a/apps/web/src/renderer/lib/store/chatStateSync.ts
+++ b/apps/web/src/renderer/lib/store/chatStateSync.ts
@@ -1,10 +1,12 @@
 import type { ChatMessage, ContentBlock } from '@chamber/shared/types';
+import type { ConversationViewState } from './state';
 
 export const CHAT_STATE_CHANNEL = 'chamber:chatState:v1';
 
 export interface SyncedChatState {
   messagesByMind: Record<string, ChatMessage[]>;
   streamingByMind: Record<string, boolean>;
+  conversationViewByMind?: Record<string, ConversationViewState>;
 }
 
 export type ChatStateSyncMessage =
@@ -54,10 +56,26 @@ function isStreamingByMind(value: unknown): value is Record<string, boolean> {
     && Object.values(value).every((streaming) => typeof streaming === 'boolean');
 }
 
+function isConversationViewState(value: unknown): value is ConversationViewState {
+  if (!isRecord(value)) return false;
+  return (value.status === 'idle' || value.status === 'hydrating' || value.status === 'ready')
+    && (value.sessionId === undefined || typeof value.sessionId === 'string')
+    && (value.pendingSessionId === undefined || typeof value.pendingSessionId === 'string')
+    && typeof value.streaming === 'boolean'
+    && typeof value.modelSwitching === 'boolean'
+    && (value.error === undefined || typeof value.error === 'string');
+}
+
+function isConversationViewByMind(value: unknown): value is Record<string, ConversationViewState> {
+  return isRecord(value)
+    && Object.values(value).every(isConversationViewState);
+}
+
 function isSyncedChatState(value: unknown): value is SyncedChatState {
   return isRecord(value)
     && isMessagesByMind(value.messagesByMind)
-    && isStreamingByMind(value.streamingByMind);
+    && isStreamingByMind(value.streamingByMind)
+    && (value.conversationViewByMind === undefined || isConversationViewByMind(value.conversationViewByMind));
 }
 
 export function parseChatStateSyncMessage(value: unknown): ChatStateSyncMessage | null {
@@ -72,12 +90,16 @@ export function parseChatStateSyncMessage(value: unknown): ChatStateSyncMessage 
 }
 
 export function createChatStateSyncMessage(state: SyncedChatState): ChatStateSyncMessage {
+  const payload: SyncedChatState = {
+    messagesByMind: state.messagesByMind,
+    streamingByMind: state.streamingByMind,
+  };
+  if (state.conversationViewByMind) {
+    payload.conversationViewByMind = state.conversationViewByMind;
+  }
+
   return {
     type: 'state',
-    payload: {
-      messagesByMind: state.messagesByMind,
-      streamingByMind: state.streamingByMind,
-    },
+    payload,
   };
 }
-

--- a/apps/web/src/renderer/lib/store/context.tsx
+++ b/apps/web/src/renderer/lib/store/context.tsx
@@ -27,8 +27,9 @@ export function AppStateProvider({ children, testInitialState }: { children: Rea
     channelRef.current.postMessage(createChatStateSyncMessage({
       messagesByMind: state.messagesByMind,
       streamingByMind: state.streamingByMind,
+      conversationViewByMind: state.conversationViewByMind,
     }));
-  }, [state.messagesByMind, state.streamingByMind, testInitialState]);
+  }, [state.conversationViewByMind, state.messagesByMind, state.streamingByMind, testInitialState]);
 
   useEffect(() => {
     if (testInitialState || typeof BroadcastChannel === 'undefined') return;
@@ -43,6 +44,7 @@ export function AppStateProvider({ children, testInitialState }: { children: Rea
         channel.postMessage(createChatStateSyncMessage({
           messagesByMind: stateRef.current.messagesByMind,
           streamingByMind: stateRef.current.streamingByMind,
+          conversationViewByMind: stateRef.current.conversationViewByMind,
         }));
         return;
       }

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -269,6 +269,95 @@ describe('appReducer', () => {
     expect(state.isStreaming).toBe(true);
   });
 
+  it('SET_CONVERSATION_HISTORY enters idle for the active conversation until it hydrates', () => {
+    const state = appReducer(withActiveMind, {
+      type: 'SET_CONVERSATION_HISTORY',
+      payload: {
+        mindId,
+        conversations: [
+          { sessionId: 'session-1', title: 'Last chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', kind: 'chat', active: true },
+        ],
+      },
+    });
+
+    expect(state.activeConversationByMind[mindId]).toBe('session-1');
+    expect(state.conversationViewByMind[mindId]).toMatchObject({
+      status: 'idle',
+      sessionId: 'session-1',
+    });
+  });
+
+  it('CONVERSATION_HYDRATING records the selected session before messages arrive', () => {
+    const state = appReducer(withActiveMind, {
+      type: 'CONVERSATION_HYDRATING',
+      payload: { mindId, sessionId: 'session-1' },
+    });
+
+    expect(state.activeConversationByMind[mindId]).toBe('session-1');
+    expect(state.conversationViewByMind[mindId]).toMatchObject({
+      status: 'hydrating',
+      sessionId: 'session-1',
+      pendingSessionId: 'session-1',
+    });
+  });
+
+  it('RESUME_CONVERSATION applies the matching hydration result atomically', () => {
+    const messages = [makeMessage([makeTextBlock('restored')], { id: 'msg-1' })];
+    const hydrating = appReducer(withActiveMind, {
+      type: 'CONVERSATION_HYDRATING',
+      payload: { mindId, sessionId: 'session-1' },
+    });
+    const state = appReducer(hydrating, {
+      type: 'RESUME_CONVERSATION',
+      payload: {
+        mindId,
+        sessionId: 'session-1',
+        messages,
+        conversations: [
+          { sessionId: 'session-1', title: 'Last chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', kind: 'chat', active: true },
+        ],
+      },
+    });
+
+    expect(state.messagesByMind[mindId]).toEqual(messages);
+    expect(state.activeConversationByMind[mindId]).toBe('session-1');
+    expect(state.conversationViewByMind[mindId]).toMatchObject({
+      status: 'ready',
+      sessionId: 'session-1',
+      pendingSessionId: undefined,
+      streaming: false,
+    });
+  });
+
+  it('RESUME_CONVERSATION ignores stale hydration results for another session', () => {
+    const hydrating = appReducer({
+      ...withActiveMind,
+      messagesByMind: { [mindId]: [makeMessage([makeTextBlock('current')], { id: 'current' })] },
+    }, {
+      type: 'CONVERSATION_HYDRATING',
+      payload: { mindId, sessionId: 'session-2' },
+    });
+    const state = appReducer(hydrating, {
+      type: 'RESUME_CONVERSATION',
+      payload: {
+        mindId,
+        sessionId: 'session-1',
+        messages: [makeMessage([makeTextBlock('stale')], { id: 'stale' })],
+        conversations: [
+          { sessionId: 'session-1', title: 'Old chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', kind: 'chat', active: false },
+          { sessionId: 'session-2', title: 'New chat', createdAt: '2026-01-02T00:00:00.000Z', updatedAt: '2026-01-02T00:00:00.000Z', kind: 'chat', active: true },
+        ],
+      },
+    });
+
+    expect(state.messagesByMind[mindId]).toHaveLength(1);
+    expect(state.messagesByMind[mindId]?.[0].id).toBe('current');
+    expect(state.conversationViewByMind[mindId]).toMatchObject({
+      status: 'hydrating',
+      pendingSessionId: 'session-2',
+    });
+  });
+
   it('SET_MINDS updates minds array', () => {
     const minds = [{ mindId: 'a', mindPath: '/a', identity: { name: 'A', systemMessage: '' }, status: 'ready' as const }];
     const state = appReducer(initialState, { type: 'SET_MINDS', payload: minds });

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -443,6 +443,27 @@ describe('appReducer', () => {
     expect(state.isStreaming).toBe(false);
   });
 
+  it('NEW_CONVERSATION can reset a specific mind without clearing the active mind', () => {
+    const prev = {
+      ...withActiveMind,
+      activeMindId: 'other-mind',
+      messagesByMind: {
+        [mindId]: [makeMessage([makeTextBlock('target')])],
+        'other-mind': [makeMessage([makeTextBlock('active')])],
+      },
+      streamingByMind: { [mindId]: true, 'other-mind': true },
+      isStreaming: true,
+    };
+
+    const state = appReducer(prev, { type: 'NEW_CONVERSATION', payload: { mindId } });
+
+    expect(state.messagesByMind[mindId]).toEqual([]);
+    expect(state.messagesByMind['other-mind']).toEqual(prev.messagesByMind['other-mind']);
+    expect(state.streamingByMind[mindId]).toBe(false);
+    expect(state.streamingByMind['other-mind']).toBe(true);
+    expect(state.isStreaming).toBe(true);
+  });
+
   it('unknown action returns state unchanged', () => {
     const state = appReducer(initialState, { type: 'BOGUS' } as unknown as AppAction);
     expect(state).toBe(initialState);

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -2,7 +2,7 @@ import type { ChatMessage, ChatEvent, ContentBlock } from '@chamber/shared/types
 import type { Task, TaskState } from '@chamber/shared/a2a-types';
 import type { ChatroomMessage, TaskLedgerItem } from '@chamber/shared/chatroom-types';
 import { isOrchestrationEvent } from '@chamber/shared/chatroom-types';
-import type { AppState, AppAction } from './state';
+import type { AppState, AppAction, ConversationViewState } from './state';
 
 /** Extract plain text from content blocks (for search, accessibility, etc.) */
 export function getPlainContent(message: ChatMessage): string {
@@ -29,7 +29,30 @@ function selectedModelForActiveMind(state: AppState, activeMindId: string | null
   if (selectedModel && (state.availableModels.length === 0 || state.availableModels.some((model) => model.id === selectedModel))) {
     return selectedModel;
   }
+
   return state.availableModels[0]?.id ?? null;
+}
+
+function defaultConversationView(): ConversationViewState {
+  return { status: 'idle', streaming: false, modelSwitching: false };
+}
+
+function conversationViewFor(state: AppState, mindId: string): ConversationViewState {
+  return state.conversationViewByMind[mindId] ?? defaultConversationView();
+}
+
+function setConversationView(
+  state: AppState,
+  mindId: string,
+  patch: Partial<ConversationViewState>,
+): Record<string, ConversationViewState> {
+  return {
+    ...state.conversationViewByMind,
+    [mindId]: {
+      ...conversationViewFor(state, mindId),
+      ...patch,
+    },
+  };
 }
 
 export function handleChatEvent<T extends ChatMessage>(messages: T[], messageId: string, event: ChatEvent): T[] {
@@ -164,12 +187,30 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     }
 
     case 'ADD_ASSISTANT_MESSAGE':
+      if (!state.activeMindId) {
+        return {
+          ...state,
+          isStreaming: true,
+          messagesByMind: setActiveMsgs([...activeMsgs(), {
+            id: action.payload.id,
+            role: 'assistant',
+            blocks: [],
+            timestamp: action.payload.timestamp,
+            isStreaming: true,
+          }]),
+        };
+      }
       return {
         ...state,
         isStreaming: true,
-        streamingByMind: state.activeMindId
-          ? { ...state.streamingByMind, [state.activeMindId]: true }
-          : state.streamingByMind,
+        streamingByMind: { ...state.streamingByMind, [state.activeMindId]: true },
+        conversationViewByMind: setConversationView(state, state.activeMindId, {
+          status: 'ready',
+          sessionId: state.activeConversationByMind[state.activeMindId] ?? conversationViewFor(state, state.activeMindId).sessionId,
+          pendingSessionId: undefined,
+          streaming: true,
+          error: undefined,
+        }),
         messagesByMind: setActiveMsgs([...activeMsgs(), {
           id: action.payload.id,
           role: 'assistant',
@@ -192,22 +233,38 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         messagesByMind: { ...state.messagesByMind, [mindId]: newMessages },
         isStreaming: isDone ? false : state.isStreaming,
         streamingByMind: newStreamingByMind,
+        conversationViewByMind: isDone
+          ? setConversationView(state, mindId, {
+            status: 'ready',
+            sessionId: state.activeConversationByMind[mindId] ?? conversationViewFor(state, mindId).sessionId,
+            pendingSessionId: undefined,
+            streaming: false,
+          })
+          : state.conversationViewByMind,
       };
     }
 
     case 'HYDRATE_CHAT_STATE': {
+      const nextConversationViewByMind = action.payload.conversationViewByMind ?? state.conversationViewByMind;
       const isActiveMindStreaming = state.activeMindId
-        ? Boolean(action.payload.streamingByMind[state.activeMindId])
+        ? Boolean(action.payload.streamingByMind[state.activeMindId] || nextConversationViewByMind[state.activeMindId]?.streaming)
         : Object.values(action.payload.streamingByMind).some(Boolean);
       return {
         ...state,
         messagesByMind: action.payload.messagesByMind,
         streamingByMind: action.payload.streamingByMind,
+        conversationViewByMind: nextConversationViewByMind,
         isStreaming: isActiveMindStreaming,
       };
     }
 
-    case 'SET_CONVERSATION_HISTORY':
+    case 'SET_CONVERSATION_HISTORY': {
+      const activeSessionId = action.payload.conversations.find((conversation) => conversation.active)?.sessionId;
+      const currentView = conversationViewFor(state, action.payload.mindId);
+      const hasLocalMessages = (state.messagesByMind[action.payload.mindId]?.length ?? 0) > 0;
+      const shouldBindLocalReadyView = currentView.status === 'ready' && currentView.sessionId === undefined && hasLocalMessages;
+      const shouldPreserveView = (currentView.status === 'ready' && currentView.sessionId === activeSessionId)
+        || (currentView.status === 'hydrating' && currentView.pendingSessionId === activeSessionId);
       return {
         ...state,
         conversationHistoryByMind: {
@@ -216,11 +273,65 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         },
         activeConversationByMind: {
           ...state.activeConversationByMind,
-          [action.payload.mindId]: action.payload.conversations.find((conversation) => conversation.active)?.sessionId,
+          [action.payload.mindId]: activeSessionId,
         },
+        conversationViewByMind: !activeSessionId
+          ? setConversationView(state, action.payload.mindId, {
+            status: 'idle',
+            sessionId: undefined,
+            pendingSessionId: undefined,
+            error: undefined,
+          })
+          : shouldBindLocalReadyView
+            ? setConversationView(state, action.payload.mindId, {
+              status: 'ready',
+              sessionId: activeSessionId,
+              pendingSessionId: undefined,
+              error: undefined,
+            })
+          : !shouldPreserveView
+            ? setConversationView(state, action.payload.mindId, {
+            status: 'idle',
+            sessionId: activeSessionId,
+            pendingSessionId: undefined,
+            error: undefined,
+            })
+            : state.conversationViewByMind,
+      };
+    }
+
+    case 'CONVERSATION_HYDRATING':
+      return {
+        ...state,
+        activeConversationByMind: {
+          ...state.activeConversationByMind,
+          [action.payload.mindId]: action.payload.sessionId,
+        },
+        conversationViewByMind: setConversationView(state, action.payload.mindId, {
+          status: 'hydrating',
+          sessionId: action.payload.sessionId,
+          pendingSessionId: action.payload.sessionId,
+          error: undefined,
+        }),
       };
 
-    case 'RESUME_CONVERSATION':
+    case 'CONVERSATION_HYDRATE_FAILED': {
+      const currentView = conversationViewFor(state, action.payload.mindId);
+      if (currentView.pendingSessionId && currentView.pendingSessionId !== action.payload.sessionId) return state;
+      return {
+        ...state,
+        conversationViewByMind: setConversationView(state, action.payload.mindId, {
+          status: 'idle',
+          sessionId: action.payload.sessionId,
+          pendingSessionId: undefined,
+          error: action.payload.error,
+        }),
+      };
+    }
+
+    case 'RESUME_CONVERSATION': {
+      const currentView = conversationViewFor(state, action.payload.mindId);
+      if (currentView.pendingSessionId && currentView.pendingSessionId !== action.payload.sessionId) return state;
       return {
         ...state,
         messagesByMind: {
@@ -239,8 +350,16 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           ...state.streamingByMind,
           [action.payload.mindId]: false,
         },
+        conversationViewByMind: setConversationView(state, action.payload.mindId, {
+          status: 'ready',
+          sessionId: action.payload.sessionId,
+          pendingSessionId: undefined,
+          streaming: false,
+          error: undefined,
+        }),
         isStreaming: state.activeMindId === action.payload.mindId ? false : state.isStreaming,
       };
+    }
 
     case 'SET_MINDS':
       return {
@@ -254,7 +373,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         ...state,
         activeMindId: action.payload,
         selectedModel: selectedModelForActiveMind(state, action.payload),
-        isStreaming: action.payload ? Boolean(state.streamingByMind[action.payload]) : false,
+        isStreaming: action.payload ? Boolean(state.streamingByMind[action.payload] || state.conversationViewByMind[action.payload]?.streaming) : false,
         streamingByMind: state.streamingByMind,
       };
 
@@ -273,9 +392,11 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       const newMsgsByMind = { ...state.messagesByMind };
       const newConversationHistoryByMind = { ...state.conversationHistoryByMind };
       const newActiveConversationByMind = { ...state.activeConversationByMind };
+      const newConversationViewByMind = { ...state.conversationViewByMind };
       delete newMsgsByMind[action.payload];
       delete newConversationHistoryByMind[action.payload];
       delete newActiveConversationByMind[action.payload];
+      delete newConversationViewByMind[action.payload];
       const newActive = state.activeMindId === action.payload
         ? (newMinds.length > 0 ? newMinds[0].mindId : null)
         : state.activeMindId;
@@ -286,6 +407,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         messagesByMind: newMsgsByMind,
         conversationHistoryByMind: newConversationHistoryByMind,
         activeConversationByMind: newActiveConversationByMind,
+        conversationViewByMind: newConversationViewByMind,
         showLanding: newMinds.length === 0,
       };
     }
@@ -313,6 +435,14 @@ export function appReducer(state: AppState, action: AppAction): AppState {
             ? { ...mind, selectedModel: action.payload ?? undefined }
             : mind)
           : state.minds,
+      };
+
+    case 'SET_MODEL_SWITCHING':
+      return {
+        ...state,
+        conversationViewByMind: setConversationView(state, action.payload.mindId, {
+          modelSwitching: action.payload.switching,
+        }),
       };
 
     case 'SET_ACTIVE_VIEW':
@@ -371,6 +501,14 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         streamingByMind: conversationMindId
           ? { ...state.streamingByMind, [conversationMindId]: false }
           : state.streamingByMind,
+        conversationViewByMind: conversationMindId
+          ? setConversationView(state, conversationMindId, {
+            status: 'idle',
+            sessionId: undefined,
+            pendingSessionId: undefined,
+            streaming: false,
+          })
+          : state.conversationViewByMind,
         chatroomMessages: [],
         chatroomStreamingByMind: {},
         chatroomActiveSpeaker: null,

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -360,15 +360,16 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           : state.messagesByMind,
       };
 
-    case 'NEW_CONVERSATION':
+    case 'NEW_CONVERSATION': {
+      const conversationMindId = action.payload?.mindId ?? state.activeMindId;
       return {
         ...state,
-        messagesByMind: state.activeMindId
-          ? { ...state.messagesByMind, [state.activeMindId]: [] }
+        messagesByMind: conversationMindId
+          ? { ...state.messagesByMind, [conversationMindId]: [] }
           : state.messagesByMind,
-        isStreaming: false,
-        streamingByMind: state.activeMindId
-          ? { ...state.streamingByMind, [state.activeMindId]: false }
+        isStreaming: conversationMindId === state.activeMindId ? false : state.isStreaming,
+        streamingByMind: conversationMindId
+          ? { ...state.streamingByMind, [conversationMindId]: false }
           : state.streamingByMind,
         chatroomMessages: [],
         chatroomStreamingByMind: {},
@@ -376,6 +377,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         chatroomTaskLedger: [],
         chatroomMetrics: null,
       };
+    }
 
     case 'A2A_INCOMING': {
       const { targetMindId, message, replyMessageId } = action.payload;

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -57,7 +57,7 @@ export type AppAction =
   | { type: 'LOGGED_OUT' }
   | { type: 'MINDS_CHECKED' }
   | { type: 'CLEAR_MESSAGES' }
-  | { type: 'NEW_CONVERSATION' }
+  | { type: 'NEW_CONVERSATION'; payload?: { mindId: string } }
   | { type: 'A2A_INCOMING'; payload: { targetMindId: string; message: Message; replyMessageId: string } }
   | { type: 'TASK_STATUS_UPDATE'; payload: TaskStatusUpdateEvent & { targetMindId: string } }
   | { type: 'TASK_ARTIFACT_UPDATE'; payload: TaskArtifactUpdateEvent & { targetMindId: string } }

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -4,6 +4,19 @@ import type { ChatroomMessage, ChatroomStreamEvent, OrchestrationMode, GroupChat
 
 export type LensView = 'chat' | string;
 
+// Per-mind conversation view state machine:
+// idle -> hydrating -> ready. Streaming and model switching are orthogonal
+// flags scoped to the same mind/session so history selection and chat content
+// cannot drift apart.
+export interface ConversationViewState {
+  status: 'idle' | 'hydrating' | 'ready';
+  sessionId?: string;
+  pendingSessionId?: string;
+  streaming: boolean;
+  modelSwitching: boolean;
+  error?: string;
+}
+
 export interface AppState {
   minds: MindContext[];
   activeMindId: string | null;
@@ -12,6 +25,7 @@ export interface AppState {
   messagesByMind: Record<string, ChatMessage[]>;
   conversationHistoryByMind: Record<string, ConversationSummary[]>;
   activeConversationByMind: Record<string, string | undefined>;
+  conversationViewByMind: Record<string, ConversationViewState>;
   isStreaming: boolean;
   streamingByMind: Record<string, boolean>;
   availableModels: ModelInfo[];
@@ -39,9 +53,12 @@ export type AppAction =
   | { type: 'ADD_USER_MESSAGE'; payload: { id: string; content: string; timestamp: number; images?: ImageBlock[] } }
   | { type: 'ADD_ASSISTANT_MESSAGE'; payload: { id: string; timestamp: number } }
   | { type: 'CHAT_EVENT'; payload: { mindId: string; messageId: string; event: ChatEvent } }
-  | { type: 'HYDRATE_CHAT_STATE'; payload: { messagesByMind: Record<string, ChatMessage[]>; streamingByMind: Record<string, boolean> } }
+  | { type: 'HYDRATE_CHAT_STATE'; payload: { messagesByMind: Record<string, ChatMessage[]>; streamingByMind: Record<string, boolean>; conversationViewByMind?: Record<string, ConversationViewState> } }
   | { type: 'SET_CONVERSATION_HISTORY'; payload: { mindId: string; conversations: ConversationSummary[] } }
+  | { type: 'CONVERSATION_HYDRATING'; payload: { mindId: string; sessionId: string } }
+  | { type: 'CONVERSATION_HYDRATE_FAILED'; payload: { mindId: string; sessionId: string; error: string } }
   | { type: 'RESUME_CONVERSATION'; payload: { mindId: string; sessionId: string; messages: ChatMessage[]; conversations: ConversationSummary[] } }
+  | { type: 'SET_MODEL_SWITCHING'; payload: { mindId: string; switching: boolean } }
   | { type: 'SET_MINDS'; payload: MindContext[] }
   | { type: 'SET_ACTIVE_MIND'; payload: string | null }
   | { type: 'ADD_MIND'; payload: MindContext }
@@ -81,6 +98,7 @@ export const initialState: AppState = {
   messagesByMind: {},
   conversationHistoryByMind: {},
   activeConversationByMind: {},
+  conversationViewByMind: {},
   isStreaming: false,
   streamingByMind: {},
   availableModels: [],

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -120,6 +120,7 @@ export function mockElectronAPI(): ElectronAPI {
       list: vi.fn().mockResolvedValue([]),
       resume: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
       rename: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
     },
     mind: {
       add: vi.fn().mockResolvedValue({ mindId: 'test-1234', mindPath: 'C:\\test', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }),

--- a/chamber-copilot-runtime/package-lock.json
+++ b/chamber-copilot-runtime/package-lock.json
@@ -8,31 +8,31 @@
       "name": "chamber-copilot-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "1.0.42-0",
+        "@github/copilot": "1.0.44-0",
         "@github/copilot-sdk": "0.3.0"
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.42-0.tgz",
-      "integrity": "sha512-QF0mnYc4PeWCtaV5WSUrlVXt+2mzqyvo694B+1Wc2FdCtmoPsimbUEQFxGsf/bNXZ6ykZnXH3wnX58gUlkwNLQ==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.44-0.tgz",
+      "integrity": "sha512-bP87j/f0VDwWvNZhvhgvdi3B29haw1LhIBxNIXadruNcqPDl1q0ckfNds5LY4mg0cnoSrbGCzGSvLE1kIETC4Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.42-0",
-        "@github/copilot-darwin-x64": "1.0.42-0",
-        "@github/copilot-linux-arm64": "1.0.42-0",
-        "@github/copilot-linux-x64": "1.0.42-0",
-        "@github/copilot-win32-arm64": "1.0.42-0",
-        "@github/copilot-win32-x64": "1.0.42-0"
+        "@github/copilot-darwin-arm64": "1.0.44-0",
+        "@github/copilot-darwin-x64": "1.0.44-0",
+        "@github/copilot-linux-arm64": "1.0.44-0",
+        "@github/copilot-linux-x64": "1.0.44-0",
+        "@github/copilot-win32-arm64": "1.0.44-0",
+        "@github/copilot-win32-x64": "1.0.44-0"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.42-0.tgz",
-      "integrity": "sha512-8t9oE0kCmMhKopRXHaOFZqx8IqG74XWggrB276z1ANBkxswH31kqq9+KYekfBZKLQemUC8shsu+PTmaQ9PPawA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.44-0.tgz",
+      "integrity": "sha512-L1MoiZ4WFgUPWYrTn/2NxUIQzLwzuVq9AnFaluhk0DbF15DnamjFggSPT7rAPJ8UnUqFF9b0yz0Oz8v2lqhz0g==",
       "cpu": [
         "arm64"
       ],
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.42-0.tgz",
-      "integrity": "sha512-xKuku6fy0342cT2RY/rDTeOXD9rF6I43NxH0CZOglVNxneXOBbZRq162j19jtMnpopq37FciGw+Kn75zVxJFhA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.44-0.tgz",
+      "integrity": "sha512-Lnp0RYDd7xtExPX6QqfZXZf43ToGWsiD1f/7CfBdKygy9GnRqA4nYxikFbhke5jkX20J/kEC1tcLxK/ofZhMnQ==",
       "cpu": [
         "x64"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.42-0.tgz",
-      "integrity": "sha512-+zvGqBHArDLreRKE6CGlkAPdqw2xGx50D0MBRIMLXoGCAB+s7o3iuuWvpK6Wh4b8WQMxyjXGnnhYhdtaLbcyvg==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.44-0.tgz",
+      "integrity": "sha512-Mtis39mIObq1nA1RWn2b7beTmbRHOpFsX4g4gQx53oD4ZDqHBvzg9WdxNqdlbd7TphLykNlo7H2wi29BKbcQFg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.42-0.tgz",
-      "integrity": "sha512-tyiiblErhUsL64xzn9b8m9/SAMRWwP+/1EcdA3kx/w9B2OuNVL8ixMVaGgCshI451tFQu2zQPoeEgOCDzHyXww==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.44-0.tgz",
+      "integrity": "sha512-1YNZSoAMTGK1vU9RYl84KSWJJHPvw0wfY7EJMQb9SZlQQJ+iehb8T1zIPI6W8nOwb1WcPtkj8V8qi9HZBkHIxg==",
       "cpu": [
         "x64"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.42-0.tgz",
-      "integrity": "sha512-kEPlbqkZhZ0/jE4vpFH0hkl74cHcVAwZVEBjLLqVy0q/uQ4nyfIR2LUImE3nEjBn82mpUkCkyqetV2DN+NQ9lA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.44-0.tgz",
+      "integrity": "sha512-rq+AyhQsgpuaGjs5vgIFg4hFbPeIyaSUfSxhSHwBJRuUpqnW5VyJn2VfjDMXfM+VqGuNkJ12D1mAmFX5HC5sDg==",
       "cpu": [
         "arm64"
       ],
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.42-0.tgz",
-      "integrity": "sha512-kGsjdpFALvsTuwCJh8ZQGNl14CNEhNQo+/vwh2nFDfeQb0dEYT9Ni9pbOPx9xhOThpxS1cle0KCI6Mn53h5yQA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.44-0.tgz",
+      "integrity": "sha512-VAZh4WJTAK+ll+2fpMlfDR2unUeYtZhSo3O5JJGKNCs1TJwE7ckyo3oGY/yliczl+nL4khCKDohh87fBtsv1eA==",
       "cpu": [
         "x64"
       ],

--- a/chamber-copilot-runtime/package.json
+++ b/chamber-copilot-runtime/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Pinned packaged runtime for Chamber Copilot SDK + CLI",
   "dependencies": {
-    "@github/copilot": "1.0.42-0",
+    "@github/copilot": "1.0.44-0",
     "@github/copilot-sdk": "0.3.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.43.5",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.43.5",
+      "version": "0.44.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -46,7 +46,7 @@
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
-        "@github/copilot": "1.0.42-0",
+        "@github/copilot": "1.0.44-0",
         "@github/copilot-sdk": "0.3.0",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1511,27 +1511,27 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.42-0.tgz",
-      "integrity": "sha512-QF0mnYc4PeWCtaV5WSUrlVXt+2mzqyvo694B+1Wc2FdCtmoPsimbUEQFxGsf/bNXZ6ykZnXH3wnX58gUlkwNLQ==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.44-0.tgz",
+      "integrity": "sha512-bP87j/f0VDwWvNZhvhgvdi3B29haw1LhIBxNIXadruNcqPDl1q0ckfNds5LY4mg0cnoSrbGCzGSvLE1kIETC4Q==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.42-0",
-        "@github/copilot-darwin-x64": "1.0.42-0",
-        "@github/copilot-linux-arm64": "1.0.42-0",
-        "@github/copilot-linux-x64": "1.0.42-0",
-        "@github/copilot-win32-arm64": "1.0.42-0",
-        "@github/copilot-win32-x64": "1.0.42-0"
+        "@github/copilot-darwin-arm64": "1.0.44-0",
+        "@github/copilot-darwin-x64": "1.0.44-0",
+        "@github/copilot-linux-arm64": "1.0.44-0",
+        "@github/copilot-linux-x64": "1.0.44-0",
+        "@github/copilot-win32-arm64": "1.0.44-0",
+        "@github/copilot-win32-x64": "1.0.44-0"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.42-0.tgz",
-      "integrity": "sha512-8t9oE0kCmMhKopRXHaOFZqx8IqG74XWggrB276z1ANBkxswH31kqq9+KYekfBZKLQemUC8shsu+PTmaQ9PPawA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.44-0.tgz",
+      "integrity": "sha512-L1MoiZ4WFgUPWYrTn/2NxUIQzLwzuVq9AnFaluhk0DbF15DnamjFggSPT7rAPJ8UnUqFF9b0yz0Oz8v2lqhz0g==",
       "cpu": [
         "arm64"
       ],
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.42-0.tgz",
-      "integrity": "sha512-xKuku6fy0342cT2RY/rDTeOXD9rF6I43NxH0CZOglVNxneXOBbZRq162j19jtMnpopq37FciGw+Kn75zVxJFhA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.44-0.tgz",
+      "integrity": "sha512-Lnp0RYDd7xtExPX6QqfZXZf43ToGWsiD1f/7CfBdKygy9GnRqA4nYxikFbhke5jkX20J/kEC1tcLxK/ofZhMnQ==",
       "cpu": [
         "x64"
       ],
@@ -1563,9 +1563,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.42-0.tgz",
-      "integrity": "sha512-+zvGqBHArDLreRKE6CGlkAPdqw2xGx50D0MBRIMLXoGCAB+s7o3iuuWvpK6Wh4b8WQMxyjXGnnhYhdtaLbcyvg==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.44-0.tgz",
+      "integrity": "sha512-Mtis39mIObq1nA1RWn2b7beTmbRHOpFsX4g4gQx53oD4ZDqHBvzg9WdxNqdlbd7TphLykNlo7H2wi29BKbcQFg==",
       "cpu": [
         "arm64"
       ],
@@ -1580,9 +1580,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.42-0.tgz",
-      "integrity": "sha512-tyiiblErhUsL64xzn9b8m9/SAMRWwP+/1EcdA3kx/w9B2OuNVL8ixMVaGgCshI451tFQu2zQPoeEgOCDzHyXww==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.44-0.tgz",
+      "integrity": "sha512-1YNZSoAMTGK1vU9RYl84KSWJJHPvw0wfY7EJMQb9SZlQQJ+iehb8T1zIPI6W8nOwb1WcPtkj8V8qi9HZBkHIxg==",
       "cpu": [
         "x64"
       ],
@@ -1732,9 +1732,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.42-0.tgz",
-      "integrity": "sha512-kEPlbqkZhZ0/jE4vpFH0hkl74cHcVAwZVEBjLLqVy0q/uQ4nyfIR2LUImE3nEjBn82mpUkCkyqetV2DN+NQ9lA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.44-0.tgz",
+      "integrity": "sha512-rq+AyhQsgpuaGjs5vgIFg4hFbPeIyaSUfSxhSHwBJRuUpqnW5VyJn2VfjDMXfM+VqGuNkJ12D1mAmFX5HC5sDg==",
       "cpu": [
         "arm64"
       ],
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.42-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.42-0.tgz",
-      "integrity": "sha512-kGsjdpFALvsTuwCJh8ZQGNl14CNEhNQo+/vwh2nFDfeQb0dEYT9Ni9pbOPx9xhOThpxS1cle0KCI6Mn53h5yQA==",
+      "version": "1.0.44-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.44-0.tgz",
+      "integrity": "sha512-VAZh4WJTAK+ll+2fpMlfDR2unUeYtZhSo3O5JJGKNCs1TJwE7ckyo3oGY/yliczl+nL4khCKDohh87fBtsv1eA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.43.5",
+  "version": "0.44.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,
@@ -49,7 +49,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "@github/copilot": "1.0.42-0",
+    "@github/copilot": "1.0.44-0",
     "@github/copilot-sdk": "0.3.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -27,6 +27,7 @@ const mockMindManager = {
     return undefined;
   }),
   recreateSession: vi.fn(),
+  recoverActiveConversationSession: vi.fn(),
   startNewConversation: vi.fn(),
   markActiveConversationHasMessages: vi.fn(),
   listConversationHistory: vi.fn(() => []),
@@ -181,7 +182,7 @@ describe('ChatService', () => {
       mockSession.send.mockRejectedValueOnce(new Error('Session not found: abc-123'));
       mockSession.on.mockReturnValue(vi.fn());
 
-      // Fresh session returned by recreateSession
+      // Fresh session returned by stale-session recovery
       const freshSession = {
         send: vi.fn().mockResolvedValue(undefined),
         abort: vi.fn().mockResolvedValue(undefined),
@@ -191,13 +192,13 @@ describe('ChatService', () => {
           return vi.fn();
         }),
       };
-      mockMindManager.recreateSession.mockResolvedValueOnce(freshSession);
+      mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(freshSession);
 
       const emit = vi.fn();
       await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
 
       expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
-      expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
+      expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledWith('valid-mind');
       expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledTimes(1);
       expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledWith('valid-mind', 'hello');
       expect(freshSession.send).toHaveBeenCalledWith({
@@ -216,7 +217,7 @@ describe('ChatService', () => {
         destroy: vi.fn().mockResolvedValue(undefined),
         on: vi.fn(() => vi.fn()),
       };
-      mockMindManager.recreateSession.mockResolvedValueOnce(freshSession);
+      mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(freshSession);
 
       const emit = vi.fn();
       await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
@@ -225,8 +226,8 @@ describe('ChatService', () => {
       expect(emit).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'error' }),
       );
-      // recreateSession called only once — no second retry
-      expect(mockMindManager.recreateSession).toHaveBeenCalledTimes(1);
+      // recovery called only once — no second retry
+      expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledTimes(1);
     });
 
     it('does not retry on non-stale errors', async () => {
@@ -236,7 +237,7 @@ describe('ChatService', () => {
       const emit = vi.fn();
       await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
 
-      expect(mockMindManager.recreateSession).not.toHaveBeenCalled();
+      expect(mockMindManager.recoverActiveConversationSession).not.toHaveBeenCalled();
       expect(emit).not.toHaveBeenCalledWith({ type: 'reconnecting' });
       expect(emit).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'error', message: 'Network error' }),
@@ -294,7 +295,7 @@ describe('ChatService', () => {
             return vi.fn();
           }),
         };
-        mockMindManager.recreateSession.mockResolvedValueOnce(freshSession);
+        mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(freshSession);
 
         const emit = vi.fn();
         const promise = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
@@ -304,7 +305,7 @@ describe('ChatService', () => {
         await promise;
 
         expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
-        expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
+        expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledWith('valid-mind');
         expect(freshSession.send).toHaveBeenCalledWith({
           prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
         });

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -27,6 +27,8 @@ const mockMindManager = {
     return undefined;
   }),
   recreateSession: vi.fn(),
+  startNewConversation: vi.fn(),
+  markActiveConversationHasMessages: vi.fn(),
   listConversationHistory: vi.fn(() => []),
   resumeConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
   renameConversation: vi.fn(() => []),
@@ -64,6 +66,7 @@ describe('ChatService', () => {
       expect(mockSession.send).toHaveBeenCalledWith({
         prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
       });
+      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledWith('valid-mind', 'hello');
       expect(emit).toHaveBeenCalledWith({ type: 'done' });
     });
 
@@ -130,9 +133,9 @@ describe('ChatService', () => {
   });
 
   describe('newConversation', () => {
-    it('delegates to mindManager.recreateSession', async () => {
+    it('delegates to mindManager.startNewConversation', async () => {
       await svc.newConversation('valid-mind');
-      expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
+      expect(mockMindManager.startNewConversation).toHaveBeenCalledWith('valid-mind');
     });
 
     it('rejects conversation switches while a message is streaming', async () => {

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -28,11 +28,11 @@ const mockMindManager = {
   }),
   recreateSession: vi.fn(),
   recoverActiveConversationSession: vi.fn(),
-  replaceActiveConversationRuntimeSession: vi.fn(),
   startNewConversation: vi.fn(),
   markActiveConversationHasMessages: vi.fn(),
   listConversationHistory: vi.fn(() => []),
   resumeConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
+  deleteConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
   renameConversation: vi.fn(() => []),
   setMindModel: vi.fn(async () => null),
 };
@@ -156,6 +156,30 @@ describe('ChatService', () => {
     });
   });
 
+  describe('deleteConversation', () => {
+    it('delegates to mindManager.deleteConversation', async () => {
+      const result = await svc.deleteConversation('valid-mind', 'session-1');
+
+      expect(mockMindManager.deleteConversation).toHaveBeenCalledWith('valid-mind', 'session-1');
+      expect(result).toEqual({ sessionId: 'session-1', messages: [], conversations: [] });
+    });
+
+    it('rejects deletes while a message is streaming', async () => {
+      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+        void eventOrCb;
+        void cb;
+        return vi.fn();
+      });
+      const send = svc.sendMessage('valid-mind', 'hello', 'msg-1', vi.fn());
+      await Promise.resolve();
+
+      await expect(svc.deleteConversation('valid-mind', 'session-1')).rejects.toThrow('Cannot switch conversations');
+
+      await svc.cancelMessage('valid-mind', 'msg-1');
+      await send;
+    });
+  });
+
   describe('listModels', () => {
     it('returns models from the minds client', async () => {
       const models = await svc.listModels('valid-mind');
@@ -208,7 +232,7 @@ describe('ChatService', () => {
       expect(emit).toHaveBeenCalledWith({ type: 'done' });
     });
 
-    it('does not loop — surfaces error when retry also fails with stale error', async () => {
+    it('does not loop — surfaces error when reattach also fails with stale error', async () => {
       mockSession.send.mockRejectedValueOnce(new Error('Session not found: abc-123'));
       mockSession.on.mockReturnValue(vi.fn());
 
@@ -219,13 +243,6 @@ describe('ChatService', () => {
         on: vi.fn(() => vi.fn()),
       };
       mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(freshSession);
-      const replacementSession = {
-        send: vi.fn().mockRejectedValueOnce(new Error('Session not found: ghi-789')),
-        abort: vi.fn().mockResolvedValue(undefined),
-        destroy: vi.fn().mockResolvedValue(undefined),
-        on: vi.fn(() => vi.fn()),
-      };
-      mockMindManager.replaceActiveConversationRuntimeSession.mockResolvedValueOnce(replacementSession);
 
       const emit = vi.fn();
       await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
@@ -234,45 +251,9 @@ describe('ChatService', () => {
       expect(emit).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'error' }),
       );
-      // Each recovery strategy is attempted once — no unbounded retry loop.
+      // Recovery is attempted exactly once; we surface the error rather than chain endless retries.
       expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledTimes(1);
-      expect(mockMindManager.replaceActiveConversationRuntimeSession).toHaveBeenCalledTimes(1);
-      expect(replacementSession.send).toHaveBeenCalledTimes(1);
-    });
-
-    it('replaces the runtime session with the same conversation id when resume recovery still sends stale', async () => {
-      mockSession.send.mockRejectedValueOnce(new Error('Session not found: abc-123'));
-      mockSession.on.mockReturnValue(vi.fn());
-
-      const resumedSession = {
-        send: vi.fn().mockRejectedValueOnce(new Error('Session not found: def-456')),
-        abort: vi.fn().mockResolvedValue(undefined),
-        destroy: vi.fn().mockResolvedValue(undefined),
-        on: vi.fn(() => vi.fn()),
-      };
-      mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(resumedSession);
-      const replacementSession = {
-        send: vi.fn().mockResolvedValue(undefined),
-        abort: vi.fn().mockResolvedValue(undefined),
-        destroy: vi.fn().mockResolvedValue(undefined),
-        on: vi.fn((event: string, cb?: (...args: unknown[]) => void) => {
-          if (event === 'session.idle' && cb) setTimeout(() => cb(), 0);
-          return vi.fn();
-        }),
-      };
-      mockMindManager.replaceActiveConversationRuntimeSession.mockResolvedValueOnce(replacementSession);
-
-      const emit = vi.fn();
-      await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
-
-      expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
-      expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledWith('valid-mind');
-      expect(mockMindManager.replaceActiveConversationRuntimeSession).toHaveBeenCalledWith('valid-mind');
-      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledTimes(1);
-      expect(replacementSession.send).toHaveBeenCalledWith({
-        prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
-      });
-      expect(emit).toHaveBeenCalledWith({ type: 'done' });
+      expect(freshSession.send).toHaveBeenCalledTimes(1);
     });
 
     it('does not retry on non-stale errors', async () => {

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -28,6 +28,7 @@ const mockMindManager = {
   }),
   recreateSession: vi.fn(),
   recoverActiveConversationSession: vi.fn(),
+  replaceActiveConversationRuntimeSession: vi.fn(),
   startNewConversation: vi.fn(),
   markActiveConversationHasMessages: vi.fn(),
   listConversationHistory: vi.fn(() => []),
@@ -218,6 +219,13 @@ describe('ChatService', () => {
         on: vi.fn(() => vi.fn()),
       };
       mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(freshSession);
+      const replacementSession = {
+        send: vi.fn().mockRejectedValueOnce(new Error('Session not found: ghi-789')),
+        abort: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn(() => vi.fn()),
+      };
+      mockMindManager.replaceActiveConversationRuntimeSession.mockResolvedValueOnce(replacementSession);
 
       const emit = vi.fn();
       await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
@@ -226,8 +234,45 @@ describe('ChatService', () => {
       expect(emit).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'error' }),
       );
-      // recovery called only once — no second retry
+      // Each recovery strategy is attempted once — no unbounded retry loop.
       expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledTimes(1);
+      expect(mockMindManager.replaceActiveConversationRuntimeSession).toHaveBeenCalledTimes(1);
+      expect(replacementSession.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('replaces the runtime session with the same conversation id when resume recovery still sends stale', async () => {
+      mockSession.send.mockRejectedValueOnce(new Error('Session not found: abc-123'));
+      mockSession.on.mockReturnValue(vi.fn());
+
+      const resumedSession = {
+        send: vi.fn().mockRejectedValueOnce(new Error('Session not found: def-456')),
+        abort: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn(() => vi.fn()),
+      };
+      mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(resumedSession);
+      const replacementSession = {
+        send: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn((event: string, cb?: (...args: unknown[]) => void) => {
+          if (event === 'session.idle' && cb) setTimeout(() => cb(), 0);
+          return vi.fn();
+        }),
+      };
+      mockMindManager.replaceActiveConversationRuntimeSession.mockResolvedValueOnce(replacementSession);
+
+      const emit = vi.fn();
+      await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+      expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
+      expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledWith('valid-mind');
+      expect(mockMindManager.replaceActiveConversationRuntimeSession).toHaveBeenCalledWith('valid-mind');
+      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledTimes(1);
+      expect(replacementSession.send).toHaveBeenCalledWith({
+        prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
+      });
+      expect(emit).toHaveBeenCalledWith({ type: 'done' });
     });
 
     it('does not retry on non-stale errors', async () => {

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -198,6 +198,8 @@ describe('ChatService', () => {
 
       expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
       expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
+      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledTimes(2);
+      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenLastCalledWith('valid-mind', 'hello');
       expect(freshSession.send).toHaveBeenCalledWith({
         prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
       });

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -198,8 +198,8 @@ describe('ChatService', () => {
 
       expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
       expect(mockMindManager.recreateSession).toHaveBeenCalledWith('valid-mind');
-      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledTimes(2);
-      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenLastCalledWith('valid-mind', 'hello');
+      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledTimes(1);
+      expect(mockMindManager.markActiveConversationHasMessages).toHaveBeenCalledWith('valid-mind', 'hello');
       expect(freshSession.send).toHaveBeenCalledWith({
         prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
       });

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -63,8 +63,8 @@ export class ChatService {
 
           // Stale session — recreate and retry once
           emit({ type: 'reconnecting' });
-          const freshSession = await this.mindManager.recreateSession(mindId);
-          await this.streamTurn(freshSession, prompt, abortController, emit, attachments, () => {
+          const recoveredSession = await this.mindManager.recoverActiveConversationSession(mindId);
+          await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
             this.mindManager.markActiveConversationHasMessages(mindId, prompt);
           });
         }

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -54,6 +54,7 @@ export class ChatService {
           const session = model ? await this.mindManager.setMindModel(mindId, model) : null;
           const currentSession = session ? this.mindManager.getMind(mindId)?.session : context.session;
           if (!currentSession) throw new Error(`Mind ${mindId} not found or has no session`);
+          this.mindManager.markActiveConversationHasMessages(mindId, prompt);
           await this.streamTurn(currentSession, prompt, abortController, emit, attachments);
         } catch (err) {
           if (abortController.signal.aborted) return;
@@ -212,7 +213,7 @@ export class ChatService {
 
   async newConversation(mindId: string): Promise<ConversationResumeResult> {
     this.assertCanSwitchConversation(mindId);
-    await this.mindManager.recreateSession(mindId);
+    await this.mindManager.startNewConversation(mindId);
     return {
       sessionId: this.mindManager.getMind(mindId)?.activeSessionId ?? '',
       messages: [],

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -61,23 +61,13 @@ export class ChatService {
           if (abortController.signal.aborted) return;
           if (!isStaleSessionError(err)) throw err;
 
-          // Stale session — recreate and retry once
+          // SDK forgot the session — recover once by reattaching, then retry.
+          // If reattach also fails stale, surface the error so the user can start a new chat.
           emit({ type: 'reconnecting' });
           const recoveredSession = await this.mindManager.recoverActiveConversationSession(mindId);
-          try {
-            await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
-              this.mindManager.markActiveConversationHasMessages(mindId, prompt);
-            });
-          } catch (retryError) {
-            if (abortController.signal.aborted) return;
-            if (!isStaleSessionError(retryError)) throw retryError;
-
-            log.warn('Recovered session was still stale; replacing runtime session while preserving Chamber conversation id.');
-            const replacementSession = await this.mindManager.replaceActiveConversationRuntimeSession(mindId);
-            await this.streamTurn(replacementSession, prompt, abortController, emit, attachments, () => {
-              this.mindManager.markActiveConversationHasMessages(mindId, prompt);
-            });
-          }
+          await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
+            this.mindManager.markActiveConversationHasMessages(mindId, prompt);
+          });
         }
       } catch (err) {
         if (abortController.signal.aborted) return;
@@ -248,6 +238,11 @@ export class ChatService {
   async resumeConversation(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
     this.assertCanSwitchConversation(mindId);
     return this.mindManager.resumeConversation(mindId, sessionId);
+  }
+
+  async deleteConversation(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
+    this.assertCanSwitchConversation(mindId);
+    return this.mindManager.deleteConversation(mindId, sessionId);
   }
 
   renameConversation(mindId: string, sessionId: string, title: string): ConversationSummary[] {

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -54,8 +54,9 @@ export class ChatService {
           const session = model ? await this.mindManager.setMindModel(mindId, model) : null;
           const currentSession = session ? this.mindManager.getMind(mindId)?.session : context.session;
           if (!currentSession) throw new Error(`Mind ${mindId} not found or has no session`);
-          this.mindManager.markActiveConversationHasMessages(mindId, prompt);
-          await this.streamTurn(currentSession, prompt, abortController, emit, attachments);
+          await this.streamTurn(currentSession, prompt, abortController, emit, attachments, () => {
+            this.mindManager.markActiveConversationHasMessages(mindId, prompt);
+          });
         } catch (err) {
           if (abortController.signal.aborted) return;
           if (!isStaleSessionError(err)) throw err;
@@ -63,8 +64,9 @@ export class ChatService {
           // Stale session — recreate and retry once
           emit({ type: 'reconnecting' });
           const freshSession = await this.mindManager.recreateSession(mindId);
-          this.mindManager.markActiveConversationHasMessages(mindId, prompt);
-          await this.streamTurn(freshSession, prompt, abortController, emit, attachments);
+          await this.streamTurn(freshSession, prompt, abortController, emit, attachments, () => {
+            this.mindManager.markActiveConversationHasMessages(mindId, prompt);
+          });
         }
       } catch (err) {
         if (abortController.signal.aborted) return;
@@ -82,6 +84,7 @@ export class ChatService {
     abortController: AbortController,
     emit: (event: ChatEvent) => void,
     attachments?: ChatImageAttachment[],
+    onSendAccepted?: () => void,
   ): Promise<void>{
     const unsubs: (() => void)[] = [];
     const guard = (fn: () => void) => { if (!abortController.signal.aborted) fn(); };
@@ -185,6 +188,7 @@ export class ChatService {
         }));
         const promptWithDateTime = injectCurrentDateTimeContext(prompt, this.dateTimeContextProvider());
         await Promise.race([session.send(sdkAttachments ? { prompt: promptWithDateTime, attachments: sdkAttachments } : { prompt: promptWithDateTime }), sendTimeout]);
+        guard(() => onSendAccepted?.());
       } finally {
         if (sendTimerId) clearTimeout(sendTimerId);
       }
@@ -210,6 +214,10 @@ export class ChatService {
     if (context?.session) {
       await context.session.abort().catch(() => { /* noop */ });
     }
+  }
+
+  async setMindModel(mindId: string, model: string | null): Promise<Awaited<ReturnType<MindManager['setMindModel']>>> {
+    return this.turnQueue.enqueue(mindId, () => this.mindManager.setMindModel(mindId, model));
   }
 
   async newConversation(mindId: string): Promise<ConversationResumeResult> {

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -64,9 +64,20 @@ export class ChatService {
           // Stale session — recreate and retry once
           emit({ type: 'reconnecting' });
           const recoveredSession = await this.mindManager.recoverActiveConversationSession(mindId);
-          await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
-            this.mindManager.markActiveConversationHasMessages(mindId, prompt);
-          });
+          try {
+            await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
+              this.mindManager.markActiveConversationHasMessages(mindId, prompt);
+            });
+          } catch (retryError) {
+            if (abortController.signal.aborted) return;
+            if (!isStaleSessionError(retryError)) throw retryError;
+
+            log.warn('Recovered session was still stale; replacing runtime session while preserving Chamber conversation id.');
+            const replacementSession = await this.mindManager.replaceActiveConversationRuntimeSession(mindId);
+            await this.streamTurn(replacementSession, prompt, abortController, emit, attachments, () => {
+              this.mindManager.markActiveConversationHasMessages(mindId, prompt);
+            });
+          }
         }
       } catch (err) {
         if (abortController.signal.aborted) return;

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -63,6 +63,7 @@ export class ChatService {
           // Stale session — recreate and retry once
           emit({ type: 'reconnecting' });
           const freshSession = await this.mindManager.recreateSession(mindId);
+          this.mindManager.markActiveConversationHasMessages(mindId, prompt);
           await this.streamTurn(freshSession, prompt, abortController, emit, attachments);
         }
       } catch (err) {

--- a/packages/services/src/chat/currentDateTimeContext.test.ts
+++ b/packages/services/src/chat/currentDateTimeContext.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from './currentDateTimeContext';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext, stripInjectedCurrentDateTimeContext } from './currentDateTimeContext';
 
 describe('currentDateTimeContext', () => {
   it('formats the current datetime as ISO with the local timezone name', () => {
@@ -21,5 +21,15 @@ describe('currentDateTimeContext', () => {
       currentDateTime: '2026-05-05T15:37:12.065Z',
       timezone: 'America/New_York',
     })).toBe('<agent-message role="user">\n  <current_datetime>2026-05-05T15:37:12.065Z</current_datetime>\n  <timezone>America/New_York</timezone>\n  <content>hello</content>\n</agent-message>');
+  });
+
+  it('strips injected datetime context from persisted user prompts', () => {
+    const hydrated = '<current_datetime>\n2026-05-07T03:19:51.220Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nyou should add another comment to the gh issue 125';
+
+    expect(stripInjectedCurrentDateTimeContext(hydrated)).toBe('you should add another comment to the gh issue 125');
+  });
+
+  it('leaves ordinary prompts untouched when no injected datetime prefix exists', () => {
+    expect(stripInjectedCurrentDateTimeContext('hello Q')).toBe('hello Q');
   });
 });

--- a/packages/services/src/chat/currentDateTimeContext.ts
+++ b/packages/services/src/chat/currentDateTimeContext.ts
@@ -23,6 +23,13 @@ export function injectCurrentDateTimeContext(prompt: string, context: CurrentDat
   return `<current_datetime>\n${context.currentDateTime}\n</current_datetime>\n<timezone>\n${context.timezone}\n</timezone>\n\n${prompt}`;
 }
 
+export function stripInjectedCurrentDateTimeContext(prompt: string): string {
+  return prompt.replace(
+    /^<current_datetime>\r?\n[\s\S]*?\r?\n<\/current_datetime>\r?\n<timezone>\r?\n[\s\S]*?\r?\n<\/timezone>\r?\n(?:\r?\n){1,2}/,
+    '',
+  );
+}
+
 function escapeXml(value: string): string {
   return value
     .replace(/&/g, '&amp;')

--- a/packages/services/src/config/ConfigService.test.ts
+++ b/packages/services/src/config/ConfigService.test.ts
@@ -100,6 +100,7 @@ describe('ConfigService', () => {
             createdAt: '2026-05-05T22:00:00.000Z',
             updatedAt: '2026-05-05T22:15:00.000Z',
             kind: 'chat',
+            hasMessages: true,
             messages: [{ role: 'user', content: 'do not persist me here' }],
           }],
         }],
@@ -119,6 +120,7 @@ describe('ConfigService', () => {
           createdAt: '2026-05-05T22:00:00.000Z',
           updatedAt: '2026-05-05T22:15:00.000Z',
           kind: 'chat',
+          hasMessages: true,
         }],
       });
     });

--- a/packages/services/src/config/ConfigService.ts
+++ b/packages/services/src/config/ConfigService.ts
@@ -149,6 +149,7 @@ function normalizeConversationRecord(value: unknown): ChamberConversationRecord 
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     kind,
+    ...(typeof record.hasMessages === 'boolean' ? { hasMessages: record.hasMessages } : {}),
   };
 }
 

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -559,6 +559,39 @@ describe('MindManager', () => {
       expect(history[1].title).toBe('Hello Q');
     });
 
+    it('recovers a real active conversation by resuming the same session id', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
+      mockCreateSession.mockClear();
+      mockResumeSession.mockClear();
+
+      await manager.recoverActiveConversationSession(mind.mindId);
+
+      expect(mockCreateSession).not.toHaveBeenCalled();
+      expect(mockResumeSession).toHaveBeenCalledWith(
+        mind.activeSessionId,
+        expect.objectContaining({ workingDirectory: '/tmp/agents/q' }),
+      );
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
+      const history = manager.listConversationHistory(mind.mindId);
+      expect(history).toHaveLength(1);
+      expect(history[0].title).toBe('Hello Q');
+      expect(history[0].active).toBe(true);
+    });
+
+    it('recovers an empty active draft by replacing it with a new session id', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const originalSessionId = mind.activeSessionId;
+
+      await manager.recoverActiveConversationSession(mind.mindId);
+
+      const history = manager.listConversationHistory(mind.mindId);
+      expect(history).toHaveLength(1);
+      expect(history[0].sessionId).not.toBe(originalSessionId);
+      expect(history[0].title).toMatch(/^New chat · /);
+      expect(history[0].active).toBe(true);
+    });
+
     it('startNewConversation reuses the active empty conversation', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       const activeSessionId = mind.activeSessionId;

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -291,6 +291,21 @@ describe('MindManager', () => {
       expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
     });
 
+    it('persists the new selectedModel before invoking setModel so stale recovery uses the requested model', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing context');
+      const liveSession = manager.getMind(mind.mindId)?.session as unknown as ReturnType<typeof createSessionStub>;
+      let observedDuringFailure: string | undefined;
+      liveSession.setModel.mockImplementationOnce(async () => {
+        observedDuringFailure = manager.getMind(mind.mindId)?.selectedModel;
+        throw new Error('Session not found: stale-runtime');
+      });
+
+      await expect(manager.setMindModel(mind.mindId, 'claude-opus')).rejects.toThrow(/Session not found/);
+      expect(observedDuringFailure).toBe('claude-opus');
+      expect(manager.getMind(mind.mindId)?.selectedModel).toBe('claude-opus');
+    });
+
     it('serializes concurrent per-mind model changes against the live session', async () => {
       const liveSession = manager.getMind((await manager.loadMind('/tmp/agents/q')).mindId)?.session as unknown as ReturnType<typeof createSessionStub>;
       const mind = manager.listMinds()[0];

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -185,6 +185,7 @@ describe('MindManager', () => {
         conversations: [expect.objectContaining({
           sessionId: sessionConfig.sessionId,
           kind: 'chat',
+          hasMessages: false,
         })],
       });
     });
@@ -522,6 +523,31 @@ describe('MindManager', () => {
       expect(manager.listConversationHistory(mind.mindId)[0].active).toBe(true);
     });
 
+    it('startNewConversation reuses the active empty conversation', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const activeSessionId = mind.activeSessionId;
+
+      await manager.startNewConversation(mind.mindId);
+
+      expect(mockCreateSession).toHaveBeenCalledTimes(1);
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(activeSessionId);
+      expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
+    });
+
+    it('startNewConversation creates one new active conversation after the current conversation has messages', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
+
+      await manager.startNewConversation(mind.mindId);
+
+      expect(mockCreateSession).toHaveBeenCalledTimes(2);
+      const history = manager.listConversationHistory(mind.mindId);
+      expect(history).toHaveLength(2);
+      expect(history[0].active).toBe(true);
+      expect(history[0].title).toMatch(/^New chat · /);
+      expect(history[1].title).toBe('Hello Q');
+    });
+
     it('throws for non-existent mind', async () => {
       await expect(manager.recreateSession('nonexistent')).rejects.toThrow();
     });
@@ -569,6 +595,32 @@ describe('MindManager', () => {
         },
       ]);
       expect(result.conversations.find((conversation) => conversation.sessionId === target.sessionId)?.active).toBe(true);
+    });
+
+    it('strips Chamber-injected datetime context from hydrated user messages', async () => {
+      const resumedSession = createSessionStub();
+      resumedSession.getMessages.mockResolvedValue([
+        {
+          type: 'user.message',
+          timestamp: '2026-05-05T22:00:00.000Z',
+          data: {
+            messageId: 'u1',
+            content: '<current_datetime>\n2026-05-07T03:19:51.220Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nyou should add another comment to the gh issue 125',
+          },
+        },
+      ]);
+      mockResumeSession.mockResolvedValueOnce(resumedSession);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+      await manager.startNewConversation(mind.mindId);
+      const target = manager.listConversationHistory(mind.mindId)[1];
+
+      const result = await manager.resumeConversation(mind.mindId, target.sessionId);
+
+      expect(result.messages[0]).toMatchObject({
+        role: 'user',
+        blocks: [{ type: 'text', content: 'you should add another comment to the gh issue 125' }],
+      });
     });
 
     it('renames only Chamber-owned conversation metadata', async () => {

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -27,26 +27,30 @@ import { bootstrapMindCapabilities } from '../lens/MindBootstrap';
 
 const mockStart = vi.fn();
 const mockStop = vi.fn();
-function createSessionStub() {
+let sessionCounter = 0;
+function createSessionStub(sessionId = `sdk-session-${sessionCounter += 1}`) {
   return {
+  sessionId,
   send: vi.fn(),
   sendAndWait: vi.fn(),
   getMessages: vi.fn(async (): Promise<unknown[]> => []),
   on: vi.fn(),
   off: vi.fn(),
   disconnect: vi.fn(async () => undefined),
+  setModel: vi.fn(async () => undefined),
   rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
   };
 }
 
 const mockCreateSession = vi.fn((config: Record<string, unknown>) => {
-  void config;
-  return createSessionStub();
+  return createSessionStub(typeof config.sessionId === 'string' ? config.sessionId : undefined);
 });
 const mockResumeSession = vi.fn((sessionId: string, config: Record<string, unknown>) => {
-  void sessionId;
   void config;
-  return createSessionStub();
+  return createSessionStub(sessionId);
+});
+const mockDeleteSession = vi.fn(async (sessionId: string) => {
+  void sessionId;
 });
 
 function makeMockClient() {
@@ -55,6 +59,7 @@ function makeMockClient() {
     stop: mockStop,
     createSession: mockCreateSession,
     resumeSession: mockResumeSession,
+    deleteSession: mockDeleteSession,
   };
 }
 
@@ -140,13 +145,14 @@ describe('MindManager', () => {
       theme: 'dark',
     };
     mockCreateSession.mockImplementation((config: Record<string, unknown>) => {
-      void config;
-      return createSessionStub();
+      return createSessionStub(typeof config.sessionId === 'string' ? config.sessionId : undefined);
     });
     mockResumeSession.mockImplementation((sessionId: string, config: Record<string, unknown>) => {
-      void sessionId;
       void config;
-      return createSessionStub();
+      return createSessionStub(sessionId);
+    });
+    mockDeleteSession.mockImplementation(async (sessionId: string) => {
+      void sessionId;
     });
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
@@ -249,112 +255,76 @@ describe('MindManager', () => {
       expect(manager.listMinds()[0].selectedModel).toBe('gpt-5.4');
     });
 
-    it('persists a per-mind model and resumes the active session with it', async () => {
+    it('persists a per-mind model and updates the live session in place via setModel', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       manager.markActiveConversationHasMessages(mind.mindId, 'Existing context');
       mockCreateSession.mockClear();
       mockResumeSession.mockClear();
+      const liveSession = manager.getMind(mind.mindId)?.session as unknown as ReturnType<typeof createSessionStub>;
 
       const updated = await manager.setMindModel(mind.mindId, 'claude-opus');
 
       expect(updated?.selectedModel).toBe('claude-opus');
       expect(lastSavedConfig().minds[0].selectedModel).toBe('claude-opus');
       expect(mockCreateSession).not.toHaveBeenCalled();
-      expect(mockResumeSession).toHaveBeenCalledWith(
-        mind.activeSessionId,
-        expect.objectContaining({ model: 'claude-opus' }),
-      );
+      expect(mockResumeSession).not.toHaveBeenCalled();
+      expect(liveSession.setModel).toHaveBeenCalledWith('claude-opus');
+      expect(liveSession.disconnect).not.toHaveBeenCalled();
+      expect(manager.getMind(mind.mindId)?.session).toBe(liveSession);
       expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
       expect(manager.listConversationHistory(mind.mindId)[0].title).toBe('Existing context');
     });
 
-    it('persists a per-mind model by recreating the same empty draft session instead of resuming it', async () => {
+    it('persists a per-mind model on an empty draft via setModel without recreating the session', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       mockCreateSession.mockClear();
       mockResumeSession.mockClear();
+      const liveSession = manager.getMind(mind.mindId)?.session as unknown as ReturnType<typeof createSessionStub>;
 
       const updated = await manager.setMindModel(mind.mindId, 'claude-opus');
 
       expect(updated?.selectedModel).toBe('claude-opus');
       expect(mockResumeSession).not.toHaveBeenCalled();
-      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
-        model: 'claude-opus',
-        sessionId: mind.activeSessionId,
-      }));
+      expect(mockCreateSession).not.toHaveBeenCalled();
+      expect(liveSession.setModel).toHaveBeenCalledWith('claude-opus');
       expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
       expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
     });
 
-    it('falls back to creating the same real conversation session when model-switch resume is stale', async () => {
-      const fallbackSession = createSessionStub();
-      const mind = await manager.loadMind('/tmp/agents/q');
+    it('serializes concurrent per-mind model changes against the live session', async () => {
+      const liveSession = manager.getMind((await manager.loadMind('/tmp/agents/q')).mindId)?.session as unknown as ReturnType<typeof createSessionStub>;
+      const mind = manager.listMinds()[0];
       manager.markActiveConversationHasMessages(mind.mindId, 'Existing context');
       mockCreateSession.mockClear();
-      mockResumeSession.mockRejectedValueOnce(new Error('Session not found: stale-session'));
-      mockCreateSession.mockResolvedValueOnce(fallbackSession);
+      mockResumeSession.mockClear();
+      liveSession.setModel.mockClear();
 
-      const updated = await manager.setMindModel(mind.mindId, 'claude-opus');
-
-      expect(updated?.selectedModel).toBe('claude-opus');
-      expect(mockResumeSession).toHaveBeenCalledWith(mind.activeSessionId, expect.objectContaining({ model: 'claude-opus' }));
-      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
-        model: 'claude-opus',
-        sessionId: mind.activeSessionId,
-      }));
-      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
-      expect(manager.getMind(mind.mindId)?.session).toBe(fallbackSession);
-      expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
-    });
-
-    it('serializes concurrent per-mind model changes', async () => {
-      const originalSession = createSessionStub();
-      const firstModelSession = createSessionStub();
-      const secondModelSession = createSessionStub();
-      let resolveFirstModelSession: (() => void) | undefined;
-      const createSession = vi.fn(() => Promise.resolve(originalSession));
-      const resumeSession = vi.fn((_sessionId: string, config: Record<string, unknown>) => {
-        if (config.model === 'model-a') {
-          return new Promise((resolve) => {
-            resolveFirstModelSession = () => resolve(firstModelSession);
-          });
-        }
-        if (config.model === 'model-b') return Promise.resolve(secondModelSession);
-        return Promise.resolve(originalSession);
+      let resolveFirst: (() => void) | undefined;
+      liveSession.setModel.mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          resolveFirst = () => resolve();
+        });
       });
-      const clientFactory = {
-        createClient: vi.fn(async () => ({ start: vi.fn(), stop: vi.fn(), createSession, resumeSession })),
-        destroyClient: vi.fn(),
-      };
-      const localManager = new MindManager(
-        clientFactory as unknown as CopilotClientFactory,
-        mockIdentityLoader as unknown as IdentityLoader,
-        mockConfigService as unknown as ConfigService,
-        mockViewDiscovery as unknown as ViewDiscovery,
-      );
+      liveSession.setModel.mockResolvedValueOnce(undefined);
 
-      const mind = await localManager.loadMind('/tmp/agents/q');
-      localManager.markActiveConversationHasMessages(mind.mindId, 'Existing context');
-      createSession.mockClear();
-      resumeSession.mockClear();
-
-      const firstChange = localManager.setMindModel(mind.mindId, 'model-a');
-      const secondChange = localManager.setMindModel(mind.mindId, 'model-b');
+      const firstChange = manager.setMindModel(mind.mindId, 'model-a');
+      const secondChange = manager.setMindModel(mind.mindId, 'model-b');
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(resumeSession).toHaveBeenCalledTimes(1);
-      expect(resumeSession).toHaveBeenCalledWith(mind.activeSessionId, expect.objectContaining({ model: 'model-a' }));
+      expect(liveSession.setModel).toHaveBeenCalledTimes(1);
+      expect(liveSession.setModel).toHaveBeenCalledWith('model-a');
 
-      resolveFirstModelSession?.();
+      resolveFirst?.();
       await Promise.all([firstChange, secondChange]);
 
-      expect(createSession).not.toHaveBeenCalled();
-      expect(resumeSession).toHaveBeenCalledTimes(2);
-      expect(resumeSession).toHaveBeenLastCalledWith(mind.activeSessionId, expect.objectContaining({ model: 'model-b' }));
-      expect(localManager.getMind(mind.mindId)?.selectedModel).toBe('model-b');
-      expect(localManager.getMind(mind.mindId)?.session).toBe(secondModelSession);
-      expect(originalSession.disconnect).toHaveBeenCalledTimes(1);
-      expect(firstModelSession.disconnect).toHaveBeenCalledTimes(1);
+      expect(mockCreateSession).not.toHaveBeenCalled();
+      expect(mockResumeSession).not.toHaveBeenCalled();
+      expect(liveSession.setModel).toHaveBeenCalledTimes(2);
+      expect(liveSession.setModel).toHaveBeenLastCalledWith('model-b');
+      expect(liveSession.disconnect).not.toHaveBeenCalled();
+      expect(manager.getMind(mind.mindId)?.selectedModel).toBe('model-b');
+      expect(manager.getMind(mind.mindId)?.session).toBe(liveSession);
     });
 
     it('bootstraps managed mind capabilities before creating the SDK session', async () => {
@@ -600,17 +570,17 @@ describe('MindManager', () => {
       expect(history[0].active).toBe(true);
     });
 
-    it('falls back to creating the same real conversation session when recovery resume is stale', async () => {
-      const fallbackSession = createSessionStub();
+    it('recovery resume re-attaches under the same Chamber session id when the SDK forgot the runtime', async () => {
+      const reattachedSession = createSessionStub();
       const mind = await manager.loadMind('/tmp/agents/q');
       manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
       mockCreateSession.mockClear();
       mockResumeSession.mockRejectedValueOnce(new Error('failed to resume session: Session not found: stale-session'));
-      mockCreateSession.mockResolvedValueOnce(fallbackSession);
+      mockCreateSession.mockResolvedValueOnce(reattachedSession);
 
       const recovered = await manager.recoverActiveConversationSession(mind.mindId);
 
-      expect(recovered).toBe(fallbackSession);
+      expect(recovered).toBe(reattachedSession);
       expect(mockResumeSession).toHaveBeenCalledWith(
         mind.activeSessionId,
         expect.objectContaining({ workingDirectory: '/tmp/agents/q' }),
@@ -628,27 +598,15 @@ describe('MindManager', () => {
       });
     });
 
-    it('replaces only the runtime session for a real active conversation', async () => {
-      const replacementSession = createSessionStub();
+    it('recovery surfaces stale errors when reattach also fails', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
       mockCreateSession.mockClear();
-      mockCreateSession.mockResolvedValueOnce(replacementSession);
+      mockResumeSession.mockRejectedValueOnce(new Error('Session not found: stale-1'));
+      mockCreateSession.mockRejectedValueOnce(new Error('Session not found: stale-2'));
 
-      const result = await manager.replaceActiveConversationRuntimeSession(mind.mindId);
-
-      expect(result).toBe(replacementSession);
-      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
-        sessionId: mind.activeSessionId,
-      }));
+      await expect(manager.recoverActiveConversationSession(mind.mindId)).rejects.toThrow(/Session not found/);
       expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
-      const history = manager.listConversationHistory(mind.mindId);
-      expect(history).toHaveLength(1);
-      expect(history[0]).toMatchObject({
-        sessionId: mind.activeSessionId,
-        title: 'Hello Q',
-        active: true,
-      });
     });
 
     it('recovers an empty active draft by replacing it with a new session id', async () => {
@@ -773,6 +731,80 @@ describe('MindManager', () => {
         },
       ]);
       expect(result.conversations.find((conversation) => conversation.sessionId === activeSessionId)?.active).toBe(true);
+    });
+
+    it('deletes an inactive conversation without changing the active conversation', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'First chat');
+      await manager.startNewConversation(mind.mindId);
+      const activeSessionId = manager.getMind(mind.mindId)?.activeSessionId;
+      const inactive = manager.listConversationHistory(mind.mindId).find((conversation) => !conversation.active);
+      expect(inactive).toBeDefined();
+
+      const result = await manager.deleteConversation(mind.mindId, inactive!.sessionId);
+
+      expect(result.sessionId).toBe(activeSessionId);
+      expect(mockDeleteSession).toHaveBeenCalledWith(inactive!.sessionId);
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(activeSessionId);
+      expect(result.conversations).toHaveLength(1);
+      expect(result.conversations[0]).toMatchObject({
+        sessionId: activeSessionId,
+        active: true,
+      });
+    });
+
+    it('deletes the active conversation and hydrates the next most recent conversation', async () => {
+      const resumedSession = createSessionStub();
+      resumedSession.getMessages.mockResolvedValue([
+        {
+          type: 'user.message',
+          timestamp: '2026-05-05T22:00:00.000Z',
+          data: { messageId: 'u1', content: 'first chat' },
+        },
+      ]);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const firstSessionId = mind.activeSessionId;
+      manager.markActiveConversationHasMessages(mind.mindId, 'First chat');
+      await manager.startNewConversation(mind.mindId);
+      const activeDraftId = manager.getMind(mind.mindId)?.activeSessionId;
+      mockResumeSession.mockResolvedValueOnce(resumedSession);
+
+      const result = await manager.deleteConversation(mind.mindId, activeDraftId!);
+
+      expect(mockResumeSession).toHaveBeenCalledWith(firstSessionId, expect.objectContaining({ workingDirectory: '/tmp/agents/q' }));
+      expect(mockDeleteSession).toHaveBeenCalledWith(activeDraftId);
+      expect(result.sessionId).toBe(firstSessionId);
+      expect(result.messages).toEqual([
+        {
+          id: 'u1',
+          role: 'user',
+          blocks: [{ type: 'text', content: 'first chat' }],
+          timestamp: Date.parse('2026-05-05T22:00:00.000Z'),
+        },
+      ]);
+      expect(result.conversations).toHaveLength(1);
+      expect(result.conversations[0]).toMatchObject({
+        sessionId: firstSessionId,
+        title: 'First chat',
+        active: true,
+      });
+    });
+
+    it('deletes the last conversation and creates exactly one empty draft', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const originalSessionId = mind.activeSessionId;
+
+      const result = await manager.deleteConversation(mind.mindId, originalSessionId!);
+
+      expect(result.messages).toEqual([]);
+      expect(mockDeleteSession).toHaveBeenCalledWith(originalSessionId);
+      expect(result.conversations).toHaveLength(1);
+      expect(result.conversations[0].sessionId).not.toBe(originalSessionId);
+      expect(result.conversations[0]).toMatchObject({
+        active: true,
+        hasMessages: false,
+      });
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(result.conversations[0].sessionId);
     });
 
     it('strips Chamber-injected datetime context from hydrated user messages', async () => {

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -251,6 +251,7 @@ describe('MindManager', () => {
 
     it('persists a per-mind model and resumes the active session with it', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing context');
       mockCreateSession.mockClear();
       mockResumeSession.mockClear();
 
@@ -263,6 +264,22 @@ describe('MindManager', () => {
         mind.activeSessionId,
         expect.objectContaining({ model: 'claude-opus' }),
       );
+    });
+
+    it('persists a per-mind model by recreating the same empty draft session instead of resuming it', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      mockCreateSession.mockClear();
+      mockResumeSession.mockClear();
+
+      const updated = await manager.setMindModel(mind.mindId, 'claude-opus');
+
+      expect(updated?.selectedModel).toBe('claude-opus');
+      expect(mockResumeSession).not.toHaveBeenCalled();
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+        model: 'claude-opus',
+        sessionId: mind.activeSessionId,
+      }));
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
     });
 
     it('serializes concurrent per-mind model changes', async () => {
@@ -292,6 +309,7 @@ describe('MindManager', () => {
       );
 
       const mind = await localManager.loadMind('/tmp/agents/q');
+      localManager.markActiveConversationHasMessages(mind.mindId, 'Existing context');
       createSession.mockClear();
       resumeSession.mockClear();
 

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -264,6 +264,8 @@ describe('MindManager', () => {
         mind.activeSessionId,
         expect.objectContaining({ model: 'claude-opus' }),
       );
+      expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
+      expect(manager.listConversationHistory(mind.mindId)[0].title).toBe('Existing context');
     });
 
     it('persists a per-mind model by recreating the same empty draft session instead of resuming it', async () => {
@@ -280,6 +282,7 @@ describe('MindManager', () => {
         sessionId: mind.activeSessionId,
       }));
       expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
+      expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
     });
 
     it('serializes concurrent per-mind model changes', async () => {
@@ -526,9 +529,9 @@ describe('MindManager', () => {
   });
 
   describe('recreateSession', () => {
-    it('destroys old session and creates new one', async () => {
+    it('replaces an empty active draft when recreating the session', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
-      manager.getMind(mind.mindId); // side-effect: verify it exists
+      const originalSessionId = mind.activeSessionId;
 
       await manager.recreateSession(mind.mindId);
 
@@ -537,8 +540,23 @@ describe('MindManager', () => {
       const newSession = newCtx.session;
       expect(newSession).toBeDefined();
       expect(mockCreateSession).toHaveBeenCalledTimes(2);
-      expect(manager.listConversationHistory(mind.mindId)).toHaveLength(2);
-      expect(manager.listConversationHistory(mind.mindId)[0].active).toBe(true);
+      const history = manager.listConversationHistory(mind.mindId);
+      expect(history).toHaveLength(1);
+      expect(history[0].active).toBe(true);
+      expect(history[0].sessionId).not.toBe(originalSessionId);
+    });
+
+    it('keeps real conversation history when recreating after messages exist', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
+
+      await manager.recreateSession(mind.mindId);
+
+      const history = manager.listConversationHistory(mind.mindId);
+      expect(history).toHaveLength(2);
+      expect(history[0].active).toBe(true);
+      expect(history[0].title).toMatch(/^New chat · /);
+      expect(history[1].title).toBe('Hello Q');
     });
 
     it('startNewConversation reuses the active empty conversation', async () => {
@@ -588,6 +606,7 @@ describe('MindManager', () => {
       ]);
       mockResumeSession.mockResolvedValueOnce(resumedSession);
       const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
       await manager.recreateSession(mind.mindId);
       const target = manager.listConversationHistory(mind.mindId)[1];
 

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -641,7 +641,8 @@ describe('MindManager', () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
       await manager.recreateSession(mind.mindId);
-      const target = manager.listConversationHistory(mind.mindId)[1];
+      const historyBeforeResume = manager.listConversationHistory(mind.mindId);
+      const target = historyBeforeResume[1];
 
       const result = await manager.resumeConversation(mind.mindId, target.sessionId);
 
@@ -665,6 +666,9 @@ describe('MindManager', () => {
         },
       ]);
       expect(result.conversations.find((conversation) => conversation.sessionId === target.sessionId)?.active).toBe(true);
+      expect(result.conversations.map((conversation) => conversation.sessionId)).toEqual(
+        historyBeforeResume.map((conversation) => conversation.sessionId),
+      );
     });
 
     it('strips Chamber-injected datetime context from hydrated user messages', async () => {

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -285,6 +285,27 @@ describe('MindManager', () => {
       expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
     });
 
+    it('falls back to creating the same real conversation session when model-switch resume is stale', async () => {
+      const fallbackSession = createSessionStub();
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing context');
+      mockCreateSession.mockClear();
+      mockResumeSession.mockRejectedValueOnce(new Error('Session not found: stale-session'));
+      mockCreateSession.mockResolvedValueOnce(fallbackSession);
+
+      const updated = await manager.setMindModel(mind.mindId, 'claude-opus');
+
+      expect(updated?.selectedModel).toBe('claude-opus');
+      expect(mockResumeSession).toHaveBeenCalledWith(mind.activeSessionId, expect.objectContaining({ model: 'claude-opus' }));
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+        model: 'claude-opus',
+        sessionId: mind.activeSessionId,
+      }));
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
+      expect(manager.getMind(mind.mindId)?.session).toBe(fallbackSession);
+      expect(manager.listConversationHistory(mind.mindId)).toHaveLength(1);
+    });
+
     it('serializes concurrent per-mind model changes', async () => {
       const originalSession = createSessionStub();
       const firstModelSession = createSessionStub();
@@ -579,6 +600,57 @@ describe('MindManager', () => {
       expect(history[0].active).toBe(true);
     });
 
+    it('falls back to creating the same real conversation session when recovery resume is stale', async () => {
+      const fallbackSession = createSessionStub();
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
+      mockCreateSession.mockClear();
+      mockResumeSession.mockRejectedValueOnce(new Error('failed to resume session: Session not found: stale-session'));
+      mockCreateSession.mockResolvedValueOnce(fallbackSession);
+
+      const recovered = await manager.recoverActiveConversationSession(mind.mindId);
+
+      expect(recovered).toBe(fallbackSession);
+      expect(mockResumeSession).toHaveBeenCalledWith(
+        mind.activeSessionId,
+        expect.objectContaining({ workingDirectory: '/tmp/agents/q' }),
+      );
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: mind.activeSessionId,
+      }));
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
+      const history = manager.listConversationHistory(mind.mindId);
+      expect(history).toHaveLength(1);
+      expect(history[0]).toMatchObject({
+        sessionId: mind.activeSessionId,
+        title: 'Hello Q',
+        active: true,
+      });
+    });
+
+    it('replaces only the runtime session for a real active conversation', async () => {
+      const replacementSession = createSessionStub();
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
+      mockCreateSession.mockClear();
+      mockCreateSession.mockResolvedValueOnce(replacementSession);
+
+      const result = await manager.replaceActiveConversationRuntimeSession(mind.mindId);
+
+      expect(result).toBe(replacementSession);
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: mind.activeSessionId,
+      }));
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(mind.activeSessionId);
+      const history = manager.listConversationHistory(mind.mindId);
+      expect(history).toHaveLength(1);
+      expect(history[0]).toMatchObject({
+        sessionId: mind.activeSessionId,
+        title: 'Hello Q',
+        active: true,
+      });
+    });
+
     it('recovers an empty active draft by replacing it with a new session id', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       const originalSessionId = mind.activeSessionId;
@@ -669,6 +741,38 @@ describe('MindManager', () => {
       expect(result.conversations.map((conversation) => conversation.sessionId)).toEqual(
         historyBeforeResume.map((conversation) => conversation.sessionId),
       );
+    });
+
+    it('hydrates the already-active conversation without resuming the SDK session again', async () => {
+      const activeSession = createSessionStub();
+      activeSession.getMessages.mockResolvedValue([
+        {
+          type: 'user.message',
+          timestamp: '2026-05-05T22:00:00.000Z',
+          data: { messageId: 'u1', content: 'already active' },
+        },
+      ]);
+      mockCreateSession.mockResolvedValueOnce(activeSession);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      expect(mind.activeSessionId).toBeDefined();
+      const activeSessionId = mind.activeSessionId!;
+      manager.markActiveConversationHasMessages(mind.mindId, 'Already active');
+      mockResumeSession.mockClear();
+
+      const result = await manager.resumeConversation(mind.mindId, activeSessionId);
+
+      expect(mockResumeSession).not.toHaveBeenCalled();
+      expect(activeSession.disconnect).not.toHaveBeenCalled();
+      expect(result.sessionId).toBe(activeSessionId);
+      expect(result.messages).toEqual([
+        {
+          id: 'u1',
+          role: 'user',
+          blocks: [{ type: 'text', content: 'already active' }],
+          timestamp: Date.parse('2026-05-05T22:00:00.000Z'),
+        },
+      ]);
+      expect(result.conversations.find((conversation) => conversation.sessionId === activeSessionId)?.active).toBe(true);
     });
 
     it('strips Chamber-injected datetime context from hydrated user messages', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -246,8 +246,12 @@ export class MindManager extends EventEmitter {
   async recreateSession(mindId: string): Promise<CopilotSession> {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
+    const activeConversation = this.getActiveConversationRecord(mindId);
+    const replaceSessionId = activeConversation?.hasMessages === false
+      ? activeConversation.sessionId
+      : undefined;
 
-    return this.createNewConversationSession(mindId, context);
+    return this.createNewConversationSession(mindId, context, replaceSessionId);
   }
 
   async startNewConversation(mindId: string): Promise<CopilotSession> {
@@ -285,7 +289,11 @@ export class MindManager extends EventEmitter {
     this.persistConfig();
   }
 
-  private async createNewConversationSession(mindId: string, context: InternalMindContext): Promise<CopilotSession> {
+  private async createNewConversationSession(
+    mindId: string,
+    context: InternalMindContext,
+    replaceSessionId?: string,
+  ): Promise<CopilotSession> {
     const conversation = this.createConversationRecord(mindId);
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
@@ -302,7 +310,7 @@ export class MindManager extends EventEmitter {
     );
     context.session = nextSession;
     context.activeSessionId = conversation.sessionId;
-    this.upsertConversationRecord(mindId, conversation);
+    this.upsertConversationRecord(mindId, conversation, replaceSessionId);
     this.persistConfig();
     await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
     return context.session;
@@ -824,7 +832,7 @@ export class MindManager extends EventEmitter {
       };
   }
 
-  private upsertConversationRecord(mindId: string, conversation: ChamberConversationRecord): void {
+  private upsertConversationRecord(mindId: string, conversation: ChamberConversationRecord, replaceSessionId?: string): void {
     const record = this.knownMindRecords.get(mindId);
     if (!record) return;
     const conversations = record.conversations ?? [];
@@ -833,7 +841,7 @@ export class MindManager extends EventEmitter {
       activeSessionId: conversation.sessionId,
       conversations: [
         conversation,
-        ...conversations.filter((existing) => existing.sessionId !== conversation.sessionId),
+        ...conversations.filter((existing) => existing.sessionId !== conversation.sessionId && existing.sessionId !== replaceSessionId),
       ],
     });
   }

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -254,6 +254,35 @@ export class MindManager extends EventEmitter {
     return this.createNewConversationSession(mindId, context, replaceSessionId);
   }
 
+  async recoverActiveConversationSession(mindId: string): Promise<CopilotSession> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+    const activeConversation = this.getActiveConversationRecord(mindId);
+    if (activeConversation?.hasMessages === false) {
+      return this.recreateSession(mindId);
+    }
+    if (!context.activeSessionId) {
+      return this.createNewConversationSession(mindId, context);
+    }
+
+    const previousSession = context.session;
+    const sessionTools = this.getSessionTools(mindId, context.mindPath);
+    const recoveredSession = await this.resumeSessionForMind(
+      context.client,
+      context.activeSessionId,
+      context.mindPath,
+      context.identity.systemMessage,
+      sessionTools,
+      undefined,
+      approveAllCompat,
+      true,
+      context.selectedModel,
+    );
+    context.session = recoveredSession;
+    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
+    return recoveredSession;
+  }
+
   async startNewConversation(mindId: string): Promise<CopilotSession> {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -6,10 +6,9 @@ import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { PermissionHandler, ResumeSessionConfig, SessionConfig } from '@github/copilot-sdk';
-import { Logger } from '../logger';
-
-const log = Logger.create('MindManager');
+import { isStaleSessionError } from '@chamber/shared/sessionErrors';
 import type { AppConfig, ChamberConversationRecord, ChatMessage, ConversationResumeResult, ConversationSummary, MindContext, MindRecord } from '@chamber/shared/types';
+import { Logger } from '../logger';
 import type { InternalMindContext, CopilotClient, CopilotSession, Tool, UserInputHandler } from './types';
 import { generateMindId } from './generateMindId';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
@@ -20,6 +19,8 @@ import type { ChamberToolProvider } from '../chamberTools';
 import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
 import { bootstrapMindCapabilities } from '../lens/MindBootstrap';
+
+const log = Logger.create('MindManager');
 
 export class MindManager extends EventEmitter {
   private minds = new Map<string, InternalMindContext>();
@@ -267,9 +268,28 @@ export class MindManager extends EventEmitter {
 
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const recoveredSession = await this.resumeSessionForMind(
-      context.client,
+    const recoveredSession = await this.resumeOrCreateSessionForMind(
+      context,
       context.activeSessionId,
+      sessionTools,
+      context.selectedModel,
+    );
+    context.session = recoveredSession;
+    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
+    return recoveredSession;
+  }
+
+  async replaceActiveConversationRuntimeSession(mindId: string): Promise<CopilotSession> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+    if (!context.activeSessionId) {
+      return this.createNewConversationSession(mindId, context);
+    }
+
+    const previousSession = context.session;
+    const sessionTools = this.getSessionTools(mindId, context.mindPath);
+    const replacementSession = await this.createSessionForMind(
+      context.client,
       context.mindPath,
       context.identity.systemMessage,
       sessionTools,
@@ -277,10 +297,11 @@ export class MindManager extends EventEmitter {
       approveAllCompat,
       true,
       context.selectedModel,
+      context.activeSessionId,
     );
-    context.session = recoveredSession;
+    context.session = replacementSession;
     await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
-    return recoveredSession;
+    return replacementSession;
   }
 
   async startNewConversation(mindId: string): Promise<CopilotSession> {
@@ -351,6 +372,16 @@ export class MindManager extends EventEmitter {
     const record = this.knownMindRecords.get(mindId);
     if (!record?.conversations?.some((conversation) => conversation.sessionId === sessionId)) {
       throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
+    }
+
+    if (context.activeSessionId === sessionId && context.session) {
+      this.touchConversationRecord(mindId, sessionId);
+      this.persistConfig();
+      return {
+        sessionId,
+        messages: await this.getMessagesForSession(context.session),
+        conversations: this.listConversationHistory(mindId),
+      };
     }
 
     const previousSession = context.session;
@@ -466,15 +497,10 @@ export class MindManager extends EventEmitter {
     }
     const shouldResumeActiveSession = Boolean(existingActiveSessionId) && activeConversation?.hasMessages !== false;
     const nextSession = shouldResumeActiveSession
-      ? await this.resumeSessionForMind(
-        context.client,
+      ? await this.resumeOrCreateSessionForMind(
+        context,
         activeSessionId,
-        context.mindPath,
-        context.identity.systemMessage,
         sessionTools,
-        undefined,
-        approveAllCompat,
-        true,
         selectedModel,
       )
       : await this.createSessionForMind(
@@ -737,6 +763,41 @@ export class MindManager extends EventEmitter {
       await session.rpc.permissions.setApproveAll({ enabled: true });
     }
     return session;
+  }
+
+  private async resumeOrCreateSessionForMind(
+    context: InternalMindContext,
+    sessionId: string,
+    tools: Tool[],
+    model?: string,
+  ): Promise<CopilotSession> {
+    try {
+      return await this.resumeSessionForMind(
+        context.client,
+        sessionId,
+        context.mindPath,
+        context.identity.systemMessage,
+        tools,
+        undefined,
+        approveAllCompat,
+        true,
+        model,
+      );
+    } catch (error) {
+      if (!isStaleSessionError(error)) throw error;
+      log.warn(`Session ${sessionId} was not found during resume; recreating it with the same Chamber session id.`);
+      return this.createSessionForMind(
+        context.client,
+        context.mindPath,
+        context.identity.systemMessage,
+        tools,
+        undefined,
+        approveAllCompat,
+        true,
+        model,
+        sessionId,
+      );
+    }
   }
 
   private async getMessagesForSession(session: CopilotSession): Promise<ChatMessage[]> {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -519,12 +519,14 @@ export class MindManager extends EventEmitter {
 
     if (context.selectedModel === selectedModel) return this.toExternalContext(context);
 
+    // Persist intent before applying so stale-recovery on send uses the new model.
+    context.selectedModel = selectedModel;
+
     // SDK preserves conversation history across in-place model switches; no resume/recreate needed.
     if (context.session && selectedModel) {
       await context.session.setModel(selectedModel);
     }
 
-    context.selectedModel = selectedModel;
     const existingRecord = this.knownMindRecords.get(mindId);
     this.knownMindRecords.set(mindId, {
       id: mindId,

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -100,40 +100,26 @@ export class MindManager extends EventEmitter {
     const selectedModel = knownRecord?.selectedModel;
     const activeSessionId = knownRecord?.activeSessionId ?? this.createConversationRecord(id).sessionId;
     const conversationRecord = this.ensureConversationRecord(id, activeSessionId, knownRecord?.conversations);
-
     const session = knownRecord?.activeSessionId
-      ? await this.resumeSessionForMind(
-        client,
-        activeSessionId,
-        resolvedMindPath,
-        identity.systemMessage,
-        sessionTools,
-        undefined,
-        approveAllCompat,
-        true,
-        selectedModel,
-      ).catch(() => this.createSessionForMind(
+      ? await this.loadConversationSession(
         client,
         resolvedMindPath,
         identity.systemMessage,
         sessionTools,
-        undefined,
-        approveAllCompat,
-        true,
+        conversationRecord.sessionId,
         selectedModel,
-        activeSessionId,
-      ))
+      )
       : await this.createSessionForMind(
-      client,
-      resolvedMindPath,
-      identity.systemMessage,
-      sessionTools,
-      undefined,
-      approveAllCompat,
-      true,
-      selectedModel,
-      activeSessionId,
-    );
+        client,
+        resolvedMindPath,
+        identity.systemMessage,
+        sessionTools,
+        undefined,
+        approveAllCompat,
+        true,
+        selectedModel,
+        activeSessionId,
+      );
 
     const context: InternalMindContext = {
       mindId: id,
@@ -265,43 +251,23 @@ export class MindManager extends EventEmitter {
     if (!context.activeSessionId) {
       return this.createNewConversationSession(mindId, context);
     }
+    if (!activeConversation) {
+      this.upsertConversationRecord(mindId, this.ensureConversationRecord(mindId, context.activeSessionId));
+    }
 
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const recoveredSession = await this.resumeOrCreateSessionForMind(
-      context,
-      context.activeSessionId,
+    const recoveredSession = await this.loadConversationSession(
+      context.client,
+      context.mindPath,
+      context.identity.systemMessage,
       sessionTools,
+      context.activeSessionId,
       context.selectedModel,
     );
     context.session = recoveredSession;
     await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
     return recoveredSession;
-  }
-
-  async replaceActiveConversationRuntimeSession(mindId: string): Promise<CopilotSession> {
-    const context = this.minds.get(mindId);
-    if (!context) throw new Error(`Mind ${mindId} not found`);
-    if (!context.activeSessionId) {
-      return this.createNewConversationSession(mindId, context);
-    }
-
-    const previousSession = context.session;
-    const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const replacementSession = await this.createSessionForMind(
-      context.client,
-      context.mindPath,
-      context.identity.systemMessage,
-      sessionTools,
-      undefined,
-      approveAllCompat,
-      true,
-      context.selectedModel,
-      context.activeSessionId,
-    );
-    context.session = replacementSession;
-    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
-    return replacementSession;
   }
 
   async startNewConversation(mindId: string): Promise<CopilotSession> {
@@ -386,15 +352,14 @@ export class MindManager extends EventEmitter {
 
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const nextSession = await this.resumeSessionForMind(
+    const conversation = record.conversations.find((candidate) => candidate.sessionId === sessionId);
+    if (!conversation) throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
+    const nextSession = await this.loadConversationSession(
       context.client,
-      sessionId,
       context.mindPath,
       context.identity.systemMessage,
       sessionTools,
-      undefined,
-      approveAllCompat,
-      true,
+      conversation.sessionId,
       context.selectedModel,
     );
     context.session = nextSession;
@@ -423,6 +388,7 @@ export class MindManager extends EventEmitter {
         updatedAt: conversation.updatedAt,
         kind: conversation.kind,
         active: conversation.sessionId === activeSessionId,
+        hasMessages: conversation.hasMessages,
       }));
   }
 
@@ -442,6 +408,75 @@ export class MindManager extends EventEmitter {
     });
     this.persistConfig();
     return this.listConversationHistory(mindId);
+  }
+
+  async deleteConversation(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+    const record = this.knownMindRecords.get(mindId);
+    if (!record) throw new Error(`Mind ${mindId} not found`);
+    const conversations = record.conversations ?? [];
+    const deletingConversation = conversations.find((conversation) => conversation.sessionId === sessionId);
+    if (!deletingConversation) {
+      throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
+    }
+
+    const remainingConversations = conversations.filter((conversation) => conversation.sessionId !== sessionId);
+    if (context.activeSessionId !== sessionId) {
+      this.knownMindRecords.set(mindId, {
+        ...record,
+        conversations: remainingConversations,
+      });
+      this.persistConfig();
+      await this.deleteSdkSession(context, deletingConversation.sessionId);
+      return {
+        sessionId: context.activeSessionId ?? '',
+        messages: context.session ? await this.getMessagesForSession(context.session) : [],
+        conversations: this.listConversationHistory(mindId),
+      };
+    }
+
+    const { activeSessionId: _deletedActiveSessionId, ...recordWithoutActiveSession } = record;
+    void _deletedActiveSessionId;
+    this.knownMindRecords.set(mindId, {
+      ...recordWithoutActiveSession,
+      conversations: remainingConversations,
+    });
+
+    if (remainingConversations.length === 0) {
+      await this.createNewConversationSession(mindId, context);
+      await this.deleteSdkSession(context, deletingConversation.sessionId);
+      return {
+        sessionId: context.activeSessionId ?? '',
+        messages: [],
+        conversations: this.listConversationHistory(mindId),
+      };
+    }
+
+    const nextConversation = [...remainingConversations]
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0];
+    const previousSession = context.session;
+    const sessionTools = this.getSessionTools(mindId, context.mindPath);
+    const nextSession = await this.loadConversationSession(
+      context.client,
+      context.mindPath,
+      context.identity.systemMessage,
+      sessionTools,
+      nextConversation.sessionId,
+      context.selectedModel,
+    );
+    context.session = nextSession;
+    context.activeSessionId = nextConversation.sessionId;
+    this.touchConversationRecord(mindId, nextConversation.sessionId);
+    this.persistConfig();
+    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
+    await this.deleteSdkSession(context, deletingConversation.sessionId);
+
+    return {
+      sessionId: nextConversation.sessionId,
+      messages: await this.getMessagesForSession(nextSession),
+      conversations: this.listConversationHistory(mindId),
+    };
   }
 
   async setMindModel(mindId: string, model: string | null): Promise<MindContext | null> {
@@ -484,48 +519,21 @@ export class MindManager extends EventEmitter {
 
     if (context.selectedModel === selectedModel) return this.toExternalContext(context);
 
-    const previousSession = context.session;
-    const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const activeConversation = this.getActiveConversationRecord(mindId);
-    const existingActiveSessionId = context.activeSessionId;
-    let activeSessionId = existingActiveSessionId;
-    if (!activeSessionId) {
-      const conversation = this.createConversationRecord(mindId);
-      activeSessionId = conversation.sessionId;
-      context.activeSessionId = activeSessionId;
-      this.upsertConversationRecord(mindId, conversation);
+    // SDK preserves conversation history across in-place model switches; no resume/recreate needed.
+    if (context.session && selectedModel) {
+      await context.session.setModel(selectedModel);
     }
-    const shouldResumeActiveSession = Boolean(existingActiveSessionId) && activeConversation?.hasMessages !== false;
-    const nextSession = shouldResumeActiveSession
-      ? await this.resumeOrCreateSessionForMind(
-        context,
-        activeSessionId,
-        sessionTools,
-        selectedModel,
-      )
-      : await this.createSessionForMind(
-        context.client,
-        context.mindPath,
-        context.identity.systemMessage,
-        sessionTools,
-        undefined,
-        approveAllCompat,
-        true,
-        selectedModel,
-        activeSessionId,
-      );
 
     context.selectedModel = selectedModel;
-    context.session = nextSession;
+    const existingRecord = this.knownMindRecords.get(mindId);
     this.knownMindRecords.set(mindId, {
       id: mindId,
       path: context.mindPath,
       ...(selectedModel ? { selectedModel } : {}),
       ...(context.activeSessionId ? { activeSessionId: context.activeSessionId } : {}),
-      ...(this.knownMindRecords.get(mindId)?.conversations ? { conversations: this.knownMindRecords.get(mindId)?.conversations } : {}),
+      ...(existingRecord?.conversations ? { conversations: existingRecord.conversations } : {}),
     });
     this.persistConfig();
-    await previousSession?.disconnect().catch(() => { /* session already disconnected */ });
 
     const external = this.toExternalContext(context);
     this.emit('mind:loaded', external);
@@ -765,18 +773,20 @@ export class MindManager extends EventEmitter {
     return session;
   }
 
-  private async resumeOrCreateSessionForMind(
-    context: InternalMindContext,
-    sessionId: string,
+  private async loadConversationSession(
+    client: CopilotClient,
+    mindPath: string,
+    systemMessage: string,
     tools: Tool[],
+    conversationSessionId: string,
     model?: string,
   ): Promise<CopilotSession> {
     try {
       return await this.resumeSessionForMind(
-        context.client,
-        sessionId,
-        context.mindPath,
-        context.identity.systemMessage,
+        client,
+        conversationSessionId,
+        mindPath,
+        systemMessage,
         tools,
         undefined,
         approveAllCompat,
@@ -785,18 +795,27 @@ export class MindManager extends EventEmitter {
       );
     } catch (error) {
       if (!isStaleSessionError(error)) throw error;
-      log.warn(`Session ${sessionId} was not found during resume; recreating it with the same Chamber session id.`);
+      log.warn(`SDK session ${conversationSessionId} was not found; reattaching by recreating the session under the same id.`);
       return this.createSessionForMind(
-        context.client,
-        context.mindPath,
-        context.identity.systemMessage,
+        client,
+        mindPath,
+        systemMessage,
         tools,
         undefined,
         approveAllCompat,
         true,
         model,
-        sessionId,
+        conversationSessionId,
       );
+    }
+  }
+
+  private async deleteSdkSession(context: InternalMindContext, sessionId: string): Promise<void> {
+    try {
+      await context.client.deleteSession(sessionId);
+    } catch (error) {
+      if (isStaleSessionError(error)) return;
+      log.warn(`Failed to delete SDK session ${sessionId}; Chamber history was already updated.`, error);
     }
   }
 

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -878,13 +878,9 @@ export class MindManager extends EventEmitter {
   private touchConversationRecord(mindId: string, sessionId: string): void {
     const record = this.knownMindRecords.get(mindId);
     if (!record) return;
-    const updatedAt = new Date().toISOString();
     this.knownMindRecords.set(mindId, {
       ...record,
       activeSessionId: sessionId,
-      conversations: (record.conversations ?? []).map((conversation) => conversation.sessionId === sessionId
-        ? { ...conversation, updatedAt }
-        : conversation),
     });
   }
 

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -418,10 +418,20 @@ export class MindManager extends EventEmitter {
 
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const nextSession = context.activeSessionId
+    const activeConversation = this.getActiveConversationRecord(mindId);
+    const existingActiveSessionId = context.activeSessionId;
+    let activeSessionId = existingActiveSessionId;
+    if (!activeSessionId) {
+      const conversation = this.createConversationRecord(mindId);
+      activeSessionId = conversation.sessionId;
+      context.activeSessionId = activeSessionId;
+      this.upsertConversationRecord(mindId, conversation);
+    }
+    const shouldResumeActiveSession = Boolean(existingActiveSessionId) && activeConversation?.hasMessages !== false;
+    const nextSession = shouldResumeActiveSession
       ? await this.resumeSessionForMind(
         context.client,
-        context.activeSessionId,
+        activeSessionId,
         context.mindPath,
         context.identity.systemMessage,
         sessionTools,
@@ -439,6 +449,7 @@ export class MindManager extends EventEmitter {
         approveAllCompat,
         true,
         selectedModel,
+        activeSessionId,
       );
 
     context.selectedModel = selectedModel;

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -15,7 +15,7 @@ import { generateMindId } from './generateMindId';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import { approveAllCompat } from '../sdk/approveAllCompat';
 import type { IdentityLoader } from '../chat/IdentityLoader';
-import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext, stripInjectedCurrentDateTimeContext } from '../chat/currentDateTimeContext';
 import type { ChamberToolProvider } from '../chamberTools';
 import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
@@ -247,6 +247,45 @@ export class MindManager extends EventEmitter {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
 
+    return this.createNewConversationSession(mindId, context);
+  }
+
+  async startNewConversation(mindId: string): Promise<CopilotSession> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+    const activeConversation = this.getActiveConversationRecord(mindId);
+    if (activeConversation?.hasMessages === false && context.session) {
+      return context.session;
+    }
+
+    return this.createNewConversationSession(mindId, context);
+  }
+
+  markActiveConversationHasMessages(mindId: string, prompt: string): void {
+    const context = this.minds.get(mindId);
+    if (!context?.activeSessionId) return;
+    const record = this.knownMindRecords.get(mindId);
+    if (!record?.conversations) return;
+    const updatedAt = new Date().toISOString();
+    const title = this.conversationTitleFromPrompt(prompt);
+    this.knownMindRecords.set(mindId, {
+      ...record,
+      activeSessionId: context.activeSessionId,
+      conversations: record.conversations.map((conversation) => {
+        if (conversation.sessionId !== context.activeSessionId) return conversation;
+        const shouldReplaceTitle = !conversation.title || conversation.title.startsWith('New chat · ');
+        return {
+          ...conversation,
+          ...(shouldReplaceTitle ? { title } : {}),
+          hasMessages: true,
+          updatedAt,
+        };
+      }),
+    });
+    this.persistConfig();
+  }
+
+  private async createNewConversationSession(mindId: string, context: InternalMindContext): Promise<CopilotSession> {
     const conversation = this.createConversationRecord(mindId);
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
@@ -663,7 +702,10 @@ export class MindManager extends EventEmitter {
     const data = typeof record.data === 'object' && record.data !== null
       ? record.data as Record<string, unknown>
       : {};
-    const content = this.extractMessageContent(data);
+    const rawContent = this.extractMessageContent(data);
+    const content = record.type === 'user.message' && rawContent
+      ? stripInjectedCurrentDateTimeContext(rawContent)
+      : rawContent;
     if (!content) return [];
     const timestamp = typeof record.timestamp === 'number'
       ? record.timestamp
@@ -751,6 +793,7 @@ export class MindManager extends EventEmitter {
       createdAt: now,
       updatedAt: now,
       kind: 'chat',
+      hasMessages: false,
     };
   }
 
@@ -766,6 +809,7 @@ export class MindManager extends EventEmitter {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         kind: 'chat',
+        hasMessages: false,
       };
   }
 
@@ -798,6 +842,17 @@ export class MindManager extends EventEmitter {
 
   private defaultConversationTitle(conversation: ChamberConversationRecord): string {
     return `Chat · ${new Date(conversation.createdAt).toLocaleString()}`;
+  }
+
+  private getActiveConversationRecord(mindId: string): ChamberConversationRecord | undefined {
+    const context = this.minds.get(mindId);
+    const activeSessionId = context?.activeSessionId ?? this.knownMindRecords.get(mindId)?.activeSessionId;
+    return this.knownMindRecords.get(mindId)?.conversations?.find((conversation) => conversation.sessionId === activeSessionId);
+  }
+
+  private conversationTitleFromPrompt(prompt: string): string {
+    const firstLine = prompt.trim().split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? 'New chat';
+    return firstLine.length > 80 ? `${firstLine.slice(0, 77)}...` : firstLine;
   }
 
   private getPersistedActiveMindId(): string | null {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -111,6 +111,7 @@ export interface ChamberConversationRecord {
   createdAt: string;
   updatedAt: string;
   kind: ChamberConversationKind;
+  hasMessages?: boolean;
 }
 
 export interface ConversationSummary {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -121,6 +121,7 @@ export interface ConversationSummary {
   updatedAt: string;
   kind: ChamberConversationKind;
   active: boolean;
+  hasMessages?: boolean;
 }
 
 export interface ConversationResumeResult {
@@ -238,6 +239,7 @@ export interface ElectronAPI {
     list: (mindId: string) => Promise<ConversationSummary[]>;
     resume: (mindId: string, sessionId: string) => Promise<ConversationResumeResult>;
     rename: (mindId: string, sessionId: string, title: string) => Promise<ConversationSummary[]>;
+    delete: (mindId: string, sessionId: string) => Promise<ConversationResumeResult>;
   };
   mind: {
     add: (mindPath: string) => Promise<MindContext>;

--- a/scripts/run-sdk-smoke-test.js
+++ b/scripts/run-sdk-smoke-test.js
@@ -86,8 +86,20 @@ async function assertNamedSessionResume({ sdk, cliPath, mindPath, logDir }) {
       '--allow-all-urls',
     ],
   });
+  const thirdClient = new sdk.CopilotClient({
+    cliPath,
+    cwd: mindPath,
+    logLevel: 'all',
+    cliArgs: [
+      '--log-dir', logDir,
+      '--allow-all-tools',
+      '--allow-all-paths',
+      '--allow-all-urls',
+    ],
+  });
   let firstSession;
   let resumedSession;
+  let resumedAgainSession;
   try {
     await firstClient.start();
     firstSession = await firstClient.createSession({
@@ -119,12 +131,64 @@ async function assertNamedSessionResume({ sdk, cliPath, mindPath, logDir }) {
     if (!response.includes('chamber-resume-smoke')) {
       throw new Error(`Named SDK session did not continue prior context: ${response}`);
     }
+    await resumedSession.disconnect();
+    resumedSession = undefined;
+    await secondClient.stop();
+
+    await thirdClient.start();
+    resumedAgainSession = await thirdClient.resumeSession(sessionId, {
+      streaming: true,
+      workingDirectory: mindPath,
+      onPermissionRequest: async () => ({ kind: 'allow' }),
+      onUserInputRequest: async () => ({ answer: 'Proceed.', wasFreeform: true }),
+    });
+    await resumedAgainSession.rpc.permissions.setApproveAll({ enabled: true });
+    const secondResumeMessages = await resumedAgainSession.getMessages();
+    if (!secondResumeMessages.some((event) => JSON.stringify(event).includes('chamber-resume-smoke'))) {
+      throw new Error('Named SDK session second resume did not restore prior messages.');
+    }
+    await resumedAgainSession.disconnect();
+    resumedAgainSession = undefined;
+
+    await assertModelResumePreservesContext({ client: thirdClient, sessionId, mindPath });
   } finally {
+    await resumedAgainSession?.disconnect().catch(() => undefined);
     await resumedSession?.disconnect().catch(() => undefined);
     await firstSession?.disconnect().catch(() => undefined);
-    await secondClient.deleteSession?.(sessionId).catch(() => undefined);
+    await thirdClient.deleteSession?.(sessionId).catch(() => undefined);
+    await thirdClient.stop().catch(() => undefined);
     await secondClient.stop().catch(() => undefined);
     await firstClient.stop().catch(() => undefined);
+  }
+}
+
+async function assertModelResumePreservesContext({ client, sessionId, mindPath }) {
+  const models = await client.listModels();
+  if (!Array.isArray(models) || models.length < 2) {
+    console.warn('SDK smoke skipped cross-model resume check: fewer than two models available.');
+    return;
+  }
+  const model = models[1].id;
+  let modelSession;
+  try {
+    modelSession = await client.resumeSession(sessionId, {
+      streaming: true,
+      workingDirectory: mindPath,
+      model,
+      onPermissionRequest: async () => ({ kind: 'allow' }),
+      onUserInputRequest: async () => ({ answer: 'Proceed.', wasFreeform: true }),
+    });
+    await modelSession.rpc.permissions.setApproveAll({ enabled: true });
+    const messages = await modelSession.getMessages();
+    if (!messages.some((event) => JSON.stringify(event).includes('chamber-resume-smoke'))) {
+      throw new Error(`Named SDK session resumed with model ${model} did not restore prior messages.`);
+    }
+    const response = await sendAndWaitForResponse(modelSession, 'What exact token did I ask you to remember?');
+    if (!response.includes('chamber-resume-smoke')) {
+      throw new Error(`Named SDK session resumed with model ${model} did not continue prior context: ${response}`);
+    }
+  } finally {
+    await modelSession?.disconnect().catch(() => undefined);
   }
 }
 

--- a/tests/e2e/electron/conversation-history-smoke.spec.ts
+++ b/tests/e2e/electron/conversation-history-smoke.spec.ts
@@ -19,7 +19,7 @@ test.describe('electron conversation history smoke', () => {
     if (root) await removeTempRoot(root);
   });
 
-  test('Monica can create, resume, and rename history entries from the right pane', async () => {
+  test('Monica can reuse an empty draft, resume, and rename history from the right pane', async () => {
     const paths = await launchWithMinds(9350, ['Monica']);
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await addMind(page, paths.Monica);
@@ -32,13 +32,12 @@ test.describe('electron conversation history smoke', () => {
     await expect.poll(
       () => history.getByLabel(/Rename /).count(),
       { timeout: 60_000 },
-    ).toBeGreaterThanOrEqual(2);
+    ).toBe(1);
 
     await renameFirstHistoryItem(page, 'Monica planning thread');
 
-    await history.getByRole('button', { name: /Resume / }).last().click();
-    await expect(history.getByText('Active')).toBeVisible();
     await history.getByRole('button', { name: 'Resume Monica planning thread' }).click();
+    await expect(history.getByText('Active')).toBeVisible();
     await expect(history.getByText('Monica planning thread')).toBeVisible();
   });
 

--- a/tests/e2e/electron/conversation-history-smoke.spec.ts
+++ b/tests/e2e/electron/conversation-history-smoke.spec.ts
@@ -98,7 +98,10 @@ test.describe('electron conversation history smoke', () => {
       ),
       { timeout: 60_000 },
     ).toBe(prompt);
-    await expect(page.getByLabel('Conversation history').getByText(prompt)).toBeVisible();
+    const history = page.getByLabel('Conversation history');
+    await expect(history.getByText(prompt)).toBeVisible();
+    await expect(history.getByText(/^New chat ·/)).toHaveCount(0);
+    await expect(history.getByLabel(/Rename /)).toHaveCount(1);
 
     await app?.close();
     app = await launchElectronApp({
@@ -106,10 +109,12 @@ test.describe('electron conversation history smoke', () => {
       env: { CHAMBER_E2E_USER_DATA: userDataPath },
     });
     const restartedPage = await findRendererPage(app.browser, app.logs);
-    const history = restartedPage.getByLabel('Conversation history');
+    const restartedHistory = restartedPage.getByLabel('Conversation history');
     await expect(restartedPage.getByRole('button', { name: 'Monica' }).first()).toBeVisible();
-    await expect(history.getByText(prompt)).toBeVisible();
-    await history.getByRole('button', { name: `Resume ${prompt}` }).click();
+    await expect(restartedHistory.getByText(prompt)).toBeVisible();
+    await expect(restartedHistory.getByText(/^New chat ·/)).toHaveCount(0);
+    await expect(restartedHistory.getByLabel(/Rename /)).toHaveCount(1);
+    await restartedHistory.getByRole('button', { name: `Resume ${prompt}` }).click();
     await expect(restartedPage.getByText(prompt).first()).toBeVisible();
   });
 

--- a/tests/e2e/electron/conversation-history-smoke.spec.ts
+++ b/tests/e2e/electron/conversation-history-smoke.spec.ts
@@ -76,6 +76,43 @@ test.describe('electron conversation history smoke', () => {
     await expect(restartedPage.getByLabel('Conversation history').getByText('Lucy restart thread')).toBeVisible();
   });
 
+  test('first prompt titles the active draft and survives restart resume', async () => {
+    const paths = await launchWithMinds(9354, ['Monica']);
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    const mind = await addMind(page, paths.Monica);
+    await installChatSendProbe(page);
+
+    const prompt = 'History smoke first prompt title';
+    const input = page.getByPlaceholder('Message your agent… (paste an image to attach)');
+    await input.fill(prompt);
+    await input.press('Enter');
+    await page.evaluate(() => (window as typeof window & { __chamberLastChatSend?: Promise<void> }).__chamberLastChatSend);
+
+    await expect.poll(
+      () => page.evaluate(
+        async ({ mindId }) => {
+          const conversations = await window.electronAPI.conversationHistory.list(mindId);
+          return conversations.find((conversation) => conversation.active)?.title;
+        },
+        { mindId: mind.mindId },
+      ),
+      { timeout: 60_000 },
+    ).toBe(prompt);
+    await expect(page.getByLabel('Conversation history').getByText(prompt)).toBeVisible();
+
+    await app?.close();
+    app = await launchElectronApp({
+      cdpPort: 9355,
+      env: { CHAMBER_E2E_USER_DATA: userDataPath },
+    });
+    const restartedPage = await findRendererPage(app.browser, app.logs);
+    const history = restartedPage.getByLabel('Conversation history');
+    await expect(restartedPage.getByRole('button', { name: 'Monica' }).first()).toBeVisible();
+    await expect(history.getByText(prompt)).toBeVisible();
+    await history.getByRole('button', { name: `Resume ${prompt}` }).click();
+    await expect(restartedPage.getByText(prompt).first()).toBeVisible();
+  });
+
   async function launchWithMinds(cdpPort: number, names: string[]): Promise<Record<string, string>> {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-history-smoke-'));
     userDataPath = path.join(root, 'user-data');
@@ -113,6 +150,18 @@ async function renameFirstHistoryItem(page: Page, title: string): Promise<void> 
   await input.fill(title);
   await input.press('Enter');
   await expect(history.getByText(title)).toBeVisible();
+}
+
+async function installChatSendProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const runtimeWindow = window as typeof window & { __chamberLastChatSend?: Promise<void> };
+    const originalSend = window.electronAPI.chat.send.bind(window.electronAPI.chat);
+    window.electronAPI.chat.send = (...args: Parameters<typeof window.electronAPI.chat.send>) => {
+      const send = originalSend(...args);
+      runtimeWindow.__chamberLastChatSend = send.then(() => undefined);
+      return send;
+    };
+  });
 }
 
 function seedMind(targetMindPath: string, name: string): void {

--- a/tests/e2e/electron/conversation-history-smoke.spec.ts
+++ b/tests/e2e/electron/conversation-history-smoke.spec.ts
@@ -117,6 +117,43 @@ test.describe('electron conversation history smoke', () => {
     await expect(restartedPage.getByText(prompt).first()).toBeVisible();
   });
 
+  test('trash deletes the active empty draft and returns to the previous conversation', async () => {
+    const paths = await launchWithMinds(9356, ['Monica']);
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    const mind = await addMind(page, paths.Monica);
+    await installChatSendProbe(page);
+
+    const prompt = 'History smoke keep this chat';
+    const input = page.getByPlaceholder('Message your agent… (paste an image to attach)');
+    await input.fill(prompt);
+    await input.press('Enter');
+    await page.evaluate(() => (window as typeof window & { __chamberLastChatSend?: Promise<void> }).__chamberLastChatSend);
+    await expect.poll(
+      () => page.evaluate(
+        async ({ mindId }) => {
+          const conversations = await window.electronAPI.conversationHistory.list(mindId);
+          return conversations.find((conversation) => conversation.active)?.title;
+        },
+        { mindId: mind.mindId },
+      ),
+      { timeout: 60_000 },
+    ).toBe(prompt);
+
+    const history = page.getByLabel('Conversation history');
+    await expect(history.getByRole('button', { name: 'New conversation' })).toBeEnabled({ timeout: 60_000 });
+    await history.getByRole('button', { name: 'New conversation' }).click();
+    await expect.poll(() => history.getByLabel(/Rename /).count(), { timeout: 60_000 }).toBe(2);
+    await expect(history.getByText(prompt)).toBeVisible();
+    await expect(history.getByText(/^New chat ·/)).toBeVisible();
+
+    await history.getByRole('button', { name: /^Delete New chat ·/ }).click();
+
+    await expect.poll(() => history.getByLabel(/Rename /).count(), { timeout: 60_000 }).toBe(1);
+    await expect(history.getByText(/^New chat ·/)).toHaveCount(0);
+    await expect(history.getByText(prompt)).toBeVisible();
+    await expect(page.getByText(prompt).first()).toBeVisible();
+  });
+
   async function launchWithMinds(cdpPort: number, names: string[]): Promise<Record<string, string>> {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-history-smoke-'));
     userDataPath = path.join(root, 'user-data');

--- a/tests/e2e/electron/conversation-history-smoke.spec.ts
+++ b/tests/e2e/electron/conversation-history-smoke.spec.ts
@@ -76,7 +76,7 @@ test.describe('electron conversation history smoke', () => {
     await expect(restartedPage.getByLabel('Conversation history').getByText('Lucy restart thread')).toBeVisible();
   });
 
-  test('first prompt titles the active draft and survives restart resume', async () => {
+  test('first prompt titles the active draft and hydrates automatically after restart', async () => {
     const paths = await launchWithMinds(9354, ['Monica']);
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     const mind = await addMind(page, paths.Monica);
@@ -114,7 +114,6 @@ test.describe('electron conversation history smoke', () => {
     await expect(restartedHistory.getByText(prompt)).toBeVisible();
     await expect(restartedHistory.getByText(/^New chat ·/)).toHaveCount(0);
     await expect(restartedHistory.getByLabel(/Rename /)).toHaveCount(1);
-    await restartedHistory.getByRole('button', { name: `Resume ${prompt}` }).click();
     await expect(restartedPage.getByText(prompt).first()).toBeVisible();
   });
 

--- a/tests/e2e/electron/genesis-lucy-cos-chat.spec.ts
+++ b/tests/e2e/electron/genesis-lucy-cos-chat.spec.ts
@@ -65,7 +65,7 @@ test.describe('electron Genesis Lucy Chief of Staff chat smoke', () => {
     await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
 
     expect(fs.existsSync(path.join(lucyPath, 'SOUL.md'))).toBe(true);
-    expect(fs.readFileSync(path.join(lucyPath, 'SOUL.md'), 'utf-8')).toContain('I am Lucy, a calm and practical Chief of Staff.');
+    expect(fs.readFileSync(path.join(lucyPath, 'SOUL.md'), 'utf-8')).toContain('Strategic Clarity');
     expect(fs.readFileSync(path.join(lucyPath, '.working-memory', 'memory.md'), 'utf-8')).toContain(memoryInstruction);
 
     const result = await page.evaluate(async ({ expected, name }) => {

--- a/tests/e2e/electron/genesis-lucy-template.spec.ts
+++ b/tests/e2e/electron/genesis-lucy-template.spec.ts
@@ -55,9 +55,9 @@ test.describe('electron Genesis Lucy template smoke', () => {
     await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
 
     expect(fs.existsSync(path.join(lucyPath, 'SOUL.md'))).toBe(true);
-    expect(fs.readFileSync(path.join(lucyPath, 'SOUL.md'), 'utf-8')).toContain('I am Lucy, a calm and practical Chief of Staff.');
+    expect(fs.readFileSync(path.join(lucyPath, 'SOUL.md'), 'utf-8')).toContain('Strategic Clarity');
     expect(fs.readFileSync(path.join(lucyPath, '.github', 'agents', 'lucy.agent.md'), 'utf-8')).toContain('name: lucy');
-    expect(fs.readFileSync(path.join(lucyPath, '.working-memory', 'memory.md'), 'utf-8')).toContain('Lucy is a Genesis-created mind template');
+    expect(fs.readFileSync(path.join(lucyPath, '.working-memory', 'memory.md'), 'utf-8')).toContain('Agent name: Lucy');
 
     const result = await page.evaluate(async (name) => {
       const minds = await window.electronAPI.mind.list();

--- a/tests/e2e/electron/model-switch-context-smoke.spec.ts
+++ b/tests/e2e/electron/model-switch-context-smoke.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import type { ModelInfo } from '@chamber/shared/types';
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+test.describe('electron model switch conversation context smoke', () => {
+  test.setTimeout(180_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let root = '';
+  let userDataPath = '';
+
+  test.afterEach(async () => {
+    await app?.close();
+    app = undefined;
+    if (root) await removeTempRoot(root);
+  });
+
+  test('switches model mid-conversation and sends another turn without creating history or losing session', async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-model-switch-context-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    const mindPath = path.join(root, 'heinz-doofenshmirtz');
+    seedMind(mindPath, 'Heinz Doofenshmirtz');
+    app = await launchElectronApp({
+      cdpPort: 9361,
+      env: { CHAMBER_E2E_USER_DATA: userDataPath },
+    });
+    const page = await findRendererPage(app.browser, app.logs);
+    await waitForMindApi(page);
+    const mind = await loadMind(page, mindPath, 'Heinz Doofenshmirtz');
+    const models = await page.evaluate((mindId) => window.electronAPI.chat.listModels(mindId), mind.mindId);
+    test.skip(models.length < 2, 'Model-switch context smoke requires at least two SDK models.');
+    await installChatSendProbe(page);
+
+    const firstPrompt = 'tell me another haiku';
+    await sendAndWait(page, firstPrompt);
+    await expect(page.getByText(firstPrompt).first()).toBeVisible();
+    await expectNoSessionError(page);
+
+    const history = page.getByLabel('Conversation history');
+    await expect(history.getByText(firstPrompt)).toBeVisible();
+    const rowsAfterFirstTurn = await history.getByLabel(/Rename /).count();
+    const nextModel = await findNextModel(page, models);
+    await selectModel(page, nextModel.name);
+    await expectMindModel(page, mind.mindId, nextModel.id);
+    await expect.poll(() => history.getByLabel(/Rename /).count(), { timeout: 30_000 }).toBe(rowsAfterFirstTurn);
+
+    const secondPrompt = 'Tell it to me again';
+    await sendAndWait(page, secondPrompt);
+
+    await expect(page.getByText(secondPrompt).first()).toBeVisible();
+    await expectNoSessionError(page);
+    await expect.poll(() => history.getByLabel(/Rename /).count(), { timeout: 30_000 }).toBe(rowsAfterFirstTurn);
+    await expect(history.getByText(firstPrompt)).toBeVisible();
+  });
+});
+
+async function waitForMindApi(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('#root')).not.toBeEmpty();
+  await expect.poll(async () => {
+    try {
+      return await page.evaluate(() => typeof window.electronAPI?.mind?.add);
+    } catch {
+      return 'unavailable';
+    }
+  }, { timeout: 30_000 }).toBe('function');
+}
+
+async function loadMind(page: Page, mindPath: string, name: string) {
+  const mind = await page.evaluate(async (pathToMind) => {
+    const loaded = await window.electronAPI.mind.add(pathToMind);
+    await window.electronAPI.mind.setActive(loaded.mindId);
+    return loaded;
+  }, mindPath);
+  const mindButton = page.getByRole('button', { name }).first();
+  await mindButton.click();
+  await expect(mindButton).toHaveClass(/bg-accent/);
+  await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
+  return mind;
+}
+
+async function installChatSendProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const runtimeWindow = window as typeof window & { __chamberLastChatSend?: Promise<void> };
+    const originalSend = window.electronAPI.chat.send.bind(window.electronAPI.chat);
+    window.electronAPI.chat.send = (...args: Parameters<typeof window.electronAPI.chat.send>) => {
+      const send = originalSend(...args);
+      runtimeWindow.__chamberLastChatSend = send.then(() => undefined);
+      return send;
+    };
+  });
+}
+
+async function sendAndWait(page: Page, prompt: string): Promise<void> {
+  const input = page.getByPlaceholder('Message your agent… (paste an image to attach)');
+  await expect(input).toBeEnabled();
+  await input.fill(prompt);
+  await input.press('Enter');
+  await page.evaluate(() => (window as typeof window & { __chamberLastChatSend?: Promise<void> }).__chamberLastChatSend);
+}
+
+async function findNextModel(page: Page, models: ModelInfo[]): Promise<ModelInfo> {
+  const currentModelName = (await page.getByRole('combobox').first().innerText()).trim();
+  return models.find((model) => model.name !== currentModelName) ?? models[1];
+}
+
+async function selectModel(page: Page, name: string): Promise<void> {
+  const picker = page.getByRole('combobox').first();
+  await expect(picker).toBeVisible();
+  await picker.click();
+  await page.getByRole('option', { name }).click();
+}
+
+async function expectMindModel(page: Page, mindId: string, selectedModel: string): Promise<void> {
+  await expect.poll(
+    () => page.evaluate(
+      ({ mindId }) => window.electronAPI.mind.list().then((minds) => minds.find((mind) => mind.mindId === mindId)?.selectedModel),
+      { mindId },
+    ),
+    { timeout: 60_000 },
+  ).toBe(selectedModel);
+}
+
+async function expectNoSessionError(page: Page): Promise<void> {
+  await expect(page.getByText(/Session not found/i)).toHaveCount(0);
+  await expect(page.getByText(/^Error:/)).toHaveCount(0);
+}
+
+function seedMind(root: string, name: string): void {
+  fs.mkdirSync(path.join(root, '.github', 'agents'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'SOUL.md'),
+    [
+      `# ${name}`,
+      '',
+      'A deterministic mind used by Electron model-switch context smoke tests.',
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(root, '.github', 'agents', 'heinz-doofenshmirtz.agent.md'),
+    [
+      '---',
+      `name: ${name}`,
+      'description: Model-switch context smoke-test persona',
+      '---',
+      '',
+      `# ${name}`,
+      '',
+      'Answer briefly so smoke tests finish quickly.',
+      '',
+    ].join('\n'),
+  );
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[model-switch-context-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}

--- a/tests/e2e/electron/model-switch-context-smoke.spec.ts
+++ b/tests/e2e/electron/model-switch-context-smoke.spec.ts
@@ -36,7 +36,8 @@ test.describe('electron model switch conversation context smoke', () => {
     test.skip(models.length < 2, 'Model-switch context smoke requires at least two SDK models.');
     await installChatSendProbe(page);
 
-    const firstPrompt = 'tell me another haiku';
+    const sentinelToken = `purplezebra${Date.now().toString(36)}`;
+    const firstPrompt = `Remember the secret token "${sentinelToken}". Reply with just the word OK.`;
     await sendAndWait(page, firstPrompt);
     await expect(page.getByText(firstPrompt).first()).toBeVisible();
     await expectNoSessionError(page);
@@ -49,13 +50,15 @@ test.describe('electron model switch conversation context smoke', () => {
     await expectMindModel(page, mind.mindId, nextModel.id);
     await expect.poll(() => history.getByLabel(/Rename /).count(), { timeout: 30_000 }).toBe(rowsAfterFirstTurn);
 
-    const secondPrompt = 'Tell it to me again';
+    const secondPrompt = 'Repeat the secret token I gave you a moment ago, exactly.';
     await sendAndWait(page, secondPrompt);
 
     await expect(page.getByText(secondPrompt).first()).toBeVisible();
     await expectNoSessionError(page);
     await expect.poll(() => history.getByLabel(/Rename /).count(), { timeout: 30_000 }).toBe(rowsAfterFirstTurn);
     await expect(history.getByText(firstPrompt)).toBeVisible();
+    // Conversation context must survive an in-place model switch — the model should recall the sentinel.
+    await expect(page.getByText(new RegExp(sentinelToken)).first()).toBeVisible({ timeout: 60_000 });
   });
 });
 

--- a/tests/e2e/electron/per-agent-model-persistence.spec.ts
+++ b/tests/e2e/electron/per-agent-model-persistence.spec.ts
@@ -102,6 +102,7 @@ test.describe('electron per-agent model persistence smoke', () => {
     await expect(page.getByRole('button', { name: 'Daily briefing' })).toBeDisabled();
 
     await expectMindModel(page, beta.mindId, nextModel.id);
+    await expect(page.getByLabel('Conversation history').getByLabel(/Rename /)).toHaveCount(1);
   });
 });
 

--- a/tests/e2e/electron/per-agent-model-persistence.spec.ts
+++ b/tests/e2e/electron/per-agent-model-persistence.spec.ts
@@ -39,7 +39,7 @@ test.describe('electron per-agent model persistence smoke', () => {
 
   test('restores each mind-specific model selection after restart', async () => {
     let page = await findRendererPage(app?.browser, app?.logs ?? []);
-    await page.waitForLoadState('domcontentloaded');
+    await waitForMindApi(page);
 
     const alpha = await loadMind(page, alphaMindPath, 'Alpha Mind');
     const beta = await loadMind(page, betaMindPath, 'Beta Mind');
@@ -67,9 +67,15 @@ test.describe('electron per-agent model persistence smoke', () => {
     app = await startApp(userDataPath);
 
     page = await findRendererPage(app.browser, app.logs);
-    await page.waitForLoadState('domcontentloaded');
+    await waitForMindApi(page);
     await expect.poll(
-      () => page.evaluate(() => window.electronAPI.mind.list().then((minds) => minds.map((mind) => mind.identity.name).sort())),
+      async () => {
+        try {
+          return await page.evaluate(() => window.electronAPI.mind.list().then((minds) => minds.map((mind) => mind.identity.name).sort()));
+        } catch {
+          return [];
+        }
+      },
       { timeout: 30_000 },
     ).toEqual(['Alpha Mind', 'Beta Mind']);
 
@@ -79,6 +85,18 @@ test.describe('electron per-agent model persistence smoke', () => {
     await expectSelectedModel(page, betaModel.name);
   });
 });
+
+async function waitForMindApi(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('#root')).not.toBeEmpty();
+  await expect.poll(async () => {
+    try {
+      return await page.evaluate(() => typeof window.electronAPI?.mind?.list);
+    } catch {
+      return 'unavailable';
+    }
+  }, { timeout: 30_000 }).toBe('function');
+}
 
 async function startApp(userDataPath: string): Promise<LaunchedElectronApp> {
   return launchElectronApp({
@@ -104,7 +122,9 @@ async function loadModels(page: Page, mindId: string): Promise<ModelInfo[]> {
 }
 
 async function selectMind(page: Page, name: string): Promise<void> {
-  await page.getByRole('button', { name }).first().click();
+  const mindButton = page.getByRole('button', { name }).first();
+  await mindButton.click();
+  await expect(mindButton).toHaveClass(/bg-accent/);
   await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
 }
 
@@ -113,7 +133,6 @@ async function selectModel(page: Page, name: string): Promise<void> {
   await expect(picker).toBeVisible();
   await picker.click();
   await page.getByRole('option', { name }).click();
-  await expect(picker).toContainText(name);
 }
 
 async function expectSelectedModel(page: Page, name: string): Promise<void> {
@@ -126,7 +145,7 @@ async function expectMindModel(page: Page, mindId: string, selectedModel: string
       ({ mindId }) => window.electronAPI.mind.list().then((minds) => minds.find((mind) => mind.mindId === mindId)?.selectedModel),
       { mindId },
     ),
-    { timeout: 10_000 },
+    { timeout: 60_000 },
   ).toBe(selectedModel);
 }
 

--- a/tests/e2e/electron/per-agent-model-persistence.spec.ts
+++ b/tests/e2e/electron/per-agent-model-persistence.spec.ts
@@ -84,6 +84,25 @@ test.describe('electron per-agent model persistence smoke', () => {
     await selectMind(page, 'Beta Mind');
     await expectSelectedModel(page, betaModel.name);
   });
+
+  test('disables empty-chat starter prompts while a model switch is pending', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await waitForMindApi(page);
+
+    const beta = await loadMind(page, betaMindPath, 'Beta Mind');
+    const models = await loadModels(page, beta.mindId);
+    test.skip(models.length < 2, 'Model-switch disabled-state smoke requires at least two SDK models.');
+    const currentModelName = (await page.getByRole('combobox').first().innerText()).trim();
+    const nextModel = models.find((model) => model.name !== currentModelName) ?? models[1];
+
+    await selectModel(page, nextModel.name);
+
+    await expect(page.getByPlaceholder('Switching model…')).toBeDisabled();
+    await expect(page.getByRole('combobox').first()).toHaveAttribute('data-disabled', '');
+    await expect(page.getByRole('button', { name: 'Daily briefing' })).toBeDisabled();
+
+    await expectMindModel(page, beta.mindId, nextModel.id);
+  });
 });
 
 async function waitForMindApi(page: Page): Promise<void> {
@@ -103,6 +122,7 @@ async function startApp(userDataPath: string): Promise<LaunchedElectronApp> {
     cdpPort,
     env: {
       CHAMBER_E2E_USER_DATA: userDataPath,
+      CHAMBER_E2E_MODEL_SWITCH_DELAY_MS: '2000',
     },
   });
 }


### PR DESCRIPTION
## Summary

Hardens the conversation history lifecycle and fixes a silent context-loss bug introduced by the previous resume/recreate model-switch path.

### Conversation lifecycle

- Switch models in place via the SDK's first-class `session.setModel()`. The SDK preserves history; no resume/recreate cycle. Eliminates the silent context loss that occurred after a mid-conversation model switch.
- Bound stale-session recovery: `ChatService` reattaches once via `recoverActiveConversationSession`; if that also returns stale, the error is surfaced rather than silently minting an empty replacement runtime session.
- Drop the `sdkSessionId` split. The Chamber `sessionId` is the SDK runtime id again. `MindManager.loadConversationSession` resumes by `sessionId` and falls back to `createSession({ sessionId })` under the same id when the SDK forgot the runtime.
- Strip Chamber-injected datetime/timezone metadata from hydrated SDK user messages.
- Reuse the empty active draft on New Chat instead of creating duplicates; title default chats from the first prompt.
- Renderer state machine for `conversationViewByMind[mindId]` (idle | hydrating | ready) plus `streaming` / `modelSwitching` flags, guarded by `pendingSessionId`.

### Trash-delete history rows

- New `deleteConversation` end-to-end through MindManager → ChatService → IPC → preload → renderer.
- Replaces the unused ellipsis in history rows with a Trash2 icon next to the rename pencil. Confirmation only triggers for conversations with messages.
- Active delete hydrates the next most recent conversation; deleting the last creates one empty draft.
- Inactive delete refreshes only the history list, leaving the active chat's tool-call / reasoning / image blocks untouched.

### Tooling

- Adds `.github/extensions/canvas/` extension scaffolding for rich visual output during agent sessions.
- Pins the packaged Copilot CLI runtime to `1.0.44-0` to match the binary version validated by the packaging sandbox.

## Closes

Closes #216

## Tests

- `npm run lint`
- `npm test` — 1157/1157 passing
- `npm run smoke:desktop -- tests/e2e/electron/model-switch-context-smoke.spec.ts` — passes; smoke now seeds a sentinel token on turn 1 and asserts the agent recalls it after the model switch
- `npm run smoke:desktop -- tests/e2e/electron/conversation-history-smoke.spec.ts -g 'trash deletes'` — passes
- Manually verified end-to-end in `npm start`: tell-me-a-haiku → switch model → tell-me-again preserves prior context

## Review notes

Uncle Bob review applied: `setMindModel` persists `context.selectedModel` before invoking `session.setModel` so stale recovery loads a fresh session pinned to the requested model; inactive delete in the renderer no longer round-trips active messages through the lossy SDK→ChatMessage mapper. Three lower-priority findings (empty-conversation recovery emitting a fresh sessionId silently, clearing model not propagating to the SDK, minor cleanups) are deferred to a follow-up — not regressions of this PR.
