### PR TITLE
Remove chat turn wall-clock timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.46.2 (2026-05-07)
+
+### Chat
+
+- **Let users control long-running chat turns** - Single-agent chat no longer has a Chamber-side wall-clock turn deadline; long-running agent work stays streaming until the SDK emits idle/error or the user presses Stop. The separate 30s `session.send()` wedge guard remains for stale-session recovery, and a real Electron smoke now clicks through the Stop flow. (#222)
+
 ## v0.46.1 (2026-05-07)
 
 ### Chat
@@ -15,7 +21,6 @@
 - **Auto-install on startup** — On app ready, `ToolsService.reconcile()` diffs marketplace `tools[]` against `config.installedTools[]` and runs `npm install -g <package>@<version>` for any new entry, then runs declared `preflight` commands (e.g. `workiq accept-eula`). Errors are logged per-tool and do not block other installs. Already-installed tools are not auto-updated. (#218)
 - **Runtime tool context in the system message** — `IdentityLoader` accepts an `InstalledTool[]` provider and appends a `## Tools` section to every session's system message. Tool descriptions live in the marketplace manifest's `agentInstructions` field and are captured into the installed-tool record at install time, so model context is available offline. Mind directories are not modified. (#218)
 - **Tools IPC + preload surface** — New `tools:list`, `tools:install`, `tools:uninstall` channels exposed via `window.electronAPI.tools.*`. Browser-mode shim returns descriptive "desktop-only" errors. (#218)
-
 ## v0.45.0 (2026-05-07)
 
 ### Chatroom

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -504,6 +504,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
             <button
               onClick={handleSubmit}
               disabled={disabled && !isStreaming}
+              aria-label={isStreaming ? 'Stop streaming' : 'Send message'}
               className={cn(
                 'shrink-0 w-8 h-8 rounded-lg flex items-center justify-center transition-colors',
                 isStreaming

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.46.1",
+      "version": "0.46.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -94,45 +94,34 @@ describe('ChatService', () => {
       expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     });
 
-    it('emits timeout (not done) when send resolves but session.idle never fires', async () => {
+    it('does not arm a wall-clock fallback timer; long turns wait indefinitely for the SDK or user cancel (#222)', async () => {
       vi.useFakeTimers();
       try {
-        // Default behavior: register listeners but never fire session.idle.
+        // session.send resolves but session.idle never fires.
         mockSession.on.mockImplementation(() => vi.fn());
         mockSession.send.mockResolvedValue(undefined);
 
         const emit = vi.fn();
         const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
 
-        // Advance past the 5-minute fallback turn timeout.
-        await vi.advanceTimersByTimeAsync(300_000);
-        await pending;
+        // Drain enough microtasks to push past turnQueue.enqueue, send,
+        // Promise.race, and the inner finally that clears SEND_TIMEOUT_MS.
+        for (let i = 0; i < 10; i += 1) await Promise.resolve();
 
-        expect(emit).toHaveBeenCalledWith({ type: 'timeout', timeoutMs: 300_000 });
+        // Far past the prior 5-minute fallback. No timer must be armed for
+        // the turn deadline; the only timer in flight should be the 30s
+        // SEND_TIMEOUT_MS, which is already cleared by send resolving.
+        expect(vi.getTimerCount()).toBe(0);
+
+        await vi.advanceTimersByTimeAsync(60 * 60_000); // one hour
         expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+        expect(emit).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'timeout' }));
         expect(emit).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
-        // No timer leak: the fallback timer was cleared by the outer finally.
-        expect(vi.getTimerCount()).toBe(0);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
 
-    it('does not leak the 5-minute fallback timer when session.send fails synchronously', async () => {
-      vi.useFakeTimers();
-      try {
-        mockSession.on.mockImplementation(() => vi.fn());
-        mockSession.send.mockRejectedValueOnce(new Error('send blew up'));
-
-        const emit = vi.fn();
-        await svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
-
-        // Outer finally must clear turnDoneTimerId even though we never
-        // reached `await turnDone`. If this leaks, getTimerCount > 0 and a
-        // future TurnTimeoutError reject would surface as unhandled.
-        expect(vi.getTimerCount()).toBe(0);
-        expect(emit).toHaveBeenCalledWith({ type: 'error', message: 'send blew up' });
-        expect(emit).not.toHaveBeenCalledWith({ type: 'timeout', timeoutMs: 300_000 });
+        // User-pressed Stop: cancelMessage aborts the controller, the
+        // turnDone abort listener resolves, and the turn unwinds cleanly.
+        await svc.cancelMessage('valid-mind', 'msg-1');
+        await pending;
       } finally {
         vi.useRealTimers();
       }
@@ -312,6 +301,39 @@ describe('ChatService', () => {
       expect(emit).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'error', message: 'Network error' }),
       );
+    });
+
+    it('does not retry stale-session recovery after the user cancels', async () => {
+      mockSession.send.mockRejectedValueOnce(new Error('Session not found: abc-123'));
+      mockSession.on.mockReturnValue(vi.fn());
+
+      const freshSession = {
+        send: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn(() => vi.fn()),
+      };
+      let resolveRecovery: ((session: typeof freshSession) => void) | undefined;
+      mockMindManager.recoverActiveConversationSession.mockImplementationOnce(
+        () => new Promise<typeof freshSession>((resolve) => {
+          resolveRecovery = resolve;
+        }),
+      );
+
+      const emit = vi.fn();
+      const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+      await vi.waitFor(() => {
+        expect(mockMindManager.recoverActiveConversationSession).toHaveBeenCalledWith('valid-mind');
+      });
+      await svc.cancelMessage('valid-mind', 'msg-1');
+      resolveRecovery?.(freshSession);
+      await pending;
+
+      expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
+      expect(freshSession.send).not.toHaveBeenCalled();
+      expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+      expect(emit).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     });
   });
 

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -4,9 +4,8 @@
 import type { MindManager } from '../mind';
 import type { ChatEvent, ChatImageAttachment, ConversationResumeResult, ConversationSummary, ModelInfo } from '@chamber/shared/types';
 import type { CopilotSession } from '../mind/types';
-import { isStaleSessionError, SEND_TIMEOUT_MS, DEFAULT_TURN_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
+import { isStaleSessionError, SEND_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
 import { Logger } from '../logger';
-import { TurnTimeoutError } from '../session-group/stream-session';
 import {
   SdkChatEventContractError,
   getSdkSessionErrorMessage,
@@ -66,6 +65,7 @@ export class ChatService {
           // If reattach also fails stale, surface the error so the user can start a new chat.
           emit({ type: 'reconnecting' });
           const recoveredSession = await this.mindManager.recoverActiveConversationSession(mindId);
+          if (abortController.signal.aborted) return;
           await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
             this.mindManager.markActiveConversationHasMessages(mindId, prompt);
           });
@@ -88,6 +88,8 @@ export class ChatService {
     attachments?: ChatImageAttachment[],
     onSendAccepted?: () => void,
   ): Promise<void>{
+    if (abortController.signal.aborted) return;
+
     const unsubs: (() => void)[] = [];
     const guard = (fn: () => void) => { if (!abortController.signal.aborted) fn(); };
     let sdkContractFailed = false;
@@ -109,14 +111,6 @@ export class ChatService {
         failSdkContract(error);
       }
     };
-    // Hoisted so the outer `finally` can guarantee the 5-minute fallback
-    // timer is cleared on every exit path (send failure, SDK contract abort,
-    // normal completion, timeout, etc.). Without this, a send-side throw
-    // unwinds before `await turnDone`, the timer keeps ticking, and the
-    // eventual `reject(new TurnTimeoutError(...))` would surface as an
-    // unhandled rejection minutes later (#222 follow-up).
-    let turnDoneTimerId: ReturnType<typeof setTimeout> | undefined;
-
     try {
       // Text streaming
       unsubs.push(session.on('assistant.message_delta', (event) => {
@@ -152,24 +146,23 @@ export class ChatService {
 
       // Set up idle/error listeners BEFORE send to avoid missing events
       // that fire synchronously inside session.send (regression-test guarded).
+      //
+      // INVARIANT: no fallback wall-clock deadline on the turn (#222).
+      // Long-running agent work - deep research, multi-step tool chains,
+      // big-codebase analysis - is a first-class Chamber use case. The
+      // user owns "this has gone on long enough" via the Stop button,
+      // which calls cancelMessage -> abortController.abort() -> session.abort().
+      // We rely on the SDK to eventually emit `session.idle`, `session.error`,
+      // or for the user to cancel. SEND_TIMEOUT_MS below still bounds the
+      // separate failure mode of `session.send()` itself wedging.
       const turnDone = new Promise<void>((resolve, reject) => {
-        // INVARIANT: a fallback timer must NOT silently complete the turn.
-        // Reject with TurnTimeoutError so the renderer sees an explicit
-        // `timeout` event instead of a success-shaped `done` (#222).
-        turnDoneTimerId = setTimeout(
-          () => reject(new TurnTimeoutError(DEFAULT_TURN_TIMEOUT_MS)),
-          DEFAULT_TURN_TIMEOUT_MS,
-        );
-
         const unsubIdle = session.on('session.idle', () => {
-          if (turnDoneTimerId) clearTimeout(turnDoneTimerId);
           unsubIdle();
           resolve();
         });
         unsubs.push(unsubIdle);
 
         const unsubError = session.on('session.error', (event) => {
-          if (turnDoneTimerId) clearTimeout(turnDoneTimerId);
           unsubError();
           try {
             reject(new Error(getSdkSessionErrorMessage(event)));
@@ -181,18 +174,15 @@ export class ChatService {
         unsubs.push(unsubError);
 
         abortController.signal.addEventListener('abort', () => {
-          if (turnDoneTimerId) clearTimeout(turnDoneTimerId);
           resolve();
         }, { once: true });
       });
       // Defensive no-op catch: if `session.send` throws and we never reach
-      // `await turnDone` below, the outer `finally` clears the timer so it
-      // cannot fire — but if it somehow does (e.g., scheduled before the
-      // clear ran), this guarantees the rejection is observed instead of
-      // surfacing as an unhandled rejection.
+      // `await turnDone` below, this guarantees a later SDK error rejection is
+      // observed instead of surfacing as an unhandled rejection.
       turnDone.catch(() => { /* observed in await below or intentionally discarded */ });
 
-      // Send with a timeout guard — if session.send() itself hangs (dead
+      // Send with a timeout guard: if session.send() itself hangs (dead
       // WebSocket, killed CLI), surface as a stale-session error so the
       // outer catch can recreate the session and retry.
       let sendTimerId: ReturnType<typeof setTimeout> | undefined;
@@ -214,28 +204,11 @@ export class ChatService {
       }
 
       // Wait for idle (listeners already active from before send).
-      // A TurnTimeoutError surfaces as a typed `timeout` event so the
-      // renderer can render timeout-specific UI; we suppress the trailing
-      // `done` to avoid a false-completion signal (#222). Other errors
-      // propagate to the outer catch which emits `{ type: 'error' }`.
-      try {
-        await turnDone;
-      } catch (err) {
-        if (err instanceof TurnTimeoutError) {
-          log.warn(`Chat turn timed out after ${err.timeoutMs}ms; SDK never emitted session.idle`);
-          // guard suppresses the emit on a racing abort — cancellation is
-          // its own terminal state and the renderer already cleared
-          // isStreaming on the abort path.
-          guard(() => emit({ type: 'timeout', timeoutMs: err.timeoutMs }));
-          return;
-        }
-        throw err;
-      }
+      await turnDone;
 
       if (abortController.signal.aborted) return;
       emit({ type: 'done' });
     } finally {
-      if (turnDoneTimerId) clearTimeout(turnDoneTimerId);
       for (const unsub of unsubs) unsub();
     }
   }

--- a/tests/e2e/electron/chat-turn-user-stop-smoke.spec.ts
+++ b/tests/e2e/electron/chat-turn-user-stop-smoke.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+// Regression smoke for #222: the user - not a wall-clock - owns when a
+// long-running agent turn ends. There is no fallback turn-deadline timer
+// in ChatService anymore. This spec proves the contract end-to-end with
+// the real Copilot SDK runtime: real CLI subprocess, real session, real
+// WS event channel, real renderer, real DOM clicks.
+//
+// What we assert (no mocks, no fakes, no env knobs):
+//   1. A streaming turn shows the Stop button (isStreaming === true).
+//   2. After several seconds with no user action, streaming is STILL active
+//      - there is no falsely-injected `done`/`timeout` event from a hidden
+//      Chamber-side deadline. The user has not chosen to stop.
+//   3. Pressing the Stop button cleanly aborts: the Stop button disappears,
+//      the textarea is enabled again, and no error block is rendered.
+const cdpPort = Number(process.env.CHAMBER_E2E_USER_STOP_CDP_PORT ?? 9362);
+
+test.describe('electron chat turn user-controlled stop smoke', () => {
+  test.setTimeout(180_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let root = '';
+  let userDataPath = '';
+
+  test.afterEach(async () => {
+    await app?.close();
+    app = undefined;
+    if (root) await removeTempRoot(root);
+  });
+
+  test('long real turn keeps streaming until the user presses Stop (#222)', async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-turn-user-stop-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    const mindPath = path.join(root, 'heinz-doofenshmirtz');
+    seedMind(mindPath, 'Heinz Doofenshmirtz');
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: { CHAMBER_E2E_USER_DATA: userDataPath },
+    });
+    const page = await findRendererPage(app.browser, app.logs);
+    await waitForMindApi(page);
+    await loadAndActivateMind(page, mindPath, 'Heinz Doofenshmirtz');
+
+    // Real interaction: click into the textarea, type a deliberately
+    // verbose prompt so the SDK is comfortably busy for the duration of
+    // the test, then press Enter.
+    const textarea = page.getByPlaceholder('Message your agent… (paste an image to attach)');
+    await expect(textarea).toBeEnabled();
+    await textarea.click();
+    await textarea.fill(
+      'Think carefully step by step, then output a numbered list from 1 ' +
+      'through 5000. Each item should be a complete sentence about Perry ' +
+      'the Platypus and inator safety. Do not summarize or skip numbers.',
+    );
+    await textarea.press('Enter');
+
+    // Stop button appears once isStreaming flips true — the user's
+    // explicit signal that "the agent is working, you can stop it."
+    const stopButton = page.getByRole('button', { name: 'Stop streaming' });
+    await expect(stopButton).toBeVisible({ timeout: 10_000 });
+
+    // Wait several seconds while doing nothing. Pre-#222 fix: a hidden
+    // 5-minute Chamber timer would not fire here, but any shorter Chamber
+    // deadline would falsely terminate the turn. Post-#222 fix: there is
+    // no Chamber deadline at all. The Stop button must remain visible
+    // because the user has not chosen to stop and the SDK hasn't idled.
+    await page.waitForTimeout(5_000);
+    await expect(stopButton).toBeVisible();
+    await expect(page.getByText(/Agent timed out after/i)).toHaveCount(0);
+    await expect(page.getByText(/^Error:/)).toHaveCount(0);
+
+    // The user's contract: click Stop, get clean abort.
+    await stopButton.click();
+
+    // Stop button disappears (isStreaming cleared) and the textarea is
+    // ready for the next prompt. No error or timeout block was rendered.
+    await expect(stopButton).toHaveCount(0, { timeout: 10_000 });
+    await expect(textarea).toBeEnabled();
+    await expect(page.getByText(/Agent timed out after/i)).toHaveCount(0);
+    await expect(page.getByText(/^Error:/)).toHaveCount(0);
+
+    // Sanity: a follow-up send should work — the per-mind TurnQueue was
+    // released cleanly by the abort.
+    await textarea.click();
+    await textarea.fill(
+      'Start another long numbered list from 1 through 1000 about clean ' +
+      'abort handling. Do not summarize or skip numbers.',
+    );
+    await textarea.press('Enter');
+    await expect(stopButton).toBeVisible({ timeout: 10_000 });
+    await stopButton.click();
+  });
+});
+
+async function waitForMindApi(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('#root')).not.toBeEmpty();
+  await expect.poll(async () => {
+    try {
+      return await page.evaluate(() => typeof window.electronAPI?.mind?.add);
+    } catch {
+      return 'unavailable';
+    }
+  }, { timeout: 30_000 }).toBe('function');
+}
+
+async function loadAndActivateMind(page: Page, mindPath: string, name: string) {
+  const mind = await page.evaluate(async (pathToMind) => {
+    const loaded = await window.electronAPI.mind.add(pathToMind);
+    await window.electronAPI.mind.setActive(loaded.mindId);
+    return loaded;
+  }, mindPath);
+  const mindButton = page.getByRole('button', { name }).first();
+  await mindButton.click();
+  await expect(mindButton).toHaveClass(/bg-accent/);
+  return mind;
+}
+
+function seedMind(root: string, name: string): void {
+  fs.mkdirSync(path.join(root, '.github', 'agents'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'SOUL.md'),
+    [
+      `# ${name}`,
+      '',
+      'A deterministic mind used by the chat user-controlled stop smoke (#222).',
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(root, '.github', 'agents', 'heinz-doofenshmirtz.agent.md'),
+    [
+      '---',
+      `name: ${name}`,
+      'description: User-controlled stop smoke-test persona',
+      '---',
+      '',
+      `# ${name}`,
+      '',
+      'Reply at length when asked to think carefully so smoke tests can',
+      'observe the streaming/stop lifecycle.',
+      '',
+    ].join('\n'),
+  );
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[chat-turn-user-stop-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Removes the single-agent ChatService wall-clock turn deadline so long-running agent work stays streaming until SDK idle/error or the user presses Stop.
- Keeps the separate 30s `session.send()` wedge guard for stale-session recovery, including cancellation protection during recovery.
- Adds an accessible Send/Stop button label and a real Electron Playwright smoke that clicks through the user-controlled Stop flow.

Closes #222

## Tests
- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npx playwright test --config config/playwright.config.ts --project=electron --workers=1 tests/e2e/electron/chat-turn-user-stop-smoke.spec.ts`

## Notes
- Replaces closed PR #223; this removes the timeout instead of making it explicit.
- Packaging smoke skipped: packaging/runtime resolution not touched.
