### PR TITLE
fix: surface long-turn timeout instead of false completion in ChatService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.45.1 (2026-05-07)
+
+### Chat
+
+- **Stop falsely completing long-running single-agent turns** — `ChatService.streamTurn` no longer emits a success-shaped `done` event purely because the 5-minute idle fallback timer elapsed. The fallback now rejects with `TurnTimeoutError` and surfaces a typed `{ type: 'timeout', timeoutMs }` chat event, mirroring the chatroom precedent in `streamAgentTurn`. The renderer reducer already handles `timeout` by clearing `isStreaming` and rendering an "Agent timed out after `<s>`s" message, so the working/stop indicator stays accurate until the SDK reports real completion, failure, cancellation, or an explicit timeout. Server-mode `/api/chat/send` continues to await `sendMessage` cleanly because the timeout is handled inside `streamTurn` rather than thrown across the HTTP boundary, so long turns no longer disconnect the request or produce duplicate events. Regression coverage in `ChatService.test.ts` exercises the "send resolves but `session.idle` never fires" path. (#222)
+
 ## v0.45.0 (2026-05-07)
 
 ### Chatroom

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.45.0",
+      "version": "0.45.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -94,6 +94,50 @@ describe('ChatService', () => {
       expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     });
 
+    it('emits timeout (not done) when send resolves but session.idle never fires', async () => {
+      vi.useFakeTimers();
+      try {
+        // Default behavior: register listeners but never fire session.idle.
+        mockSession.on.mockImplementation(() => vi.fn());
+        mockSession.send.mockResolvedValue(undefined);
+
+        const emit = vi.fn();
+        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+        // Advance past the 5-minute fallback turn timeout.
+        await vi.advanceTimersByTimeAsync(300_000);
+        await pending;
+
+        expect(emit).toHaveBeenCalledWith({ type: 'timeout', timeoutMs: 300_000 });
+        expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+        expect(emit).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+        // No timer leak: the fallback timer was cleared by the outer finally.
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not leak the 5-minute fallback timer when session.send fails synchronously', async () => {
+      vi.useFakeTimers();
+      try {
+        mockSession.on.mockImplementation(() => vi.fn());
+        mockSession.send.mockRejectedValueOnce(new Error('send blew up'));
+
+        const emit = vi.fn();
+        await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+        // Outer finally must clear turnDoneTimerId even though we never
+        // reached `await turnDone`. If this leaks, getTimerCount > 0 and a
+        // future TurnTimeoutError reject would surface as unhandled.
+        expect(vi.getTimerCount()).toBe(0);
+        expect(emit).toHaveBeenCalledWith({ type: 'error', message: 'send blew up' });
+        expect(emit).not.toHaveBeenCalledWith({ type: 'timeout', timeoutMs: 300_000 });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('emits a clear error when the SDK chat event contract drifts', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
       let deltaListener: ((event: unknown) => void) | undefined;

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -6,6 +6,7 @@ import type { ChatEvent, ChatImageAttachment, ConversationResumeResult, Conversa
 import type { CopilotSession } from '../mind/types';
 import { isStaleSessionError, SEND_TIMEOUT_MS, DEFAULT_TURN_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
 import { Logger } from '../logger';
+import { TurnTimeoutError } from '../session-group/stream-session';
 import {
   SdkChatEventContractError,
   getSdkSessionErrorMessage,
@@ -108,6 +109,13 @@ export class ChatService {
         failSdkContract(error);
       }
     };
+    // Hoisted so the outer `finally` can guarantee the 5-minute fallback
+    // timer is cleared on every exit path (send failure, SDK contract abort,
+    // normal completion, timeout, etc.). Without this, a send-side throw
+    // unwinds before `await turnDone`, the timer keeps ticking, and the
+    // eventual `reject(new TurnTimeoutError(...))` would surface as an
+    // unhandled rejection minutes later (#222 follow-up).
+    let turnDoneTimerId: ReturnType<typeof setTimeout> | undefined;
 
     try {
       // Text streaming
@@ -144,9 +152,14 @@ export class ChatService {
 
       // Set up idle/error listeners BEFORE send to avoid missing events
       // that fire synchronously inside session.send (regression-test guarded).
-      let turnDoneTimerId: ReturnType<typeof setTimeout> | undefined;
       const turnDone = new Promise<void>((resolve, reject) => {
-        turnDoneTimerId = setTimeout(resolve, DEFAULT_TURN_TIMEOUT_MS);
+        // INVARIANT: a fallback timer must NOT silently complete the turn.
+        // Reject with TurnTimeoutError so the renderer sees an explicit
+        // `timeout` event instead of a success-shaped `done` (#222).
+        turnDoneTimerId = setTimeout(
+          () => reject(new TurnTimeoutError(DEFAULT_TURN_TIMEOUT_MS)),
+          DEFAULT_TURN_TIMEOUT_MS,
+        );
 
         const unsubIdle = session.on('session.idle', () => {
           if (turnDoneTimerId) clearTimeout(turnDoneTimerId);
@@ -172,6 +185,12 @@ export class ChatService {
           resolve();
         }, { once: true });
       });
+      // Defensive no-op catch: if `session.send` throws and we never reach
+      // `await turnDone` below, the outer `finally` clears the timer so it
+      // cannot fire — but if it somehow does (e.g., scheduled before the
+      // clear ran), this guarantees the rejection is observed instead of
+      // surfacing as an unhandled rejection.
+      turnDone.catch(() => { /* observed in await below or intentionally discarded */ });
 
       // Send with a timeout guard — if session.send() itself hangs (dead
       // WebSocket, killed CLI), surface as a stale-session error so the
@@ -194,12 +213,29 @@ export class ChatService {
         if (sendTimerId) clearTimeout(sendTimerId);
       }
 
-      // Wait for idle (listeners already active from before send)
-      await turnDone;
+      // Wait for idle (listeners already active from before send).
+      // A TurnTimeoutError surfaces as a typed `timeout` event so the
+      // renderer can render timeout-specific UI; we suppress the trailing
+      // `done` to avoid a false-completion signal (#222). Other errors
+      // propagate to the outer catch which emits `{ type: 'error' }`.
+      try {
+        await turnDone;
+      } catch (err) {
+        if (err instanceof TurnTimeoutError) {
+          log.warn(`Chat turn timed out after ${err.timeoutMs}ms; SDK never emitted session.idle`);
+          // guard suppresses the emit on a racing abort — cancellation is
+          // its own terminal state and the renderer already cleared
+          // isStreaming on the abort path.
+          guard(() => emit({ type: 'timeout', timeoutMs: err.timeoutMs }));
+          return;
+        }
+        throw err;
+      }
 
       if (abortController.signal.aborted) return;
       emit({ type: 'done' });
     } finally {
+      if (turnDoneTimerId) clearTimeout(turnDoneTimerId);
       for (const unsub of unsubs) unsub();
     }
   }


### PR DESCRIPTION
## Summary

Long-running single-agent chat turns could appear complete in the UI while the underlying SDK operation was still running. Root cause: `ChatService.streamTurn()` resolved its `turnDone` promise on a 5-minute fallback `setTimeout` that was indistinguishable from a real `session.idle` event, so the renderer reducer received `{ type: 'done' }` and cleared `isStreaming` (and the stop affordance) prematurely.

Fix mirrors the chatroom precedent in `packages/services/src/session-group/stream-session.ts`:

- Fallback timer now `reject`s with `TurnTimeoutError` instead of resolving.
- `await turnDone` is wrapped: `TurnTimeoutError` is converted to a typed `{ type: 'timeout', timeoutMs }` chat event (and a structured `log.warn`), and the function returns without emitting `done`. Other errors continue to propagate to the outer catch which emits `{ type: 'error' }`.
- `turnDoneTimerId` is hoisted so the outer `finally` always clears it — including when `session.send` throws before we reach `await turnDone`. A defensive `turnDone.catch(() => {})` ensures any racing late rejection is observed.

The renderer reducer already handles the `'timeout'` event (clears `isStreaming`, renders an "Agent timed out after Ns" text block) — no UI changes needed.

## Server / browser audit

`/api/chat/send` continues to `await` `sendMessage` cleanly because the timeout is handled inside `streamTurn` rather than thrown across the HTTP boundary, so long turns no longer disconnect the request, return 500, or produce duplicate timeout events. The renderer learns of the timeout via the existing WS event channel.

## Test evidence

- `npm run lint` — clean
- `npm test` — 1197 passed
- `npm run smoke:sdk` — passed
- New regression in `ChatService.test.ts`:
  - "emits timeout (not done) when send resolves but session.idle never fires"
  - "does not leak the 5-minute fallback timer when session.send fails synchronously"

## Notes / follow-ups (out of scope for #222)

- `TurnTimeoutError` is currently exported from `packages/services/src/session-group/stream-session.ts`. If a third caller appears, hoist it to `@chamber/shared/sessionErrors` next to `sendTimeoutError` / `SEND_TIMEOUT_MS`.
- On timeout we do not call `session.abort()` — the SDK session remains alive and a late `session.idle` may fire after we've returned. Listeners are unsubbed by `finally`, so the next turn will not see the stale event, but the session is technically dangling. Consider an explicit `session.abort()` on timeout in a follow-up if operational signal warrants it.
- HTTP `/api/chat/send` is held open up to 5 minutes pre-existing behavior. Not changed by this PR.

Closes #222

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
