### PR TITLE
Expand SDK contract smoke coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.46.4 (2026-05-08)
+
+### SDK
+
+- **Expand SDK contract smoke coverage** - Chamber now validates live SDK model-list and deterministic tool execution event shapes through the same Zod-backed contract mappers used at runtime. Chatroom streaming also reuses the SDK event mapper boundary so contract drift surfaces as a clear streaming error instead of raw SDK field assumptions. (#194)
+
 ## v0.46.3 (2026-05-07)
 
 ### Updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.46.3",
+  "version": "0.46.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.46.3",
+      "version": "0.46.4",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.46.3",
+  "version": "0.46.4",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -13,7 +13,7 @@ const mockSession = {
 
 const validModelClient = {
   modelsCache: {} as unknown,
-  listModels: vi.fn(async () => [{ id: 'm1', name: 'Model 1' }]),
+  listModels: vi.fn(async () => [{ id: 'm1', name: 'Model 1', extra: true }]),
 };
 
 const mockMindManager = {
@@ -23,6 +23,9 @@ const mockMindManager = {
     }
     if (mindId === 'broken-models') {
       return { session: mockSession, client: { listModels: vi.fn(async () => { throw new Error('model discovery failed'); }) } };
+    }
+    if (mindId === 'drifted-models') {
+      return { session: mockSession, client: { listModels: vi.fn(async () => [{ modelId: 'm1', displayName: 'Model 1' }]) } };
     }
     return undefined;
   }),
@@ -231,6 +234,12 @@ describe('ChatService', () => {
 
     it('surfaces model discovery failures', async () => {
       await expect(svc.listModels('broken-models')).rejects.toThrow('model discovery failed');
+    });
+
+    it('surfaces SDK model-list contract drift', async () => {
+      await expect(svc.listModels('drifted-models')).rejects.toThrow(
+        'SDK contract mismatch for client.listModels',
+      );
     });
   });
 

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -18,6 +18,7 @@ import {
   mapSdkToolExecutionStart,
 } from '../sdk/sdkChatEventMapper';
 import { clearCopilotModelsCache } from '../sdk/modelCacheCompat';
+import { mapSdkModelList } from '../sdk/sdkModelMapper';
 import { TurnQueue } from './TurnQueue';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext, type DateTimeContextProvider } from './currentDateTimeContext';
 
@@ -265,7 +266,7 @@ export class ChatService {
     // Clear the cache so we always get a fresh list from the CLI.
     clearCopilotModelsCache(context.client);
     const models = await context.client.listModels();
-    return models.map((m: { id: string; name: string }) => ({ id: m.id, name: m.name }));
+    return mapSdkModelList(models);
   }
 
   private assertCanSwitchConversation(mindId: string): void {

--- a/packages/services/src/sdk/index.ts
+++ b/packages/services/src/sdk/index.ts
@@ -1,4 +1,16 @@
 export { CopilotClientFactory } from './CopilotClientFactory';
+export { SdkChatEventContractError } from './sdkChatEventMapper';
+export {
+  mapSdkAssistantMessage,
+  mapSdkAssistantMessageDelta,
+  mapSdkAssistantReasoningDelta,
+  mapSdkToolExecutionComplete,
+  mapSdkToolExecutionPartialResult,
+  mapSdkToolExecutionProgress,
+  mapSdkToolExecutionStart,
+  getSdkSessionErrorMessage,
+} from './sdkChatEventMapper';
+export { SdkModelListContractError, mapSdkModelList } from './sdkModelMapper';
 export { findSystemNode, requireSystemNode } from './nodeResolver';
 export {
   configureSdkRuntimeLayout,

--- a/packages/services/src/sdk/sdkChatEventMapper.ts
+++ b/packages/services/src/sdk/sdkChatEventMapper.ts
@@ -5,11 +5,14 @@ const sdkEvent = <Shape extends z.ZodRawShape>(shape: Shape) =>
   z.object({ data: z.object(shape).passthrough() }).passthrough();
 
 export class SdkChatEventContractError extends Error {
+  readonly eventName: string;
+
   constructor(
-    readonly eventName: string,
+    eventName: string,
     cause: unknown,
   ) {
     super(`SDK contract mismatch for ${eventName}`, { cause });
+    this.eventName = eventName;
     this.name = 'SdkChatEventContractError';
   }
 }

--- a/packages/services/src/sdk/sdkModelMapper.test.ts
+++ b/packages/services/src/sdk/sdkModelMapper.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { SdkModelListContractError, mapSdkModelList } from './sdkModelMapper';
+
+describe('sdkModelMapper', () => {
+  it('maps the SDK model fields Chamber exposes', () => {
+    expect(mapSdkModelList([
+      { id: 'gpt-5.4', name: 'GPT-5.4', extra: true },
+    ])).toEqual([
+      { id: 'gpt-5.4', name: 'GPT-5.4' },
+    ]);
+  });
+
+  it('rejects SDK model-list drift that would break Chamber model selection', () => {
+    expect(() => mapSdkModelList([
+      { modelId: 'gpt-5.4', displayName: 'GPT-5.4' },
+    ])).toThrow(SdkModelListContractError);
+
+    expect(() => mapSdkModelList({ id: 'gpt-5.4', name: 'GPT-5.4' })).toThrow(
+      'SDK contract mismatch for client.listModels',
+    );
+  });
+});

--- a/packages/services/src/sdk/sdkModelMapper.ts
+++ b/packages/services/src/sdk/sdkModelMapper.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { ModelInfo } from '@chamber/shared/types';
+
+export class SdkModelListContractError extends Error {
+  constructor(cause: unknown) {
+    super('SDK contract mismatch for client.listModels', { cause });
+    this.name = 'SdkModelListContractError';
+  }
+}
+
+const sdkModel = z.object({
+  id: z.string(),
+  name: z.string(),
+}).passthrough();
+
+const sdkModelList = z.array(sdkModel);
+
+export function mapSdkModelList(models: unknown): ModelInfo[] {
+  const parsed = sdkModelList.safeParse(models);
+  if (!parsed.success) {
+    throw new SdkModelListContractError(parsed.error);
+  }
+  return parsed.data.map((model) => ({
+    id: model.id,
+    name: model.name,
+  }));
+}

--- a/packages/services/src/session-group/stream-session.test.ts
+++ b/packages/services/src/session-group/stream-session.test.ts
@@ -210,6 +210,37 @@ describe('streamAgentTurn', () => {
     expect(types).toContain('tool_progress');
     expect(types).toContain('tool_output');
     expect(types).toContain('tool_done');
+    expect(events.find((e) => e.event.type === 'tool_start')?.event).toMatchObject({
+      type: 'tool_start',
+      args: {},
+    });
+  });
+
+  it('emits a clear error when the SDK chatroom stream event contract drifts', async () => {
+    const sess = createMockSession();
+    const ctx = createContext(sessions);
+
+    sess.send.mockImplementation(async () => {
+      setTimeout(() => {
+        sess._emit('tool.execution_complete', {
+          data: { toolCallId: 'tc-1', success: 'yes' },
+        });
+      }, 0);
+    });
+
+    await expect(streamAgentTurn(makeStreamOpts(sess, { context: ctx }))).rejects.toThrow(
+      'SDK contract mismatch for tool.execution_complete',
+    );
+
+    const events = (ctx.emitEvent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as ChatroomStreamEvent,
+    );
+    expect(events.filter((e) => e.event.type === 'error')).toHaveLength(1);
+    expect(events.find((e) => e.event.type === 'error')?.event).toEqual({
+      type: 'error',
+      message: 'SDK contract mismatch for tool.execution_complete',
+    });
+    expect(sess.abort).toHaveBeenCalled();
   });
 
   it('emits reasoning events', async () => {

--- a/packages/services/src/session-group/stream-session.ts
+++ b/packages/services/src/session-group/stream-session.ts
@@ -5,6 +5,17 @@ import type { OrchestrationContext } from './orchestrators/legacy-types';
 import type { CopilotSession } from '../mind';
 import { isStaleSessionError, SEND_TIMEOUT_MS, DEFAULT_TURN_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
+import {
+  SdkChatEventContractError,
+  getSdkSessionErrorMessage,
+  mapSdkAssistantMessage,
+  mapSdkAssistantMessageDelta,
+  mapSdkAssistantReasoningDelta,
+  mapSdkToolExecutionComplete,
+  mapSdkToolExecutionPartialResult,
+  mapSdkToolExecutionProgress,
+  mapSdkToolExecutionStart,
+} from '../sdk/sdkChatEventMapper';
 
 // ---------------------------------------------------------------------------
 // TurnTimeoutError — distinguishable timeout for callers
@@ -64,86 +75,86 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
   };
 
   let finalContent = '';
+  let sdkContractFailed = false;
+  let rejectTurnDone: ((error: Error) => void) | undefined;
+  let turnDoneTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  const failSdkContract = (error: unknown) => {
+    if (abortSignal.aborted || sdkContractFailed) return;
+    sdkContractFailed = true;
+    const message = error instanceof SdkChatEventContractError
+      ? error.message
+      : 'SDK contract mismatch while streaming chatroom turn';
+    clearTimeout(turnDoneTimeoutId);
+    emitEvent({ type: 'error', message });
+    void session.abort().catch(() => undefined);
+    rejectTurnDone?.(error instanceof Error ? error : new Error(message));
+  };
+  const emitMapped = (mapper: () => ChatroomStreamEvent['event'] | null, afterMap?: (event: ChatroomStreamEvent['event']) => void) => {
+    try {
+      const mapped = mapper();
+      if (!mapped) return;
+      afterMap?.(mapped);
+      emitEvent(mapped);
+    } catch (error) {
+      failSdkContract(error);
+    }
+  };
 
   unsubs.push(
     session.on('assistant.message_delta', (e) => {
-      emitEvent({ type: 'chunk', sdkMessageId: e.data.messageId, content: e.data.deltaContent });
+      emitMapped(() => mapSdkAssistantMessageDelta(e));
     }),
   );
 
   unsubs.push(
     session.on('assistant.message', (e) => {
-      if (e.data.content) {
-        finalContent = e.data.content;
-        emitEvent({
-          type: 'message_final',
-          sdkMessageId: e.data.messageId,
-          content: e.data.content,
-        });
-      }
+      emitMapped(
+        () => mapSdkAssistantMessage(e),
+        (event) => {
+          if (event.type === 'message_final') {
+            finalContent = event.content;
+          }
+        },
+      );
     }),
   );
 
   unsubs.push(
     session.on('assistant.reasoning_delta', (e) => {
-      emitEvent({
-        type: 'reasoning',
-        reasoningId: e.data.reasoningId,
-        content: e.data.deltaContent,
-      });
+      emitMapped(() => mapSdkAssistantReasoningDelta(e));
     }),
   );
 
   unsubs.push(
     session.on('tool.execution_start', (e) => {
-      emitEvent({
-        type: 'tool_start',
-        toolCallId: e.data.toolCallId,
-        toolName: e.data.toolName,
-        args: e.data.arguments,
-        parentToolCallId: e.data.parentToolCallId,
-      });
+      emitMapped(() => mapSdkToolExecutionStart(e));
     }),
   );
 
   unsubs.push(
     session.on('tool.execution_progress', (e) => {
-      emitEvent({
-        type: 'tool_progress',
-        toolCallId: e.data.toolCallId,
-        message: e.data.progressMessage,
-      });
+      emitMapped(() => mapSdkToolExecutionProgress(e));
     }),
   );
 
   unsubs.push(
     session.on('tool.execution_partial_result', (e) => {
-      emitEvent({
-        type: 'tool_output',
-        toolCallId: e.data.toolCallId,
-        output: e.data.partialOutput,
-      });
+      emitMapped(() => mapSdkToolExecutionPartialResult(e));
     }),
   );
 
   unsubs.push(
     session.on('tool.execution_complete', (e) => {
-      emitEvent({
-        type: 'tool_done',
-        toolCallId: e.data.toolCallId,
-        success: e.data.success,
-        result: e.data.result?.content,
-        error: e.data.error?.message,
-      });
+      emitMapped(() => mapSdkToolExecutionComplete(e));
     }),
   );
 
   // Set up idle/error listeners BEFORE send to avoid missing events.
   // The turnDone timeout ID is hoisted so it can be cleared on any exit path
   // (send timeout, abort, or normal completion) to prevent 5-minute timer leaks.
-  let turnDoneTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const turnTimeoutMs = opts.turnTimeout ?? DEFAULT_TURN_TIMEOUT_MS;
   const turnDone = new Promise<void>((resolve, reject) => {
+    rejectTurnDone = reject;
     turnDoneTimeoutId = setTimeout(
       () => reject(new TurnTimeoutError(turnTimeoutMs)),
       turnTimeoutMs,
@@ -159,7 +170,11 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
     const unsubError = session.on('session.error', (e) => {
       clearTimeout(turnDoneTimeoutId);
       unsubError();
-      reject(new Error(e.data.message));
+      try {
+        reject(new Error(getSdkSessionErrorMessage(e)));
+      } catch (error) {
+        failSdkContract(error);
+      }
     });
     unsubs.push(unsubError);
 
@@ -184,6 +199,7 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
   }
 
   await turnDone.catch((err) => {
+    if (sdkContractFailed) throw err;
     // Emit a discriminated event so the renderer clears the streaming state and
     // can render timeout-specific UI without parsing error messages.
     if (err instanceof TurnTimeoutError) {

--- a/scripts/run-sdk-smoke-test.js
+++ b/scripts/run-sdk-smoke-test.js
@@ -26,6 +26,7 @@ async function main() {
   fs.writeFileSync(path.join(mindPath, 'SOUL.md'), '# Smoke Mind\n\nReply briefly and do not use tools.\n');
 
   const sdk = await import(pathToFileURL(sdkEntry).href);
+  const contracts = await importSdkContractMappers(repoRoot);
   const client = new sdk.CopilotClient({
     cliPath,
     cwd: mindPath,
@@ -53,7 +54,8 @@ async function main() {
     if (!response.includes('Chamber')) {
       throw new Error(`Unexpected SDK smoke response: ${response}`);
     }
-    await assertNamedSessionResume({ sdk, cliPath, mindPath, logDir });
+    await assertToolEventContract({ client, contracts, logDir });
+    await assertNamedSessionResume({ sdk, cliPath, mindPath, logDir, contracts });
     console.log('SDK smoke passed.');
   } finally {
     await session?.destroy().catch(() => undefined);
@@ -62,7 +64,7 @@ async function main() {
   }
 }
 
-async function assertNamedSessionResume({ sdk, cliPath, mindPath, logDir }) {
+async function assertNamedSessionResume({ sdk, cliPath, mindPath, logDir, contracts }) {
   const sessionId = `chamber-sdk-smoke-${Date.now()}`;
   const firstClient = new sdk.CopilotClient({
     cliPath,
@@ -150,7 +152,7 @@ async function assertNamedSessionResume({ sdk, cliPath, mindPath, logDir }) {
     await resumedAgainSession.disconnect();
     resumedAgainSession = undefined;
 
-    await assertModelResumePreservesContext({ client: thirdClient, sessionId, mindPath });
+    await assertModelResumePreservesContext({ client: thirdClient, sessionId, mindPath, contracts });
   } finally {
     await resumedAgainSession?.disconnect().catch(() => undefined);
     await resumedSession?.disconnect().catch(() => undefined);
@@ -162,8 +164,8 @@ async function assertNamedSessionResume({ sdk, cliPath, mindPath, logDir }) {
   }
 }
 
-async function assertModelResumePreservesContext({ client, sessionId, mindPath }) {
-  const models = await client.listModels();
+async function assertModelResumePreservesContext({ client, sessionId, mindPath, contracts }) {
+  const models = assertLiveModelListContract(await client.listModels(), contracts);
   if (!Array.isArray(models) || models.length < 2) {
     console.warn('SDK smoke skipped cross-model resume check: fewer than two models available.');
     return;
@@ -192,6 +194,104 @@ async function assertModelResumePreservesContext({ client, sessionId, mindPath }
   }
 }
 
+async function assertToolEventContract({ client, contracts }) {
+  const toolMindPath = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-sdk-tool-smoke-'));
+  fs.writeFileSync(
+    path.join(toolMindPath, 'SOUL.md'),
+    [
+      '# Tool Contract Smoke Mind',
+      '',
+      'When asked to run the Chamber SDK contract probe, call the chamber_contract_probe tool exactly once.',
+      'After the tool result returns, reply briefly with the returned token.',
+    ].join('\n'),
+  );
+
+  const tool = {
+    name: 'chamber_contract_probe',
+    description: 'Return a deterministic Chamber SDK contract smoke payload. Use this when asked to run the Chamber SDK contract probe.',
+    parameters: {
+      type: 'object',
+      properties: {
+        token: { type: 'string', description: 'The exact token to echo.' },
+      },
+      required: ['token'],
+    },
+    skipPermission: true,
+    handler: async (args) => {
+      return `CHAMBER_TOOL_CONTRACT_OK:${args?.token ?? ''}`;
+    },
+  };
+
+  let lastResponse = '';
+  try {
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      const startEvents = [];
+      const completeEvents = [];
+      let toolSession;
+      const unsubs = [];
+      try {
+        toolSession = await client.createSession({
+          streaming: true,
+          workingDirectory: toolMindPath,
+          tools: [tool],
+          systemMessage: {
+            mode: 'append',
+            content: 'For this smoke test, tool use is required when the user asks for the Chamber SDK contract probe.',
+          },
+          onPermissionRequest: async () => ({ kind: 'allow' }),
+          onUserInputRequest: async () => ({ answer: 'Proceed.', wasFreeform: true }),
+        });
+        await toolSession.rpc.permissions.setApproveAll({ enabled: true });
+        unsubs.push(
+          toolSession.on('tool.execution_start', (event) => startEvents.push(event)),
+          toolSession.on('tool.execution_complete', (event) => completeEvents.push(event)),
+        );
+
+        lastResponse = await sendAndWaitForResponse(
+          toolSession,
+          'Run the Chamber SDK contract probe now. Call chamber_contract_probe with token "chamber-tool-contract" before answering.',
+        );
+
+        const start = startEvents.find((event) => {
+          const mapped = contracts.mapSdkToolExecutionStart(event);
+          return mapped.toolName === 'chamber_contract_probe';
+        });
+        if (start) {
+          const mappedStart = contracts.mapSdkToolExecutionStart(start);
+          const complete = completeEvents.find((event) => {
+            const mapped = contracts.mapSdkToolExecutionComplete(event);
+            return mapped.toolCallId === mappedStart.toolCallId;
+          });
+          if (!complete) continue;
+          const mappedComplete = contracts.mapSdkToolExecutionComplete(complete);
+          if (mappedStart.args?.token !== 'chamber-tool-contract') {
+            throw new Error(`SDK tool start contract emitted unexpected arguments: ${JSON.stringify(mappedStart.args)}`);
+          }
+          if (!mappedComplete.success || !mappedComplete.result?.includes('CHAMBER_TOOL_CONTRACT_OK:chamber-tool-contract')) {
+            throw new Error(`SDK tool complete contract emitted unexpected result: ${JSON.stringify(mappedComplete)}`);
+          }
+          return;
+        }
+      } finally {
+        for (const unsub of unsubs) unsub();
+        await toolSession?.destroy().catch(() => undefined);
+      }
+    }
+
+    throw new Error(`SDK smoke did not observe deterministic tool execution events. Last response: ${lastResponse}`);
+  } finally {
+    await cleanupMind(toolMindPath);
+  }
+}
+
+function assertLiveModelListContract(rawModels, contracts) {
+  const models = contracts.mapSdkModelList(rawModels);
+  if (!models.some((model) => model.id.trim() && model.name.trim())) {
+    throw new Error('SDK model-list contract returned no usable models.');
+  }
+  return models;
+}
+
 async function cleanupMind(mindPath) {
   for (let attempt = 0; attempt < 5; attempt += 1) {
     try {
@@ -205,6 +305,20 @@ async function cleanupMind(mindPath) {
       await new Promise((resolve) => setTimeout(resolve, 250));
     }
   }
+}
+
+async function importSdkContractMappers(repoRoot) {
+  const sdkDir = path.join(repoRoot, 'packages', 'services', 'src', 'sdk');
+  const [chatContracts, modelContracts] = await Promise.all([
+    import(pathToFileURL(path.join(sdkDir, 'sdkChatEventMapper.ts')).href),
+    import(pathToFileURL(path.join(sdkDir, 'sdkModelMapper.ts')).href),
+  ]);
+
+  return {
+    mapSdkModelList: modelContracts.mapSdkModelList,
+    mapSdkToolExecutionStart: chatContracts.mapSdkToolExecutionStart,
+    mapSdkToolExecutionComplete: chatContracts.mapSdkToolExecutionComplete,
+  };
 }
 
 function sendAndWaitForResponse(session, prompt) {


### PR DESCRIPTION
## Summary
- Adds Zod-backed SDK model-list contract validation for `client.listModels()` before mapping into Chamber `ModelInfo`.
- Reuses SDK chat event contract mappers in chatroom session streaming so SDK drift surfaces as explicit stream errors.
- Expands the live SDK smoke to validate real model-list output and deterministic `tool.execution_start` / `tool.execution_complete` payloads through the runtime mappers.
- Bumps Chamber to v0.46.4 and updates the changelog.

Closes #194

## Validation
- Uncle Bob review: no blocking or material issues found.
- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npm run smoke:server-sdk`
- `npm run smoke:web`
- `npm run smoke:desktop` (full run had 3 unrelated flaky desktop failures; each passed on targeted rerun)
  - `npx playwright test --config config/playwright.config.ts --project=electron --workers=1 --grep 'Lucy history reloads'`
  - `npx playwright test --config config/playwright.config.ts --project=electron --workers=1 --grep 'first prompt titles'`
  - `npx playwright test --config config/playwright.config.ts --project=electron --workers=1 --grep 'switches model mid-conversation'`
