### PR TITLE
refactor(ipc): centralize channel constants in @chamber/shared (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.49.4 (2026-05-08)
+
+### IPC
+
+- **Centralize IPC channel constants in `@chamber/shared`** — All IPC channel names are now declared in a single `IPC_CHANNELS` constant in `packages/shared/src/ipc-channels.ts`, with a typed `IpcChannel` union and the existing `createIpcListener` helper updated to consume them. Main-process IPC handlers in `apps/desktop/src/main/ipc/{auth,chat,chatroom,conversationHistory,genesis,lens,marketplace,mind,tools,updater}.ts` and the renderer's `preload.ts` channel registrations now reference the constants instead of magic strings. Adds 118 lines of unit coverage in `ipc-channels.test.ts` for naming convention, uniqueness, and cross-package consumer alignment. No behavior change. (#61)
+
 ## v0.49.3 (2026-05-08)
 
 ### Tests

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import started from 'electron-squirrel-startup';
+import { IPC } from '@chamber/shared';
 
 import {
   A2aToolProvider,
@@ -536,14 +537,14 @@ app.on('ready', async () => {
   reconcileMarketplaceTools();
 
   // Window controls
-  ipcMain.on('window:minimize', () => mainWindow?.minimize());
-  ipcMain.on('window:maximize', () => {
+  ipcMain.on(IPC.WINDOW.MINIMIZE, () => mainWindow?.minimize());
+  ipcMain.on(IPC.WINDOW.MAXIMIZE, () => {
     if (mainWindow?.isMaximized()) mainWindow.unmaximize();
     else mainWindow?.maximize();
   });
-  ipcMain.on('window:close', () => mainWindow?.close());
-  ipcMain.handle('desktop:getBranding', () => ({ name: app.getName(), version: app.getVersion() }));
-  ipcMain.handle('desktop:confirm', (_event, message: string) => {
+  ipcMain.on(IPC.WINDOW.CLOSE, () => mainWindow?.close());
+  ipcMain.handle(IPC.DESKTOP.GET_BRANDING, () => ({ name: app.getName(), version: app.getVersion() }));
+  ipcMain.handle(IPC.DESKTOP.CONFIRM, (_event, message: string) => {
     const choice = mainWindow
       ? dialog.showMessageBoxSync(mainWindow, {
           type: 'question',

--- a/apps/desktop/src/main/ipc/a2a.ts
+++ b/apps/desktop/src/main/ipc/a2a.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import type { EventEmitter } from 'events';
+import { IPC } from '@chamber/shared';
 import type { AgentCardRegistry, TaskManager } from '@chamber/services';
 import { isA2AIncomingPayload, narrowTaskState } from '@chamber/shared/a2a-types';
 import type { A2AIncomingPayload, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@chamber/shared/a2a-types';
@@ -9,58 +10,61 @@ export function setupA2AIPC(
   agentCardRegistry: AgentCardRegistry,
   taskManager: TaskManager,
 ): void {
-  ipcMain.on('e2e:is-enabled', (event) => {
+  ipcMain.on(IPC.E2E.IS_ENABLED, (event) => {
     event.returnValue = process.env.CHAMBER_E2E === '1';
   });
 
-  // Forward a2a:incoming events to all renderer windows
+  // Forward a2a:incoming events to all renderer windows.
+  // Note: 'a2a:incoming' on the EventEmitter is an internal main-process bus
+  // event name that happens to share the wire-channel string; the
+  // webContents.send call uses the IPC.A2A.INCOMING constant for the IPC wire.
   ipcEmitter.on('a2a:incoming', (payload: A2AIncomingPayload) => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('a2a:incoming', payload);
+      win.webContents.send(IPC.A2A.INCOMING, payload);
     }
   });
 
   // Forward A2A chat events (streaming from target agent) to all renderer windows
   ipcEmitter.on('a2a:chat-event', (payload: { mindId: string; messageId: string; event: unknown }) => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('chat:event', payload.mindId, payload.messageId, payload.event);
+      win.webContents.send(IPC.CHAT.EVENT, payload.mindId, payload.messageId, payload.event);
     }
   });
 
   // Forward task events to all renderer windows
   ipcEmitter.on('task:status-update', (payload: TaskStatusUpdateEvent) => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('a2a:task-status-update', payload);
+      win.webContents.send(IPC.A2A.TASK_STATUS_UPDATE, payload);
     }
   });
 
   ipcEmitter.on('task:artifact-update', (payload: TaskArtifactUpdateEvent) => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('a2a:task-artifact-update', payload);
+      win.webContents.send(IPC.A2A.TASK_ARTIFACT_UPDATE, payload);
     }
   });
 
-  ipcMain.handle('a2a:listAgents', async () => {
+  ipcMain.handle(IPC.A2A.LIST_AGENTS, async () => {
     return agentCardRegistry.getCards();
   });
 
   // Task query handlers
-  ipcMain.handle('a2a:getTask', async (_, taskId: string, historyLength?: number) => {
+  ipcMain.handle(IPC.A2A.GET_TASK, async (_, taskId: string, historyLength?: number) => {
     return taskManager.getTask(taskId, historyLength);
   });
 
-  ipcMain.handle('a2a:listTasks', async (_, filter?: { contextId?: string; status?: string }) => {
+  ipcMain.handle(IPC.A2A.LIST_TASKS, async (_, filter?: { contextId?: string; status?: string }) => {
     return taskManager.listTasks(
       filter ? { contextId: filter.contextId, status: narrowTaskState(filter.status) } : undefined,
     );
   });
 
-  ipcMain.handle('a2a:cancelTask', async (_, taskId: string) => {
+  ipcMain.handle(IPC.A2A.CANCEL_TASK, async (_, taskId: string) => {
     return taskManager.cancelTask(taskId);
   });
 
   if (process.env.CHAMBER_E2E === '1') {
-    ipcMain.handle('e2e:a2a:incoming', async (_, payload: unknown) => {
+    ipcMain.handle(IPC.E2E.A2A_INCOMING, async (_, payload: unknown) => {
       if (!isA2AIncomingPayload(payload)) {
         throw new Error('Invalid E2E A2A incoming payload');
       }

--- a/apps/desktop/src/main/ipc/auth.ts
+++ b/apps/desktop/src/main/ipc/auth.ts
@@ -1,13 +1,20 @@
 // Auth IPC handlers
 import { ipcMain, BrowserWindow, shell } from 'electron';
+import { IPC } from '@chamber/shared';
 import { AuthService, Logger, type MindManager } from '@chamber/services';
 
 const log = Logger.create('Auth');
 
 const E2E_ENABLED = process.env.CHAMBER_E2E === '1';
 
+type AuthBroadcastChannel =
+  | typeof IPC.AUTH.LOGGED_OUT
+  | typeof IPC.AUTH.ACCOUNT_SWITCH_STARTED
+  | typeof IPC.AUTH.ACCOUNT_SWITCHED
+  | typeof IPC.AUTH.PROGRESS;
+
 function broadcast(
-  channel: 'auth:loggedOut' | 'auth:accountSwitchStarted' | 'auth:accountSwitched' | 'auth:progress',
+  channel: AuthBroadcastChannel,
   payload?: { login: string } | Record<string, unknown>,
 ): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -24,7 +31,7 @@ export function setupAuthIPC(
   mindManager: MindManager,
 ): void {
 
-  ipcMain.handle('auth:getStatus', async () => {
+  ipcMain.handle(IPC.AUTH.GET_STATUS, async () => {
     const cred = await authService.getStoredCredential();
     return {
       authenticated: cred !== null,
@@ -32,7 +39,7 @@ export function setupAuthIPC(
     };
   });
 
-  ipcMain.handle('auth:listAccounts', async () => authService.listAccounts());
+  ipcMain.handle(IPC.AUTH.LIST_ACCOUNTS, async () => authService.listAccounts());
 
   // E2E short-circuit: when CHAMBER_E2E=1, do not hit the real GitHub device flow.
   // Tests drive auth:progress via e2e:auth:emit-progress and resolve startLogin
@@ -40,7 +47,7 @@ export function setupAuthIPC(
   // a network roundtrip or external browser launch.
   let e2eStartLoginResolver: ((value: { success: boolean; login?: string }) => void) | null = null;
 
-  ipcMain.handle('auth:startLogin', async (event) => {
+  ipcMain.handle(IPC.AUTH.START_LOGIN, async (event) => {
     if (E2E_ENABLED) {
       // Resolve any prior pending stub before starting a new one.
       if (e2eStartLoginResolver) {
@@ -52,13 +59,13 @@ export function setupAuthIPC(
       });
       if (result.success && result.login) {
         authService.setActiveLogin(result.login);
-        broadcast('auth:accountSwitchStarted', { login: result.login });
+        broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login: result.login });
         try {
           await mindManager.reloadAllMinds();
         } catch (err) {
           log.error('Failed to reload minds after e2e login:', err);
         }
-        broadcast('auth:accountSwitched', { login: result.login });
+        broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login: result.login });
       }
       return result;
     }
@@ -67,7 +74,7 @@ export function setupAuthIPC(
 
     authService.setProgressHandler((progress) => {
       if (win) {
-        win.webContents.send('auth:progress', progress);
+        win.webContents.send(IPC.AUTH.PROGRESS, progress);
       }
       if (progress.step === 'device_code' && progress.verificationUri) {
         shell.openExternal(progress.verificationUri);
@@ -77,13 +84,13 @@ export function setupAuthIPC(
     const result = await authService.startLogin();
     if (result.success && result.login) {
       authService.setActiveLogin(result.login);
-      broadcast('auth:accountSwitchStarted', { login: result.login });
+      broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login: result.login });
       try {
         await mindManager.reloadAllMinds();
       } catch (err) {
         log.error('Failed to reload minds after login:', err);
       }
-      broadcast('auth:accountSwitched', { login: result.login });
+      broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login: result.login });
     }
 
     return result;
@@ -92,7 +99,7 @@ export function setupAuthIPC(
   // Lets the renderer abort a pending device-code login (e.g. user cancels the
   // Add Account modal). Maps onto AuthService.abort() which trips the polling
   // loop's exit flag. In E2E mode it short-circuits the stub resolver instead.
-  ipcMain.handle('auth:cancelLogin', async () => {
+  ipcMain.handle(IPC.AUTH.CANCEL_LOGIN, async () => {
     if (E2E_ENABLED && e2eStartLoginResolver) {
       e2eStartLoginResolver({ success: false });
       e2eStartLoginResolver = null;
@@ -101,35 +108,35 @@ export function setupAuthIPC(
     authService.abort();
   });
 
-  ipcMain.handle('auth:switchAccount', async (_event, login: string) => {
+  ipcMain.handle(IPC.AUTH.SWITCH_ACCOUNT, async (_event, login: string) => {
     const accounts = await authService.listAccounts();
     if (!accounts.some((account) => account.login === login)) {
       throw new Error(`Account ${login} is not available`);
     }
 
     authService.setActiveLogin(login);
-    broadcast('auth:accountSwitchStarted', { login });
+    broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login });
     try {
       await mindManager.reloadAllMinds();
     } catch (err) {
       log.error('Failed to reload minds after account switch:', err);
     }
-    broadcast('auth:accountSwitched', { login });
+    broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login });
   });
 
-  ipcMain.handle('auth:logout', async () => {
+  ipcMain.handle(IPC.AUTH.LOGOUT, async () => {
     await authService.logout();
-    broadcast('auth:loggedOut');
+    broadcast(IPC.AUTH.LOGGED_OUT);
   });
 
   // Test-only handlers — gated on CHAMBER_E2E=1 so they are never registered
   // in production builds. Mirrors the existing e2e:a2a:incoming pattern.
   if (E2E_ENABLED) {
-    ipcMain.handle('e2e:auth:emit-progress', async (_event, payload: Record<string, unknown>) => {
-      broadcast('auth:progress', payload);
+    ipcMain.handle(IPC.E2E.AUTH_EMIT_PROGRESS, async (_event, payload: Record<string, unknown>) => {
+      broadcast(IPC.AUTH.PROGRESS, payload);
     });
 
-    ipcMain.handle('e2e:auth:complete-login', async (_event, payload: { success?: boolean; login?: string }) => {
+    ipcMain.handle(IPC.E2E.AUTH_COMPLETE_LOGIN, async (_event, payload: { success?: boolean; login?: string }) => {
       const resolver = e2eStartLoginResolver;
       e2eStartLoginResolver = null;
       if (resolver) {

--- a/apps/desktop/src/main/ipc/chat.ts
+++ b/apps/desktop/src/main/ipc/chat.ts
@@ -1,31 +1,32 @@
 // Chat IPC handlers — thin adapters for ChatService
 import { ipcMain, BrowserWindow } from 'electron';
+import { IPC } from '@chamber/shared';
 import type { ChatService, MindManager } from '@chamber/services';
 import type { ChatEvent, ChatImageAttachment } from '@chamber/shared/types';
 
 export function setupChatIPC(chatService: ChatService, mindManager: MindManager): void {
-  ipcMain.handle('chat:send', async (event, mindId: string, message: string, messageId: string, model?: string, attachments?: ChatImageAttachment[]) => {
+  ipcMain.handle(IPC.CHAT.SEND, async (event, mindId: string, message: string, messageId: string, model?: string, attachments?: ChatImageAttachment[]) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return;
 
-    const emit = (evt: ChatEvent) => win.webContents.send('chat:event', mindId, messageId, evt);
+    const emit = (evt: ChatEvent) => win.webContents.send(IPC.CHAT.EVENT, mindId, messageId, evt);
     await chatService.sendMessage(mindId, message, messageId, emit, model, attachments);
   });
 
-  ipcMain.handle('chat:listModels', async (_event, mindId?: string) => {
+  ipcMain.handle(IPC.CHAT.LIST_MODELS, async (_event, mindId?: string) => {
     // Fall back to any available mind if no mindId provided
     const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
     if (!id) return [];
     return chatService.listModels(id);
   });
 
-  ipcMain.handle('chat:stop', async (event, mindId: string, messageId: string) => {
+  ipcMain.handle(IPC.CHAT.STOP, async (event, mindId: string, messageId: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     await chatService.cancelMessage(mindId, messageId);
-    if (win) win.webContents.send('chat:event', mindId, messageId, { type: 'done' });
+    if (win) win.webContents.send(IPC.CHAT.EVENT, mindId, messageId, { type: 'done' });
   });
 
-  ipcMain.handle('chat:newConversation', async (_event, mindId: string) => {
+  ipcMain.handle(IPC.CHAT.NEW_CONVERSATION, async (_event, mindId: string) => {
     return chatService.newConversation(mindId);
   });
 }

--- a/apps/desktop/src/main/ipc/chatroom.ts
+++ b/apps/desktop/src/main/ipc/chatroom.ts
@@ -1,4 +1,5 @@
 import { ipcMain, BrowserWindow } from 'electron';
+import { IPC } from '@chamber/shared';
 import type { ChatroomService } from '@chamber/services';
 import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig, ChatroomStateChange } from '@chamber/shared/chatroom-types';
 
@@ -32,48 +33,51 @@ function parseSendArgs(message: unknown, model: unknown, roundId: unknown): Chat
 }
 
 export function setupChatroomIPC(chatroomService: ChatroomService): void {
-  ipcMain.handle('chatroom:send', async (_event, message: unknown, model?: unknown, roundId?: unknown) => {
+  ipcMain.handle(IPC.CHATROOM.SEND, async (_event, message: unknown, model?: unknown, roundId?: unknown) => {
     const args = parseSendArgs(message, model, roundId);
     await chatroomService.broadcast(args.message, args.model, args.roundId);
   });
 
-  ipcMain.handle('chatroom:history', async () => {
+  ipcMain.handle(IPC.CHATROOM.HISTORY, async () => {
     return chatroomService.getHistory();
   });
 
-  ipcMain.handle('chatroom:task-ledger', async () => {
+  ipcMain.handle(IPC.CHATROOM.TASK_LEDGER, async () => {
     return chatroomService.getTaskLedger();
   });
 
-  ipcMain.handle('chatroom:clear', async () => {
+  ipcMain.handle(IPC.CHATROOM.CLEAR, async () => {
     await chatroomService.clearHistory();
   });
 
-  ipcMain.handle('chatroom:stop', async () => {
+  ipcMain.handle(IPC.CHATROOM.STOP, async () => {
     chatroomService.stopAll();
   });
 
-  ipcMain.handle('chatroom:set-orchestration', async (_event, mode: OrchestrationMode, config?: GroupChatConfig | HandoffConfig | MagenticConfig) => {
+  ipcMain.handle(IPC.CHATROOM.SET_ORCHESTRATION, async (_event, mode: OrchestrationMode, config?: GroupChatConfig | HandoffConfig | MagenticConfig) => {
     chatroomService.setOrchestration(mode, config);
   });
 
-  ipcMain.handle('chatroom:get-orchestration', async () => {
+  ipcMain.handle(IPC.CHATROOM.GET_ORCHESTRATION, async () => {
     return chatroomService.getOrchestration();
   });
 
-  ipcMain.handle('chatroom:set-mind-enabled', async (_event, mindId: string, enabled: boolean) => {
+  ipcMain.handle(IPC.CHATROOM.SET_MIND_ENABLED, async (_event, mindId: string, enabled: boolean) => {
     chatroomService.setMindEnabled(mindId, enabled);
   });
 
-  ipcMain.handle('chatroom:get-disabled-mind-ids', async () => {
+  ipcMain.handle(IPC.CHATROOM.GET_DISABLED_MIND_IDS, async () => {
     return chatroomService.getDisabledMindIds();
   });
 
-  // Forward chatroom streaming events to all renderer windows
+  // Forward chatroom streaming events to all renderer windows.
+  // The 'chatroom:event' string passed to chatroomService.on(...) is an internal
+  // EventEmitter event name on the service, not an IPC wire channel; the
+  // webContents.send call uses the IPC.CHATROOM.EVENT constant for the IPC wire.
   chatroomService.on('chatroom:event', (event) => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) {
-        win.webContents.send('chatroom:event', event);
+        win.webContents.send(IPC.CHATROOM.EVENT, event);
       }
     }
   });
@@ -84,7 +88,7 @@ export function setupChatroomIPC(chatroomService: ChatroomService): void {
   chatroomService.on('chatroom:state-changed', (state: ChatroomStateChange) => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) {
-        win.webContents.send('chatroom:state-changed', state);
+        win.webContents.send(IPC.CHATROOM.STATE_CHANGED, state);
       }
     }
   });

--- a/apps/desktop/src/main/ipc/conversationHistory.ts
+++ b/apps/desktop/src/main/ipc/conversationHistory.ts
@@ -1,16 +1,17 @@
 import { ipcMain } from 'electron';
+import { IPC } from '@chamber/shared';
 import type { ChatService } from '@chamber/services';
 
 export function setupConversationHistoryIPC(chatService: ChatService): void {
-  ipcMain.handle('conversationHistory:list', async (_event, mindId: string) =>
+  ipcMain.handle(IPC.CONVERSATION_HISTORY.LIST, async (_event, mindId: string) =>
     chatService.listConversationHistory(mindId));
 
-  ipcMain.handle('conversationHistory:resume', async (_event, mindId: string, sessionId: string) =>
+  ipcMain.handle(IPC.CONVERSATION_HISTORY.RESUME, async (_event, mindId: string, sessionId: string) =>
     chatService.resumeConversation(mindId, sessionId));
 
-  ipcMain.handle('conversationHistory:rename', async (_event, mindId: string, sessionId: string, title: string) =>
+  ipcMain.handle(IPC.CONVERSATION_HISTORY.RENAME, async (_event, mindId: string, sessionId: string, title: string) =>
     chatService.renameConversation(mindId, sessionId, title));
 
-  ipcMain.handle('conversationHistory:delete', async (_event, mindId: string, sessionId: string) =>
+  ipcMain.handle(IPC.CONVERSATION_HISTORY.DELETE, async (_event, mindId: string, sessionId: string) =>
     chatService.deleteConversation(mindId, sessionId));
 }

--- a/apps/desktop/src/main/ipc/genesis.ts
+++ b/apps/desktop/src/main/ipc/genesis.ts
@@ -2,6 +2,7 @@
 import { ipcMain, dialog, BrowserWindow } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { IPC } from '@chamber/shared';
 import {
   MindManager,
   MindScaffold,
@@ -26,11 +27,11 @@ export function setupGenesisIPC(
   templateInstaller: GenesisMindTemplateInstallerPort,
 ): void {
 
-  ipcMain.handle('genesis:getDefaultPath', async () => {
+  ipcMain.handle(IPC.GENESIS.GET_DEFAULT_PATH, async () => {
     return getDefaultGenesisBasePath();
   });
 
-  ipcMain.handle('genesis:pickPath', async (event) => {
+  ipcMain.handle(IPC.GENESIS.PICK_PATH, async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return null;
 
@@ -44,15 +45,15 @@ export function setupGenesisIPC(
     return result.filePaths[0];
   });
 
-  ipcMain.handle('genesis:listTemplates', async () => {
+  ipcMain.handle(IPC.GENESIS.LIST_TEMPLATES, async () => {
     return await templateCatalog.listTemplates();
   });
 
-  ipcMain.handle('genesis:create', async (event, config: GenesisConfig) => {
+  ipcMain.handle(IPC.GENESIS.CREATE, async (event, config: GenesisConfig) => {
     const win = BrowserWindow.fromWebContents(event.sender);
 
     scaffold.setProgressHandler((progress) => {
-      if (win) win.webContents.send('genesis:progress', progress);
+      if (win) win.webContents.send(IPC.GENESIS.PROGRESS, progress);
     });
 
     try {
@@ -60,23 +61,23 @@ export function setupGenesisIPC(
       return await activateCreatedMind(mindManager, mindPath);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (win) win.webContents.send('genesis:progress', { step: 'error', detail: message });
+      if (win) win.webContents.send(IPC.GENESIS.PROGRESS, { step: 'error', detail: message });
       return { success: false, error: message };
     }
   });
 
-  ipcMain.handle('genesis:createFromTemplate', async (event, request: GenesisMindTemplateInstallRequest) => {
+  ipcMain.handle(IPC.GENESIS.CREATE_FROM_TEMPLATE, async (event, request: GenesisMindTemplateInstallRequest) => {
     const win = BrowserWindow.fromWebContents(event.sender);
 
     try {
-      if (win) win.webContents.send('genesis:progress', { step: 'template', detail: 'Installing Genesis mind template...' });
+      if (win) win.webContents.send(IPC.GENESIS.PROGRESS, { step: 'template', detail: 'Installing Genesis mind template...' });
       const mindPath = await templateInstaller.install(request);
       const result = await activateCreatedMind(mindManager, mindPath);
-      if (win) win.webContents.send('genesis:progress', { step: 'complete', detail: 'Genesis template install complete.' });
+      if (win) win.webContents.send(IPC.GENESIS.PROGRESS, { step: 'complete', detail: 'Genesis template install complete.' });
       return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (win) win.webContents.send('genesis:progress', { step: 'error', detail: message });
+      if (win) win.webContents.send(IPC.GENESIS.PROGRESS, { step: 'error', detail: message });
       return { success: false, error: message };
     }
   });

--- a/apps/desktop/src/main/ipc/lens.ts
+++ b/apps/desktop/src/main/ipc/lens.ts
@@ -1,5 +1,6 @@
 // Lens IPC handlers — thin adapters for ViewDiscovery
 import { BrowserWindow, ipcMain } from 'electron';
+import { IPC } from '@chamber/shared';
 import type { CanvasService, MindManager, ViewDiscovery } from '@chamber/services';
 import type { LensViewManifest } from '@chamber/shared/types';
 
@@ -14,27 +15,27 @@ export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindMana
     return id ? mindManager.getMind(id) : undefined;
   };
 
-  ipcMain.handle('lens:getViews', async (_event, mindId?: string) => {
+  ipcMain.handle(IPC.LENS.GET_VIEWS, async (_event, mindId?: string) => {
     return viewDiscovery.getViews(resolveMindPath(mindId));
   });
 
-  ipcMain.handle('lens:getViewData', async (_event, viewId: string, mindId?: string) => {
+  ipcMain.handle(IPC.LENS.GET_VIEW_DATA, async (_event, viewId: string, mindId?: string) => {
     return viewDiscovery.getViewData(viewId, resolveMindPath(mindId));
   });
 
-  ipcMain.handle('lens:refreshView', async (_event, viewId: string, mindId?: string) => {
+  ipcMain.handle(IPC.LENS.REFRESH_VIEW, async (_event, viewId: string, mindId?: string) => {
     const mindPath = resolveMindPath(mindId);
     if (!mindPath) return null;
     return viewDiscovery.refreshView(viewId, mindPath);
   });
 
-  ipcMain.handle('lens:sendAction', async (_event, viewId: string, action: string, mindId?: string) => {
+  ipcMain.handle(IPC.LENS.SEND_ACTION, async (_event, viewId: string, action: string, mindId?: string) => {
     const mindPath = resolveMindPath(mindId);
     if (!mindPath) return null;
     return viewDiscovery.sendAction(viewId, action, mindPath);
   });
 
-  ipcMain.handle('lens:getCanvasUrl', async (_event, viewId: string, mindId?: string) => {
+  ipcMain.handle(IPC.LENS.GET_CANVAS_URL, async (_event, viewId: string, mindId?: string) => {
     const mind = resolveMind(mindId);
     if (!mind) return null;
     const sourcePath = viewDiscovery.getViewSourcePath(viewId, mind.mindPath);
@@ -42,9 +43,11 @@ export function setupLensIPC(viewDiscovery: ViewDiscovery, mindManager: MindMana
     return canvasService.showLensCanvas(mind.mindId, mind.mindPath, viewId, sourcePath);
   });
 
+  // MindManager EventEmitter channel name (intentionally string, not IPC.*)
+  // because this is an internal pub/sub channel within the main process.
   mindManager.on('lens:viewsChanged', (views: LensViewManifest[], mindId: string) => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('lens:viewsChanged', views, mindId);
+      win.webContents.send(IPC.LENS.VIEWS_CHANGED, views, mindId);
     }
   });
 }

--- a/apps/desktop/src/main/ipc/marketplace.ts
+++ b/apps/desktop/src/main/ipc/marketplace.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron';
+import { IPC } from '@chamber/shared';
 import type { MarketplaceRegistryService } from '@chamber/services';
 
 interface MarketplaceIPCOptions {
@@ -9,29 +10,29 @@ export function setupMarketplaceIPC(
   marketplaceRegistryService: MarketplaceRegistryService,
   options: MarketplaceIPCOptions = {},
 ): void {
-  ipcMain.handle('marketplace:listGenesisRegistries', async () => {
+  ipcMain.handle(IPC.MARKETPLACE.LIST_GENESIS_REGISTRIES, async () => {
     return marketplaceRegistryService.listGenesisRegistries();
   });
 
-  ipcMain.handle('marketplace:addGenesisRegistry', async (_event, url: string) => {
+  ipcMain.handle(IPC.MARKETPLACE.ADD_GENESIS_REGISTRY, async (_event, url: string) => {
     const result = await marketplaceRegistryService.addGenesisRegistry(url);
     if (result.success) options.onRegistryToolsChanged?.();
     return result;
   });
 
-  ipcMain.handle('marketplace:refreshGenesisRegistry', async (_event, id: string) => {
+  ipcMain.handle(IPC.MARKETPLACE.REFRESH_GENESIS_REGISTRY, async (_event, id: string) => {
     const result = await marketplaceRegistryService.refreshGenesisRegistry(id);
     if (result.success) options.onRegistryToolsChanged?.();
     return result;
   });
 
-  ipcMain.handle('marketplace:setGenesisRegistryEnabled', async (_event, id: string, enabled: boolean) => {
+  ipcMain.handle(IPC.MARKETPLACE.SET_GENESIS_REGISTRY_ENABLED, async (_event, id: string, enabled: boolean) => {
     const result = await marketplaceRegistryService.setGenesisRegistryEnabled(id, enabled);
     if (result.success && enabled) options.onRegistryToolsChanged?.();
     return result;
   });
 
-  ipcMain.handle('marketplace:removeGenesisRegistry', async (_event, id: string) => {
+  ipcMain.handle(IPC.MARKETPLACE.REMOVE_GENESIS_REGISTRY, async (_event, id: string) => {
     return marketplaceRegistryService.removeGenesisRegistry(id);
   });
 }

--- a/apps/desktop/src/main/ipc/mind.ts
+++ b/apps/desktop/src/main/ipc/mind.ts
@@ -3,6 +3,7 @@ import { ipcMain, dialog, BrowserWindow, type NativeImage } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
 import { setTimeout as delay } from 'node:timers/promises';
+import { IPC } from '@chamber/shared';
 import type { ChatService, MindManager } from '@chamber/services';
 import type { MindContext } from '@chamber/shared/types';
 import { installExternalNavigationGuard } from '../navigationGuard';
@@ -22,31 +23,31 @@ export function setupMindIPC(mindManager: MindManager, chatService: ChatService,
       windowed: windowByMind.has(mind.mindId),
     }));
 
-  ipcMain.handle('mind:add', async (event, mindPath: string) => {
+  ipcMain.handle(IPC.MIND.ADD, async (event, mindPath: string) => {
     return mindManager.loadMind(mindPath);
   });
 
-  ipcMain.handle('mind:remove', async (_event, mindId: string) => {
+  ipcMain.handle(IPC.MIND.REMOVE, async (_event, mindId: string) => {
     await mindManager.unloadMind(mindId);
   });
 
-  ipcMain.handle('mind:list', async () => {
+  ipcMain.handle(IPC.MIND.LIST, async () => {
     // Wait for restore to complete before returning the list
     await mindManager.awaitRestore();
     return listMinds();
   });
 
-  ipcMain.handle('mind:setActive', async (_event, mindId: string) => {
+  ipcMain.handle(IPC.MIND.SET_ACTIVE, async (_event, mindId: string) => {
     mindManager.setActiveMind(mindId);
   });
 
-  ipcMain.handle('mind:setModel', async (_event, mindId: string, model: string | null) => {
+  ipcMain.handle(IPC.MIND.SET_MODEL, async (_event, mindId: string, model: string | null) => {
     const e2eDelayMs = Number(process.env.CHAMBER_E2E_MODEL_SWITCH_DELAY_MS ?? 0);
     if (e2eDelayMs > 0) await delay(e2eDelayMs);
     return chatService.setMindModel(mindId, model);
   });
 
-  ipcMain.handle('mind:selectDirectory', async (event) => {
+  ipcMain.handle(IPC.MIND.SELECT_DIRECTORY, async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return null;
 
@@ -60,7 +61,7 @@ export function setupMindIPC(mindManager: MindManager, chatService: ChatService,
     return result.filePaths[0];
   });
 
-  ipcMain.handle('mind:openWindow', async (_event, mindId: string) => {
+  ipcMain.handle(IPC.MIND.OPEN_WINDOW, async (_event, mindId: string) => {
     // If already popped out, focus existing window
     const existing = windowByMind.get(mindId);
     if (existing) {
@@ -117,7 +118,7 @@ export function setupMindIPC(mindManager: MindManager, chatService: ChatService,
   const broadcastMinds = () => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) {
-      win.webContents.send('mind:changed', listMinds());
+      win.webContents.send(IPC.MIND.CHANGED, listMinds());
       }
     }
   };

--- a/apps/desktop/src/main/ipc/tools.ts
+++ b/apps/desktop/src/main/ipc/tools.ts
@@ -1,10 +1,11 @@
 import { ipcMain } from 'electron';
+import { IPC } from '@chamber/shared';
 import type { ToolsService } from '@chamber/services';
 
 export function setupToolsIPC(toolsService: ToolsService): void {
-  ipcMain.handle('tools:list', async () => toolsService.list());
-  ipcMain.handle('tools:install', async (_event, toolId: string, marketplaceId?: string) =>
+  ipcMain.handle(IPC.TOOLS.LIST, async () => toolsService.list());
+  ipcMain.handle(IPC.TOOLS.INSTALL, async (_event, toolId: string, marketplaceId?: string) =>
     toolsService.install(toolId, marketplaceId),
   );
-  ipcMain.handle('tools:uninstall', async (_event, toolId: string) => toolsService.uninstall(toolId));
+  ipcMain.handle(IPC.TOOLS.UNINSTALL, async (_event, toolId: string) => toolsService.uninstall(toolId));
 }

--- a/apps/desktop/src/main/ipc/updater.ts
+++ b/apps/desktop/src/main/ipc/updater.ts
@@ -1,18 +1,19 @@
 import { BrowserWindow, ipcMain } from 'electron';
+import { IPC } from '@chamber/shared';
 import type { DesktopUpdateState } from '@chamber/shared/types';
 import type { UpdaterService } from '../updater/UpdaterService';
 
 function broadcastState(state: DesktopUpdateState): void {
   for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send('updater:state-changed', state);
+    win.webContents.send(IPC.UPDATER.STATE_CHANGED, state);
   }
 }
 
 export function setupUpdaterIPC(updaterService: UpdaterService): void {
-  ipcMain.handle('updater:get-state', () => updaterService.getState());
-  ipcMain.handle('updater:check', () => updaterService.checkForUpdates('web-ui'));
-  ipcMain.handle('updater:download', () => updaterService.downloadUpdate());
-  ipcMain.handle('updater:install-and-restart', () => updaterService.installAndRestart());
+  ipcMain.handle(IPC.UPDATER.GET_STATE, () => updaterService.getState());
+  ipcMain.handle(IPC.UPDATER.CHECK, () => updaterService.checkForUpdates('web-ui'));
+  ipcMain.handle(IPC.UPDATER.DOWNLOAD, () => updaterService.downloadUpdate());
+  ipcMain.handle(IPC.UPDATER.INSTALL_AND_RESTART, () => updaterService.installAndRestart());
 
   updaterService.onStateChanged((state) => {
     broadcastState(state);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,34 +1,34 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { createIpcListener } from '@chamber/shared';
+import { createIpcListener, IPC } from '@chamber/shared';
 import type { A2AIncomingPayload, ElectronAPI } from '@chamber/shared/types';
 import type { Message, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@chamber/shared/a2a-types';
 
 const electronAPI: ElectronAPI = {
   chat: {
     send: (mindId, message, messageId, model, attachments) =>
-      ipcRenderer.invoke('chat:send', mindId, message, messageId, model, attachments),
+      ipcRenderer.invoke(IPC.CHAT.SEND, mindId, message, messageId, model, attachments),
     stop: (mindId, messageId) =>
-      ipcRenderer.invoke('chat:stop', mindId, messageId),
+      ipcRenderer.invoke(IPC.CHAT.STOP, mindId, messageId),
     newConversation: (mindId) =>
-      ipcRenderer.invoke('chat:newConversation', mindId),
-    listModels: (mindId?) => ipcRenderer.invoke('chat:listModels', mindId),
-    onEvent: (callback) => createIpcListener(ipcRenderer, 'chat:event', callback),
+      ipcRenderer.invoke(IPC.CHAT.NEW_CONVERSATION, mindId),
+    listModels: (mindId?) => ipcRenderer.invoke(IPC.CHAT.LIST_MODELS, mindId),
+    onEvent: (callback) => createIpcListener(ipcRenderer, IPC.CHAT.EVENT, callback),
   },
   conversationHistory: {
-    list: (mindId) => ipcRenderer.invoke('conversationHistory:list', mindId),
-    resume: (mindId, sessionId) => ipcRenderer.invoke('conversationHistory:resume', mindId, sessionId),
-    rename: (mindId, sessionId, title) => ipcRenderer.invoke('conversationHistory:rename', mindId, sessionId, title),
-    delete: (mindId, sessionId) => ipcRenderer.invoke('conversationHistory:delete', mindId, sessionId),
+    list: (mindId) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.LIST, mindId),
+    resume: (mindId, sessionId) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.RESUME, mindId, sessionId),
+    rename: (mindId, sessionId, title) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.RENAME, mindId, sessionId, title),
+    delete: (mindId, sessionId) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.DELETE, mindId, sessionId),
   },
   mind: {
-    add: (mindPath) => ipcRenderer.invoke('mind:add', mindPath),
-    remove: (mindId) => ipcRenderer.invoke('mind:remove', mindId),
-    list: () => ipcRenderer.invoke('mind:list'),
-    setActive: (mindId) => ipcRenderer.invoke('mind:setActive', mindId),
-    setModel: (mindId, model) => ipcRenderer.invoke('mind:setModel', mindId, model),
-    selectDirectory: () => ipcRenderer.invoke('mind:selectDirectory'),
-    openWindow: (mindId) => ipcRenderer.invoke('mind:openWindow', mindId),
-    onMindChanged: (callback) => createIpcListener(ipcRenderer, 'mind:changed', callback),
+    add: (mindPath) => ipcRenderer.invoke(IPC.MIND.ADD, mindPath),
+    remove: (mindId) => ipcRenderer.invoke(IPC.MIND.REMOVE, mindId),
+    list: () => ipcRenderer.invoke(IPC.MIND.LIST),
+    setActive: (mindId) => ipcRenderer.invoke(IPC.MIND.SET_ACTIVE, mindId),
+    setModel: (mindId, model) => ipcRenderer.invoke(IPC.MIND.SET_MODEL, mindId, model),
+    selectDirectory: () => ipcRenderer.invoke(IPC.MIND.SELECT_DIRECTORY),
+    openWindow: (mindId) => ipcRenderer.invoke(IPC.MIND.OPEN_WINDOW, mindId),
+    onMindChanged: (callback) => createIpcListener(ipcRenderer, IPC.MIND.CHANGED, callback),
   },
   mindProfile: {
     get: (mindId) => ipcRenderer.invoke('mindProfile:get', mindId),
@@ -39,91 +39,91 @@ const electronAPI: ElectronAPI = {
     restart: (mindId) => ipcRenderer.invoke('mindProfile:restart', mindId),
   },
   lens: {
-    getViews: (mindId?) => ipcRenderer.invoke('lens:getViews', mindId),
-    getViewData: (viewId, mindId?) => ipcRenderer.invoke('lens:getViewData', viewId, mindId),
-    refreshView: (viewId, mindId?) => ipcRenderer.invoke('lens:refreshView', viewId, mindId),
-    sendAction: (viewId, action, mindId?) => ipcRenderer.invoke('lens:sendAction', viewId, action, mindId),
-    getCanvasUrl: (viewId, mindId?) => ipcRenderer.invoke('lens:getCanvasUrl', viewId, mindId),
-    onViewsChanged: (callback) => createIpcListener(ipcRenderer, 'lens:viewsChanged', callback),
+    getViews: (mindId?) => ipcRenderer.invoke(IPC.LENS.GET_VIEWS, mindId),
+    getViewData: (viewId, mindId?) => ipcRenderer.invoke(IPC.LENS.GET_VIEW_DATA, viewId, mindId),
+    refreshView: (viewId, mindId?) => ipcRenderer.invoke(IPC.LENS.REFRESH_VIEW, viewId, mindId),
+    sendAction: (viewId, action, mindId?) => ipcRenderer.invoke(IPC.LENS.SEND_ACTION, viewId, action, mindId),
+    getCanvasUrl: (viewId, mindId?) => ipcRenderer.invoke(IPC.LENS.GET_CANVAS_URL, viewId, mindId),
+    onViewsChanged: (callback) => createIpcListener(ipcRenderer, IPC.LENS.VIEWS_CHANGED, callback),
   },
   auth: {
-    getStatus: () => ipcRenderer.invoke('auth:getStatus'),
-    listAccounts: () => ipcRenderer.invoke('auth:listAccounts'),
-    startLogin: () => ipcRenderer.invoke('auth:startLogin'),
-    cancelLogin: () => ipcRenderer.invoke('auth:cancelLogin'),
-    switchAccount: (login) => ipcRenderer.invoke('auth:switchAccount', login),
-    logout: () => ipcRenderer.invoke('auth:logout'),
-    onProgress: (callback) => createIpcListener(ipcRenderer, 'auth:progress', callback),
-    onAccountSwitchStarted: (callback) => createIpcListener(ipcRenderer, 'auth:accountSwitchStarted', callback),
-    onAccountSwitched: (callback) => createIpcListener(ipcRenderer, 'auth:accountSwitched', callback),
-    onLoggedOut: (callback) => createIpcListener(ipcRenderer, 'auth:loggedOut', callback),
+    getStatus: () => ipcRenderer.invoke(IPC.AUTH.GET_STATUS),
+    listAccounts: () => ipcRenderer.invoke(IPC.AUTH.LIST_ACCOUNTS),
+    startLogin: () => ipcRenderer.invoke(IPC.AUTH.START_LOGIN),
+    cancelLogin: () => ipcRenderer.invoke(IPC.AUTH.CANCEL_LOGIN),
+    switchAccount: (login) => ipcRenderer.invoke(IPC.AUTH.SWITCH_ACCOUNT, login),
+    logout: () => ipcRenderer.invoke(IPC.AUTH.LOGOUT),
+    onProgress: (callback) => createIpcListener(ipcRenderer, IPC.AUTH.PROGRESS, callback),
+    onAccountSwitchStarted: (callback) => createIpcListener(ipcRenderer, IPC.AUTH.ACCOUNT_SWITCH_STARTED, callback),
+    onAccountSwitched: (callback) => createIpcListener(ipcRenderer, IPC.AUTH.ACCOUNT_SWITCHED, callback),
+    onLoggedOut: (callback) => createIpcListener(ipcRenderer, IPC.AUTH.LOGGED_OUT, callback),
   },
   genesis: {
-    getDefaultPath: () => ipcRenderer.invoke('genesis:getDefaultPath'),
-    pickPath: () => ipcRenderer.invoke('genesis:pickPath'),
-    listTemplates: () => ipcRenderer.invoke('genesis:listTemplates'),
-    create: (config) => ipcRenderer.invoke('genesis:create', config),
-    createFromTemplate: (request) => ipcRenderer.invoke('genesis:createFromTemplate', request),
-    onProgress: (callback) => createIpcListener(ipcRenderer, 'genesis:progress', callback),
+    getDefaultPath: () => ipcRenderer.invoke(IPC.GENESIS.GET_DEFAULT_PATH),
+    pickPath: () => ipcRenderer.invoke(IPC.GENESIS.PICK_PATH),
+    listTemplates: () => ipcRenderer.invoke(IPC.GENESIS.LIST_TEMPLATES),
+    create: (config) => ipcRenderer.invoke(IPC.GENESIS.CREATE, config),
+    createFromTemplate: (request) => ipcRenderer.invoke(IPC.GENESIS.CREATE_FROM_TEMPLATE, request),
+    onProgress: (callback) => createIpcListener(ipcRenderer, IPC.GENESIS.PROGRESS, callback),
   },
   marketplace: {
-    listGenesisRegistries: () => ipcRenderer.invoke('marketplace:listGenesisRegistries'),
-    addGenesisRegistry: (url) => ipcRenderer.invoke('marketplace:addGenesisRegistry', url),
-    refreshGenesisRegistry: (id) => ipcRenderer.invoke('marketplace:refreshGenesisRegistry', id),
-    setGenesisRegistryEnabled: (id, enabled) => ipcRenderer.invoke('marketplace:setGenesisRegistryEnabled', id, enabled),
-    removeGenesisRegistry: (id) => ipcRenderer.invoke('marketplace:removeGenesisRegistry', id),
+    listGenesisRegistries: () => ipcRenderer.invoke(IPC.MARKETPLACE.LIST_GENESIS_REGISTRIES),
+    addGenesisRegistry: (url) => ipcRenderer.invoke(IPC.MARKETPLACE.ADD_GENESIS_REGISTRY, url),
+    refreshGenesisRegistry: (id) => ipcRenderer.invoke(IPC.MARKETPLACE.REFRESH_GENESIS_REGISTRY, id),
+    setGenesisRegistryEnabled: (id, enabled) => ipcRenderer.invoke(IPC.MARKETPLACE.SET_GENESIS_REGISTRY_ENABLED, id, enabled),
+    removeGenesisRegistry: (id) => ipcRenderer.invoke(IPC.MARKETPLACE.REMOVE_GENESIS_REGISTRY, id),
   },
   tools: {
-    list: () => ipcRenderer.invoke('tools:list'),
-    install: (toolId, marketplaceId) => ipcRenderer.invoke('tools:install', toolId, marketplaceId),
-    uninstall: (toolId) => ipcRenderer.invoke('tools:uninstall', toolId),
+    list: () => ipcRenderer.invoke(IPC.TOOLS.LIST),
+    install: (toolId, marketplaceId) => ipcRenderer.invoke(IPC.TOOLS.INSTALL, toolId, marketplaceId),
+    uninstall: (toolId) => ipcRenderer.invoke(IPC.TOOLS.UNINSTALL, toolId),
   },
   chatroom: {
-    send: (message: string, model?: string, roundId?: string) => ipcRenderer.invoke('chatroom:send', message, model, roundId),
-    history: () => ipcRenderer.invoke('chatroom:history'),
-    taskLedger: () => ipcRenderer.invoke('chatroom:task-ledger'),
-    clear: () => ipcRenderer.invoke('chatroom:clear'),
-    stop: () => ipcRenderer.invoke('chatroom:stop'),
-    setOrchestration: (mode: string, config?: unknown) => ipcRenderer.invoke('chatroom:set-orchestration', mode, config),
-    getOrchestration: () => ipcRenderer.invoke('chatroom:get-orchestration'),
-    onEvent: (callback) => createIpcListener(ipcRenderer, 'chatroom:event', callback),
-    setMindEnabled: (mindId: string, enabled: boolean) => ipcRenderer.invoke('chatroom:set-mind-enabled', mindId, enabled),
-    getDisabledMindIds: () => ipcRenderer.invoke('chatroom:get-disabled-mind-ids'),
-    onStateChanged: (callback) => createIpcListener(ipcRenderer, 'chatroom:state-changed', callback),
+    send: (message: string, model?: string, roundId?: string) => ipcRenderer.invoke(IPC.CHATROOM.SEND, message, model, roundId),
+    history: () => ipcRenderer.invoke(IPC.CHATROOM.HISTORY),
+    taskLedger: () => ipcRenderer.invoke(IPC.CHATROOM.TASK_LEDGER),
+    clear: () => ipcRenderer.invoke(IPC.CHATROOM.CLEAR),
+    stop: () => ipcRenderer.invoke(IPC.CHATROOM.STOP),
+    setOrchestration: (mode: string, config?: unknown) => ipcRenderer.invoke(IPC.CHATROOM.SET_ORCHESTRATION, mode, config),
+    getOrchestration: () => ipcRenderer.invoke(IPC.CHATROOM.GET_ORCHESTRATION),
+    onEvent: (callback) => createIpcListener(ipcRenderer, IPC.CHATROOM.EVENT, callback),
+    setMindEnabled: (mindId: string, enabled: boolean) => ipcRenderer.invoke(IPC.CHATROOM.SET_MIND_ENABLED, mindId, enabled),
+    getDisabledMindIds: () => ipcRenderer.invoke(IPC.CHATROOM.GET_DISABLED_MIND_IDS),
+    onStateChanged: (callback) => createIpcListener(ipcRenderer, IPC.CHATROOM.STATE_CHANGED, callback),
   },
   updater: {
-    getState: () => ipcRenderer.invoke('updater:get-state'),
-    check: () => ipcRenderer.invoke('updater:check'),
-    download: () => ipcRenderer.invoke('updater:download'),
-    installAndRestart: () => ipcRenderer.invoke('updater:install-and-restart'),
-    onStateChanged: (callback) => createIpcListener(ipcRenderer, 'updater:state-changed', callback),
+    getState: () => ipcRenderer.invoke(IPC.UPDATER.GET_STATE),
+    check: () => ipcRenderer.invoke(IPC.UPDATER.CHECK),
+    download: () => ipcRenderer.invoke(IPC.UPDATER.DOWNLOAD),
+    installAndRestart: () => ipcRenderer.invoke(IPC.UPDATER.INSTALL_AND_RESTART),
+    onStateChanged: (callback) => createIpcListener(ipcRenderer, IPC.UPDATER.STATE_CHANGED, callback),
   },
   a2a: {
-    onIncoming: (callback: (payload: { targetMindId: string; message: Message; replyMessageId: string }) => void) => createIpcListener(ipcRenderer, 'a2a:incoming', callback),
-    listAgents: () => ipcRenderer.invoke('a2a:listAgents'),
-    onTaskStatusUpdate: (callback: (payload: TaskStatusUpdateEvent & { targetMindId: string }) => void) => createIpcListener(ipcRenderer, 'a2a:task-status-update', callback),
-    onTaskArtifactUpdate: (callback: (payload: TaskArtifactUpdateEvent & { targetMindId: string }) => void) => createIpcListener(ipcRenderer, 'a2a:task-artifact-update', callback),
-    getTask: (taskId: string, historyLength?: number) => ipcRenderer.invoke('a2a:getTask', taskId, historyLength),
-    listTasks: (filter?: { contextId?: string; status?: string }) => ipcRenderer.invoke('a2a:listTasks', filter),
-    cancelTask: (taskId: string) => ipcRenderer.invoke('a2a:cancelTask', taskId),
+    onIncoming: (callback: (payload: { targetMindId: string; message: Message; replyMessageId: string }) => void) => createIpcListener(ipcRenderer, IPC.A2A.INCOMING, callback),
+    listAgents: () => ipcRenderer.invoke(IPC.A2A.LIST_AGENTS),
+    onTaskStatusUpdate: (callback: (payload: TaskStatusUpdateEvent & { targetMindId: string }) => void) => createIpcListener(ipcRenderer, IPC.A2A.TASK_STATUS_UPDATE, callback),
+    onTaskArtifactUpdate: (callback: (payload: TaskArtifactUpdateEvent & { targetMindId: string }) => void) => createIpcListener(ipcRenderer, IPC.A2A.TASK_ARTIFACT_UPDATE, callback),
+    getTask: (taskId: string, historyLength?: number) => ipcRenderer.invoke(IPC.A2A.GET_TASK, taskId, historyLength),
+    listTasks: (filter?: { contextId?: string; status?: string }) => ipcRenderer.invoke(IPC.A2A.LIST_TASKS, filter),
+    cancelTask: (taskId: string) => ipcRenderer.invoke(IPC.A2A.CANCEL_TASK, taskId),
   },
   window: {
-    minimize: () => ipcRenderer.send('window:minimize'),
-    maximize: () => ipcRenderer.send('window:maximize'),
-    close: () => ipcRenderer.send('window:close'),
+    minimize: () => ipcRenderer.send(IPC.WINDOW.MINIMIZE),
+    maximize: () => ipcRenderer.send(IPC.WINDOW.MAXIMIZE),
+    close: () => ipcRenderer.send(IPC.WINDOW.CLOSE),
   },
 };
 
-if (ipcRenderer.sendSync('e2e:is-enabled') === true) {
+if (ipcRenderer.sendSync(IPC.E2E.IS_ENABLED) === true) {
   electronAPI.e2e = {
     emitA2AIncoming: async (payload: A2AIncomingPayload) => {
-      await ipcRenderer.invoke('e2e:a2a:incoming', payload);
+      await ipcRenderer.invoke(IPC.E2E.A2A_INCOMING, payload);
     },
     emitAuthProgress: async (payload: Record<string, unknown>) => {
-      await ipcRenderer.invoke('e2e:auth:emit-progress', payload);
+      await ipcRenderer.invoke(IPC.E2E.AUTH_EMIT_PROGRESS, payload);
     },
     completeLoginStub: async (payload: { success?: boolean; login?: string }) => {
-      await ipcRenderer.invoke('e2e:auth:complete-login', payload);
+      await ipcRenderer.invoke(IPC.E2E.AUTH_COMPLETE_LOGIN, payload);
     },
   };
 }
@@ -131,13 +131,13 @@ if (ipcRenderer.sendSync('e2e:is-enabled') === true) {
 contextBridge.exposeInMainWorld('electronAPI', electronAPI);
 
 contextBridge.exposeInMainWorld('desktop', {
-  pickFolder: () => ipcRenderer.invoke('mind:selectDirectory'),
-  openMindWindow: (mindId: string) => ipcRenderer.invoke('mind:openWindow', mindId),
-  getAppBranding: () => ipcRenderer.invoke('desktop:getBranding'),
-  confirm: (message: string) => ipcRenderer.invoke('desktop:confirm', message),
+  pickFolder: () => ipcRenderer.invoke(IPC.MIND.SELECT_DIRECTORY),
+  openMindWindow: (mindId: string) => ipcRenderer.invoke(IPC.MIND.OPEN_WINDOW, mindId),
+  getAppBranding: () => ipcRenderer.invoke(IPC.DESKTOP.GET_BRANDING),
+  confirm: (message: string) => ipcRenderer.invoke(IPC.DESKTOP.CONFIRM, message),
   window: {
-    minimize: () => ipcRenderer.send('window:minimize'),
-    maximize: () => ipcRenderer.send('window:maximize'),
-    close: () => ipcRenderer.send('window:close'),
+    minimize: () => ipcRenderer.send(IPC.WINDOW.MINIMIZE),
+    maximize: () => ipcRenderer.send(IPC.WINDOW.MAXIMIZE),
+    close: () => ipcRenderer.send(IPC.WINDOW.CLOSE),
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.49.3",
+      "version": "0.49.4",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export { createIpcListener } from './createIpcListener';
+export { IPC, type IpcChannel } from './ipc-channels';

--- a/packages/shared/src/ipc-channels.test.ts
+++ b/packages/shared/src/ipc-channels.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { IPC, type IpcChannel } from './ipc-channels';
+
+describe('IPC channel constants', () => {
+  it('preserves the exact channel strings used on the IPC wire', () => {
+    expect(IPC.CHAT.SEND).toBe('chat:send');
+    expect(IPC.CHAT.STOP).toBe('chat:stop');
+    expect(IPC.CHAT.NEW_CONVERSATION).toBe('chat:newConversation');
+    expect(IPC.CHAT.LIST_MODELS).toBe('chat:listModels');
+    expect(IPC.CHAT.EVENT).toBe('chat:event');
+
+    expect(IPC.CONVERSATION_HISTORY.LIST).toBe('conversationHistory:list');
+    expect(IPC.CONVERSATION_HISTORY.RESUME).toBe('conversationHistory:resume');
+    expect(IPC.CONVERSATION_HISTORY.RENAME).toBe('conversationHistory:rename');
+    expect(IPC.CONVERSATION_HISTORY.DELETE).toBe('conversationHistory:delete');
+
+    expect(IPC.MIND.ADD).toBe('mind:add');
+    expect(IPC.MIND.REMOVE).toBe('mind:remove');
+    expect(IPC.MIND.LIST).toBe('mind:list');
+    expect(IPC.MIND.SET_ACTIVE).toBe('mind:setActive');
+    expect(IPC.MIND.SET_MODEL).toBe('mind:setModel');
+    expect(IPC.MIND.SELECT_DIRECTORY).toBe('mind:selectDirectory');
+    expect(IPC.MIND.OPEN_WINDOW).toBe('mind:openWindow');
+    expect(IPC.MIND.CHANGED).toBe('mind:changed');
+
+    expect(IPC.LENS.GET_VIEWS).toBe('lens:getViews');
+    expect(IPC.LENS.GET_VIEW_DATA).toBe('lens:getViewData');
+    expect(IPC.LENS.REFRESH_VIEW).toBe('lens:refreshView');
+    expect(IPC.LENS.SEND_ACTION).toBe('lens:sendAction');
+    expect(IPC.LENS.GET_CANVAS_URL).toBe('lens:getCanvasUrl');
+    expect(IPC.LENS.VIEWS_CHANGED).toBe('lens:viewsChanged');
+
+    expect(IPC.AUTH.GET_STATUS).toBe('auth:getStatus');
+    expect(IPC.AUTH.LIST_ACCOUNTS).toBe('auth:listAccounts');
+    expect(IPC.AUTH.START_LOGIN).toBe('auth:startLogin');
+    expect(IPC.AUTH.CANCEL_LOGIN).toBe('auth:cancelLogin');
+    expect(IPC.AUTH.SWITCH_ACCOUNT).toBe('auth:switchAccount');
+    expect(IPC.AUTH.LOGOUT).toBe('auth:logout');
+    expect(IPC.AUTH.PROGRESS).toBe('auth:progress');
+    expect(IPC.AUTH.ACCOUNT_SWITCH_STARTED).toBe('auth:accountSwitchStarted');
+    expect(IPC.AUTH.ACCOUNT_SWITCHED).toBe('auth:accountSwitched');
+    expect(IPC.AUTH.LOGGED_OUT).toBe('auth:loggedOut');
+
+    expect(IPC.GENESIS.GET_DEFAULT_PATH).toBe('genesis:getDefaultPath');
+    expect(IPC.GENESIS.PICK_PATH).toBe('genesis:pickPath');
+    expect(IPC.GENESIS.LIST_TEMPLATES).toBe('genesis:listTemplates');
+    expect(IPC.GENESIS.CREATE).toBe('genesis:create');
+    expect(IPC.GENESIS.CREATE_FROM_TEMPLATE).toBe('genesis:createFromTemplate');
+    expect(IPC.GENESIS.PROGRESS).toBe('genesis:progress');
+
+    expect(IPC.MARKETPLACE.LIST_GENESIS_REGISTRIES).toBe('marketplace:listGenesisRegistries');
+    expect(IPC.MARKETPLACE.ADD_GENESIS_REGISTRY).toBe('marketplace:addGenesisRegistry');
+    expect(IPC.MARKETPLACE.REFRESH_GENESIS_REGISTRY).toBe('marketplace:refreshGenesisRegistry');
+    expect(IPC.MARKETPLACE.SET_GENESIS_REGISTRY_ENABLED).toBe('marketplace:setGenesisRegistryEnabled');
+    expect(IPC.MARKETPLACE.REMOVE_GENESIS_REGISTRY).toBe('marketplace:removeGenesisRegistry');
+
+    expect(IPC.TOOLS.LIST).toBe('tools:list');
+    expect(IPC.TOOLS.INSTALL).toBe('tools:install');
+    expect(IPC.TOOLS.UNINSTALL).toBe('tools:uninstall');
+
+    expect(IPC.CHATROOM.SEND).toBe('chatroom:send');
+    expect(IPC.CHATROOM.HISTORY).toBe('chatroom:history');
+    expect(IPC.CHATROOM.TASK_LEDGER).toBe('chatroom:task-ledger');
+    expect(IPC.CHATROOM.CLEAR).toBe('chatroom:clear');
+    expect(IPC.CHATROOM.STOP).toBe('chatroom:stop');
+    expect(IPC.CHATROOM.SET_ORCHESTRATION).toBe('chatroom:set-orchestration');
+    expect(IPC.CHATROOM.GET_ORCHESTRATION).toBe('chatroom:get-orchestration');
+    expect(IPC.CHATROOM.EVENT).toBe('chatroom:event');
+    expect(IPC.CHATROOM.SET_MIND_ENABLED).toBe('chatroom:set-mind-enabled');
+    expect(IPC.CHATROOM.GET_DISABLED_MIND_IDS).toBe('chatroom:get-disabled-mind-ids');
+    expect(IPC.CHATROOM.STATE_CHANGED).toBe('chatroom:state-changed');
+
+    expect(IPC.UPDATER.GET_STATE).toBe('updater:get-state');
+    expect(IPC.UPDATER.CHECK).toBe('updater:check');
+    expect(IPC.UPDATER.DOWNLOAD).toBe('updater:download');
+    expect(IPC.UPDATER.INSTALL_AND_RESTART).toBe('updater:install-and-restart');
+    expect(IPC.UPDATER.STATE_CHANGED).toBe('updater:state-changed');
+
+    expect(IPC.A2A.INCOMING).toBe('a2a:incoming');
+    expect(IPC.A2A.LIST_AGENTS).toBe('a2a:listAgents');
+    expect(IPC.A2A.TASK_STATUS_UPDATE).toBe('a2a:task-status-update');
+    expect(IPC.A2A.TASK_ARTIFACT_UPDATE).toBe('a2a:task-artifact-update');
+    expect(IPC.A2A.GET_TASK).toBe('a2a:getTask');
+    expect(IPC.A2A.LIST_TASKS).toBe('a2a:listTasks');
+    expect(IPC.A2A.CANCEL_TASK).toBe('a2a:cancelTask');
+
+    expect(IPC.WINDOW.MINIMIZE).toBe('window:minimize');
+    expect(IPC.WINDOW.MAXIMIZE).toBe('window:maximize');
+    expect(IPC.WINDOW.CLOSE).toBe('window:close');
+
+    expect(IPC.DESKTOP.GET_BRANDING).toBe('desktop:getBranding');
+    expect(IPC.DESKTOP.CONFIRM).toBe('desktop:confirm');
+
+    expect(IPC.E2E.IS_ENABLED).toBe('e2e:is-enabled');
+    expect(IPC.E2E.A2A_INCOMING).toBe('e2e:a2a:incoming');
+    expect(IPC.E2E.AUTH_EMIT_PROGRESS).toBe('e2e:auth:emit-progress');
+    expect(IPC.E2E.AUTH_COMPLETE_LOGIN).toBe('e2e:auth:complete-login');
+  });
+
+  it('exposes channels as readonly literals via IpcChannel', () => {
+    expectTypeOf<typeof IPC.CHAT.SEND>().toEqualTypeOf<'chat:send'>();
+    expectTypeOf<'chat:send'>().toMatchTypeOf<IpcChannel>();
+    expectTypeOf<'chatroom:set-orchestration'>().toMatchTypeOf<IpcChannel>();
+    // Sanity: an unrelated string is not assignable to IpcChannel.
+    expectTypeOf<'not:a:channel'>().not.toMatchTypeOf<IpcChannel>();
+  });
+
+  it('has no duplicate channel strings across namespaces', () => {
+    const all: string[] = [];
+    for (const ns of Object.values(IPC)) {
+      for (const value of Object.values(ns)) {
+        all.push(value);
+      }
+    }
+    const unique = new Set(all);
+    expect(unique.size).toBe(all.length);
+  });
+});

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -1,0 +1,129 @@
+/**
+ * Centralized IPC channel constants.
+ *
+ * Every channel string used between the desktop main process, preload, and
+ * renderer must be declared here and consumed via the `IPC` object so there
+ * is a single source of truth for channel names. Adding a new channel: pick
+ * the appropriate namespace (or add one), add the constant, and use it from
+ * both ends of the IPC.
+ *
+ * The literal values must remain stable — they are part of the IPC wire
+ * format between main and renderer. Renaming a constant is fine; changing
+ * its string value is a breaking change.
+ */
+export const IPC = {
+  CHAT: {
+    SEND: 'chat:send',
+    STOP: 'chat:stop',
+    NEW_CONVERSATION: 'chat:newConversation',
+    LIST_MODELS: 'chat:listModels',
+    EVENT: 'chat:event',
+  },
+  CONVERSATION_HISTORY: {
+    LIST: 'conversationHistory:list',
+    RESUME: 'conversationHistory:resume',
+    RENAME: 'conversationHistory:rename',
+    DELETE: 'conversationHistory:delete',
+  },
+  MIND: {
+    ADD: 'mind:add',
+    REMOVE: 'mind:remove',
+    LIST: 'mind:list',
+    SET_ACTIVE: 'mind:setActive',
+    SET_MODEL: 'mind:setModel',
+    SELECT_DIRECTORY: 'mind:selectDirectory',
+    OPEN_WINDOW: 'mind:openWindow',
+    CHANGED: 'mind:changed',
+  },
+  LENS: {
+    GET_VIEWS: 'lens:getViews',
+    GET_VIEW_DATA: 'lens:getViewData',
+    REFRESH_VIEW: 'lens:refreshView',
+    SEND_ACTION: 'lens:sendAction',
+    GET_CANVAS_URL: 'lens:getCanvasUrl',
+    VIEWS_CHANGED: 'lens:viewsChanged',
+  },
+  AUTH: {
+    GET_STATUS: 'auth:getStatus',
+    LIST_ACCOUNTS: 'auth:listAccounts',
+    START_LOGIN: 'auth:startLogin',
+    CANCEL_LOGIN: 'auth:cancelLogin',
+    SWITCH_ACCOUNT: 'auth:switchAccount',
+    LOGOUT: 'auth:logout',
+    PROGRESS: 'auth:progress',
+    ACCOUNT_SWITCH_STARTED: 'auth:accountSwitchStarted',
+    ACCOUNT_SWITCHED: 'auth:accountSwitched',
+    LOGGED_OUT: 'auth:loggedOut',
+  },
+  GENESIS: {
+    GET_DEFAULT_PATH: 'genesis:getDefaultPath',
+    PICK_PATH: 'genesis:pickPath',
+    LIST_TEMPLATES: 'genesis:listTemplates',
+    CREATE: 'genesis:create',
+    CREATE_FROM_TEMPLATE: 'genesis:createFromTemplate',
+    PROGRESS: 'genesis:progress',
+  },
+  MARKETPLACE: {
+    LIST_GENESIS_REGISTRIES: 'marketplace:listGenesisRegistries',
+    ADD_GENESIS_REGISTRY: 'marketplace:addGenesisRegistry',
+    REFRESH_GENESIS_REGISTRY: 'marketplace:refreshGenesisRegistry',
+    SET_GENESIS_REGISTRY_ENABLED: 'marketplace:setGenesisRegistryEnabled',
+    REMOVE_GENESIS_REGISTRY: 'marketplace:removeGenesisRegistry',
+  },
+  TOOLS: {
+    LIST: 'tools:list',
+    INSTALL: 'tools:install',
+    UNINSTALL: 'tools:uninstall',
+  },
+  CHATROOM: {
+    SEND: 'chatroom:send',
+    HISTORY: 'chatroom:history',
+    TASK_LEDGER: 'chatroom:task-ledger',
+    CLEAR: 'chatroom:clear',
+    STOP: 'chatroom:stop',
+    SET_ORCHESTRATION: 'chatroom:set-orchestration',
+    GET_ORCHESTRATION: 'chatroom:get-orchestration',
+    EVENT: 'chatroom:event',
+    SET_MIND_ENABLED: 'chatroom:set-mind-enabled',
+    GET_DISABLED_MIND_IDS: 'chatroom:get-disabled-mind-ids',
+    STATE_CHANGED: 'chatroom:state-changed',
+  },
+  UPDATER: {
+    GET_STATE: 'updater:get-state',
+    CHECK: 'updater:check',
+    DOWNLOAD: 'updater:download',
+    INSTALL_AND_RESTART: 'updater:install-and-restart',
+    STATE_CHANGED: 'updater:state-changed',
+  },
+  A2A: {
+    INCOMING: 'a2a:incoming',
+    LIST_AGENTS: 'a2a:listAgents',
+    TASK_STATUS_UPDATE: 'a2a:task-status-update',
+    TASK_ARTIFACT_UPDATE: 'a2a:task-artifact-update',
+    GET_TASK: 'a2a:getTask',
+    LIST_TASKS: 'a2a:listTasks',
+    CANCEL_TASK: 'a2a:cancelTask',
+  },
+  WINDOW: {
+    MINIMIZE: 'window:minimize',
+    MAXIMIZE: 'window:maximize',
+    CLOSE: 'window:close',
+  },
+  DESKTOP: {
+    GET_BRANDING: 'desktop:getBranding',
+    CONFIRM: 'desktop:confirm',
+  },
+  E2E: {
+    IS_ENABLED: 'e2e:is-enabled',
+    A2A_INCOMING: 'e2e:a2a:incoming',
+    AUTH_EMIT_PROGRESS: 'e2e:auth:emit-progress',
+    AUTH_COMPLETE_LOGIN: 'e2e:auth:complete-login',
+  },
+} as const;
+
+type IpcNamespace = typeof IPC;
+type ChannelOf<NS extends keyof IpcNamespace> = IpcNamespace[NS][keyof IpcNamespace[NS]];
+
+export type IpcChannel = {
+  [NS in keyof IpcNamespace]: ChannelOf<NS>;
+}[keyof IpcNamespace];


### PR DESCRIPTION
## Summary

Adds a single source of truth for the IPC wire format and migrates every desktop callsite to consume it. Pure refactor — channel string literal values are byte-identical to `master`. Stack root for the IPC-hardening series #61 → #62 → #63 → #203.

## Notable changes

- New `packages/shared/src/ipc-channels.ts`: nested `IPC.<NAMESPACE>.<NAME>` const object plus an `IpcChannel` type union (literal-narrowed via `as const`).
- `packages/shared/src/ipc-channels.test.ts` pins every literal value, asserts `IpcChannel` is the literal union, and verifies channel strings are unique across namespaces.
- Migrated every `ipcMain.handle/on`, `ipcRenderer.invoke/send/sendSync`, `webContents.send`, and `createIpcListener` callsite across:
  - `apps/desktop/src/main.ts` (`window:*` / `desktop:*`)
  - `apps/desktop/src/main/ipc/{a2a,auth,chat,chatroom,conversationHistory,genesis,lens,marketplace,mind,tools,updater}.ts`
  - `apps/desktop/src/preload.ts`
- Internal `EventEmitter` event names that happen to share a string with an IPC channel (e.g. `mindManager.on('lens:viewsChanged', ...)`, `chatroomService.on('chatroom:event', ...)`) are intentionally **not** consolidated under `IPC.*` — they're an in-process bus, not the IPC wire. Each such site has an explanatory comment.
- v0.47.1 patch bump + matching CHANGELOG entry.

## Out of scope (next in the stack)

The constants are the source of truth, but `ipcMain.handle` / `ipcRenderer.invoke` / `webContents.send` still accept `string`. Constraining the wrappers to `IpcChannel` belongs naturally with #62 (shared `ElectronAPI` type) and #63 (Zod IPC validation framework).

## Closes

Closes #61

## Test evidence

- `npm run lint` — clean (tsc, eslint, depcruise: 0 violations across 354 modules)
- `npm test` — 1267 / 1267 passing across 126 files
- New `packages/shared/src/ipc-channels.test.ts` (3 tests) pins wire values, type union, and uniqueness invariant
- Existing IPC adapter tests (`apps/desktop/src/main/ipc/{a2a,auth,chatroom,genesis}.test.ts`: 52 tests) still green — assertions on raw channel strings remain correct because the constants resolve to the same literals

## Skipped smoke

No SDK / runtime / packaging / installer surface changed; `smoke:sdk` / `smoke:web` / `npm run package` not run.

## Uncle Bob review

Verdict: ship it. One in-scope consistency follow-up applied (added "internal EventEmitter, not IPC wire" comments to the remaining `mindManager.on`, `ipcEmitter.on/emit` callsites that share strings with IPC constants). Larger structural follow-up — making the IPC wrappers themselves accept only `IpcChannel` — deferred to #62 as already planned.