### PR TITLE
fix: make updater refreshable when up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.46.3 (2026-05-07)
+
+### Updates
+
+- **Refresh from the up-to-date updater icon** - The Activity Bar updater button now remains clickable when Chamber is already marked up to date, using the existing manual check path to refresh release state while still disabling duplicate actions during checking, downloading, and installing. (#226)
+
 ## v0.46.2 (2026-05-07)
 
 ### Chat

--- a/apps/web/src/renderer/components/layout/ActivityBar.test.tsx
+++ b/apps/web/src/renderer/components/layout/ActivityBar.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ActivityBar } from './ActivityBar';
 import { AppStateProvider } from '../../lib/store';
 import type { AppState } from '../../lib/store/state';
@@ -61,6 +61,56 @@ describe('ActivityBar', () => {
       expect(screen.getByLabelText('Download Chamber 0.33.3')).toBeTruthy();
     });
   });
+
+  it('checks for updates when clicking the up-to-date updater action', async () => {
+    const api = mockElectronAPI();
+    api.updater.getState = vi.fn().mockResolvedValue({
+      enabled: true,
+      status: 'up-to-date',
+      currentVersion: '0.33.2',
+      downloadPercent: null,
+      message: 'Chamber is up to date.',
+      canRetry: false,
+    });
+    api.updater.check = vi.fn().mockResolvedValue({ success: true });
+    installElectronAPI(api);
+
+    renderActivityBar();
+
+    const updaterButton = await screen.findByRole('button', { name: 'Check for updates' });
+    expect(updaterButton).not.toHaveProperty('disabled', true);
+    fireEvent.click(updaterButton);
+
+    expect(api.updater.check).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { status: 'checking' as const, message: 'Checking for updates…', downloadPercent: null, label: 'Checking for updates…' },
+    { status: 'downloading' as const, message: null, downloadPercent: 25, label: 'Downloading update 25%' },
+    { status: 'installing' as const, message: 'Installing update…', downloadPercent: null, label: 'Installing update…' },
+  ])(
+    'keeps the updater action disabled while $status',
+    async ({ status, message, downloadPercent, label }) => {
+      const api = mockElectronAPI();
+      api.updater.getState = vi.fn().mockResolvedValue({
+        enabled: true,
+        status,
+        currentVersion: '0.33.2',
+        downloadPercent,
+        message,
+        canRetry: false,
+      });
+      api.updater.check = vi.fn().mockResolvedValue({ success: true });
+      installElectronAPI(api);
+
+      renderActivityBar();
+
+      const updaterButton = await screen.findByRole('button', { name: label });
+      expect(updaterButton).toHaveProperty('disabled', true);
+      fireEvent.click(updaterButton);
+      expect(api.updater.check).not.toHaveBeenCalled();
+    },
+  );
 
   // -------------------------------------------------------------------------
   // Running indicator — yellow dot when any chatroom mind is streaming

--- a/apps/web/src/renderer/components/layout/UpdateIndicator.tsx
+++ b/apps/web/src/renderer/components/layout/UpdateIndicator.tsx
@@ -12,7 +12,7 @@ export function UpdateIndicator() {
   const isBusy = state.status === 'checking'
     || state.status === 'downloading'
     || state.status === 'installing';
-  const canAct = !isBusy && state.status !== 'up-to-date';
+  const canAct = !isBusy;
   const percent = typeof state.downloadPercent === 'number'
     ? Math.round(state.downloadPercent)
     : null;
@@ -44,7 +44,9 @@ export function UpdateIndicator() {
       ? `Restart to install Chamber ${state.downloadedVersion}`
       : state.status === 'downloading'
         ? `Downloading update${percent === null ? '' : ` ${percent}%`}`
-        : state.message ?? 'Check for updates';
+        : state.status === 'up-to-date'
+          ? 'Check for updates'
+          : state.message ?? 'Check for updates';
 
   return (
     <Tooltip delayDuration={300}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.46.2",
+      "version": "0.46.3",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary

Makes the Activity Bar updater icon refreshable when Chamber is currently marked up to date, using the existing updater check IPC path.

## Notable changes

- Allows the updater button to be clicked for `up-to-date` state.
- Keeps `checking`, `downloading`, and `installing` disabled to avoid duplicate actions.
- Labels the up-to-date button as "Check for updates" for tooltip/accessibility clarity.
- Adds ActivityBar renderer coverage for click-to-refresh and busy-state protection.

Closes #226

## Test evidence

- `npx vitest run --config config\vitest.config.ts apps\web\src\renderer\components\layout\ActivityBar.test.tsx`
- `npm run lint`
- `npm test`

## Skipped smoke

- `npm run smoke:web` skipped: updater control is a desktop-only Activity Bar IPC surface and is covered by renderer tests; no browser smoke path exercises the desktop updater.
- Packaging smoke skipped: no packaging, runtime wiring, installer, or first-launch behavior changed.