### PR TITLE
feat(marketplace): install A365 release tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.47.0 (2026-05-08)
+
+### Marketplace
+
+- **Install internal CLI tools from GitHub release assets** — Marketplace `tools[]` entries can now use `install.type: "github-release-asset"` with platform/arch asset selectors and required SHA-256 checksums. Chamber downloads private release assets through the GitHub API using stored credentials, avoids forwarding tokens across release-download redirects, installs verified binaries into the Chamber tools bin directory, and prepends that directory to SDK subprocess PATH so advertised tools are executable. (#229)
+- **Ship A365 tools through the internal marketplace** — The internal Genesis marketplace now declares A365 Teams, Mail, Calendar, Copilot, Planner, Whois, Word, Excel, and Sales tools from `agency-microsoft/a365-cli` release `v0.5.0`, preserving public/default marketplace behavior while enabling internal users to install prebuilt binaries without `gh`, Go, or a source checkout. (#229)
+
 ## v0.46.4 (2026-05-08)
 
 ### SDK

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Marketplace maintainers can add a click-to-enroll link to a README or internal p
 
 The GitHub Pages interstitial at `https://chmbr.dev/install.html?registry=<encoded registry URL>` opens the matching `chamber://install?registry=...` URL and shows a fallback copy button if Chamber is not installed.
 
+### Marketplace CLI tools
+
+Marketplace plugin manifests can declare a `tools[]` array alongside `minds[]`. Chamber supports `npm-global` tools and GitHub release asset tools. Release asset tools use the GitHub API directly, require per-platform SHA-256 metadata, and install prebuilt binaries into Chamber's managed tools directory so end-user machines do not need `gh`, Go, or a source checkout.
+
 ## Architecture
 
 Chamber is being split into a transport-oriented workspace layout so the UI can run either in a browser or inside Electron:

--- a/ai-docs/edge-marketplace-install-link-smoke.md
+++ b/ai-docs/edge-marketplace-install-link-smoke.md
@@ -7,6 +7,7 @@ Use this runbook to validate the real README badge flow for an internal Genesis 
 3. Edge hands off the `chamber://install?registry=...` URL to the installed Chamber app.
 4. Chamber prompts to add the marketplace.
 5. After approval, Chamber persists `agency-microsoft/genesis-minds` as an enabled Genesis marketplace.
+6. For A365 release-tool validation, Chamber reconciles the newly enrolled marketplace tools, installs the A365 release assets, and Heinz's identity includes those tools in the generated `## Tools` section.
 
 This smoke intentionally crosses outside the hermetic Playwright Electron test harness. It uses your running Edge browser via the Playwright MCP Bridge extension and an installed Chamber build so Windows protocol registration is exercised.
 
@@ -66,6 +67,16 @@ npm run smoke:desktop -- tests/e2e/electron/marketplace-install-link-edge.spec.t
 Remove-Item Env:\CHAMBER_E2E_EDGE_MARKETPLACE_INSTALL_LINK
 ```
 
+To validate the full A365 marketplace-tool path with Heinz:
+
+```powershell
+$env:CHAMBER_E2E_A365_EDGE_MARKETPLACE_TOOLS = '1'
+npm run smoke:desktop -- tests/e2e/electron/a365-marketplace-install-link-edge.spec.ts
+Remove-Item Env:\CHAMBER_E2E_A365_EDGE_MARKETPLACE_TOOLS
+```
+
+By default, the A365 smoke restores `~\.chamber\config.json` after the run but leaves downloaded binaries in Chamber's tools bin. Set `CHAMBER_E2E_A365_EDGE_KEEP_CONFIG=1` if you want to keep the internal marketplace enrollment and installed-tool records after a successful run.
+
 For demos, add a pause between each browser handoff step:
 
 ```powershell
@@ -83,6 +94,8 @@ playwright-cli config --extension --browser=msedge
 ```
 
 It then opens the internal repo, snapshots the page, finds the `Add to Chamber` badge, clicks it, follows the GitHub Pages interstitial to `chamber://`, and waits for Chamber's persisted config to include `github:agency-microsoft/genesis-minds`.
+
+The A365 variant also removes existing A365 installed-tool records before clicking the badge, waits for the nine A365 release-asset tools to be installed, checks the binaries exist, and verifies Heinz's generated identity includes the A365 tool headings.
 
 ## During the test
 

--- a/ai-docs/edge-marketplace-install-link-smoke.md
+++ b/ai-docs/edge-marketplace-install-link-smoke.md
@@ -7,7 +7,7 @@ Use this runbook to validate the real README badge flow for an internal Genesis 
 3. Edge hands off the `chamber://install?registry=...` URL to the installed Chamber app.
 4. Chamber prompts to add the marketplace.
 5. After approval, Chamber persists `agency-microsoft/genesis-minds` as an enabled Genesis marketplace.
-6. For A365 release-tool validation, Chamber reconciles the newly enrolled marketplace tools, installs the A365 release assets, and Heinz's identity includes those tools in the generated `## Tools` section.
+6. For A365 release-tool validation, Chamber reconciles the newly enrolled marketplace tools, installs the A365 release assets, Heinz's identity includes those tools in the generated `## Tools` section, and Heinz answers that he can see the Teams tool.
 
 This smoke intentionally crosses outside the hermetic Playwright Electron test harness. It uses your running Edge browser via the Playwright MCP Bridge extension and an installed Chamber build so Windows protocol registration is exercised.
 
@@ -95,7 +95,7 @@ playwright-cli config --extension --browser=msedge
 
 It then opens the internal repo, snapshots the page, finds the `Add to Chamber` badge, clicks it, follows the GitHub Pages interstitial to `chamber://`, and waits for Chamber's persisted config to include `github:agency-microsoft/genesis-minds`.
 
-The A365 variant also removes existing A365 installed-tool records before clicking the badge, waits for the nine A365 release-asset tools to be installed, checks the binaries exist, and verifies Heinz's generated identity includes the A365 tool headings.
+The A365 variant also removes existing A365 installed-tool records before clicking the badge, waits for the nine A365 release-asset tools to be installed, checks the binaries exist, verifies Heinz's generated identity includes the A365 tool headings, then starts a Heinz chat turn and expects him to answer `YES_TEAMS_TOOL_AVAILABLE` when asked whether he can see the Teams CLI tool.
 
 ## During the test
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -20,6 +20,7 @@ import {
   GenesisMindTemplateInstaller,
   GenesisMindTemplateMarketplaceCatalog,
   GitHubRegistryClient,
+  GitHubReleaseAssetClient,
   CronService,
   IdentityLoader,
   MarketplaceToolCatalog,
@@ -28,11 +29,13 @@ import {
   MindManager,
   MindScaffold,
   TaskManager,
+  ChildProcessRunner,
   ToolInstaller,
   ToolsService,
   TurnQueue,
   ViewDiscovery,
   configureSdkRuntimeLayout,
+  getChamberToolsBinDir,
   type AppPaths,
   type CredentialStore,
   type GenesisMindTemplateMarketplaceSource,
@@ -118,7 +121,8 @@ const notifier: Notifier = {
   },
 };
 
-const clientFactory = new CopilotClientFactory();
+const chamberToolsBinDir = getChamberToolsBinDir();
+const clientFactory = new CopilotClientFactory({ toolsBinDir: chamberToolsBinDir });
 const configService = new ConfigService();
 const identityLoader = new IdentityLoader(() => configService.load().installedTools ?? []);
 const getGenesisMarketplaceSources = (): GenesisMindTemplateMarketplaceSource[] =>
@@ -140,7 +144,15 @@ const genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(githubR
 const genesisTemplateInstaller = new GenesisMindTemplateInstaller(githubRegistryClient, clientFactory, getGenesisMarketplaceSources);
 const marketplaceRegistryService = new MarketplaceRegistryService(configService, githubRegistryClient);
 const marketplaceToolCatalog = new MarketplaceToolCatalog(githubRegistryClient, getGenesisMarketplaceSources);
-const toolsService = new ToolsService(marketplaceToolCatalog, new ToolInstaller(), configService);
+const toolsService = new ToolsService(
+  marketplaceToolCatalog,
+  new ToolInstaller(
+    new ChildProcessRunner(),
+    GitHubReleaseAssetClient.withCredentialStore(credentialStore),
+    chamberToolsBinDir,
+  ),
+  configService,
+);
 const viewDiscovery = new ViewDiscovery();
 
 // --- Services (business rules, all dependencies injected) ---

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -336,6 +336,19 @@ const showMarketplaceProtocolMessage = (type: 'info' | 'error', message: string,
   }
 };
 
+const reconcileMarketplaceTools = (): void => {
+  toolsService.reconcile()
+    .then((outcome) => {
+      if (outcome.installed.length > 0) {
+        log.info(`Installed ${outcome.installed.length} new marketplace tool(s):`, outcome.installed.map((tool) => tool.id));
+      }
+      if (outcome.errors.length > 0) {
+        log.warn(`Tool reconcile encountered ${outcome.errors.length} error(s):`, outcome.errors);
+      }
+    })
+    .catch((error: unknown) => log.warn('Tool reconciliation failed:', error));
+};
+
 const confirmMarketplaceProtocolEnrollment = async (registryUrl: string): Promise<boolean> => {
   const options: MessageBoxOptions = {
     type: 'question',
@@ -375,6 +388,7 @@ const handleProtocolUrl = (rawUrl: string): void => {
     })
     .then((added) => {
       if (added) {
+        reconcileMarketplaceTools();
         showMarketplaceProtocolMessage('info', 'Marketplace added to Chamber', installUrl.registryUrl);
       }
     })
@@ -492,7 +506,7 @@ app.on('ready', async () => {
     }},
     genesisTemplateInstaller,
   );
-  setupMarketplaceIPC(marketplaceRegistryService);
+  setupMarketplaceIPC(marketplaceRegistryService, { onRegistryToolsChanged: reconcileMarketplaceTools });
   setupToolsIPC(toolsService);
   setupAuthIPC(authService, mindManager);
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager);
@@ -501,16 +515,7 @@ app.on('ready', async () => {
 
   // Fire-and-forget tool reconciliation: install any new marketplace tools.
   // Errors are logged in ToolsService and surface via tools:list later.
-  toolsService.reconcile()
-    .then((outcome) => {
-      if (outcome.installed.length > 0) {
-        log.info(`Installed ${outcome.installed.length} new marketplace tool(s):`, outcome.installed.map((tool) => tool.id));
-      }
-      if (outcome.errors.length > 0) {
-        log.warn(`Tool reconcile encountered ${outcome.errors.length} error(s):`, outcome.errors);
-      }
-    })
-    .catch((error: unknown) => log.warn('Tool reconciliation failed:', error));
+  reconcileMarketplaceTools();
 
   // Window controls
   ipcMain.on('window:minimize', () => mainWindow?.minimize());

--- a/apps/desktop/src/main/ipc/marketplace.ts
+++ b/apps/desktop/src/main/ipc/marketplace.ts
@@ -1,21 +1,34 @@
 import { ipcMain } from 'electron';
 import type { MarketplaceRegistryService } from '@chamber/services';
 
-export function setupMarketplaceIPC(marketplaceRegistryService: MarketplaceRegistryService): void {
+interface MarketplaceIPCOptions {
+  onRegistryToolsChanged?: () => void;
+}
+
+export function setupMarketplaceIPC(
+  marketplaceRegistryService: MarketplaceRegistryService,
+  options: MarketplaceIPCOptions = {},
+): void {
   ipcMain.handle('marketplace:listGenesisRegistries', async () => {
     return marketplaceRegistryService.listGenesisRegistries();
   });
 
   ipcMain.handle('marketplace:addGenesisRegistry', async (_event, url: string) => {
-    return marketplaceRegistryService.addGenesisRegistry(url);
+    const result = await marketplaceRegistryService.addGenesisRegistry(url);
+    if (result.success) options.onRegistryToolsChanged?.();
+    return result;
   });
 
   ipcMain.handle('marketplace:refreshGenesisRegistry', async (_event, id: string) => {
-    return marketplaceRegistryService.refreshGenesisRegistry(id);
+    const result = await marketplaceRegistryService.refreshGenesisRegistry(id);
+    if (result.success) options.onRegistryToolsChanged?.();
+    return result;
   });
 
   ipcMain.handle('marketplace:setGenesisRegistryEnabled', async (_event, id: string, enabled: boolean) => {
-    return marketplaceRegistryService.setGenesisRegistryEnabled(id, enabled);
+    const result = await marketplaceRegistryService.setGenesisRegistryEnabled(id, enabled);
+    if (result.success && enabled) options.onRegistryToolsChanged?.();
+    return result;
   });
 
   ipcMain.handle('marketplace:removeGenesisRegistry', async (_event, id: string) => {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -8,6 +8,7 @@ import {
   ChatService,
   ConfigService,
   CopilotClientFactory,
+  getChamberToolsBinDir,
   IdentityLoader,
   MindManager,
   TurnQueue,
@@ -32,7 +33,12 @@ const saveActiveLogin = (login: string | null) => {
 };
 const authService = new AuthService(keytar as CredentialStore, () => configService.load().activeLogin, saveActiveLogin);
 const viewDiscovery = new ViewDiscovery();
-const mindManager = new MindManager(new CopilotClientFactory(), new IdentityLoader(() => configService.load().installedTools ?? []), configService, viewDiscovery);
+const mindManager = new MindManager(
+  new CopilotClientFactory({ toolsBinDir: getChamberToolsBinDir() }),
+  new IdentityLoader(() => configService.load().installedTools ?? []),
+  configService,
+  viewDiscovery,
+);
 const chatService = new ChatService(mindManager, new TurnQueue());
 viewDiscovery.setRefreshHandler({
   sendBackgroundPrompt: (mindPath, prompt) => mindManager.sendBackgroundPrompt(mindPath, prompt),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.46.4",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.46.4",
+      "version": "0.47.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.46.4",
+  "version": "0.47.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/config/ConfigService.test.ts
+++ b/packages/services/src/config/ConfigService.test.ts
@@ -243,6 +243,7 @@ describe('ConfigService', () => {
         id: 'workiq',
         package: '@microsoft/workiq',
         version: 'latest',
+        install: { type: 'npm-global', package: '@microsoft/workiq', version: 'latest' },
         bin: 'workiq',
         displayName: 'Microsoft Work IQ',
         description: 'Query M365 data.',
@@ -263,6 +264,59 @@ describe('ConfigService', () => {
       expect(loaded.installedTools).toEqual([installedTool]);
     });
 
+    it('round-trips a GitHub release asset installed tool record', () => {
+      const installedTool = {
+        id: 'a365-teams',
+        version: 'v0.5.0',
+        bin: 'teams',
+        displayName: 'A365 Teams CLI',
+        description: 'Read and post Teams messages.',
+        help: 'teams --help',
+        agentInstructions: 'Use teams read.',
+        source: { marketplaceId: 'github:agency-microsoft/genesis-minds', pluginId: 'genesis-minds' },
+        installedAt: '2026-05-08T04:00:00.000Z',
+        install: {
+          type: 'github-release-asset',
+          owner: 'agency-microsoft',
+          repo: 'a365-cli',
+          tag: 'v0.5.0',
+          assetName: 'teams.exe',
+          sha256: 'ab6d078c26648a9409137c0ae3b245d006c12c39a9222efeb0c5847b8554aa31',
+          platform: 'win32',
+          arch: 'x64',
+          installedPath: 'C:\\Users\\ianphil\\.chamber\\tools\\bin\\teams.exe',
+        },
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [],
+        activeMindId: null,
+        activeLogin: null,
+        theme: 'dark',
+        installedTools: [installedTool],
+      }));
+      const loaded = svc.load();
+      expect(loaded.installedTools).toEqual([installedTool]);
+    });
+
+    it('adds install metadata to legacy npm installed tool records', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 2,
+        minds: [],
+        activeMindId: null,
+        activeLogin: null,
+        theme: 'dark',
+        installedTools: [
+          { id: 'workiq', package: '@microsoft/workiq', version: 'latest', bin: 'workiq', displayName: 'A', description: 'a', source: { marketplaceId: 'm', pluginId: 'p' }, installedAt: '2026-01-01T00:00:00Z' },
+        ],
+      }));
+      const loaded = svc.load();
+      expect(loaded.installedTools?.[0]).toMatchObject({
+        package: '@microsoft/workiq',
+        install: { type: 'npm-global', package: '@microsoft/workiq', version: 'latest' },
+      });
+    });
+
     it('drops malformed tool records and deduplicates by id', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         version: 2,
@@ -279,7 +333,7 @@ describe('ConfigService', () => {
       }));
       const loaded = svc.load();
       expect(loaded.installedTools).toHaveLength(1);
-      expect(loaded.installedTools?.[0].package).toBe('@microsoft/workiq');
+      expect(loaded.installedTools?.[0].install).toEqual({ type: 'npm-global', package: '@microsoft/workiq', version: '1' });
     });
 
     it('omits installedTools entirely when none are persisted', () => {

--- a/packages/services/src/config/ConfigService.ts
+++ b/packages/services/src/config/ConfigService.ts
@@ -178,17 +178,7 @@ function normalizeInstalledTools(raw: unknown): InstalledTool[] {
   for (const value of raw) {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) continue;
     const record = value as Record<string, unknown>;
-    if (
-      typeof record.id !== 'string'
-      || typeof record.package !== 'string'
-      || typeof record.version !== 'string'
-      || typeof record.bin !== 'string'
-      || typeof record.installedAt !== 'string'
-      || typeof record.displayName !== 'string'
-      || typeof record.description !== 'string'
-    ) {
-      continue;
-    }
+    if (!hasBaseInstalledToolFields(record)) continue;
     const source = record.source;
     if (typeof source !== 'object' || source === null || Array.isArray(source)) continue;
     const sourceRecord = source as Record<string, unknown>;
@@ -196,10 +186,11 @@ function normalizeInstalledTools(raw: unknown): InstalledTool[] {
       continue;
     }
     if (seen.has(record.id)) continue;
+    const install = normalizeInstalledToolInstall(record);
+    if (!install) continue;
     seen.add(record.id);
-    tools.push({
+    const base = {
       id: record.id,
-      package: record.package,
       version: record.version,
       bin: record.bin,
       displayName: record.displayName,
@@ -208,9 +199,77 @@ function normalizeInstalledTools(raw: unknown): InstalledTool[] {
       ...(typeof record.agentInstructions === 'string' ? { agentInstructions: record.agentInstructions } : {}),
       source: { marketplaceId: sourceRecord.marketplaceId, pluginId: sourceRecord.pluginId },
       installedAt: record.installedAt,
-    });
+    };
+    if (install.type === 'npm-global') {
+      tools.push({
+        ...base,
+        package: install.package,
+        install,
+      });
+    } else {
+      tools.push({
+        ...base,
+        install,
+      });
+    }
   }
   return tools;
+}
+
+function hasBaseInstalledToolFields(record: Record<string, unknown>): record is Record<string, unknown> & {
+  id: string;
+  version: string;
+  bin: string;
+  installedAt: string;
+  displayName: string;
+  description: string;
+} {
+  return typeof record.id === 'string'
+    && typeof record.version === 'string'
+    && typeof record.bin === 'string'
+    && typeof record.installedAt === 'string'
+    && typeof record.displayName === 'string'
+    && typeof record.description === 'string';
+}
+
+function normalizeInstalledToolInstall(record: Record<string, unknown>): InstalledTool['install'] | null {
+  const install = record.install;
+  if (typeof install === 'object' && install !== null && !Array.isArray(install)) {
+    const installRecord = install as Record<string, unknown>;
+    if (installRecord.type === 'npm-global'
+      && typeof installRecord.package === 'string'
+      && typeof installRecord.version === 'string') {
+      return { type: 'npm-global', package: installRecord.package, version: installRecord.version };
+    }
+    if (installRecord.type === 'github-release-asset'
+      && typeof installRecord.owner === 'string'
+      && typeof installRecord.repo === 'string'
+      && typeof installRecord.tag === 'string'
+      && typeof installRecord.assetName === 'string'
+      && typeof installRecord.sha256 === 'string'
+      && typeof installRecord.platform === 'string'
+      && typeof installRecord.arch === 'string'
+      && typeof installRecord.installedPath === 'string') {
+      return {
+        type: 'github-release-asset',
+        owner: installRecord.owner,
+        repo: installRecord.repo,
+        tag: installRecord.tag,
+        assetName: installRecord.assetName,
+        sha256: installRecord.sha256,
+        platform: installRecord.platform,
+        arch: installRecord.arch,
+        installedPath: installRecord.installedPath,
+        ...(installRecord.archive === 'zip' || installRecord.archive === 'tar.gz' ? { archive: installRecord.archive } : {}),
+        ...(typeof installRecord.binPath === 'string' ? { binPath: installRecord.binPath } : {}),
+      };
+    }
+    return null;
+  }
+  if (typeof record.package === 'string') {
+    return { type: 'npm-global', package: record.package, version: record.version as string };
+  }
+  return null;
 }
 
 function deduplicateRegistries(registries: MarketplaceRegistry[]): MarketplaceRegistry[] {

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -81,6 +81,27 @@ describe('CopilotClientFactory', () => {
       expect(cliArgs).not.toContain(expect.stringMatching(/npm-loader\.js$/));
     });
 
+    it('prepends the Chamber tools bin directory to the CLI PATH when configured', async () => {
+      factory = new CopilotClientFactory({ toolsBinDir: 'C:\\Users\\ianphil\\AppData\\Roaming\\Chamber\\tools\\bin' });
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      const env = client.options.env as Record<string, string>;
+      const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+
+      expect(env[pathKey].split(';')[0]).toBe('C:\\Users\\ianphil\\AppData\\Roaming\\Chamber\\tools\\bin');
+    });
+
+    it('does not duplicate the Chamber tools bin directory in the CLI PATH', async () => {
+      const toolsBinDir = 'C:\\Users\\ianphil\\AppData\\Roaming\\Chamber\\tools\\bin';
+      factory = new CopilotClientFactory({
+        toolsBinDir,
+        env: { Path: `${toolsBinDir};C:\\Windows\\System32` },
+      });
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      const env = client.options.env as Record<string, string>;
+
+      expect(env.Path).toBe(`${toolsBinDir};C:\\Windows\\System32`);
+    });
+
     it('creates separate clients for different mind paths', async () => {
       const client1 = await factory.createClient('C:\\agents\\q');
       const client2 = await factory.createClient('C:\\agents\\fox');

--- a/packages/services/src/sdk/CopilotClientFactory.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.ts
@@ -10,8 +10,15 @@ import { getPlatformCopilotBinaryPath } from './SdkBootstrap';
 
 import type { CopilotClient } from '@github/copilot-sdk';
 
+export interface CopilotClientFactoryOptions {
+  toolsBinDir?: string;
+  env?: Record<string, string | undefined>;
+}
+
 export class CopilotClientFactory {
   private sdkModule: typeof import('@github/copilot-sdk') | null = null;
+
+  constructor(private readonly options: CopilotClientFactoryOptions = {}) {}
 
   async createClient(mindPath: string): Promise<CopilotClient> {
     const sdk = await this.getSdk();
@@ -39,6 +46,7 @@ export class CopilotClientFactory {
       cwd: mindPath,
       logLevel: 'all',
       cliArgs,
+      ...(this.options.toolsBinDir ? { env: prependToPath(this.options.env ?? process.env, this.options.toolsBinDir) } : {}),
     });
 
     await client.start();
@@ -59,4 +67,21 @@ export class CopilotClientFactory {
     }
     return this.sdkModule;
   }
+}
+
+function prependToPath(env: Record<string, string | undefined>, entry: string): Record<string, string | undefined> {
+  const next = { ...env };
+  const pathKey = Object.keys(next).find((key) => key.toLowerCase() === 'path') ?? (process.platform === 'win32' ? 'Path' : 'PATH');
+  const current = next[pathKey] ?? '';
+  const parts = current.split(path.delimiter).filter(Boolean);
+  if (parts.some((part) => samePath(part, entry))) {
+    next[pathKey] = current;
+    return next;
+  }
+  next[pathKey] = [entry, ...parts].join(path.delimiter);
+  return next;
+}
+
+function samePath(left: string, right: string): boolean {
+  return process.platform === 'win32' ? left.toLowerCase() === right.toLowerCase() : left === right;
 }

--- a/packages/services/src/tools/GitHubReleaseAssetClient.test.ts
+++ b/packages/services/src/tools/GitHubReleaseAssetClient.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { GitHubReleaseAssetClient } from './GitHubReleaseAssetClient';
+
+class FakeResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Headers;
+
+  constructor(
+    private readonly body: unknown,
+    init: { status?: number; statusText?: string; headers?: Record<string, string> } = {},
+  ) {
+    this.status = init.status ?? 200;
+    this.statusText = init.statusText ?? 'OK';
+    this.ok = this.status >= 200 && this.status < 300;
+    this.headers = new Headers(init.headers);
+  }
+
+  async json(): Promise<unknown> {
+    return this.body;
+  }
+
+  async text(): Promise<string> {
+    return typeof this.body === 'string' ? this.body : JSON.stringify(this.body);
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    if (this.body instanceof Uint8Array) {
+      return this.body.buffer.slice(this.body.byteOffset, this.body.byteOffset + this.body.byteLength) as ArrayBuffer;
+    }
+    const encoded = new TextEncoder().encode(String(this.body));
+    return encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength) as ArrayBuffer;
+  }
+}
+
+function response(fake: FakeResponse): Response {
+  return fake as unknown as Response;
+}
+
+describe('GitHubReleaseAssetClient', () => {
+  it('downloads a tagged release asset using stored credentials and strips auth on redirect', async () => {
+    const calls: Array<{ url: string; headers: Headers; redirect?: RequestRedirect }> = [];
+    const fetchImpl = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      calls.push({
+        url: String(url),
+        headers: new Headers(init?.headers),
+        redirect: init?.redirect,
+      });
+      if (String(url).includes('/releases/tags/v0.5.0')) {
+        if (!new Headers(init?.headers).has('authorization')) {
+          return response(new FakeResponse({ message: 'Not Found' }, { status: 404, statusText: 'Not Found' }));
+        }
+        return response(new FakeResponse({
+          assets: [{ id: 123, name: 'teams.exe', digest: 'sha256:abc' }],
+        }));
+      }
+      if (String(url).includes('/releases/assets/123')) {
+        if (!new Headers(init?.headers).has('authorization')) {
+          return response(new FakeResponse({ message: 'Not Found' }, { status: 404, statusText: 'Not Found' }));
+        }
+        return response(new FakeResponse('', {
+          status: 302,
+          statusText: 'Found',
+          headers: { location: 'https://objects.example/teams.exe' },
+        }));
+      }
+      if (String(url) === 'https://objects.example/teams.exe') {
+        return response(new FakeResponse(new Uint8Array([1, 2, 3])));
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+    const client = new GitHubReleaseAssetClient({
+      fetch: fetchImpl as typeof fetch,
+      credentialProvider: async () => [{ login: 'ianphil_microsoft', token: 'secret-token' }],
+    });
+
+    const result = await client.downloadAsset({
+      owner: 'agency-microsoft',
+      repo: 'a365-cli',
+      tag: 'v0.5.0',
+      assetName: 'teams.exe',
+    });
+
+    expect(result.bytes).toEqual(Buffer.from([1, 2, 3]));
+    expect(result.assetName).toBe('teams.exe');
+    expect(calls[0].headers.get('authorization')).toBeNull();
+    expect(calls[1].headers.get('authorization')).toBe('Bearer secret-token');
+    expect(calls[2].redirect).toBe('manual');
+    expect(calls[2].headers.get('authorization')).toBeNull();
+    expect(calls[3].redirect).toBe('manual');
+    expect(calls[3].headers.get('authorization')).toBe('Bearer secret-token');
+    expect(calls[4].headers.get('authorization')).toBeNull();
+  });
+
+  it('uses the latest release endpoint when tag is latest', async () => {
+    const urls: string[] = [];
+    const fetchImpl = async (url: string | URL | Request): Promise<Response> => {
+      urls.push(String(url));
+      if (String(url).includes('/releases/latest')) {
+        return response(new FakeResponse({ assets: [{ id: 1, name: 'mail.exe' }] }));
+      }
+      if (String(url).includes('/releases/assets/1')) {
+        return response(new FakeResponse(new Uint8Array([4]), { status: 200 }));
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+    const client = new GitHubReleaseAssetClient({ fetch: fetchImpl as typeof fetch });
+
+    await client.downloadAsset({
+      owner: 'agency-microsoft',
+      repo: 'a365-cli',
+      tag: 'latest',
+      assetName: 'mail.exe',
+    });
+
+    expect(urls[0]).toContain('/repos/agency-microsoft/a365-cli/releases/latest');
+  });
+
+  it('reports a clear error when a release asset is missing', async () => {
+    const client = new GitHubReleaseAssetClient({
+      fetch: (async () => response(new FakeResponse({ assets: [{ id: 1, name: 'mail.exe' }] }))) as typeof fetch,
+    });
+
+    await expect(client.downloadAsset({
+      owner: 'agency-microsoft',
+      repo: 'a365-cli',
+      tag: 'v0.5.0',
+      assetName: 'teams.exe',
+    })).rejects.toThrow('Release v0.5.0 in agency-microsoft/a365-cli does not include asset teams.exe');
+  });
+
+  it('surfaces private repository access guidance when GitHub returns not found', async () => {
+    const client = new GitHubReleaseAssetClient({
+      fetch: (async () => response(new FakeResponse({ message: 'Not Found' }, { status: 404, statusText: 'Not Found' }))) as typeof fetch,
+    });
+
+    await expect(client.downloadAsset({
+      owner: 'agency-microsoft',
+      repo: 'a365-cli',
+      tag: 'v0.5.0',
+      assetName: 'teams.exe',
+    })).rejects.toThrow('Check that you are signed in to GitHub with access to agency-microsoft/a365-cli');
+  });
+});

--- a/packages/services/src/tools/GitHubReleaseAssetClient.ts
+++ b/packages/services/src/tools/GitHubReleaseAssetClient.ts
@@ -1,0 +1,205 @@
+import { AuthService, listStoredGitHubCredentials } from '../auth';
+import type { CredentialStore } from '../ports';
+import type { GitHubRegistryCredential, GitHubRegistryCredentialProvider } from '../genesis/GitHubRegistryClient';
+
+export interface GitHubReleaseAssetClientOptions {
+  fetch?: typeof fetch;
+  credentialProvider?: GitHubRegistryCredentialProvider;
+  requestTimeoutMs?: number;
+}
+
+export interface DownloadReleaseAssetRequest {
+  owner: string;
+  repo: string;
+  tag: string;
+  assetName: string;
+}
+
+export interface DownloadedReleaseAsset {
+  assetName: string;
+  bytes: Buffer;
+}
+
+interface GitHubReleaseResponse {
+  assets: unknown;
+}
+
+export class GitHubReleaseAssetClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly credentialProvider: GitHubRegistryCredentialProvider;
+  private readonly requestTimeoutMs: number;
+
+  constructor(options: GitHubReleaseAssetClientOptions = {}) {
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.credentialProvider = options.credentialProvider ?? (() => Promise.resolve([]));
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  }
+
+  static withCredentialStore(credentials: CredentialStore): GitHubReleaseAssetClient {
+    return new GitHubReleaseAssetClient({
+      credentialProvider: async () => (await listStoredGitHubCredentials(credentials))
+        .map((credential) => ({ login: credential.login, token: credential.password })),
+    });
+  }
+
+  async downloadAsset(request: DownloadReleaseAssetRequest): Promise<DownloadedReleaseAsset> {
+    const release = await this.requestJson<GitHubReleaseResponse>(
+      releasePath(request.owner, request.repo, request.tag),
+      request.owner,
+      request.repo,
+    );
+    if (!Array.isArray(release.assets)) {
+      throw new Error(`GitHub release ${request.tag} in ${request.owner}/${request.repo} did not include assets`);
+    }
+    const assets = release.assets.map(parseReleaseAsset);
+    const asset = assets.find((entry) => entry.name === request.assetName);
+    if (!asset) {
+      throw new Error(`Release ${request.tag} in ${request.owner}/${request.repo} does not include asset ${request.assetName}`);
+    }
+    const bytes = await this.downloadAssetById(request.owner, request.repo, asset.id);
+    return { assetName: asset.name, bytes };
+  }
+
+  private async requestJson<T>(pathAndQuery: string, owner: string, repo: string): Promise<T> {
+    const anonymousAttempt = await this.fetchJsonAttempt<T>(pathAndQuery, null, null, owner, repo);
+    if (anonymousAttempt.ok) return anonymousAttempt.value;
+
+    let lastError = anonymousAttempt.error;
+    for (const credential of await this.safeCredentials()) {
+      const credentialAttempt = await this.fetchJsonAttempt<T>(pathAndQuery, credential.token, credential.login, owner, repo);
+      if (credentialAttempt.ok) return credentialAttempt.value;
+      lastError = credentialAttempt.error;
+    }
+
+    throw lastError ?? new Error('GitHub release request failed');
+  }
+
+  private async fetchJsonAttempt<T>(
+    pathAndQuery: string,
+    token: string | null,
+    login: string | null,
+    owner: string,
+    repo: string,
+  ): Promise<{ ok: true; value: T } | { ok: false; error: Error }> {
+    const response = await this.fetchWithTimeout(`https://api.github.com${pathAndQuery}`, {
+      headers: jsonHeaders(token),
+    });
+    if (response.ok) {
+      return { ok: true, value: await response.json() as T };
+    }
+    return { ok: false, error: await githubRequestError(response, login, owner, repo) };
+  }
+
+  private async downloadAssetById(owner: string, repo: string, assetId: number): Promise<Buffer> {
+    const pathAndQuery = `/repos/${encodePath(owner)}/${encodePath(repo)}/releases/assets/${assetId}`;
+    const anonymousAttempt = await this.downloadAssetAttempt(pathAndQuery, null, null, owner, repo);
+    if (anonymousAttempt.ok) return anonymousAttempt.value;
+
+    let lastError = anonymousAttempt.error;
+    for (const credential of await this.safeCredentials()) {
+      const credentialAttempt = await this.downloadAssetAttempt(pathAndQuery, credential.token, credential.login, owner, repo);
+      if (credentialAttempt.ok) return credentialAttempt.value;
+      lastError = credentialAttempt.error;
+    }
+    throw lastError ?? new Error('GitHub release asset download failed');
+  }
+
+  private async downloadAssetAttempt(
+    pathAndQuery: string,
+    token: string | null,
+    login: string | null,
+    owner: string,
+    repo: string,
+  ): Promise<{ ok: true; value: Buffer } | { ok: false; error: Error }> {
+    const response = await this.fetchWithTimeout(`https://api.github.com${pathAndQuery}`, {
+      headers: assetHeaders(token),
+      redirect: 'manual',
+    });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        return { ok: false, error: new Error(`GitHub release asset redirect for ${owner}/${repo} did not include a location`) };
+      }
+      const redirected = await this.fetchWithTimeout(location, {
+        headers: { 'User-Agent': AuthService.userAgent },
+      });
+      if (!redirected.ok) {
+        return { ok: false, error: await githubRequestError(redirected, null, owner, repo) };
+      }
+      return { ok: true, value: Buffer.from(await redirected.arrayBuffer()) };
+    }
+    if (response.ok) {
+      return { ok: true, value: Buffer.from(await response.arrayBuffer()) };
+    }
+    return { ok: false, error: await githubRequestError(response, login, owner, repo) };
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), this.requestTimeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: abort.signal });
+    } catch (error) {
+      throw new Error(`GitHub release request failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async safeCredentials(): Promise<GitHubRegistryCredential[]> {
+    try {
+      return await this.credentialProvider();
+    } catch {
+      return [];
+    }
+  }
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+function releasePath(owner: string, repo: string, tag: string): string {
+  if (tag === 'latest') {
+    return `/repos/${encodePath(owner)}/${encodePath(repo)}/releases/latest`;
+  }
+  return `/repos/${encodePath(owner)}/${encodePath(repo)}/releases/tags/${encodePath(tag)}`;
+}
+
+function jsonHeaders(token: string | null): HeadersInit {
+  return {
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': AuthService.userAgent,
+    ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+  };
+}
+
+function assetHeaders(token: string | null): HeadersInit {
+  return {
+    'Accept': 'application/octet-stream',
+    'User-Agent': AuthService.userAgent,
+    ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+  };
+}
+
+async function githubRequestError(response: Response, login: string | null, owner: string, repo: string): Promise<Error> {
+  const message = await response.text().catch(() => '');
+  const account = login ? ` using stored credential "${login}"` : ' anonymously';
+  const accessHint = response.status === 401 || response.status === 403 || response.status === 404
+    ? ` Check that you are signed in to GitHub with access to ${owner}/${repo}.`
+    : '';
+  return new Error(`GitHub release request failed${account}: ${response.status} ${response.statusText}${message ? ` - ${message}` : ''}.${accessHint}`);
+}
+
+function parseReleaseAsset(value: unknown): { id: number; name: string } {
+  if (!isRecord(value) || typeof value.id !== 'number' || typeof value.name !== 'string') {
+    throw new Error('GitHub release response included an invalid asset');
+  }
+  return { id: value.id, name: value.name };
+}
+
+function encodePath(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/services/src/tools/MarketplaceToolCatalog.test.ts
+++ b/packages/services/src/tools/MarketplaceToolCatalog.test.ts
@@ -140,6 +140,25 @@ describe('MarketplaceToolCatalog', () => {
     expect(result.errors[0].message).toContain('sha256');
   });
 
+  it('rejects tool bins that can escape the managed tools directory', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', {
+      tools: [
+        {
+          id: 'a365',
+          displayName: 'A365 CLI',
+          description: 'Run Microsoft 365 internal automation tools.',
+          install: { type: 'npm-global', package: '@agency/a365', version: 'latest' },
+          bin: '..\\Startup\\evil',
+        },
+      ],
+    });
+    const catalog = new MarketplaceToolCatalog(client, [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.tools).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('bin must be a command name');
+  });
+
   it('skips disabled marketplaces', async () => {
     const catalog = new MarketplaceToolCatalog(client, [{ ...SOURCE, enabled: false }]);
     const result = await catalog.listTools();

--- a/packages/services/src/tools/MarketplaceToolCatalog.test.ts
+++ b/packages/services/src/tools/MarketplaceToolCatalog.test.ts
@@ -66,6 +66,80 @@ describe('MarketplaceToolCatalog', () => {
     expect(tool.source.marketplaceId).toBe('github:ianphil/genesis-minds');
   });
 
+  it('parses a GitHub release asset install entry', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', {
+      name: 'genesis-minds',
+      tools: [
+        {
+          id: 'a365',
+          displayName: 'A365 CLI',
+          description: 'Run Microsoft 365 internal automation tools.',
+          install: {
+            type: 'github-release-asset',
+            owner: 'agency-microsoft',
+            repo: 'a365-cli',
+            tag: 'latest',
+            assets: [
+              {
+                platform: 'win32',
+                arch: 'x64',
+                name: 'a365-windows-amd64.exe',
+                sha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+              },
+            ],
+          },
+          bin: 'a365',
+          help: 'a365 --help',
+          agentInstructions: 'Use a365 for Microsoft 365 internal workflows.',
+        },
+      ],
+    });
+    const catalog = new MarketplaceToolCatalog(client, [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.errors).toEqual([]);
+    expect(result.tools).toHaveLength(1);
+    const tool = result.tools[0];
+    expect(tool.install).toEqual({
+      type: 'github-release-asset',
+      owner: 'agency-microsoft',
+      repo: 'a365-cli',
+      tag: 'latest',
+      assets: [
+        {
+          platform: 'win32',
+          arch: 'x64',
+          name: 'a365-windows-amd64.exe',
+          sha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        },
+      ],
+    });
+  });
+
+  it('rejects GitHub release asset entries without checksums', async () => {
+    client.manifests.set('plugins/genesis-minds/plugin.json', {
+      tools: [
+        {
+          id: 'a365',
+          displayName: 'A365 CLI',
+          description: 'Run Microsoft 365 internal automation tools.',
+          install: {
+            type: 'github-release-asset',
+            owner: 'agency-microsoft',
+            repo: 'a365-cli',
+            tag: 'latest',
+            assets: [{ platform: 'win32', arch: 'x64', name: 'a365-windows-amd64.exe' }],
+          },
+          bin: 'a365',
+        },
+      ],
+    });
+    const catalog = new MarketplaceToolCatalog(client, [SOURCE]);
+    const result = await catalog.listTools();
+    expect(result.tools).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('sha256');
+  });
+
   it('skips disabled marketplaces', async () => {
     const catalog = new MarketplaceToolCatalog(client, [{ ...SOURCE, enabled: false }]);
     const result = await catalog.listTools();

--- a/packages/services/src/tools/MarketplaceToolCatalog.ts
+++ b/packages/services/src/tools/MarketplaceToolCatalog.ts
@@ -1,5 +1,5 @@
 import { GitHubRegistryClient, type TreeEntry } from '../genesis/GitHubRegistryClient';
-import type { MarketplaceToolEntry } from '@chamber/shared/types';
+import type { GitHubReleaseAssetSelector, MarketplaceToolEntry, MarketplaceToolInstall } from '@chamber/shared/types';
 import type { ToolMarketplaceSource } from './toolTypes';
 
 interface RegistryClient {
@@ -77,11 +77,7 @@ function parseToolEntry(
   const description = stringField(entry, 'description', pluginPath, index);
   const bin = stringField(entry, 'bin', pluginPath, index);
 
-  const install = entry.install;
-  if (!isRecord(install) || install.type !== 'npm-global'
-    || typeof install.package !== 'string' || typeof install.version !== 'string') {
-    throw new Error(`${pluginPath} tools[${index}].install must be { type: 'npm-global', package, version }`);
-  }
+  const install = parseInstall(entry.install, pluginPath, index);
 
   const help = optionalString(entry, 'help');
   const agentInstructions = optionalString(entry, 'agentInstructions');
@@ -91,7 +87,7 @@ function parseToolEntry(
     id,
     displayName,
     description,
-    install: { type: 'npm-global', package: install.package, version: install.version },
+    install,
     bin,
     ...(help ? { help } : {}),
     ...(preflight ? { preflight } : {}),
@@ -108,6 +104,74 @@ function parseToolEntry(
   };
 }
 
+function parseInstall(value: unknown, pluginPath: string, index: number): MarketplaceToolInstall {
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    throw new Error(`${pluginPath} tools[${index}].install must be a tool install object`);
+  }
+  if (value.type === 'npm-global') {
+    if (typeof value.package !== 'string' || value.package.length === 0
+      || typeof value.version !== 'string' || value.version.length === 0) {
+      throw new Error(`${pluginPath} tools[${index}].install must be { type: 'npm-global', package, version }`);
+    }
+    return { type: 'npm-global', package: value.package, version: value.version };
+  }
+  if (value.type === 'github-release-asset') {
+    return parseGitHubReleaseAssetInstall(value, pluginPath, index);
+  }
+  throw new Error(`${pluginPath} tools[${index}].install.type is not supported: ${value.type}`);
+}
+
+function parseGitHubReleaseAssetInstall(
+  install: Record<string, unknown>,
+  pluginPath: string,
+  index: number,
+): MarketplaceToolInstall {
+  const installPrefix = `${pluginPath} tools[${index}].install`;
+  const owner = requiredString(install, 'owner', installPrefix);
+  const repo = requiredString(install, 'repo', installPrefix);
+  const tag = requiredString(install, 'tag', installPrefix);
+  const assets = install.assets;
+  if (!Array.isArray(assets) || assets.length === 0) {
+    throw new Error(`${pluginPath} tools[${index}].install.assets must be a non-empty array`);
+  }
+  return {
+    type: 'github-release-asset',
+    owner,
+    repo,
+    tag,
+    assets: assets.map((asset, assetIndex) => parseGitHubReleaseAsset(asset, pluginPath, index, assetIndex)),
+  };
+}
+
+function parseGitHubReleaseAsset(
+  value: unknown,
+  pluginPath: string,
+  toolIndex: number,
+  assetIndex: number,
+): GitHubReleaseAssetSelector {
+  if (!isRecord(value)) {
+    throw new Error(`${pluginPath} tools[${toolIndex}].install.assets[${assetIndex}] is not an object`);
+  }
+  const prefix = `${pluginPath} tools[${toolIndex}].install.assets[${assetIndex}]`;
+  const platform = requiredString(value, 'platform', prefix);
+  const arch = requiredString(value, 'arch', prefix);
+  const name = requiredString(value, 'name', prefix);
+  const sha256 = requiredString(value, 'sha256', prefix);
+  if (!/^[a-fA-F0-9]{64}$/.test(sha256)) {
+    throw new Error(`${prefix}.sha256 must be a 64-character hex string`);
+  }
+  const archive = optionalArchive(value, prefix);
+  const binPath = optionalString(value, 'binPath');
+  return {
+    platform,
+    arch,
+    name,
+    sha256: sha256.toLowerCase(),
+    ...(archive ? { archive } : {}),
+    ...(binPath ? { binPath } : {}),
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -116,6 +180,14 @@ function stringField(record: Record<string, unknown>, key: string, pluginPath: s
   const value = record[key];
   if (typeof value !== 'string' || value.length === 0) {
     throw new Error(`${pluginPath} tools[${index}].${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requiredString(record: Record<string, unknown>, key: string, prefix: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${prefix}.${key} must be a non-empty string`);
   }
   return value;
 }
@@ -137,4 +209,13 @@ function optionalStringArray(
     throw new Error(`${pluginPath} tools[${index}].${key} must be a string array`);
   }
   return value as string[];
+}
+
+function optionalArchive(record: Record<string, unknown>, prefix: string): 'zip' | 'tar.gz' | undefined {
+  const value = record.archive;
+  if (value === undefined) return undefined;
+  if (value !== 'zip' && value !== 'tar.gz') {
+    throw new Error(`${prefix}.archive must be "zip" or "tar.gz"`);
+  }
+  return value;
 }

--- a/packages/services/src/tools/MarketplaceToolCatalog.ts
+++ b/packages/services/src/tools/MarketplaceToolCatalog.ts
@@ -76,6 +76,9 @@ function parseToolEntry(
   const displayName = stringField(entry, 'displayName', pluginPath, index);
   const description = stringField(entry, 'description', pluginPath, index);
   const bin = stringField(entry, 'bin', pluginPath, index);
+  if (!isSafeCommandName(bin)) {
+    throw new Error(`${pluginPath} tools[${index}].bin must be a command name without path separators or traversal`);
+  }
 
   const install = parseInstall(entry.install, pluginPath, index);
 
@@ -209,6 +212,10 @@ function optionalStringArray(
     throw new Error(`${pluginPath} tools[${index}].${key} must be a string array`);
   }
   return value as string[];
+}
+
+function isSafeCommandName(value: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(value) && !value.includes('..');
 }
 
 function optionalArchive(record: Record<string, unknown>, prefix: string): 'zip' | 'tar.gz' | undefined {

--- a/packages/services/src/tools/ToolInstaller.test.ts
+++ b/packages/services/src/tools/ToolInstaller.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type { MarketplaceToolEntry } from '@chamber/shared/types';
-import { ToolInstaller, type CommandRunner, type CommandResult } from './ToolInstaller';
+import { ToolInstaller, type CommandRunner, type CommandResult, type ReleaseAssetDownloader } from './ToolInstaller';
 
 class FakeRunner implements CommandRunner {
   calls: Array<{ command: string; args: string[] }> = [];
@@ -9,6 +13,16 @@ class FakeRunner implements CommandRunner {
   async run(command: string, args: string[]): Promise<CommandResult> {
     this.calls.push({ command, args });
     return this.responses.shift() ?? this.fallback;
+  }
+}
+
+class FakeReleaseAssetDownloader implements ReleaseAssetDownloader {
+  calls: Array<{ owner: string; repo: string; tag: string; assetName: string }> = [];
+  bytes = Buffer.from('fake binary');
+
+  async downloadAsset(request: { owner: string; repo: string; tag: string; assetName: string }): Promise<{ assetName: string; bytes: Buffer }> {
+    this.calls.push(request);
+    return { assetName: request.assetName, bytes: this.bytes };
   }
 }
 
@@ -33,6 +47,20 @@ const TOOL: MarketplaceToolEntry = {
 };
 
 describe('ToolInstaller', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-tool-installer-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
   it('runs npm install -g, the verify command, and any preflight commands', async () => {
     const runner = new FakeRunner();
     const installer = new ToolInstaller(runner);
@@ -42,7 +70,7 @@ describe('ToolInstaller', () => {
     expect(runner.calls[1]).toEqual({ command: 'workiq', args: ['--version'] });
     expect(runner.calls[2]).toEqual({ command: 'workiq', args: ['accept-eula'] });
     expect(result.id).toBe('workiq');
-    expect(result.package).toBe('@microsoft/workiq');
+    expect(result.install).toEqual({ type: 'npm-global', package: '@microsoft/workiq', version: 'latest' });
     expect(result.bin).toBe('workiq');
     expect(result.displayName).toBe('Microsoft Work IQ');
     expect(result.agentInstructions).toBe('Use workiq ask.');
@@ -83,5 +111,97 @@ describe('ToolInstaller', () => {
       installedAt: '2026-01-01T00:00:00Z',
     });
     expect(runner.calls[0]).toEqual({ command: 'npm', args: ['uninstall', '-g', '@microsoft/workiq'] });
+  });
+
+  it('downloads a GitHub release asset, verifies its checksum, and installs it into the tools bin directory', async () => {
+    const runner = new FakeRunner();
+    const downloader = new FakeReleaseAssetDownloader();
+    const toolsBinDir = makeTempDir();
+    const sha256 = createHash('sha256').update(downloader.bytes).digest('hex');
+    const installer = new ToolInstaller(runner, downloader, toolsBinDir);
+
+    const result = await installer.install({
+      ...TOOL,
+      id: 'a365-teams',
+      displayName: 'A365 Teams CLI',
+      description: 'Read and post Teams messages.',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.5.0',
+        assets: [{ platform: process.platform, arch: process.arch, name: 'teams.exe', sha256 }],
+      },
+      bin: 'teams',
+      help: 'teams --help',
+      preflight: undefined,
+      agentInstructions: 'Use teams read.',
+    });
+
+    expect(downloader.calls).toEqual([{
+      owner: 'agency-microsoft',
+      repo: 'a365-cli',
+      tag: 'v0.5.0',
+      assetName: 'teams.exe',
+    }]);
+    expect(result.install?.type).toBe('github-release-asset');
+    if (result.install?.type !== 'github-release-asset') {
+      throw new Error('Expected a GitHub release asset install record');
+    }
+    expect(fs.readFileSync(result.install.installedPath)).toEqual(downloader.bytes);
+    expect(result.install.assetName).toBe('teams.exe');
+    expect(result.install.sha256).toBe(sha256);
+    expect(result.bin).toBe('teams');
+    expect(runner.calls.map((call) => call.command)).not.toEqual(expect.arrayContaining(['gh', 'go']));
+  });
+
+  it('refuses to install a GitHub release asset with a checksum mismatch', async () => {
+    const downloader = new FakeReleaseAssetDownloader();
+    const installer = new ToolInstaller(new FakeRunner(), downloader, makeTempDir());
+
+    await expect(installer.install({
+      ...TOOL,
+      id: 'a365-teams',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.5.0',
+        assets: [{ platform: process.platform, arch: process.arch, name: 'teams.exe', sha256: '0'.repeat(64) }],
+      },
+      bin: 'teams',
+    })).rejects.toThrow('checksum mismatch');
+  });
+
+  it('uninstalls a GitHub release asset by deleting its installed binary', async () => {
+    const toolsBinDir = makeTempDir();
+    const installedPath = path.join(toolsBinDir, 'teams.exe');
+    fs.writeFileSync(installedPath, 'binary');
+    const runner = new FakeRunner();
+    const installer = new ToolInstaller(runner, new FakeReleaseAssetDownloader(), toolsBinDir);
+
+    await installer.uninstall({
+      id: 'a365-teams',
+      version: 'v0.5.0',
+      bin: 'teams',
+      displayName: 'A365 Teams CLI',
+      description: 'Read and post Teams messages.',
+      source: { marketplaceId: 'm', pluginId: 'p' },
+      installedAt: '2026-01-01T00:00:00Z',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.5.0',
+        assetName: 'teams.exe',
+        sha256: '1'.repeat(64),
+        platform: 'win32',
+        arch: 'x64',
+        installedPath,
+      },
+    });
+
+    expect(fs.existsSync(installedPath)).toBe(false);
+    expect(runner.calls).toEqual([]);
   });
 });

--- a/packages/services/src/tools/ToolInstaller.test.ts
+++ b/packages/services/src/tools/ToolInstaller.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -171,6 +171,55 @@ describe('ToolInstaller', () => {
       },
       bin: 'teams',
     })).rejects.toThrow('checksum mismatch');
+  });
+
+  it('refuses to install a GitHub release asset outside the tools bin directory', async () => {
+    const downloader = new FakeReleaseAssetDownloader();
+    const sha256 = createHash('sha256').update(downloader.bytes).digest('hex');
+    const installer = new ToolInstaller(new FakeRunner(), downloader, makeTempDir());
+
+    await expect(installer.install({
+      ...TOOL,
+      id: 'a365-teams',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.5.0',
+        assets: [{ platform: process.platform, arch: process.arch, name: 'teams.exe', sha256 }],
+      },
+      bin: '..\\Startup\\evil',
+    })).rejects.toThrow('outside the tools bin directory');
+  });
+
+  it('cleans up the temporary release asset when replacement fails', async () => {
+    const downloader = new FakeReleaseAssetDownloader();
+    const toolsBinDir = makeTempDir();
+    const sha256 = createHash('sha256').update(downloader.bytes).digest('hex');
+    const installer = new ToolInstaller(new FakeRunner(), downloader, toolsBinDir);
+    const rename = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      const error = new Error('locked') as NodeJS.ErrnoException;
+      error.code = 'EPERM';
+      throw error;
+    });
+
+    try {
+      await expect(installer.install({
+        ...TOOL,
+        id: 'a365-teams',
+        install: {
+          type: 'github-release-asset',
+          owner: 'agency-microsoft',
+          repo: 'a365-cli',
+          tag: 'v0.5.0',
+          assets: [{ platform: process.platform, arch: process.arch, name: 'teams.exe', sha256 }],
+        },
+        bin: 'teams',
+      })).rejects.toThrow('locked');
+      expect(fs.readdirSync(toolsBinDir).filter((file) => file.includes('.tmp-'))).toEqual([]);
+    } finally {
+      rename.mockRestore();
+    }
   });
 
   it('uninstalls a GitHub release asset by deleting its installed binary', async () => {

--- a/packages/services/src/tools/ToolInstaller.ts
+++ b/packages/services/src/tools/ToolInstaller.ts
@@ -1,6 +1,11 @@
 import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { InstalledTool, MarketplaceToolEntry } from '@chamber/shared/types';
 import { Logger } from '../logger';
+import { GitHubReleaseAssetClient, type DownloadReleaseAssetRequest, type DownloadedReleaseAsset } from './GitHubReleaseAssetClient';
+import { getChamberToolsBinDir } from './toolPaths';
 
 const log = Logger.create('ToolInstaller');
 
@@ -14,10 +19,28 @@ export interface CommandRunner {
   run(command: string, args: string[]): Promise<CommandResult>;
 }
 
+export interface ReleaseAssetDownloader {
+  downloadAsset(request: DownloadReleaseAssetRequest): Promise<DownloadedReleaseAsset>;
+}
+
 export class ToolInstaller {
-  constructor(private readonly runner: CommandRunner = new ChildProcessRunner()) {}
+  constructor(
+    private readonly runner: CommandRunner = new ChildProcessRunner(),
+    private readonly releaseAssetDownloader: ReleaseAssetDownloader = new GitHubReleaseAssetClient(),
+    private readonly toolsBinDir: string = getChamberToolsBinDir(),
+  ) {}
 
   async install(tool: MarketplaceToolEntry): Promise<InstalledTool> {
+    if (tool.install.type === 'github-release-asset') {
+      return this.installGitHubReleaseAsset(tool);
+    }
+    return this.installNpmGlobal(tool);
+  }
+
+  private async installNpmGlobal(tool: MarketplaceToolEntry): Promise<InstalledTool> {
+    if (tool.install.type !== 'npm-global') {
+      throw new Error(`Unsupported npm install type: ${tool.install.type}`);
+    }
     const spec = `${tool.install.package}@${tool.install.version}`;
     log.info(`Installing tool ${tool.id} (${spec}) globally via npm`);
     const installResult = await this.runner.run('npm', ['install', '-g', spec]);
@@ -46,6 +69,7 @@ export class ToolInstaller {
       id: tool.id,
       package: tool.install.package,
       version: tool.install.version,
+      install: { type: 'npm-global', package: tool.install.package, version: tool.install.version },
       bin: tool.bin,
       displayName: tool.displayName,
       description: tool.description,
@@ -56,7 +80,72 @@ export class ToolInstaller {
     };
   }
 
+  private async installGitHubReleaseAsset(tool: MarketplaceToolEntry): Promise<InstalledTool> {
+    if (tool.install.type !== 'github-release-asset') {
+      throw new Error(`Unsupported release asset install type: ${tool.install.type}`);
+    }
+    const asset = tool.install.assets.find((candidate) =>
+      candidate.platform === process.platform && candidate.arch === process.arch,
+    );
+    if (!asset) {
+      throw new Error(`Tool ${tool.id} does not provide a release asset for ${process.platform}/${process.arch}`);
+    }
+
+    log.info(`Installing tool ${tool.id} from GitHub release asset ${tool.install.owner}/${tool.install.repo}@${tool.install.tag}/${asset.name}`);
+    const downloaded = await this.releaseAssetDownloader.downloadAsset({
+      owner: tool.install.owner,
+      repo: tool.install.repo,
+      tag: tool.install.tag,
+      assetName: asset.name,
+    });
+    const actualSha256 = createHash('sha256').update(downloaded.bytes).digest('hex');
+    if (actualSha256 !== asset.sha256) {
+      throw new Error(`GitHub release asset checksum mismatch for ${tool.id}: expected ${asset.sha256}, got ${actualSha256}`);
+    }
+
+    fs.mkdirSync(this.toolsBinDir, { recursive: true });
+    const installedPath = path.join(this.toolsBinDir, executableName(tool.bin));
+    const tempPath = `${installedPath}.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(tempPath, downloaded.bytes, { mode: 0o755 });
+    if (process.platform !== 'win32') {
+      fs.chmodSync(tempPath, 0o755);
+    }
+    fs.renameSync(tempPath, installedPath);
+
+    return {
+      id: tool.id,
+      version: tool.install.tag,
+      bin: tool.bin,
+      displayName: tool.displayName,
+      description: tool.description,
+      ...(tool.help ? { help: tool.help } : {}),
+      ...(tool.agentInstructions ? { agentInstructions: tool.agentInstructions } : {}),
+      source: { marketplaceId: tool.source.marketplaceId, pluginId: tool.source.plugin },
+      installedAt: new Date().toISOString(),
+      install: {
+        type: 'github-release-asset',
+        owner: tool.install.owner,
+        repo: tool.install.repo,
+        tag: tool.install.tag,
+        assetName: asset.name,
+        sha256: asset.sha256,
+        platform: asset.platform,
+        arch: asset.arch,
+        installedPath,
+        ...(asset.archive ? { archive: asset.archive } : {}),
+        ...(asset.binPath ? { binPath: asset.binPath } : {}),
+      },
+    };
+  }
+
   async uninstall(tool: InstalledTool): Promise<void> {
+    if (tool.install?.type === 'github-release-asset') {
+      fs.rmSync(tool.install.installedPath, { force: true });
+      return;
+    }
+    if (!('package' in tool)) {
+      throw new Error(`Cannot uninstall npm tool ${tool.id}: package is missing`);
+    }
     const result = await this.runner.run('npm', ['uninstall', '-g', tool.package]);
     if (result.exitCode !== 0) {
       throw new Error(
@@ -64,6 +153,7 @@ export class ToolInstaller {
       );
     }
   }
+
 }
 
 export class ChildProcessRunner implements CommandRunner {
@@ -82,4 +172,8 @@ export class ChildProcessRunner implements CommandRunner {
       });
     });
   }
+}
+
+function executableName(bin: string): string {
+  return process.platform === 'win32' && !bin.toLowerCase().endsWith('.exe') ? `${bin}.exe` : bin;
 }

--- a/packages/services/src/tools/ToolInstaller.ts
+++ b/packages/services/src/tools/ToolInstaller.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import type { InstalledTool, MarketplaceToolEntry } from '@chamber/shared/types';
 import { Logger } from '../logger';
 import { GitHubReleaseAssetClient, type DownloadReleaseAssetRequest, type DownloadedReleaseAsset } from './GitHubReleaseAssetClient';
@@ -104,13 +105,18 @@ export class ToolInstaller {
     }
 
     fs.mkdirSync(this.toolsBinDir, { recursive: true });
-    const installedPath = path.join(this.toolsBinDir, executableName(tool.bin));
+    const installedPath = resolveInstallPath(this.toolsBinDir, tool.bin);
     const tempPath = `${installedPath}.tmp-${process.pid}-${Date.now()}`;
-    fs.writeFileSync(tempPath, downloaded.bytes, { mode: 0o755 });
-    if (process.platform !== 'win32') {
-      fs.chmodSync(tempPath, 0o755);
+    try {
+      fs.writeFileSync(tempPath, downloaded.bytes, { mode: 0o755 });
+      if (process.platform !== 'win32') {
+        fs.chmodSync(tempPath, 0o755);
+      }
+      await replaceFile(tempPath, installedPath);
+    } catch (error) {
+      fs.rmSync(tempPath, { force: true });
+      throw error;
     }
-    fs.renameSync(tempPath, installedPath);
 
     return {
       id: tool.id,
@@ -176,4 +182,34 @@ export class ChildProcessRunner implements CommandRunner {
 
 function executableName(bin: string): string {
   return process.platform === 'win32' && !bin.toLowerCase().endsWith('.exe') ? `${bin}.exe` : bin;
+}
+
+function resolveInstallPath(toolsBinDir: string, bin: string): string {
+  const toolsBinRoot = path.resolve(toolsBinDir);
+  const installedPath = path.resolve(toolsBinRoot, executableName(bin));
+  if (installedPath !== toolsBinRoot && installedPath.startsWith(`${toolsBinRoot}${path.sep}`)) {
+    return installedPath;
+  }
+  throw new Error(`Refusing to install tool ${bin} outside the tools bin directory`);
+}
+
+async function replaceFile(tempPath: string, installedPath: string): Promise<void> {
+  const retryDelaysMs = process.platform === 'win32' ? [100, 250, 500, 1_000, 2_000] : [];
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      fs.renameSync(tempPath, installedPath);
+      return;
+    } catch (error) {
+      if (!isRetryableReplaceError(error) || attempt >= retryDelaysMs.length) {
+        throw error;
+      }
+      await delay(retryDelaysMs[attempt]);
+    }
+  }
+}
+
+function isRetryableReplaceError(error: unknown): boolean {
+  if (process.platform !== 'win32') return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EPERM' || code === 'EBUSY';
 }

--- a/packages/services/src/tools/ToolsService.test.ts
+++ b/packages/services/src/tools/ToolsService.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type { AppConfig, InstalledTool } from '@chamber/shared/types';
 import { ToolsService } from './ToolsService';
 import { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
-import { ToolInstaller, type CommandRunner, type CommandResult } from './ToolInstaller';
+import { ToolInstaller, type CommandRunner, type CommandResult, type ReleaseAssetDownloader } from './ToolInstaller';
 import type { ToolMarketplaceSource } from './toolTypes';
 
 class FakeRegistryClient {
@@ -18,6 +22,13 @@ class FakeRunner implements CommandRunner {
   async run(command: string, args: string[]): Promise<CommandResult> {
     const key = `${command} ${args.join(' ')}`;
     return this.responses.get(key) ?? { exitCode: 0, stdout: '', stderr: '' };
+  }
+}
+
+class FakeReleaseAssetDownloader implements ReleaseAssetDownloader {
+  bytes = Buffer.from('a365 binary');
+  async downloadAsset(request: { assetName: string }): Promise<{ assetName: string; bytes: Buffer }> {
+    return { assetName: request.assetName, bytes: this.bytes };
   }
 }
 
@@ -63,6 +74,7 @@ describe('ToolsService', () => {
   let runner: FakeRunner;
   let store: FakeConfigStore;
   let svc: ToolsService;
+  const tempDirs: string[] = [];
 
   beforeEach(() => {
     client = new FakeRegistryClient();
@@ -73,6 +85,12 @@ describe('ToolsService', () => {
       new ToolInstaller(runner),
       store,
     );
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('lists tools as available when not installed', async () => {
@@ -135,6 +153,103 @@ describe('ToolsService', () => {
     const second = await svc.reconcile();
     expect(second.installed).toHaveLength(0);
     expect(second.errors.map((e) => e.toolId)).toEqual(['broken']);
+  });
+
+  it('reconcile persists GitHub release asset tools so IdentityLoader can advertise them offline', async () => {
+    const downloader = new FakeReleaseAssetDownloader();
+    const toolsBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-tools-service-'));
+    tempDirs.push(toolsBinDir);
+    const sha256 = createHash('sha256').update(downloader.bytes).digest('hex');
+    setupTools(client, [{
+      id: 'a365-teams',
+      displayName: 'A365 Teams CLI',
+      description: 'Read and post Teams messages.',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.5.0',
+        assets: [{ platform: process.platform, arch: process.arch, name: 'teams.exe', sha256 }],
+      },
+      bin: 'teams',
+      help: 'teams --help',
+      agentInstructions: 'Use teams read.',
+    }]);
+    svc = new ToolsService(
+      new MarketplaceToolCatalog(client, [SOURCE]),
+      new ToolInstaller(runner, downloader, toolsBinDir),
+      store,
+    );
+
+    const outcome = await svc.reconcile();
+
+    expect(outcome.errors).toEqual([]);
+    expect(outcome.installed).toHaveLength(1);
+    expect(store.config.installedTools?.[0]).toMatchObject({
+      id: 'a365-teams',
+      version: 'v0.5.0',
+      bin: 'teams',
+      help: 'teams --help',
+      agentInstructions: 'Use teams read.',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.5.0',
+        assetName: 'teams.exe',
+        sha256,
+      },
+    });
+  });
+
+  it('reconcile updates an installed release asset tool when the marketplace tag changes', async () => {
+    const downloader = new FakeReleaseAssetDownloader();
+    const toolsBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-tools-service-'));
+    tempDirs.push(toolsBinDir);
+    const sha256 = createHash('sha256').update(downloader.bytes).digest('hex');
+    store.config.installedTools = [{
+      id: 'a365-teams',
+      version: 'v0.4.0',
+      bin: 'teams',
+      displayName: 'A365 Teams CLI',
+      description: 'Old description.',
+      source: { marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' },
+      installedAt: '2026-05-01T00:00:00.000Z',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.4.0',
+        assetName: 'teams.exe',
+        sha256: '1'.repeat(64),
+        platform: process.platform,
+        arch: process.arch,
+        installedPath: path.join(toolsBinDir, 'teams.exe'),
+      },
+    }];
+    setupTools(client, [{
+      id: 'a365-teams',
+      displayName: 'A365 Teams CLI',
+      description: 'Read and post Teams messages.',
+      install: {
+        type: 'github-release-asset',
+        owner: 'agency-microsoft',
+        repo: 'a365-cli',
+        tag: 'v0.5.0',
+        assets: [{ platform: process.platform, arch: process.arch, name: 'teams.exe', sha256 }],
+      },
+      bin: 'teams',
+    }]);
+    svc = new ToolsService(
+      new MarketplaceToolCatalog(client, [SOURCE]),
+      new ToolInstaller(runner, downloader, toolsBinDir),
+      store,
+    );
+
+    const outcome = await svc.reconcile();
+
+    expect(outcome.installed.map((tool) => tool.id)).toEqual(['a365-teams']);
+    expect(store.config.installedTools?.[0].version).toBe('v0.5.0');
   });
 });
 

--- a/packages/services/src/tools/ToolsService.ts
+++ b/packages/services/src/tools/ToolsService.ts
@@ -71,8 +71,11 @@ export class ToolsService {
   async reconcile(): Promise<{ installed: InstalledTool[]; errors: Array<{ toolId: string; message: string }> }> {
     const result = await this.catalog.listTools();
     const installed = this.getInstalled();
-    const installedIds = new Set(installed.map((tool) => tool.id));
-    const newTools = result.tools.filter((tool) => !installedIds.has(tool.id));
+    const installedById = new Map(installed.map((tool) => [tool.id, tool]));
+    const newTools = result.tools.filter((tool) => {
+      const persisted = installedById.get(tool.id);
+      return !persisted || persisted.version !== marketplaceToolVersion(tool);
+    });
 
     const newlyInstalled: InstalledTool[] = [];
     const errors: Array<{ toolId: string; message: string }> = [];
@@ -85,6 +88,10 @@ export class ToolsService {
         log.warn(`Reconcile failed for tool ${tool.id}: ${outcome.error}`);
         errors.push({ toolId: tool.id, message: outcome.error });
       }
+    }
+
+    function marketplaceToolVersion(tool: MarketplaceToolEntry): string {
+      return tool.install.type === 'npm-global' ? tool.install.version : tool.install.tag;
     }
 
     return { installed: newlyInstalled, errors };

--- a/packages/services/src/tools/index.ts
+++ b/packages/services/src/tools/index.ts
@@ -1,6 +1,8 @@
 export { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
 export type { MarketplaceToolCatalogResult } from './MarketplaceToolCatalog';
+export { GitHubReleaseAssetClient } from './GitHubReleaseAssetClient';
 export { ToolInstaller, ChildProcessRunner } from './ToolInstaller';
-export type { CommandRunner, CommandResult } from './ToolInstaller';
+export type { CommandRunner, CommandResult, ReleaseAssetDownloader } from './ToolInstaller';
 export { ToolsService } from './ToolsService';
 export { buildToolsSection } from './toolsSystemMessage';
+export { getChamberToolsBinDir } from './toolPaths';

--- a/packages/services/src/tools/toolPaths.ts
+++ b/packages/services/src/tools/toolPaths.ts
@@ -1,0 +1,7 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export function getChamberToolsBinDir(): string {
+  const configRoot = process.env.CHAMBER_E2E_USER_DATA ?? path.join(os.homedir(), '.chamber');
+  return path.join(configRoot, 'tools', 'bin');
+}

--- a/packages/services/src/tools/toolsSystemMessage.test.ts
+++ b/packages/services/src/tools/toolsSystemMessage.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect } from 'vitest';
 import type { InstalledTool } from '@chamber/shared/types';
 import { buildToolsSection } from './toolsSystemMessage';
 
-function tool(overrides: Partial<InstalledTool> = {}): InstalledTool {
+type InstalledNpmTool = Extract<InstalledTool, { package: string }>;
+
+function tool(overrides: Partial<InstalledNpmTool> = {}): InstalledTool {
   return {
     id: 'workiq',
     package: '@microsoft/workiq',
     version: 'latest',
+    install: { type: 'npm-global', package: '@microsoft/workiq', version: 'latest' },
     bin: 'workiq',
     displayName: 'Microsoft Work IQ',
     description: 'Query M365 data via natural language.',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -167,16 +167,8 @@ export interface AppConfig {
   installedTools?: InstalledTool[];
 }
 
-/**
- * Persistent record of a CLI tool installed via the marketplace.
- * The tool itself lives on the user's PATH (installed via `npm i -g`); this record
- * tracks what we installed so startup reconciliation can avoid reinstalling, and
- * carries the agent-facing description so the system message can advertise the
- * tool offline (no marketplace fetch needed at session start).
- */
-export interface InstalledTool {
+interface InstalledToolBase {
   id: string;
-  package: string;
   version: string;
   bin: string;
   displayName: string;
@@ -187,11 +179,60 @@ export interface InstalledTool {
   installedAt: string;
 }
 
+/**
+ * Persistent record of a CLI tool installed via the marketplace. Records carry
+ * the agent-facing description so the system message can advertise tools
+ * offline (no marketplace fetch needed at session start).
+ */
+export type InstalledTool = InstalledNpmGlobalTool | InstalledGitHubReleaseAssetTool;
+
+export interface InstalledNpmGlobalTool extends InstalledToolBase {
+  package: string;
+  install?: { type: 'npm-global'; package: string; version: string };
+}
+
+export interface InstalledGitHubReleaseAssetTool extends InstalledToolBase {
+  install: {
+    type: 'github-release-asset';
+    owner: string;
+    repo: string;
+    tag: string;
+    assetName: string;
+    sha256: string;
+    platform: string;
+    arch: string;
+    installedPath: string;
+    archive?: GitHubReleaseAssetArchiveType;
+    binPath?: string;
+  };
+}
+
+export type GitHubReleaseAssetArchiveType = 'zip' | 'tar.gz';
+
+export interface GitHubReleaseAssetSelector {
+  platform: string;
+  arch: string;
+  name: string;
+  sha256: string;
+  archive?: GitHubReleaseAssetArchiveType;
+  binPath?: string;
+}
+
+export type MarketplaceToolInstall =
+  | { type: 'npm-global'; package: string; version: string }
+  | {
+    type: 'github-release-asset';
+    owner: string;
+    repo: string;
+    tag: string;
+    assets: GitHubReleaseAssetSelector[];
+  };
+
 export interface MarketplaceToolEntry {
   id: string;
   displayName: string;
   description: string;
-  install: { type: 'npm-global'; package: string; version: string };
+  install: MarketplaceToolInstall;
   bin: string;
   help?: string;
   preflight?: string[];

--- a/tests/e2e/electron/a365-marketplace-install-link-edge.spec.ts
+++ b/tests/e2e/electron/a365-marketplace-install-link-edge.spec.ts
@@ -6,12 +6,14 @@ import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { IdentityLoader } from '@chamber/services';
 import type { AppConfig, InstalledTool } from '@chamber/shared/types';
+import { findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
 
 const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
 const internalMarketplaceRepoUrl = 'https://github.com/agency-microsoft/genesis-minds';
 const configPath = path.join(os.homedir(), '.chamber', 'config.json');
 const heinzPath = process.env.CHAMBER_E2E_HEINZ_MIND_PATH ?? path.join(os.homedir(), 'agents', 'heinz-doofenshmirtz');
 const playwrightSnapshotDir = path.resolve(process.cwd(), '.playwright-cli');
+const cdpPort = Number(process.env.CHAMBER_E2E_A365_EDGE_CDP_PORT ?? 9350);
 const keepConfig = process.env.CHAMBER_E2E_A365_EDGE_KEEP_CONFIG === '1';
 const a365ToolIds = [
   'a365-teams',
@@ -43,6 +45,7 @@ test.describe('Edge A365 marketplace install-link smoke', () => {
       prepareConfigForA365Smoke();
       await demoPause('Connecting playwright-cli to the running Edge browser.');
       runPlaywrightCli(['config', '--extension', '--browser=msedge']);
+      waitForPlaywrightConnector();
       await demoPause('Opening the internal Genesis marketplace README in Edge.');
       runPlaywrightCli(['open', internalMarketplaceRepoUrl]);
       runPlaywrightCli(['snapshot']);
@@ -91,6 +94,10 @@ test.describe('Edge A365 marketplace install-link smoke', () => {
       expect(identity?.systemMessage).toContain('### word — A365 Word CLI');
       expect(identity?.systemMessage).toContain('### excel — A365 Excel CLI');
       expect(identity?.systemMessage).toContain('### sales — A365 Sales CLI');
+
+      const answer = await askHeinzAboutTeamsTool();
+      expect(answer.errorMessage).toBe('');
+      expect(answer.assistantText).toContain('YES_TEAMS_TOOL_AVAILABLE');
     } finally {
       if (keepConfig) {
         console.log(`Keeping Chamber config changes because CHAMBER_E2E_A365_EDGE_KEEP_CONFIG=1. Backup: ${backupPath ?? '(none)'}`);
@@ -100,6 +107,64 @@ test.describe('Edge A365 marketplace install-link smoke', () => {
     }
   });
 });
+
+async function askHeinzAboutTeamsTool(): Promise<{ assistantText: string; errorMessage: string }> {
+  let app: LaunchedElectronApp | undefined;
+  try {
+    app = await launchElectronApp({ cdpPort });
+    const page = await findRendererPage(app.browser, app.logs);
+    await page.waitForLoadState('domcontentloaded');
+    return await page.evaluate(async () => {
+      const minds = await window.electronAPI.mind.list();
+      const heinz = minds.find((mind) => mind.mindId === 'heinz-doofenshmirtz-295a');
+      if (!heinz) throw new Error('Heinz mind was not loaded.');
+
+      await window.electronAPI.chat.newConversation(heinz.mindId);
+
+      const messageId = `a365-edge-teams-tool-smoke-${Date.now()}`;
+      let assistantText = '';
+      let errorMessage = '';
+      let resolveTerminal: () => void = () => undefined;
+      const terminal = new Promise<void>((resolve) => {
+        resolveTerminal = resolve;
+      });
+      const unsubscribe = window.electronAPI.chat.onEvent((mindId, receivedMessageId, event) => {
+        if (mindId !== heinz.mindId || receivedMessageId !== messageId) return;
+        if (event.type === 'chunk' || event.type === 'message_final') {
+          assistantText += event.content;
+        }
+        if (event.type === 'error') {
+          errorMessage = event.message;
+          resolveTerminal();
+        }
+        if (event.type === 'done') {
+          resolveTerminal();
+        }
+      });
+
+      try {
+        const send = window.electronAPI.chat.send(
+          heinz.mindId,
+          [
+            'Can you see the A365 Teams CLI tool in your available tools?',
+            'If the tools section contains a teams command, reply exactly YES_TEAMS_TOOL_AVAILABLE and no other text.',
+            'If not, reply exactly NO_TEAMS_TOOL_AVAILABLE and no other text.',
+          ].join(' '),
+          messageId,
+        );
+        const timeout = new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('Timed out waiting for Heinz Teams tool response.')), 180_000);
+        });
+        await Promise.race([Promise.all([send, terminal]), timeout]);
+        return { assistantText, errorMessage };
+      } finally {
+        unsubscribe();
+      }
+    });
+  } finally {
+    await app?.close();
+  }
+}
 
 async function demoPause(message: string): Promise<void> {
   const delayMs = Number(process.env.CHAMBER_E2E_A365_EDGE_MARKETPLACE_TOOLS_SLOW_MS ?? 0);
@@ -121,6 +186,15 @@ function runPlaywrightCli(args: string[]): string {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+}
+
+function waitForPlaywrightConnector(): void {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const output = runPlaywrightCli(['snapshot']);
+    if (output.includes('MCP client') && output.includes('connected')) return;
+  }
+  throw new Error('Timed out waiting for Playwright MCP Bridge extension connection.');
 }
 
 function quotePowerShellArg(value: string): string {

--- a/tests/e2e/electron/a365-marketplace-install-link-edge.spec.ts
+++ b/tests/e2e/electron/a365-marketplace-install-link-edge.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { IdentityLoader } from '@chamber/services';
+import type { AppConfig, InstalledTool } from '@chamber/shared/types';
+
+const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
+const internalMarketplaceRepoUrl = 'https://github.com/agency-microsoft/genesis-minds';
+const configPath = path.join(os.homedir(), '.chamber', 'config.json');
+const heinzPath = process.env.CHAMBER_E2E_HEINZ_MIND_PATH ?? path.join(os.homedir(), 'agents', 'heinz-doofenshmirtz');
+const playwrightSnapshotDir = path.resolve(process.cwd(), '.playwright-cli');
+const keepConfig = process.env.CHAMBER_E2E_A365_EDGE_KEEP_CONFIG === '1';
+const a365ToolIds = [
+  'a365-teams',
+  'a365-mail',
+  'a365-calendar',
+  'a365-copilot365',
+  'a365-planner',
+  'a365-whois365',
+  'a365-word',
+  'a365-excel',
+  'a365-sales',
+];
+
+test.describe('Edge A365 marketplace install-link smoke', () => {
+  test.skip(
+    process.env.CHAMBER_E2E_A365_EDGE_MARKETPLACE_TOOLS !== '1',
+    'Set CHAMBER_E2E_A365_EDGE_MARKETPLACE_TOOLS=1 to run the real Edge/chamber:// A365 tools smoke.',
+  );
+  test.setTimeout(420_000);
+
+  test('clicks the internal marketplace badge, installs A365 tools, and injects them into Heinz identity', async () => {
+    expect(process.env.PLAYWRIGHT_MCP_EXTENSION_TOKEN, 'PLAYWRIGHT_MCP_EXTENSION_TOKEN must be loaded from local .env.').toBeTruthy();
+    expect(isChamberProtocolRegistered(), 'The chamber:// protocol must be registered by an installed Chamber build.').toBe(true);
+    expect(hasCommand('playwright-cli'), 'playwright-cli must be available on PATH for Edge extension-mode automation.').toBe(true);
+    expect(fs.existsSync(heinzPath), `Heinz mind must exist at ${heinzPath}.`).toBe(true);
+
+    const backupPath = backupConfig();
+    try {
+      prepareConfigForA365Smoke();
+      await demoPause('Connecting playwright-cli to the running Edge browser.');
+      runPlaywrightCli(['config', '--extension', '--browser=msedge']);
+      await demoPause('Opening the internal Genesis marketplace README in Edge.');
+      runPlaywrightCli(['open', internalMarketplaceRepoUrl]);
+      runPlaywrightCli(['snapshot']);
+      const badgeRef = findLatestSnapshotRef(/link "Add to Chamber"/);
+
+      console.log('Clicking the internal marketplace Add to Chamber badge in Edge.');
+      console.log('Approve the Edge external-protocol prompt and the Chamber add-marketplace confirmation if they appear.');
+      await demoPause('Ready to click the Add to Chamber badge.');
+      runPlaywrightCli(['click', badgeRef]);
+      await demoPause('Badge clicked; approve any Edge or Chamber prompts now.');
+
+      await expect.poll(() => readInternalMarketplaceEnabled(), {
+        timeout: 120_000,
+        intervals: [1_000, 2_000, 5_000],
+        message: `Expected ${internalMarketplaceId} to be persisted and enabled in ${configPath}.`,
+      }).toBe(true);
+
+      await waitFor(() => a365ToolIds.every((id) => readInstalledTools().some((tool) => tool.id === id)), {
+        timeoutMs: 300_000,
+        intervalMs: 1_000,
+        label: 'all A365 installedTools persisted',
+      });
+
+      const installedTools = readInstalledTools();
+      for (const id of a365ToolIds) {
+        const tool = installedTools.find((candidate) => candidate.id === id);
+        expect(tool, `${id} should be persisted`).toBeDefined();
+        if (!tool) continue;
+        expect(tool.install?.type).toBe('github-release-asset');
+        if (tool.install?.type !== 'github-release-asset') continue;
+        expect(tool.install.owner).toBe('agency-microsoft');
+        expect(tool.install.repo).toBe('a365-cli');
+        expect(tool.install.tag).toBe('v0.5.0');
+        expect(tool.install.sha256).toMatch(/^[a-f0-9]{64}$/);
+        expect(fs.existsSync(tool.install.installedPath), `${id} binary should exist at ${tool.install.installedPath}`).toBe(true);
+      }
+
+      const identity = new IdentityLoader(() => installedTools).load(heinzPath);
+      expect(identity?.systemMessage).toContain('## Tools');
+      expect(identity?.systemMessage).toContain('### teams — A365 Teams CLI');
+      expect(identity?.systemMessage).toContain('### mail — A365 Mail CLI');
+      expect(identity?.systemMessage).toContain('### calendar — A365 Calendar CLI');
+      expect(identity?.systemMessage).toContain('### copilot365 — A365 Copilot CLI');
+      expect(identity?.systemMessage).toContain('### planner — A365 Planner CLI');
+      expect(identity?.systemMessage).toContain('### whois365 — A365 Whois CLI');
+      expect(identity?.systemMessage).toContain('### word — A365 Word CLI');
+      expect(identity?.systemMessage).toContain('### excel — A365 Excel CLI');
+      expect(identity?.systemMessage).toContain('### sales — A365 Sales CLI');
+    } finally {
+      if (keepConfig) {
+        console.log(`Keeping Chamber config changes because CHAMBER_E2E_A365_EDGE_KEEP_CONFIG=1. Backup: ${backupPath ?? '(none)'}`);
+      } else {
+        restoreConfig(backupPath);
+      }
+    }
+  });
+});
+
+async function demoPause(message: string): Promise<void> {
+  const delayMs = Number(process.env.CHAMBER_E2E_A365_EDGE_MARKETPLACE_TOOLS_SLOW_MS ?? 0);
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return;
+  console.log(`[a365-edge-marketplace-smoke] ${message} Pausing ${delayMs}ms for demo.`);
+  await delay(delayMs);
+}
+
+function runPlaywrightCli(args: string[]): string {
+  return execFileSync('powershell', [
+    '-NoProfile',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-Command',
+    `playwright-cli ${args.map(quotePowerShellArg).join(' ')}`,
+  ], {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function quotePowerShellArg(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function hasCommand(command: string): boolean {
+  try {
+    execFileSync('powershell', ['-NoProfile', '-Command', `Get-Command ${command} -ErrorAction Stop | Out-Null`], {
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isChamberProtocolRegistered(): boolean {
+  const script = [
+    "$paths = @('HKCU:\\Software\\Classes\\chamber', 'HKLM:\\Software\\Classes\\chamber')",
+    'if ($paths | Where-Object { Test-Path $_ }) { exit 0 }',
+    'exit 1',
+  ].join('; ');
+  try {
+    execFileSync('powershell', ['-NoProfile', '-Command', script], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findLatestSnapshotRef(pattern: RegExp): string {
+  const snapshots = fs.readdirSync(playwrightSnapshotDir)
+    .filter((fileName) => /^page-.*\.yml$/.test(fileName))
+    .map((fileName) => path.join(playwrightSnapshotDir, fileName))
+    .sort((left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs);
+
+  for (const snapshotPath of snapshots) {
+    const content = fs.readFileSync(snapshotPath, 'utf-8');
+    const line = content.split(/\r?\n/).find((candidate) => pattern.test(candidate));
+    const match = line?.match(/\[ref=(e\d+)\]/);
+    if (match) return match[1];
+  }
+
+  throw new Error(`Unable to find a snapshot element matching ${pattern}.`);
+}
+
+function backupConfig(): string | null {
+  if (!fs.existsSync(configPath)) return null;
+  const backupPath = `${configPath}.a365-edge-marketplace-smoke-${Date.now()}.bak`;
+  fs.copyFileSync(configPath, backupPath);
+  console.log(`Backed up Chamber config to ${backupPath}`);
+  return backupPath;
+}
+
+function restoreConfig(backupPath: string | null): void {
+  if (backupPath && fs.existsSync(backupPath)) {
+    fs.copyFileSync(backupPath, configPath);
+    fs.rmSync(backupPath, { force: true });
+    return;
+  }
+
+  if (fs.existsSync(configPath)) {
+    const config = readConfig();
+    config.marketplaceRegistries = config.marketplaceRegistries?.filter((registry) => registry.id !== internalMarketplaceId);
+    config.installedTools = config.installedTools?.filter((tool) => !a365ToolIds.includes(tool.id));
+    writeConfig(config);
+  }
+}
+
+function prepareConfigForA365Smoke(): void {
+  const config = readConfig();
+  config.minds = [
+    { id: 'heinz-doofenshmirtz-295a', path: heinzPath },
+    ...(config.minds ?? []).filter((mind) => mind.id !== 'heinz-doofenshmirtz-295a'),
+  ];
+  config.activeMindId = 'heinz-doofenshmirtz-295a';
+  config.marketplaceRegistries = (config.marketplaceRegistries ?? []).filter((registry) => registry.id !== internalMarketplaceId);
+  config.installedTools = (config.installedTools ?? []).filter((tool) => !a365ToolIds.includes(tool.id));
+  writeConfig(config);
+}
+
+function readConfig(): AppConfig {
+  if (!fs.existsSync(configPath)) {
+    return {
+      version: 2,
+      minds: [],
+      activeMindId: null,
+      activeLogin: 'ianphil_microsoft',
+      theme: 'dark',
+    };
+  }
+  return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as AppConfig;
+}
+
+function writeConfig(config: AppConfig): void {
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+}
+
+function readInternalMarketplaceEnabled(): boolean {
+  const config = readConfig();
+  return config.marketplaceRegistries?.some((registry) =>
+    registry.id === internalMarketplaceId && registry.enabled === true
+  ) ?? false;
+}
+
+function readInstalledTools(): InstalledTool[] {
+  return readConfig().installedTools ?? [];
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  options: { timeoutMs: number; intervalMs: number; label: string },
+): Promise<void> {
+  const deadline = Date.now() + options.timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(options.intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${options.label}`);
+}

--- a/tests/e2e/electron/a365-release-tools-smoke.spec.ts
+++ b/tests/e2e/electron/a365-release-tools-smoke.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { canAccessRepo, findRendererPage, launchElectronApp, type LaunchedElectronApp } from './electronApp';
+
+const enabled = process.env.CHAMBER_E2E_A365_RELEASE_TOOLS === '1';
+const cdpPort = Number(process.env.CHAMBER_E2E_A365_RELEASE_TOOLS_CDP_PORT ?? 9348);
+const heinzPath = process.env.CHAMBER_E2E_HEINZ_MIND_PATH ?? path.join(os.homedir(), 'agents', 'heinz-doofenshmirtz');
+const internalMarketplaceRef = process.env.CHAMBER_E2E_A365_MARKETPLACE_REF ?? 'main';
+const internalMarketplaceId = 'github:agency-microsoft/genesis-minds';
+const a365ToolIds = [
+  'a365-teams',
+  'a365-mail',
+  'a365-calendar',
+  'a365-copilot365',
+  'a365-planner',
+  'a365-whois365',
+  'a365-word',
+  'a365-excel',
+  'a365-sales',
+];
+
+interface InstalledToolRecord {
+  id: string;
+  version: string;
+  bin: string;
+  install?: {
+    type?: string;
+    owner?: string;
+    repo?: string;
+    tag?: string;
+    assetName?: string;
+    sha256?: string;
+    installedPath?: string;
+  };
+}
+
+test.describe('electron A365 release tools smoke', () => {
+  test.skip(!enabled, 'Set CHAMBER_E2E_A365_RELEASE_TOOLS=1 to run the live A365 release-asset marketplace smoke.');
+  test.setTimeout(420_000);
+
+  let app: LaunchedElectronApp | undefined;
+  let userDataPath = '';
+  const tempRoots: string[] = [];
+
+  test.beforeAll(async () => {
+    test.skip(!fs.existsSync(heinzPath), `Heinz mind not found at ${heinzPath}`);
+    test.skip(!await canAccessRepo('agency-microsoft/genesis-minds'), 'Stored GitHub credentials cannot access agency-microsoft/genesis-minds.');
+    test.skip(!await canAccessRepo('agency-microsoft/a365-cli'), 'Stored GitHub credentials cannot access agency-microsoft/a365-cli.');
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-a365-release-tools-smoke-'));
+    userDataPath = path.join(root, 'user-data');
+    tempRoots.push(root);
+    fs.mkdirSync(userDataPath, { recursive: true });
+    fs.writeFileSync(path.join(userDataPath, 'config.json'), JSON.stringify({
+      version: 2,
+      minds: [{ id: 'heinz-doofenshmirtz-295a', path: heinzPath }],
+      activeMindId: 'heinz-doofenshmirtz-295a',
+      activeLogin: 'ianphil_microsoft',
+      theme: 'dark',
+      marketplaceRegistries: [
+        {
+          id: 'github:ianphil/genesis-minds',
+          label: 'Public Genesis Minds',
+          url: 'https://github.com/ianphil/genesis-minds',
+          owner: 'ianphil',
+          repo: 'genesis-minds',
+          ref: 'master',
+          plugin: 'genesis-minds',
+          enabled: false,
+          isDefault: true,
+        },
+        {
+          id: internalMarketplaceId,
+          label: 'Internal Genesis Minds',
+          url: 'https://github.com/agency-microsoft/genesis-minds',
+          owner: 'agency-microsoft',
+          repo: 'genesis-minds',
+          ref: internalMarketplaceRef,
+          plugin: 'genesis-minds',
+          enabled: true,
+          isDefault: false,
+        },
+      ],
+    }, null, 2));
+
+    app = await launchElectronApp({
+      cdpPort,
+      env: {
+        CHAMBER_E2E_USER_DATA: userDataPath,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    for (const root of tempRoots) {
+      await removeTempRoot(root);
+    }
+  });
+
+  test('installs A365 release assets and injects them into Heinz identity tools', async () => {
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.waitForLoadState('domcontentloaded');
+
+    await waitFor(async () => {
+      const installed = readConfig(userDataPath).installedTools ?? [];
+      return a365ToolIds.every((id) => installed.some((tool) => tool.id === id));
+    }, { timeoutMs: 300_000, intervalMs: 1_000, label: 'all A365 installedTools persisted' });
+
+    const installed = readConfig(userDataPath).installedTools ?? [];
+    for (const id of a365ToolIds) {
+      const record = installed.find((tool) => tool.id === id);
+      expect(record, `${id} should be persisted`).toBeDefined();
+      expect(record?.install?.type).toBe('github-release-asset');
+      expect(record?.install?.owner).toBe('agency-microsoft');
+      expect(record?.install?.repo).toBe('a365-cli');
+      expect(record?.install?.tag).toBe('v0.5.0');
+      expect(record?.install?.sha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(record?.install?.installedPath && fs.existsSync(record.install.installedPath)).toBe(true);
+    }
+
+    const toolsList = await page.evaluate(() => window.electronAPI.tools.list());
+    for (const id of a365ToolIds) {
+      expect(toolsList.find((entry) => entry.id === id)?.status, `${id} should be installed in tools:list`).toBe('installed');
+    }
+
+    const minds = await page.evaluate(() => window.electronAPI.mind.list());
+    const heinz = minds.find((mind) => mind.mindId === 'heinz-doofenshmirtz-295a');
+    expect(heinz, 'Heinz should be loaded').toBeDefined();
+    if (!heinz) return;
+
+    await page.evaluate((mindId) => window.electronAPI.chat.newConversation(mindId), heinz.mindId);
+
+    await expect.poll(async () => {
+      const refreshedMinds = await page.evaluate(() => window.electronAPI.mind.list());
+      return refreshedMinds.find((mind) => mind.mindId === 'heinz-doofenshmirtz-295a')?.identity.systemMessage ?? '';
+    }, {
+      timeout: 30_000,
+      intervals: [500, 1_000, 2_000],
+      message: 'Heinz identity should refresh with the marketplace ## Tools section.',
+    }).toContain('## Tools');
+
+    const refreshed = await page.evaluate(() => window.electronAPI.mind.list());
+    const systemMessage = refreshed.find((mind) => mind.mindId === 'heinz-doofenshmirtz-295a')?.identity.systemMessage ?? '';
+    expect(systemMessage).toContain('### teams — A365 Teams CLI');
+    expect(systemMessage).toContain('### mail — A365 Mail CLI');
+    expect(systemMessage).toContain('### calendar — A365 Calendar CLI');
+    expect(systemMessage).toContain('### copilot365 — A365 Copilot CLI');
+    expect(systemMessage).toContain('### planner — A365 Planner CLI');
+    expect(systemMessage).toContain('### whois365 — A365 Whois CLI');
+    expect(systemMessage).toContain('### word — A365 Word CLI');
+    expect(systemMessage).toContain('### excel — A365 Excel CLI');
+    expect(systemMessage).toContain('### sales — A365 Sales CLI');
+  });
+});
+
+function readConfig(userDataPath: string): { installedTools?: InstalledToolRecord[] } {
+  const configPath = path.join(userDataPath, 'config.json');
+  if (!fs.existsSync(configPath)) return {};
+  return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as { installedTools?: InstalledToolRecord[] };
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  options: { timeoutMs: number; intervalMs: number; label: string },
+): Promise<void> {
+  const deadline = Date.now() + options.timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await delay(options.intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${options.label}`);
+}
+
+async function removeTempRoot(root: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EPERM' || attempt === 9) {
+        console.warn(`[a365-release-tools-smoke] Failed to remove temp root ${root}:`, error);
+        return;
+      }
+      await delay(250);
+    }
+  }
+}

--- a/tests/e2e/electron/marketplace-install-link-edge.spec.ts
+++ b/tests/e2e/electron/marketplace-install-link-edge.spec.ts
@@ -25,6 +25,7 @@ test.describe('Edge marketplace install link smoke', () => {
     try {
       await demoPause('Connecting playwright-cli to the running Edge browser.');
       runPlaywrightCli(['config', '--extension', '--browser=msedge']);
+      waitForPlaywrightConnector();
       await demoPause('Opening the internal Genesis marketplace README in Edge.');
       runPlaywrightCli(['open', internalMarketplaceRepoUrl]);
       runPlaywrightCli(['snapshot']);
@@ -67,6 +68,15 @@ function runPlaywrightCli(args: string[]): string {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+}
+
+function waitForPlaywrightConnector(): void {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const output = runPlaywrightCli(['snapshot']);
+    if (output.includes('MCP client') && output.includes('connected')) return;
+  }
+  throw new Error('Timed out waiting for Playwright MCP Bridge extension connection.');
 }
 
 function quotePowerShellArg(value: string): string {


### PR DESCRIPTION
## Summary

Ships A365 CLI tools through the internal Genesis marketplace by adding a `github-release-asset` marketplace tool install type, downloading private release assets through the GitHub API, verifying SHA-256 checksums, installing binaries into Chamber's managed tools bin, and adding that bin to SDK subprocess PATH.

## Notable changes

- Adds GitHub release asset marketplace tool parsing, persistence migration, install/update/uninstall support, and token-safe asset download redirect handling.
- Reconciles marketplace tools after protocol and IPC marketplace enrollment so install links immediately install declared tools.
- Adds A365 release-tool smoke coverage, including an Edge install-link smoke that verifies Heinz sees the installed Teams tool.
- Bumps Chamber to `v0.47.0` and documents the marketplace release-asset capability.
- Hardens release tool installs by rejecting path-like `bin` values, enforcing installed paths stay under Chamber's tools bin, and cleaning up failed replacements.

Closes #229

## Test evidence

- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npm run package`
- A365 Edge marketplace smoke was run interactively against an installed branch build and confirmed the full badge -> Chamber -> install -> Heinz Teams-tool path.

## Skipped smoke

- `npm run make:sandbox` not run; `npm run package` covered packaging for this PR, and no installer signing/update sandbox behavior changed.