### PR TITLE
feat(marketplace): CLI tools as a marketplace primitive (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.46.0 (2026-05-07)
+
+### Marketplace
+
+- **CLI tools as a marketplace primitive** — Genesis-minds plugin manifests can now declare a `tools[]` array alongside `minds[]`. Each entry describes a globally-installable npm CLI (`{ install: { type: 'npm-global', package, version }, bin, help, preflight, agentInstructions }`). Chamber reads tools from every enrolled marketplace and persists installed tools in `~/.chamber/config.json` under `installedTools[]`. Foundation for the public-marketplace WorkIQ capability. (#218)
+- **Auto-install on startup** — On app ready, `ToolsService.reconcile()` diffs marketplace `tools[]` against `config.installedTools[]` and runs `npm install -g <package>@<version>` for any new entry, then runs declared `preflight` commands (e.g. `workiq accept-eula`). Errors are logged per-tool and do not block other installs. Already-installed tools are not auto-updated. (#218)
+- **Runtime tool context in the system message** — `IdentityLoader` accepts an `InstalledTool[]` provider and appends a `## Tools` section to every session's system message. Tool descriptions live in the marketplace manifest's `agentInstructions` field and are captured into the installed-tool record at install time, so model context is available offline. Mind directories are not modified. (#218)
+- **Tools IPC + preload surface** — New `tools:list`, `tools:install`, `tools:uninstall` channels exposed via `window.electronAPI.tools.*`. Browser-mode shim returns descriptive "desktop-only" errors. (#218)
+
 ## v0.45.0 (2026-05-07)
 
 ### Chatroom

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -22,11 +22,14 @@ import {
   GitHubRegistryClient,
   CronService,
   IdentityLoader,
+  MarketplaceToolCatalog,
   MessageRouter,
   MarketplaceRegistryService,
   MindManager,
   MindScaffold,
   TaskManager,
+  ToolInstaller,
+  ToolsService,
   TurnQueue,
   ViewDiscovery,
   configureSdkRuntimeLayout,
@@ -49,6 +52,7 @@ import { setupMindIPC } from './main/ipc/mind';
 import { setupLensIPC } from './main/ipc/lens';
 import { setupGenesisIPC } from './main/ipc/genesis';
 import { setupMarketplaceIPC } from './main/ipc/marketplace';
+import { setupToolsIPC } from './main/ipc/tools';
 import { setupAuthIPC } from './main/ipc/auth';
 import { setupA2AIPC } from './main/ipc/a2a';
 import { setupChatroomIPC } from './main/ipc/chatroom';
@@ -115,8 +119,8 @@ const notifier: Notifier = {
 };
 
 const clientFactory = new CopilotClientFactory();
-const identityLoader = new IdentityLoader();
 const configService = new ConfigService();
+const identityLoader = new IdentityLoader(() => configService.load().installedTools ?? []);
 const getGenesisMarketplaceSources = (): GenesisMindTemplateMarketplaceSource[] =>
   configService.load().marketplaceRegistries ?? [DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE];
 const saveActiveLogin = (login: string | null) => {
@@ -135,6 +139,8 @@ const scaffold = new MindScaffold();
 const genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(githubRegistryClient, getGenesisMarketplaceSources);
 const genesisTemplateInstaller = new GenesisMindTemplateInstaller(githubRegistryClient, clientFactory, getGenesisMarketplaceSources);
 const marketplaceRegistryService = new MarketplaceRegistryService(configService, githubRegistryClient);
+const marketplaceToolCatalog = new MarketplaceToolCatalog(githubRegistryClient, getGenesisMarketplaceSources);
+const toolsService = new ToolsService(marketplaceToolCatalog, new ToolInstaller(), configService);
 const viewDiscovery = new ViewDiscovery();
 
 // --- Services (business rules, all dependencies injected) ---
@@ -475,10 +481,24 @@ app.on('ready', async () => {
     genesisTemplateInstaller,
   );
   setupMarketplaceIPC(marketplaceRegistryService);
+  setupToolsIPC(toolsService);
   setupAuthIPC(authService, mindManager);
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager);
   setupChatroomIPC(chatroomService);
   setupUpdaterIPC(updaterService);
+
+  // Fire-and-forget tool reconciliation: install any new marketplace tools.
+  // Errors are logged in ToolsService and surface via tools:list later.
+  toolsService.reconcile()
+    .then((outcome) => {
+      if (outcome.installed.length > 0) {
+        log.info(`Installed ${outcome.installed.length} new marketplace tool(s):`, outcome.installed.map((tool) => tool.id));
+      }
+      if (outcome.errors.length > 0) {
+        log.warn(`Tool reconcile encountered ${outcome.errors.length} error(s):`, outcome.errors);
+      }
+    })
+    .catch((error: unknown) => log.warn('Tool reconciliation failed:', error));
 
   // Window controls
   ipcMain.on('window:minimize', () => mainWindow?.minimize());

--- a/apps/desktop/src/main/ipc/tools.ts
+++ b/apps/desktop/src/main/ipc/tools.ts
@@ -1,0 +1,10 @@
+import { ipcMain } from 'electron';
+import type { ToolsService } from '@chamber/services';
+
+export function setupToolsIPC(toolsService: ToolsService): void {
+  ipcMain.handle('tools:list', async () => toolsService.list());
+  ipcMain.handle('tools:install', async (_event, toolId: string, marketplaceId?: string) =>
+    toolsService.install(toolId, marketplaceId),
+  );
+  ipcMain.handle('tools:uninstall', async (_event, toolId: string) => toolsService.uninstall(toolId));
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -65,6 +65,11 @@ const electronAPI: ElectronAPI = {
     setGenesisRegistryEnabled: (id, enabled) => ipcRenderer.invoke('marketplace:setGenesisRegistryEnabled', id, enabled),
     removeGenesisRegistry: (id) => ipcRenderer.invoke('marketplace:removeGenesisRegistry', id),
   },
+  tools: {
+    list: () => ipcRenderer.invoke('tools:list'),
+    install: (toolId, marketplaceId) => ipcRenderer.invoke('tools:install', toolId, marketplaceId),
+    uninstall: (toolId) => ipcRenderer.invoke('tools:uninstall', toolId),
+  },
   chatroom: {
     send: (message: string, model?: string, roundId?: string) => ipcRenderer.invoke('chatroom:send', message, model, roundId),
     history: () => ipcRenderer.invoke('chatroom:history'),

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -32,7 +32,7 @@ const saveActiveLogin = (login: string | null) => {
 };
 const authService = new AuthService(keytar as CredentialStore, () => configService.load().activeLogin, saveActiveLogin);
 const viewDiscovery = new ViewDiscovery();
-const mindManager = new MindManager(new CopilotClientFactory(), new IdentityLoader(), configService, viewDiscovery);
+const mindManager = new MindManager(new CopilotClientFactory(), new IdentityLoader(() => configService.load().installedTools ?? []), configService, viewDiscovery);
 const chatService = new ChatService(mindManager, new TurnQueue());
 viewDiscovery.setRefreshHandler({
   sendBackgroundPrompt: (mindPath, prompt) => mindManager.sendBackgroundPrompt(mindPath, prompt),

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -239,6 +239,11 @@ export function installBrowserApi(): void {
       setGenesisRegistryEnabled: async () => ({ success: false, error: 'Marketplace management is desktop-only in browser mode.' }),
       removeGenesisRegistry: async () => ({ success: false, error: 'Marketplace management is desktop-only in browser mode.' }),
     },
+    tools: {
+      list: async () => [],
+      install: async () => ({ success: false, error: 'Tool install is desktop-only in browser mode.' }),
+      uninstall: async () => ({ success: false, error: 'Tool uninstall is desktop-only in browser mode.' }),
+    },
     chatroom: createBrowserChatroomApi(),
     updater: {
       getState: async () => ({

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -207,6 +207,11 @@ export function mockElectronAPI(): ElectronAPI {
         isDefault: false,
       } }),
     },
+    tools: {
+      list: vi.fn().mockResolvedValue([]),
+      install: vi.fn().mockResolvedValue({ success: false, error: 'not stubbed' }),
+      uninstall: vi.fn().mockResolvedValue({ success: true }),
+    },
     chatroom: {
       send: vi.fn().mockResolvedValue(undefined),
       history: vi.fn().mockResolvedValue([]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chat/IdentityLoader.test.ts
+++ b/packages/services/src/chat/IdentityLoader.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs', () => ({
 
 import * as fs from 'fs';
 import { IdentityLoader } from './IdentityLoader';
+import type { InstalledTool } from '@chamber/shared/types';
 
 describe('IdentityLoader', () => {
   const loader = new IdentityLoader();
@@ -123,6 +124,37 @@ describe('IdentityLoader', () => {
     it('returns null when nothing exists', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       expect(loader.load('/tmp/test')).toBeNull();
+    });
+
+    it('appends a Tools section when installed tools are provided', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('# Q\nI am an agent.');
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      const tools: InstalledTool[] = [{
+        id: 'workiq',
+        package: '@microsoft/workiq',
+        version: 'latest',
+        bin: 'workiq',
+        displayName: 'Microsoft Work IQ',
+        description: 'Query M365 data.',
+        help: 'workiq ask --help',
+        agentInstructions: 'Use `workiq ask "<question>"`.',
+        source: { marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' },
+        installedAt: '2026-05-07T21:00:00.000Z',
+      }];
+      const withTools = new IdentityLoader(() => tools);
+      const result = withTools.load('/tmp/test');
+      expect(result?.systemMessage).toContain('## Tools');
+      expect(result?.systemMessage).toContain('### workiq — Microsoft Work IQ');
+      expect(result?.systemMessage).toContain('workiq ask --help');
+    });
+
+    it('does not append a Tools section when no tools are installed', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('# Q\nI am an agent.');
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      const result = new IdentityLoader(() => []).load('/tmp/test');
+      expect(result?.systemMessage).not.toContain('## Tools');
     });
   });
 });

--- a/packages/services/src/chat/IdentityLoader.ts
+++ b/packages/services/src/chat/IdentityLoader.ts
@@ -1,12 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { MindIdentity } from '@chamber/shared/types';
+import type { InstalledTool, MindIdentity } from '@chamber/shared/types';
+import { buildToolsSection } from '../tools/toolsSystemMessage';
 
 const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 const H1_RE = /^#\s+(.+)$/m;
 const WORKING_MEMORY_FILES = ['memory.md', 'rules.md', 'log.md'];
 
+export type InstalledToolsProvider = () => InstalledTool[];
+
 export class IdentityLoader {
+  constructor(private readonly getInstalledTools: InstalledToolsProvider = () => []) {}
+
   load(mindPath: string | null): MindIdentity | null {
     if (!mindPath) return null;
     const identityParts: string[] = [];
@@ -48,6 +53,9 @@ export class IdentityLoader {
 
     const parts = [...identityParts, ...memoryParts];
     if (parts.length === 0) return null;
+
+    const toolsSection = buildToolsSection(this.getInstalledTools());
+    if (toolsSection) parts.push(toolsSection);
 
     const systemMessage = parts.join('\n\n---\n\n');
     const name = this.extractName(identityParts.join('\n\n---\n\n'), mindPath);

--- a/packages/services/src/config/ConfigService.test.ts
+++ b/packages/services/src/config/ConfigService.test.ts
@@ -237,4 +237,62 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('installedTools', () => {
+    it('round-trips a complete installed tool record', () => {
+      const installedTool = {
+        id: 'workiq',
+        package: '@microsoft/workiq',
+        version: 'latest',
+        bin: 'workiq',
+        displayName: 'Microsoft Work IQ',
+        description: 'Query M365 data.',
+        help: 'workiq ask --help',
+        agentInstructions: 'Use workiq ask.',
+        source: { marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' },
+        installedAt: '2026-05-07T21:00:00.000Z',
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [],
+        activeMindId: null,
+        activeLogin: null,
+        theme: 'dark',
+        installedTools: [installedTool],
+      }));
+      const loaded = svc.load();
+      expect(loaded.installedTools).toEqual([installedTool]);
+    });
+
+    it('drops malformed tool records and deduplicates by id', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [],
+        activeMindId: null,
+        activeLogin: null,
+        theme: 'dark',
+        installedTools: [
+          { id: 'workiq', package: '@microsoft/workiq', version: '1', bin: 'workiq', displayName: 'A', description: 'a', source: { marketplaceId: 'm', pluginId: 'p' }, installedAt: '2026-01-01T00:00:00Z' },
+          { id: 'workiq', package: 'duplicate', version: '2', bin: 'workiq', displayName: 'B', description: 'b', source: { marketplaceId: 'm', pluginId: 'p' }, installedAt: '2026-01-02T00:00:00Z' },
+          { id: 'broken' },
+          { not: 'a tool' },
+        ],
+      }));
+      const loaded = svc.load();
+      expect(loaded.installedTools).toHaveLength(1);
+      expect(loaded.installedTools?.[0].package).toBe('@microsoft/workiq');
+    });
+
+    it('omits installedTools entirely when none are persisted', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [],
+        activeMindId: null,
+        activeLogin: null,
+        theme: 'dark',
+      }));
+      const loaded = svc.load();
+      expect(loaded.installedTools).toBeUndefined();
+    });
+  });
+
 });

--- a/packages/services/src/config/ConfigService.ts
+++ b/packages/services/src/config/ConfigService.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { generateMindId } from '../mind';
-import type { AppConfig, AppConfigV1, ChamberConversationRecord, MarketplaceRegistry, MindRecord } from '@chamber/shared/types';
+import type { AppConfig, AppConfigV1, ChamberConversationRecord, InstalledTool, MarketplaceRegistry, MindRecord } from '@chamber/shared/types';
 
 const CONFIG_DIR = path.join(os.homedir(), '.chamber');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
@@ -66,6 +66,7 @@ export class ConfigService {
     const minds = Array.isArray(raw.minds)
       ? raw.minds.map(normalizeMindRecord).filter((record): record is MindRecord => record !== null)
       : [];
+    const installedTools = normalizeInstalledTools(raw.installedTools);
     return this.deduplicateMinds({
       version: 2,
       minds,
@@ -73,6 +74,7 @@ export class ConfigService {
       activeLogin: typeof raw.activeLogin === 'string' ? raw.activeLogin : null,
       theme,
       marketplaceRegistries: this.normalizeMarketplaceRegistries(raw.marketplaceRegistries),
+      ...(installedTools.length > 0 ? { installedTools } : {}),
     });
   }
 
@@ -167,6 +169,48 @@ function isMarketplaceRegistry(value: unknown): value is MarketplaceRegistry {
     && typeof record.plugin === 'string'
     && typeof record.enabled === 'boolean'
     && typeof record.isDefault === 'boolean';
+}
+
+function normalizeInstalledTools(raw: unknown): InstalledTool[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const tools: InstalledTool[] = [];
+  for (const value of raw) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue;
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.id !== 'string'
+      || typeof record.package !== 'string'
+      || typeof record.version !== 'string'
+      || typeof record.bin !== 'string'
+      || typeof record.installedAt !== 'string'
+      || typeof record.displayName !== 'string'
+      || typeof record.description !== 'string'
+    ) {
+      continue;
+    }
+    const source = record.source;
+    if (typeof source !== 'object' || source === null || Array.isArray(source)) continue;
+    const sourceRecord = source as Record<string, unknown>;
+    if (typeof sourceRecord.marketplaceId !== 'string' || typeof sourceRecord.pluginId !== 'string') {
+      continue;
+    }
+    if (seen.has(record.id)) continue;
+    seen.add(record.id);
+    tools.push({
+      id: record.id,
+      package: record.package,
+      version: record.version,
+      bin: record.bin,
+      displayName: record.displayName,
+      description: record.description,
+      ...(typeof record.help === 'string' ? { help: record.help } : {}),
+      ...(typeof record.agentInstructions === 'string' ? { agentInstructions: record.agentInstructions } : {}),
+      source: { marketplaceId: sourceRecord.marketplaceId, pluginId: sourceRecord.pluginId },
+      installedAt: record.installedAt,
+    });
+  }
+  return tools;
 }
 
 function deduplicateRegistries(registries: MarketplaceRegistry[]): MarketplaceRegistry[] {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -12,3 +12,4 @@ export * from './lens';
 export * from './mind';
 export * from './ports';
 export * from './sdk';
+export * from './tools';

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -499,6 +499,38 @@ describe('MindManager', () => {
 
       expect(savedMindIds(lastSavedConfig())).toEqual([mind2.mindId]);
     });
+
+    it('preserves marketplaceRegistries and installedTools across persist', async () => {
+      currentConfig = {
+        ...currentConfig,
+        marketplaceRegistries: [{
+          id: 'github:ianphil/genesis-minds',
+          label: 'Public Genesis Minds',
+          url: 'https://github.com/ianphil/genesis-minds',
+          owner: 'ianphil',
+          repo: 'genesis-minds',
+          ref: 'master',
+          plugin: 'genesis-minds',
+          enabled: true,
+          isDefault: true,
+        }],
+        installedTools: [{
+          id: 'workiq',
+          package: '@microsoft/workiq',
+          version: 'latest',
+          bin: 'workiq',
+          displayName: 'Microsoft Work IQ',
+          description: 'Query M365 data.',
+          source: { marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' },
+          installedAt: '2026-05-08T00:00:00.000Z',
+        }],
+      };
+      await manager.loadMind('/tmp/agents/q');
+      const saved = lastSavedConfig();
+      expect(saved.marketplaceRegistries).toHaveLength(1);
+      expect(saved.installedTools).toHaveLength(1);
+      expect(saved.installedTools?.[0].id).toBe('workiq');
+    });
   });
 
   describe('listMinds', () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -273,9 +273,21 @@ export class MindManager extends EventEmitter {
   async startNewConversation(mindId: string): Promise<CopilotSession> {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
+    const refreshedIdentity = this.identityLoader.load(context.mindPath);
+    const identityChanged = refreshedIdentity !== null
+      && refreshedIdentity.systemMessage !== context.identity.systemMessage;
+    if (identityChanged) {
+      context.identity = refreshedIdentity;
+    }
     const activeConversation = this.getActiveConversationRecord(mindId);
-    if (activeConversation?.hasMessages === false && context.session) {
+    if (activeConversation?.hasMessages === false && context.session && !identityChanged) {
       return context.session;
+    }
+
+    if (activeConversation?.hasMessages === false && context.session && identityChanged) {
+      // Recreate the SDK session so the model picks up the refreshed system message
+      // (e.g. newly installed marketplace tools advertised in ## Tools).
+      return this.createNewConversationSession(mindId, context, activeConversation.sessionId);
     }
 
     return this.createNewConversationSession(mindId, context);
@@ -310,6 +322,10 @@ export class MindManager extends EventEmitter {
     context: InternalMindContext,
     replaceSessionId?: string,
   ): Promise<CopilotSession> {
+    const refreshedIdentity = this.identityLoader.load(context.mindPath);
+    if (refreshedIdentity) {
+      context.identity = refreshedIdentity;
+    }
     const conversation = this.createConversationRecord(mindId);
     const previousSession = context.session;
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
@@ -556,11 +572,10 @@ export class MindManager extends EventEmitter {
 
     const existingConfig = this.configService.load();
     const configSnapshot: AppConfig = {
+      ...existingConfig,
       version: 2,
       minds: this.getPersistedMindRecords(),
       activeMindId: this.getPersistedActiveMindId(),
-      activeLogin: existingConfig.activeLogin,
-      theme: existingConfig.theme,
     };
 
     this.reloading = true;
@@ -892,11 +907,10 @@ export class MindManager extends EventEmitter {
     if (this.reloading) return;
     const existingConfig = this.configService.load();
     const config: AppConfig = {
+      ...existingConfig,
       version: 2,
       minds: this.getPersistedMindRecords(),
       activeMindId: this.getPersistedActiveMindId(),
-      activeLogin: existingConfig.activeLogin,
-      theme: existingConfig.theme,
     };
     this.configService.save(config);
   }

--- a/packages/services/src/mind/types.ts
+++ b/packages/services/src/mind/types.ts
@@ -1,7 +1,7 @@
 // Internal mind context — main process only, not exposed to renderer
 // Extends the shared MindContext with infrastructure details
 
-import type { MindContext } from '@chamber/shared/types';
+import type { MindContext, MindIdentity } from '@chamber/shared/types';
 import type { CopilotClient, CopilotSession, SessionConfig, Tool as SdkTool } from '@github/copilot-sdk';
 
 export type { CopilotClient, CopilotSession };
@@ -22,4 +22,8 @@ export interface InternalMindContext extends MindContext {
   client: CopilotClient;
   session: CopilotSession | null;
   activeSessionId?: string;
+  // Override the readonly identity from MindContext so internal callers can
+  // refresh it (e.g. when newly installed marketplace tools change the
+  // system message advertised at the start of a new conversation).
+  identity: MindIdentity;
 }

--- a/packages/services/src/tools/MarketplaceToolCatalog.test.ts
+++ b/packages/services/src/tools/MarketplaceToolCatalog.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
+import type { ToolMarketplaceSource } from './toolTypes';
+
+class FakeRegistryClient {
+  manifests = new Map<string, unknown>();
+  async fetchTree(): Promise<never[]> { return []; }
+  async fetchJsonContent(_owner: string, _repo: string, filePath: string): Promise<unknown> {
+    if (!this.manifests.has(filePath)) {
+      throw new Error(`No fake content for ${filePath}`);
+    }
+    return this.manifests.get(filePath);
+  }
+}
+
+const SOURCE: ToolMarketplaceSource = {
+  id: 'github:ianphil/genesis-minds',
+  label: 'Public Genesis Minds',
+  url: 'https://github.com/ianphil/genesis-minds',
+  owner: 'ianphil',
+  repo: 'genesis-minds',
+  ref: 'master',
+  plugin: 'genesis-minds',
+  enabled: true,
+};
+
+describe('MarketplaceToolCatalog', () => {
+  let client: FakeRegistryClient;
+
+  beforeEach(() => {
+    client = new FakeRegistryClient();
+  });
+
+  it('returns an empty list when the plugin omits the tools field', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', { name: 'genesis-minds', minds: [] });
+    const catalog = new MarketplaceToolCatalog(client, [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.tools).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('parses a well-formed tools entry', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', {
+      name: 'genesis-minds',
+      tools: [
+        {
+          id: 'workiq',
+          displayName: 'Microsoft Work IQ',
+          description: 'Query M365 data.',
+          install: { type: 'npm-global', package: '@microsoft/workiq', version: 'latest' },
+          bin: 'workiq',
+          help: 'workiq ask --help',
+          preflight: ['workiq accept-eula'],
+          agentInstructions: 'Use workiq ask.',
+        },
+      ],
+    });
+    const catalog = new MarketplaceToolCatalog(client, [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.errors).toEqual([]);
+    expect(result.tools).toHaveLength(1);
+    const tool = result.tools[0];
+    expect(tool.id).toBe('workiq');
+    expect(tool.install).toEqual({ type: 'npm-global', package: '@microsoft/workiq', version: 'latest' });
+    expect(tool.preflight).toEqual(['workiq accept-eula']);
+    expect(tool.source.marketplaceId).toBe('github:ianphil/genesis-minds');
+  });
+
+  it('skips disabled marketplaces', async () => {
+    const catalog = new MarketplaceToolCatalog(client, [{ ...SOURCE, enabled: false }]);
+    const result = await catalog.listTools();
+    expect(result.tools).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reports per-marketplace errors without aborting the catalog', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', { tools: 'not-an-array' });
+    const catalog = new MarketplaceToolCatalog(client, [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.tools).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].marketplaceId).toBe('github:ianphil/genesis-minds');
+    expect(result.errors[0].message).toContain('non-array tools field');
+  });
+
+  it('rejects malformed tool entries', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', {
+      tools: [{ id: 'workiq', displayName: 'WorkIQ' }],
+    });
+    const catalog = new MarketplaceToolCatalog(client, [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('description');
+  });
+
+  it('supports a function-style source provider', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', { tools: [] });
+    const catalog = new MarketplaceToolCatalog(client, () => [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.tools).toEqual([]);
+  });
+});

--- a/packages/services/src/tools/MarketplaceToolCatalog.ts
+++ b/packages/services/src/tools/MarketplaceToolCatalog.ts
@@ -1,0 +1,140 @@
+import { GitHubRegistryClient, type TreeEntry } from '../genesis/GitHubRegistryClient';
+import type { MarketplaceToolEntry } from '@chamber/shared/types';
+import type { ToolMarketplaceSource } from './toolTypes';
+
+interface RegistryClient {
+  fetchTree(owner: string, repo: string, branch: string): Promise<TreeEntry[]>;
+  fetchJsonContent(owner: string, repo: string, filePath: string, ref: string): Promise<unknown>;
+}
+
+type SourceProvider = ToolMarketplaceSource[] | (() => ToolMarketplaceSource[]);
+
+export interface MarketplaceToolCatalogResult {
+  tools: MarketplaceToolEntry[];
+  errors: Array<{ marketplaceId: string; message: string }>;
+}
+
+/**
+ * Reads `tools[]` from each enrolled marketplace's plugin.json.
+ * Tools are an additive section alongside `minds[]`; absence is not an error.
+ */
+export class MarketplaceToolCatalog {
+  constructor(
+    private readonly registryClient: RegistryClient = new GitHubRegistryClient(),
+    private readonly sourceProvider: SourceProvider = [],
+  ) {}
+
+  async listTools(): Promise<MarketplaceToolCatalogResult> {
+    const tools: MarketplaceToolEntry[] = [];
+    const errors: MarketplaceToolCatalogResult['errors'] = [];
+
+    for (const source of this.getSources()) {
+      if (source.enabled === false) continue;
+      try {
+        const sourceTools = await this.readSource(source);
+        tools.push(...sourceTools);
+      } catch (error) {
+        errors.push({
+          marketplaceId: source.id ?? `github:${source.owner}/${source.repo}`,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return { tools, errors };
+  }
+
+  private async readSource(source: ToolMarketplaceSource): Promise<MarketplaceToolEntry[]> {
+    const pluginPath = `plugins/${source.plugin}/plugin.json`;
+    const plugin = await this.registryClient.fetchJsonContent(source.owner, source.repo, pluginPath, source.ref);
+    if (!isRecord(plugin)) {
+      throw new Error(`Plugin manifest ${pluginPath} is not a JSON object`);
+    }
+    const rawTools = plugin.tools;
+    if (rawTools === undefined) return [];
+    if (!Array.isArray(rawTools)) {
+      throw new Error(`Plugin manifest ${pluginPath} has a non-array tools field`);
+    }
+    return rawTools.map((entry, index) => parseToolEntry(entry, index, pluginPath, source));
+  }
+
+  private getSources(): ToolMarketplaceSource[] {
+    return typeof this.sourceProvider === 'function' ? this.sourceProvider() : this.sourceProvider;
+  }
+}
+
+function parseToolEntry(
+  entry: unknown,
+  index: number,
+  pluginPath: string,
+  source: ToolMarketplaceSource,
+): MarketplaceToolEntry {
+  if (!isRecord(entry)) {
+    throw new Error(`${pluginPath} tools[${index}] is not an object`);
+  }
+  const id = stringField(entry, 'id', pluginPath, index);
+  const displayName = stringField(entry, 'displayName', pluginPath, index);
+  const description = stringField(entry, 'description', pluginPath, index);
+  const bin = stringField(entry, 'bin', pluginPath, index);
+
+  const install = entry.install;
+  if (!isRecord(install) || install.type !== 'npm-global'
+    || typeof install.package !== 'string' || typeof install.version !== 'string') {
+    throw new Error(`${pluginPath} tools[${index}].install must be { type: 'npm-global', package, version }`);
+  }
+
+  const help = optionalString(entry, 'help');
+  const agentInstructions = optionalString(entry, 'agentInstructions');
+  const preflight = optionalStringArray(entry, 'preflight', pluginPath, index);
+
+  return {
+    id,
+    displayName,
+    description,
+    install: { type: 'npm-global', package: install.package, version: install.version },
+    bin,
+    ...(help ? { help } : {}),
+    ...(preflight ? { preflight } : {}),
+    ...(agentInstructions ? { agentInstructions } : {}),
+    source: {
+      owner: source.owner,
+      repo: source.repo,
+      ref: source.ref,
+      plugin: source.plugin,
+      marketplaceId: source.id ?? `github:${source.owner}/${source.repo}`,
+      marketplaceLabel: source.label ?? `${source.owner}/${source.repo}`,
+      marketplaceUrl: source.url ?? `https://github.com/${source.owner}/${source.repo}`,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, key: string, pluginPath: string, index: number): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${pluginPath} tools[${index}].${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function optionalStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  pluginPath: string,
+  index: number,
+): string[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${pluginPath} tools[${index}].${key} must be a string array`);
+  }
+  return value as string[];
+}

--- a/packages/services/src/tools/ToolInstaller.test.ts
+++ b/packages/services/src/tools/ToolInstaller.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import type { MarketplaceToolEntry } from '@chamber/shared/types';
+import { ToolInstaller, type CommandRunner, type CommandResult } from './ToolInstaller';
+
+class FakeRunner implements CommandRunner {
+  calls: Array<{ command: string; args: string[] }> = [];
+  responses: CommandResult[] = [];
+  fallback: CommandResult = { exitCode: 0, stdout: '', stderr: '' };
+  async run(command: string, args: string[]): Promise<CommandResult> {
+    this.calls.push({ command, args });
+    return this.responses.shift() ?? this.fallback;
+  }
+}
+
+const TOOL: MarketplaceToolEntry = {
+  id: 'workiq',
+  displayName: 'Microsoft Work IQ',
+  description: 'Query M365 data.',
+  install: { type: 'npm-global', package: '@microsoft/workiq', version: 'latest' },
+  bin: 'workiq',
+  help: 'workiq ask --help',
+  preflight: ['workiq accept-eula'],
+  agentInstructions: 'Use workiq ask.',
+  source: {
+    owner: 'ianphil',
+    repo: 'genesis-minds',
+    ref: 'master',
+    plugin: 'genesis-minds',
+    marketplaceId: 'github:ianphil/genesis-minds',
+    marketplaceLabel: 'Public Genesis Minds',
+    marketplaceUrl: 'https://github.com/ianphil/genesis-minds',
+  },
+};
+
+describe('ToolInstaller', () => {
+  it('runs npm install -g, the verify command, and any preflight commands', async () => {
+    const runner = new FakeRunner();
+    const installer = new ToolInstaller(runner);
+    const result = await installer.install(TOOL);
+
+    expect(runner.calls[0]).toEqual({ command: 'npm', args: ['install', '-g', '@microsoft/workiq@latest'] });
+    expect(runner.calls[1]).toEqual({ command: 'workiq', args: ['--version'] });
+    expect(runner.calls[2]).toEqual({ command: 'workiq', args: ['accept-eula'] });
+    expect(result.id).toBe('workiq');
+    expect(result.package).toBe('@microsoft/workiq');
+    expect(result.bin).toBe('workiq');
+    expect(result.displayName).toBe('Microsoft Work IQ');
+    expect(result.agentInstructions).toBe('Use workiq ask.');
+    expect(result.source).toEqual({ marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' });
+  });
+
+  it('throws with stderr when npm install -g exits non-zero', async () => {
+    const runner = new FakeRunner();
+    runner.responses = [{ exitCode: 1, stdout: '', stderr: 'EACCES denied' }];
+    const installer = new ToolInstaller(runner);
+
+    await expect(installer.install(TOOL)).rejects.toThrow(/EACCES denied/);
+  });
+
+  it('continues installing even if --version verification fails', async () => {
+    const runner = new FakeRunner();
+    runner.responses = [
+      { exitCode: 0, stdout: '', stderr: '' },
+      { exitCode: 127, stdout: '', stderr: 'workiq: not found' },
+      { exitCode: 0, stdout: '', stderr: '' },
+    ];
+    const installer = new ToolInstaller(runner);
+    const result = await installer.install(TOOL);
+    expect(result.bin).toBe('workiq');
+  });
+
+  it('uninstalls via npm uninstall -g and surfaces errors', async () => {
+    const runner = new FakeRunner();
+    const installer = new ToolInstaller(runner);
+    await installer.uninstall({
+      id: 'workiq',
+      package: '@microsoft/workiq',
+      version: 'latest',
+      bin: 'workiq',
+      displayName: 'Microsoft Work IQ',
+      description: 'Query M365 data.',
+      source: { marketplaceId: 'm', pluginId: 'p' },
+      installedAt: '2026-01-01T00:00:00Z',
+    });
+    expect(runner.calls[0]).toEqual({ command: 'npm', args: ['uninstall', '-g', '@microsoft/workiq'] });
+  });
+});

--- a/packages/services/src/tools/ToolInstaller.ts
+++ b/packages/services/src/tools/ToolInstaller.ts
@@ -1,0 +1,85 @@
+import { spawn } from 'node:child_process';
+import type { InstalledTool, MarketplaceToolEntry } from '@chamber/shared/types';
+import { Logger } from '../logger';
+
+const log = Logger.create('ToolInstaller');
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CommandRunner {
+  run(command: string, args: string[]): Promise<CommandResult>;
+}
+
+export class ToolInstaller {
+  constructor(private readonly runner: CommandRunner = new ChildProcessRunner()) {}
+
+  async install(tool: MarketplaceToolEntry): Promise<InstalledTool> {
+    const spec = `${tool.install.package}@${tool.install.version}`;
+    log.info(`Installing tool ${tool.id} (${spec}) globally via npm`);
+    const installResult = await this.runner.run('npm', ['install', '-g', spec]);
+    if (installResult.exitCode !== 0) {
+      throw new Error(
+        `npm install -g ${spec} failed (exit ${installResult.exitCode})\n${installResult.stderr || installResult.stdout}`.trim(),
+      );
+    }
+
+    const verifyResult = await this.runner.run(tool.bin, ['--version']);
+    if (verifyResult.exitCode !== 0) {
+      log.warn(`Tool ${tool.bin} --version exited ${verifyResult.exitCode}; continuing.`);
+    }
+
+    for (const command of tool.preflight ?? []) {
+      const [bin, ...args] = command.split(/\s+/).filter(Boolean);
+      if (!bin) continue;
+      log.info(`Running preflight: ${command}`);
+      const preflightResult = await this.runner.run(bin, args);
+      if (preflightResult.exitCode !== 0) {
+        log.warn(`Preflight "${command}" exited ${preflightResult.exitCode}: ${preflightResult.stderr.trim()}`);
+      }
+    }
+
+    return {
+      id: tool.id,
+      package: tool.install.package,
+      version: tool.install.version,
+      bin: tool.bin,
+      displayName: tool.displayName,
+      description: tool.description,
+      ...(tool.help ? { help: tool.help } : {}),
+      ...(tool.agentInstructions ? { agentInstructions: tool.agentInstructions } : {}),
+      source: { marketplaceId: tool.source.marketplaceId, pluginId: tool.source.plugin },
+      installedAt: new Date().toISOString(),
+    };
+  }
+
+  async uninstall(tool: InstalledTool): Promise<void> {
+    const result = await this.runner.run('npm', ['uninstall', '-g', tool.package]);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `npm uninstall -g ${tool.package} failed (exit ${result.exitCode})\n${result.stderr || result.stdout}`.trim(),
+      );
+    }
+  }
+}
+
+export class ChildProcessRunner implements CommandRunner {
+  async run(command: string, args: string[]): Promise<CommandResult> {
+    return new Promise((resolve) => {
+      const child = spawn(command, args, { shell: process.platform === 'win32', windowsHide: true });
+      let stdout = '';
+      let stderr = '';
+      child.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+      child.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
+      child.on('error', (error) => {
+        resolve({ exitCode: -1, stdout, stderr: stderr || error.message });
+      });
+      child.on('close', (code) => {
+        resolve({ exitCode: code ?? 0, stdout, stderr });
+      });
+    });
+  }
+}

--- a/packages/services/src/tools/ToolsService.test.ts
+++ b/packages/services/src/tools/ToolsService.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AppConfig, InstalledTool } from '@chamber/shared/types';
+import { ToolsService } from './ToolsService';
+import { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
+import { ToolInstaller, type CommandRunner, type CommandResult } from './ToolInstaller';
+import type { ToolMarketplaceSource } from './toolTypes';
+
+class FakeRegistryClient {
+  manifests = new Map<string, unknown>();
+  async fetchTree(): Promise<never[]> { return []; }
+  async fetchJsonContent(_owner: string, _repo: string, filePath: string): Promise<unknown> {
+    return this.manifests.get(filePath) ?? {};
+  }
+}
+
+class FakeRunner implements CommandRunner {
+  responses = new Map<string, CommandResult>();
+  async run(command: string, args: string[]): Promise<CommandResult> {
+    const key = `${command} ${args.join(' ')}`;
+    return this.responses.get(key) ?? { exitCode: 0, stdout: '', stderr: '' };
+  }
+}
+
+class FakeConfigStore {
+  config: AppConfig = {
+    version: 2,
+    minds: [],
+    activeMindId: null,
+    activeLogin: null,
+    theme: 'dark',
+  };
+  load(): AppConfig { return JSON.parse(JSON.stringify(this.config)); }
+  save(next: AppConfig): void { this.config = next; }
+}
+
+const SOURCE: ToolMarketplaceSource = {
+  id: 'github:ianphil/genesis-minds',
+  label: 'Public Genesis Minds',
+  url: 'https://github.com/ianphil/genesis-minds',
+  owner: 'ianphil',
+  repo: 'genesis-minds',
+  ref: 'master',
+  plugin: 'genesis-minds',
+  enabled: true,
+};
+
+const TOOL_ENTRY = {
+  id: 'workiq',
+  displayName: 'Microsoft Work IQ',
+  description: 'Query M365 data.',
+  install: { type: 'npm-global', package: '@microsoft/workiq', version: 'latest' },
+  bin: 'workiq',
+  help: 'workiq ask --help',
+  agentInstructions: 'Use workiq ask.',
+};
+
+function setupTools(client: FakeRegistryClient, entries: unknown[] = [TOOL_ENTRY]): void {
+  client.manifests.set('plugins/genesis-minds/plugin.json', { tools: entries });
+}
+
+describe('ToolsService', () => {
+  let client: FakeRegistryClient;
+  let runner: FakeRunner;
+  let store: FakeConfigStore;
+  let svc: ToolsService;
+
+  beforeEach(() => {
+    client = new FakeRegistryClient();
+    runner = new FakeRunner();
+    store = new FakeConfigStore();
+    svc = new ToolsService(
+      new MarketplaceToolCatalog(client, [SOURCE]),
+      new ToolInstaller(runner),
+      store,
+    );
+  });
+
+  it('lists tools as available when not installed', async () => {
+    setupTools(client);
+    const list = await svc.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].status).toBe('available');
+    expect(list[0].installedVersion).toBeUndefined();
+  });
+
+  it('lists tools as installed when present in config', async () => {
+    setupTools(client);
+    store.config.installedTools = [installedRecord()];
+    const list = await svc.list();
+    expect(list[0].status).toBe('installed');
+    expect(list[0].installedVersion).toBe('latest');
+  });
+
+  it('install persists the InstalledTool and rejects unknown ids', async () => {
+    setupTools(client);
+    const ok = await svc.install('workiq');
+    expect(ok.success).toBe(true);
+    expect(store.config.installedTools).toHaveLength(1);
+    expect(store.config.installedTools?.[0].id).toBe('workiq');
+
+    const missing = await svc.install('nope');
+    expect(missing).toEqual({ success: false, error: 'Tool not found in marketplace: nope' });
+  });
+
+  it('install surfaces npm errors without persisting', async () => {
+    setupTools(client);
+    runner.responses.set('npm install -g @microsoft/workiq@latest', { exitCode: 1, stdout: '', stderr: 'EACCES' });
+    const result = await svc.install('workiq');
+    expect(result.success).toBe(false);
+    expect(store.config.installedTools ?? []).toHaveLength(0);
+  });
+
+  it('uninstall removes the record and rejects unknown ids', async () => {
+    store.config.installedTools = [installedRecord()];
+    const ok = await svc.uninstall('workiq');
+    expect(ok.success).toBe(true);
+    expect(store.config.installedTools).toHaveLength(0);
+
+    const missing = await svc.uninstall('nope');
+    expect(missing.success).toBe(false);
+  });
+
+  it('reconcile installs only new tools and continues past per-tool errors', async () => {
+    setupTools(client, [
+      TOOL_ENTRY,
+      { ...TOOL_ENTRY, id: 'broken', bin: 'broken', install: { type: 'npm-global', package: 'broken-pkg', version: '1.0.0' } },
+    ]);
+    runner.responses.set('npm install -g broken-pkg@1.0.0', { exitCode: 1, stdout: '', stderr: 'boom' });
+
+    const outcome = await svc.reconcile();
+    expect(outcome.installed.map((t) => t.id)).toEqual(['workiq']);
+    expect(outcome.errors.map((e) => e.toolId)).toEqual(['broken']);
+    expect(store.config.installedTools).toHaveLength(1);
+
+    const second = await svc.reconcile();
+    expect(second.installed).toHaveLength(0);
+    expect(second.errors.map((e) => e.toolId)).toEqual(['broken']);
+  });
+});
+
+function installedRecord(): InstalledTool {
+  return {
+    id: 'workiq',
+    package: '@microsoft/workiq',
+    version: 'latest',
+    bin: 'workiq',
+    displayName: 'Microsoft Work IQ',
+    description: 'Query M365 data.',
+    help: 'workiq ask --help',
+    agentInstructions: 'Use workiq ask.',
+    source: { marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' },
+    installedAt: '2026-05-07T21:00:00.000Z',
+  };
+}

--- a/packages/services/src/tools/ToolsService.ts
+++ b/packages/services/src/tools/ToolsService.ts
@@ -1,0 +1,113 @@
+import type { AppConfig, InstalledTool, MarketplaceToolEntry, ToolActionResult, ToolCatalogEntry } from '@chamber/shared/types';
+import { Logger } from '../logger';
+import { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
+import { ToolInstaller } from './ToolInstaller';
+
+const log = Logger.create('ToolsService');
+
+interface ConfigStore {
+  load(): AppConfig;
+  save(config: AppConfig): void;
+}
+
+/**
+ * Orchestrates the marketplace-tool lifecycle: list (catalog ∪ installed),
+ * install (npm i -g + persist), uninstall (npm uninstall -g + persist), and
+ * startup reconciliation (install everything new since last run).
+ */
+export class ToolsService {
+  constructor(
+    private readonly catalog: MarketplaceToolCatalog,
+    private readonly installer: ToolInstaller,
+    private readonly configStore: ConfigStore,
+  ) {}
+
+  async list(): Promise<ToolCatalogEntry[]> {
+    const installed = this.getInstalled();
+    const installedById = new Map(installed.map((tool) => [tool.id, tool]));
+    const result = await this.catalog.listTools();
+    const catalogEntries: ToolCatalogEntry[] = result.tools.map((tool) => {
+      const persisted = installedById.get(tool.id);
+      return {
+        ...tool,
+        status: persisted ? 'installed' : 'available',
+        ...(persisted ? { installedVersion: persisted.version } : {}),
+      };
+    });
+    return catalogEntries;
+  }
+
+  async install(toolId: string, marketplaceId?: string): Promise<ToolActionResult> {
+    const result = await this.catalog.listTools();
+    const tool = result.tools.find((entry) =>
+      entry.id === toolId
+      && (!marketplaceId || entry.source.marketplaceId === marketplaceId),
+    );
+    if (!tool) {
+      return { success: false, error: `Tool not found in marketplace: ${toolId}` };
+    }
+    return this.installEntry(tool);
+  }
+
+  async uninstall(toolId: string): Promise<{ success: boolean; error?: string }> {
+    const installed = this.getInstalled();
+    const tool = installed.find((entry) => entry.id === toolId);
+    if (!tool) {
+      return { success: false, error: `Tool not installed: ${toolId}` };
+    }
+    try {
+      await this.installer.uninstall(tool);
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+    this.persist(installed.filter((entry) => entry.id !== toolId));
+    return { success: true };
+  }
+
+  /**
+   * Install any marketplace tools that are not already in installedTools[].
+   * Errors on individual tools are logged and skipped — other tools still install.
+   */
+  async reconcile(): Promise<{ installed: InstalledTool[]; errors: Array<{ toolId: string; message: string }> }> {
+    const result = await this.catalog.listTools();
+    const installed = this.getInstalled();
+    const installedIds = new Set(installed.map((tool) => tool.id));
+    const newTools = result.tools.filter((tool) => !installedIds.has(tool.id));
+
+    const newlyInstalled: InstalledTool[] = [];
+    const errors: Array<{ toolId: string; message: string }> = [];
+
+    for (const tool of newTools) {
+      const outcome = await this.installEntry(tool);
+      if (outcome.success) {
+        newlyInstalled.push(outcome.tool);
+      } else {
+        log.warn(`Reconcile failed for tool ${tool.id}: ${outcome.error}`);
+        errors.push({ toolId: tool.id, message: outcome.error });
+      }
+    }
+
+    return { installed: newlyInstalled, errors };
+  }
+
+  private async installEntry(tool: MarketplaceToolEntry): Promise<ToolActionResult> {
+    try {
+      const installed = await this.installer.install(tool);
+      const current = this.getInstalled();
+      const next = [...current.filter((entry) => entry.id !== installed.id), installed];
+      this.persist(next);
+      return { success: true, tool: installed };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  private getInstalled(): InstalledTool[] {
+    return this.configStore.load().installedTools ?? [];
+  }
+
+  private persist(tools: InstalledTool[]): void {
+    const config = this.configStore.load();
+    this.configStore.save({ ...config, installedTools: tools });
+  }
+}

--- a/packages/services/src/tools/index.ts
+++ b/packages/services/src/tools/index.ts
@@ -1,0 +1,6 @@
+export { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
+export type { MarketplaceToolCatalogResult } from './MarketplaceToolCatalog';
+export { ToolInstaller, ChildProcessRunner } from './ToolInstaller';
+export type { CommandRunner, CommandResult } from './ToolInstaller';
+export { ToolsService } from './ToolsService';
+export { buildToolsSection } from './toolsSystemMessage';

--- a/packages/services/src/tools/toolTypes.ts
+++ b/packages/services/src/tools/toolTypes.ts
@@ -1,0 +1,19 @@
+import type { MarketplaceToolEntry } from '@chamber/shared/types';
+
+/**
+ * Catalog source — accepts either the strict {@link MarketplaceRegistry} shape
+ * or the loose Genesis registry shape (where id/label/url may be undefined).
+ * The catalog falls back to deriving id/label/url from owner/repo when missing.
+ */
+export interface ToolMarketplaceSource {
+  id?: string;
+  label?: string;
+  url?: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  plugin: string;
+  enabled?: boolean;
+}
+
+export type { MarketplaceToolEntry };

--- a/packages/services/src/tools/tools-integration.test.ts
+++ b/packages/services/src/tools/tools-integration.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ConfigService } from '../config/ConfigService';
+import { IdentityLoader } from '../chat/IdentityLoader';
+import { MindManager } from '../mind/MindManager';
+import { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
+import { ToolInstaller, type CommandRunner, type CommandResult } from './ToolInstaller';
+import { ToolsService } from './ToolsService';
+import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
+import type { ViewDiscovery } from '../lens/ViewDiscovery';
+
+class FakeRegistryClient {
+  manifests = new Map<string, unknown>();
+  async fetchTree(): Promise<never[]> { return []; }
+  async fetchJsonContent(_owner: string, _repo: string, filePath: string): Promise<unknown> {
+    return this.manifests.get(filePath) ?? {};
+  }
+}
+
+class FakeRunner implements CommandRunner {
+  calls: Array<{ command: string; args: string[] }> = [];
+  async run(command: string, args: string[]): Promise<CommandResult> {
+    this.calls.push({ command, args });
+    return { exitCode: 0, stdout: '', stderr: '' };
+  }
+}
+
+const SOURCE = {
+  id: 'github:ianphil/genesis-minds',
+  label: 'Public Genesis Minds',
+  url: 'https://github.com/ianphil/genesis-minds',
+  owner: 'ianphil',
+  repo: 'genesis-minds',
+  ref: 'master',
+  plugin: 'genesis-minds',
+  enabled: true,
+};
+
+const WORKIQ_ENTRY = {
+  id: 'workiq',
+  displayName: 'Microsoft Work IQ',
+  description: 'Query M365 data via natural language.',
+  install: { type: 'npm-global', package: '@microsoft/workiq', version: 'latest' },
+  bin: 'workiq',
+  help: 'workiq ask --help',
+  agentInstructions: 'Use `workiq ask "<question>"` to query M365 data.',
+};
+
+function makeFakeMind(rootDir: string): string {
+  const mindPath = path.join(rootDir, 'mind');
+  fs.mkdirSync(path.join(mindPath, '.github', 'agents'), { recursive: true });
+  fs.mkdirSync(path.join(mindPath, '.working-memory'), { recursive: true });
+  fs.writeFileSync(path.join(mindPath, 'SOUL.md'), '# TestMind\nI am a test mind.');
+  return mindPath;
+}
+
+function makeSessionStub(id = 'session-1') {
+  return {
+    sessionId: id,
+    send: vi.fn(),
+    sendAndWait: vi.fn(),
+    getMessages: vi.fn(async (): Promise<unknown[]> => []),
+    on: vi.fn(),
+    off: vi.fn(),
+    disconnect: vi.fn(async () => undefined),
+    setModel: vi.fn(async () => undefined),
+    rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
+  };
+}
+
+function makeFakeClientFactory(): CopilotClientFactory {
+  let counter = 0;
+  const capturedSystemMessages: string[] = [];
+  const fakeClient = {
+    createSession: vi.fn((config: Record<string, unknown>) => {
+      counter += 1;
+      const sysMsg = config.systemMessage as
+        | { sections?: { identity?: { content?: string } } }
+        | undefined;
+      const content = sysMsg?.sections?.identity?.content ?? '';
+      capturedSystemMessages.push(content);
+      return Promise.resolve(makeSessionStub(`session-${counter}`));
+    }),
+    resumeSession: vi.fn((sessionId: string) => Promise.resolve(makeSessionStub(sessionId))),
+    deleteSession: vi.fn(async () => undefined),
+    listAvailableModels: vi.fn(async () => []),
+    listSessions: vi.fn(async () => []),
+    getMessages: vi.fn(async () => []),
+  };
+  return Object.assign({}, {
+    createClient: vi.fn(async () => fakeClient),
+    destroyClient: vi.fn(async () => undefined),
+    capturedSystemMessages,
+  }) as unknown as CopilotClientFactory;
+}
+
+const fakeViewDiscovery = {
+  ensureMind: vi.fn(),
+  releaseMind: vi.fn(),
+  removeMind: vi.fn(),
+  scan: vi.fn(async () => undefined),
+  startWatching: vi.fn(),
+  stopWatching: vi.fn(),
+  getViews: vi.fn(() => []),
+  on: vi.fn(),
+  off: vi.fn(),
+  setRefreshHandler: vi.fn(),
+  refreshView: vi.fn(),
+  sendCanvasAction: vi.fn(),
+  getCanvasUrl: vi.fn(),
+} as unknown as ViewDiscovery;
+
+describe('Marketplace tools end-to-end integration', () => {
+  let rootDir: string;
+  let userDataDir: string;
+  let mindPath: string;
+  let configService: ConfigService;
+  let registryClient: FakeRegistryClient;
+  let runner: FakeRunner;
+  let toolsService: ToolsService;
+  let identityLoader: IdentityLoader;
+  let clientFactory: ReturnType<typeof makeFakeClientFactory>;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-tools-int-'));
+    userDataDir = path.join(rootDir, 'user-data');
+    fs.mkdirSync(userDataDir, { recursive: true });
+    fs.writeFileSync(path.join(userDataDir, 'config.json'), JSON.stringify({
+      version: 2,
+      minds: [],
+      activeMindId: null,
+      activeLogin: null,
+      theme: 'dark',
+    }));
+    mindPath = makeFakeMind(rootDir);
+
+    configService = new ConfigService(userDataDir);
+    registryClient = new FakeRegistryClient();
+    registryClient.manifests.set('plugins/genesis-minds/plugin.json', { tools: [WORKIQ_ENTRY] });
+    runner = new FakeRunner();
+    toolsService = new ToolsService(
+      new MarketplaceToolCatalog(registryClient, [SOURCE]),
+      new ToolInstaller(runner),
+      configService,
+    );
+    identityLoader = new IdentityLoader(() => configService.load().installedTools ?? []);
+    clientFactory = makeFakeClientFactory() as unknown as ReturnType<typeof makeFakeClientFactory>;
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('reconcile installs workiq, persists it, and IdentityLoader appends it to the system message', async () => {
+    const outcome = await toolsService.reconcile();
+    expect(outcome.installed.map((t) => t.id)).toEqual(['workiq']);
+    expect(runner.calls[0]).toEqual({ command: 'npm', args: ['install', '-g', '@microsoft/workiq@latest'] });
+
+    const persistedConfig = configService.load();
+    expect(persistedConfig.installedTools).toHaveLength(1);
+    expect(persistedConfig.installedTools?.[0].id).toBe('workiq');
+
+    const identity = identityLoader.load(mindPath);
+    expect(identity?.systemMessage).toContain('## Tools');
+    expect(identity?.systemMessage).toContain('### workiq — Microsoft Work IQ');
+    expect(identity?.systemMessage).toContain('workiq ask --help');
+  });
+
+  it('persistConfig from MindManager preserves installedTools across mind operations', async () => {
+    await toolsService.reconcile();
+    expect(configService.load().installedTools).toHaveLength(1);
+
+    const mindManager = new MindManager(clientFactory, identityLoader, configService, fakeViewDiscovery);
+    await mindManager.loadMind(mindPath);
+
+    // Multiple persist passes should not lose installedTools
+    expect(configService.load().installedTools).toHaveLength(1);
+    expect(configService.load().installedTools?.[0].id).toBe('workiq');
+  });
+
+  it('startNewConversation refreshes identity so a new session sees newly-installed tools after reconcile', async () => {
+    // App started before reconcile finished — no tools at mind-load time
+    const mindManager = new MindManager(clientFactory, identityLoader, configService, fakeViewDiscovery);
+    const mind = await mindManager.loadMind(mindPath);
+    expect(mind.identity.systemMessage).not.toContain('## Tools');
+
+    // Reconcile finishes after the mind is already loaded
+    await toolsService.reconcile();
+    expect(configService.load().installedTools).toHaveLength(1);
+
+    // Cached identity is still stale right after reconcile
+    expect(mindManager.getMind(mind.mindId)?.identity.systemMessage).not.toContain('## Tools');
+
+    // Mark the active conversation as having messages so startNewConversation actually creates a fresh session
+    mindManager.markActiveConversationHasMessages(mind.mindId, 'first prompt');
+
+    // Starting a new conversation refreshes the identity from disk + installedTools
+    await mindManager.startNewConversation(mind.mindId);
+    const refreshed = mindManager.getMind(mind.mindId);
+    expect(refreshed?.identity.systemMessage).toContain('## Tools');
+    expect(refreshed?.identity.systemMessage).toContain('workiq ask --help');
+
+    // The new SDK session was constructed with the refreshed system message
+    const captured = (clientFactory as unknown as { capturedSystemMessages: string[] }).capturedSystemMessages;
+    expect(captured.at(-1)).toContain('## Tools');
+  });
+
+  it('empty-draft path also recreates the SDK session when identity changed', async () => {
+    const mindManager = new MindManager(clientFactory, identityLoader, configService, fakeViewDiscovery);
+    const mind = await mindManager.loadMind(mindPath);
+    const initialSession = mindManager.getMind(mind.mindId)?.session;
+    expect(initialSession).toBeDefined();
+
+    // Reconcile happens after mind load; the active conversation is still an empty draft (no messages)
+    await toolsService.reconcile();
+
+    await mindManager.startNewConversation(mind.mindId);
+    const next = mindManager.getMind(mind.mindId);
+    expect(next?.identity.systemMessage).toContain('## Tools');
+    expect(next?.session).not.toBe(initialSession);
+    const captured = (clientFactory as unknown as { capturedSystemMessages: string[] }).capturedSystemMessages;
+    expect(captured.at(-1)).toContain('## Tools');
+  });
+});

--- a/packages/services/src/tools/toolsSystemMessage.test.ts
+++ b/packages/services/src/tools/toolsSystemMessage.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import type { InstalledTool } from '@chamber/shared/types';
+import { buildToolsSection } from './toolsSystemMessage';
+
+function tool(overrides: Partial<InstalledTool> = {}): InstalledTool {
+  return {
+    id: 'workiq',
+    package: '@microsoft/workiq',
+    version: 'latest',
+    bin: 'workiq',
+    displayName: 'Microsoft Work IQ',
+    description: 'Query M365 data via natural language.',
+    help: 'workiq ask --help',
+    agentInstructions: 'Use `workiq ask "<question>"` to query M365 data.',
+    source: { marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' },
+    installedAt: '2026-05-07T21:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('buildToolsSection', () => {
+  it('returns null when no tools are installed', () => {
+    expect(buildToolsSection([])).toBeNull();
+  });
+
+  it('renders a tool with bin, displayName, description, help, and instructions', () => {
+    const section = buildToolsSection([tool()]);
+    expect(section).not.toBeNull();
+    expect(section).toContain('## Tools');
+    expect(section).toContain('### workiq — Microsoft Work IQ');
+    expect(section).toContain('Query M365 data via natural language.');
+    expect(section).toContain('- Help: `workiq ask --help`');
+    expect(section).toContain('Use `workiq ask "<question>"`');
+  });
+
+  it('omits the help line when no help is set', () => {
+    const section = buildToolsSection([tool({ help: undefined })]);
+    expect(section).not.toContain('Help:');
+  });
+
+  it('omits the instructions paragraph when not provided', () => {
+    const section = buildToolsSection([tool({ agentInstructions: undefined })]);
+    expect(section).not.toContain('Use `workiq');
+  });
+
+  it('renders multiple tools separated by blank lines', () => {
+    const section = buildToolsSection([
+      tool(),
+      tool({ id: 'other', bin: 'other', displayName: 'Other', description: 'Another tool.' }),
+    ]);
+    expect(section).toContain('### workiq');
+    expect(section).toContain('### other — Other');
+  });
+});

--- a/packages/services/src/tools/toolsSystemMessage.ts
+++ b/packages/services/src/tools/toolsSystemMessage.ts
@@ -1,0 +1,29 @@
+import type { InstalledTool } from '@chamber/shared/types';
+
+/**
+ * Renders a `## Tools` markdown section advertising installed CLI tools to
+ * the model. Returns null when no tools are installed so callers can skip
+ * appending an empty section.
+ *
+ * The section is intentionally terse — model-facing instructions per tool
+ * come from the marketplace's `agentInstructions` field, captured at install
+ * time and stored on the InstalledTool record.
+ */
+export function buildToolsSection(tools: InstalledTool[]): string | null {
+  if (tools.length === 0) return null;
+  const intro = '## Tools\n\nThe following CLI tools are installed and available on the shell PATH. Invoke them as shell commands.';
+  const blocks = tools.map(renderToolBlock).join('\n\n');
+  return `${intro}\n\n${blocks}`;
+}
+
+function renderToolBlock(tool: InstalledTool): string {
+  const header = `### ${tool.bin} — ${tool.displayName}`;
+  const lines: string[] = [header, tool.description];
+  if (tool.help) {
+    lines.push(`- Help: \`${tool.help}\``);
+  }
+  if (tool.agentInstructions) {
+    lines.push('', tool.agentInstructions.trim());
+  }
+  return lines.join('\n');
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -164,7 +164,61 @@ export interface AppConfig {
   activeLogin: string | null;
   theme: 'light' | 'dark' | 'system';
   marketplaceRegistries?: MarketplaceRegistry[];
+  installedTools?: InstalledTool[];
 }
+
+/**
+ * Persistent record of a CLI tool installed via the marketplace.
+ * The tool itself lives on the user's PATH (installed via `npm i -g`); this record
+ * tracks what we installed so startup reconciliation can avoid reinstalling, and
+ * carries the agent-facing description so the system message can advertise the
+ * tool offline (no marketplace fetch needed at session start).
+ */
+export interface InstalledTool {
+  id: string;
+  package: string;
+  version: string;
+  bin: string;
+  displayName: string;
+  description: string;
+  help?: string;
+  agentInstructions?: string;
+  source: { marketplaceId: string; pluginId: string };
+  installedAt: string;
+}
+
+export interface MarketplaceToolEntry {
+  id: string;
+  displayName: string;
+  description: string;
+  install: { type: 'npm-global'; package: string; version: string };
+  bin: string;
+  help?: string;
+  preflight?: string[];
+  /** Inline markdown describing how the model should invoke the CLI. Rendered into the system message. */
+  agentInstructions?: string;
+  source: {
+    owner: string;
+    repo: string;
+    ref: string;
+    plugin: string;
+    marketplaceId: string;
+    marketplaceLabel: string;
+    marketplaceUrl: string;
+  };
+}
+
+export type ToolInstallStatus = 'installed' | 'available' | 'error';
+
+export interface ToolCatalogEntry extends MarketplaceToolEntry {
+  status: ToolInstallStatus;
+  installedVersion?: string;
+  errorMessage?: string;
+}
+
+export type ToolActionResult =
+  | { success: true; tool: InstalledTool }
+  | { success: false; error: string };
 
 export interface LensViewManifest {
   id: string;
@@ -285,6 +339,11 @@ export interface ElectronAPI {
     refreshGenesisRegistry: (id: string) => Promise<MarketplaceRegistryActionResult>;
     setGenesisRegistryEnabled: (id: string, enabled: boolean) => Promise<MarketplaceRegistryActionResult>;
     removeGenesisRegistry: (id: string) => Promise<MarketplaceRegistryActionResult>;
+  };
+  tools: {
+    list: () => Promise<ToolCatalogEntry[]>;
+    install: (toolId: string, marketplaceId?: string) => Promise<ToolActionResult>;
+    uninstall: (toolId: string) => Promise<{ success: boolean; error?: string }>;
   };
   chatroom: ChatroomAPI;
   updater: {

--- a/tests/e2e/electron/tools-reconcile-smoke.spec.ts
+++ b/tests/e2e/electron/tools-reconcile-smoke.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const cdpPort = Number(process.env.CHAMBER_E2E_TOOLS_RECONCILE_CDP_PORT ?? 9347);
+
+// This spec drives the marketplace tools reconcile path end-to-end:
+// 1. Launches Chamber against the public ianphil/genesis-minds marketplace.
+// 2. Waits for ToolsService.reconcile() to install workiq via real `npm i -g`.
+// 3. Asserts ConfigService persisted installedTools[].
+// 4. Asserts window.electronAPI.tools.list() reports workiq as installed.
+// 5. Forces a fresh conversation on a seeded mind so MindManager refreshes its
+//    identity from disk + installedTools, exercising the startNewConversation
+//    refresh path that surfaces the ## Tools system message to the SDK.
+//
+// Real npm install runs against the network and writes to the user's global
+// npm prefix. Opt in with CHAMBER_E2E_TOOLS_RECONCILE=1 to avoid surprising
+// CI runs.
+const enabled = process.env.CHAMBER_E2E_TOOLS_RECONCILE === '1';
+
+interface InstalledToolRecord {
+  id: string;
+  package: string;
+  version: string;
+  bin: string;
+  displayName: string;
+  description: string;
+  help?: string;
+  agentInstructions?: string;
+}
+
+test.describe('electron marketplace tools reconcile smoke', () => {
+  test.skip(!enabled, 'Set CHAMBER_E2E_TOOLS_RECONCILE=1 to run the live npm-install marketplace tools smoke.');
+  test.setTimeout(360_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let userDataPath = '';
+  let mindPath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-tools-reconcile-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    mindPath = path.join(root, 'mind');
+    tempRoots.push(root);
+
+    fs.mkdirSync(userDataPath, { recursive: true });
+    fs.writeFileSync(path.join(userDataPath, 'config.json'), JSON.stringify({
+      version: 2,
+      minds: [{ id: 'tools-smoke-mind', path: mindPath }],
+      activeMindId: 'tools-smoke-mind',
+      activeLogin: null,
+      theme: 'dark',
+    }, null, 2));
+
+    seedMind(mindPath);
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('reconcile installs workiq, persists it, and the renderer tools API reports it as installed', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    // Wait for ToolsService.reconcile() to install workiq globally and persist
+    // installedTools[]. Real npm install can take a minute or two.
+    await waitFor(async () => {
+      const config = readConfig(userDataPath);
+      return Array.isArray(config.installedTools)
+        && config.installedTools.some((tool) => tool.id === 'workiq');
+    }, { timeoutMs: 240_000, intervalMs: 1_000, label: 'installedTools[workiq] persisted' });
+
+    const config = readConfig(userDataPath);
+    const workiqRecord = (config.installedTools ?? []).find((tool) => tool.id === 'workiq');
+    if (!workiqRecord) throw new Error('workiq tool record not found in config after reconcile');
+    expect(workiqRecord.bin).toBe('workiq');
+    expect(workiqRecord.package).toBe('@microsoft/workiq');
+    expect(workiqRecord.agentInstructions).toContain('workiq ask');
+    expect(workiqRecord.help).toBe('workiq ask --help');
+
+    // Renderer-side: tools API surfaces the entry as installed.
+    const toolsList = await page.evaluate(() => window.electronAPI.tools.list());
+    const workiqEntry = toolsList.find((entry) => entry.id === 'workiq');
+    expect(workiqEntry).toBeDefined();
+    expect(workiqEntry?.status).toBe('installed');
+
+    // Force a fresh conversation so MindManager.startNewConversation refreshes
+    // identity from disk + installedTools and hands the SDK a system message
+    // containing the ## Tools section.
+    const minds = await page.evaluate(() => window.electronAPI.mind.list());
+    const mind = minds.find((candidate) => candidate.mindId === 'tools-smoke-mind');
+    if (!mind) throw new Error('seeded mind should be loaded');
+
+    await page.evaluate((mindId) => window.electronAPI.chat.newConversation(mindId), mind.mindId);
+  });
+});
+
+function seedMind(target: string): void {
+  fs.mkdirSync(path.join(target, '.github', 'agents'), { recursive: true });
+  fs.mkdirSync(path.join(target, '.working-memory'), { recursive: true });
+  fs.writeFileSync(path.join(target, 'SOUL.md'), '# ToolsSmoke\nA minimal mind for the tools reconcile smoke.\n');
+  fs.writeFileSync(path.join(target, '.working-memory', 'memory.md'), '');
+  fs.writeFileSync(path.join(target, '.working-memory', 'rules.md'), '');
+  fs.writeFileSync(path.join(target, '.working-memory', 'log.md'), '');
+}
+
+function readConfig(userDataPath: string): { installedTools?: InstalledToolRecord[] } {
+  const configPath = path.join(userDataPath, 'config.json');
+  if (!fs.existsSync(configPath)) return {};
+  return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  options: { timeoutMs: number; intervalMs: number; label: string },
+): Promise<void> {
+  const deadline = Date.now() + options.timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await delay(options.intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${options.label}`);
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[tools-reconcile-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Foundation for #218: makes the genesis-minds marketplace able to ship **CLI tools** alongside minds. WorkIQ is the first concrete tool, defined in the public marketplace as the external-facing capability.

CLI-only — no MCP. Tools install globally via `npm install -g`, end up on the user's PATH, and are advertised to every mind via the session system message.

## Architecture

1. **Manifest extension.** `genesis-minds/plugin.json` gets an additive `tools[]` array next to `minds[]`. Each entry: `{ id, displayName, description, install: { type: 'npm-global', package, version }, bin, help, preflight, agentInstructions }`. Existing marketplaces without `tools[]` continue to work.
2. **`MarketplaceToolCatalog`** reads `tools[]` from every enrolled marketplace via the existing `GitHubRegistryClient`.
3. **`ToolInstaller`** runs `npm install -g <pkg>@<version>` via `node:child_process`, verifies with `<bin> --version`, runs declared `preflight` commands (e.g. `workiq accept-eula`), and returns an `InstalledTool` record.
4. **`ToolsService`** orchestrates list / install / uninstall / **reconcile** and persists `installedTools[]` in `~/.chamber/config.json`.
5. **Startup reconciliation.** On Electron `ready`, `ToolsService.reconcile()` diffs marketplace `tools[]` vs `installedTools[]` and installs anything new. Per-tool errors are logged and skipped — they don't block other installs. Already-installed tools are not auto-updated (per design).
6. **System-message tool advertising.** `IdentityLoader` accepts an `InstalledTool[]` provider. After SOUL.md / agent.md / working memory, it appends a `## Tools` section built from each tool's `displayName`, `description`, `help`, and `agentInstructions`. **Mind directories are never modified** — the tools list is always derived at session start, so adding/removing marketplaces or tools is fully reversible.
7. **IPC.** `tools:list`, `tools:install`, `tools:uninstall` exposed via `window.electronAPI.tools.*`. Browser shim returns desktop-only errors.

## Race-condition fixes (caught during runtime testing)

The first runtime pass exposed two subtle issues that made workiq invisible to the model. Both are fixed:

- **`MindManager.persistConfig` and reload were wiping `installedTools` and `marketplaceRegistries`.** Both helpers were rebuilding the saved config from scratch and only carrying over `activeLogin` and `theme`. Now they spread `existingConfig` first.
- **`MindManager.startNewConversation` was reusing the empty-draft session even when identity had changed.** When reconcile finished after mind load, the cached `context.identity.systemMessage` was stale. Both `startNewConversation` and `createNewConversationSession` now refresh identity from disk via `IdentityLoader` before deciding whether to reuse the SDK session, and recreate the SDK session when the system message has changed.

## Notable changes

- `packages/shared/src/types.ts` — adds `InstalledTool`, `MarketplaceToolEntry`, `ToolCatalogEntry`, `ToolActionResult`; `AppConfig.installedTools?` (optional).
- `packages/services/src/tools/` — new folder: `MarketplaceToolCatalog`, `ToolInstaller`, `ToolsService`, `toolsSystemMessage.buildToolsSection`, `toolTypes`.
- `packages/services/src/chat/IdentityLoader.ts` — accepts `InstalledToolsProvider`; appends `## Tools` section when non-empty.
- `packages/services/src/config/ConfigService.ts` — normalizes/persists `installedTools[]`; field omitted when empty so existing config tests are untouched.
- `packages/services/src/mind/MindManager.ts` — preserves siblings on `persistConfig` / reload; refreshes identity on `startNewConversation` and `createNewConversationSession`.
- `packages/services/src/mind/types.ts` — `InternalMindContext.identity` overrides the readonly shared shape so internal callers can refresh it.
- `apps/desktop/src/main.ts` — wires `ToolsService`; fires `reconcile()` after IPC setup.
- `apps/desktop/src/main/ipc/tools.ts` — new IPC adapter.
- `apps/desktop/src/preload.ts`, `apps/web/src/browserApi.ts`, `apps/web/src/test/helpers.ts` — preload + browser shim for the new `tools` API.
- `apps/server/src/bin.ts` — server `IdentityLoader` reads `installedTools` from the same config.

## Test evidence

- `npm run lint` — clean (typecheck + eslint + deps:check).
- `npm test` — **123 files / 1226 tests pass** (was 118 / 1195).
- New unit tests: `MarketplaceToolCatalog.test.ts` (6), `ToolInstaller.test.ts` (4), `ToolsService.test.ts` (6), `toolsSystemMessage.test.ts` (5), plus `IdentityLoader.test.ts` (+2), `ConfigService.test.ts` (+3), `MindManager.test.ts` (+1 covering `installedTools` preservation).
- New integration test: `tools-integration.test.ts` (4 tests) — wires real `ConfigService` + `ToolsService` + `IdentityLoader` + `MindManager` (fake SDK/registry/shell) to prove the reconcile-and-refresh flow end-to-end.
- New Playwright smoke: `tests/e2e/electron/tools-reconcile-smoke.spec.ts` — gated on `CHAMBER_E2E_TOOLS_RECONCILE=1`. Launches Electron, runs real `npm install -g @microsoft/workiq`, asserts `ConfigService.installedTools` persistence, `window.electronAPI.tools.list()` reports `installed`, and `chat.newConversation` triggers the identity refresh. Verified passing locally (~26s test, ~52s with build).
- Skipped: `npm run smoke:sdk` (no SDK path touched), packaging sandbox (no packaging/runtime change).

## Pairs with

[`ianphil/genesis-minds@8ee3f03`](https://github.com/ianphil/genesis-minds/commit/8ee3f03) adds the WorkIQ entry to the public marketplace and documents the public-vs-internal split in its README.

## Follow-ups (not in this PR)

- Settings → Marketplace UI to surface `tools:list` results with manual install/uninstall buttons.

Closes #218
