### PR TITLE
fix(ipc): validate chatroom:set-orchestration payload with Zod (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.49.7 (2026-05-08)
+
+### IPC
+
+- **Validate `chatroom:set-orchestration` payload with Zod** — The previously unvalidated `chatroom:set-orchestration` channel in `apps/desktop/src/main/ipc/chatroom.ts` now runs through `parseIpcArgs` (#63) with a `z.discriminatedUnion('mode', …)` schema that mirrors `OrchestrationMode` and the per-mode config interfaces from `packages/shared/src/chatroom-types.ts`. The five variants are: `concurrent`/`sequential` (config must be `undefined`); `group-chat` (optional strict `{ moderatorMindId: string, maxTurns: positive int, minRounds: non-negative int, maxSpeakerRepeats: positive int }`); `handoff` (optional strict `{ initialMindId?: string, maxHandoffHops: positive int }`); `magentic` (optional strict `{ managerMindId: string, maxSteps: positive int, allowedMindIds?: string[] }`). Per-mode config is `.optional()` because the renderer fires `setOrchestration(mode, undefined)` first when switching modes, then a second time with the auto-default config (see `apps/web/src/renderer/components/chatroom/OrchestrationPicker.tsx`). Failures surface as a `TypeError` whose message names the channel and lists every Zod issue path under `config.<field>`. 29 new tests cover the happy path for every mode (with and without config) plus the rejection lattice (unknown mode, non-string mode, unexpected config on `concurrent`/`sequential`, `null` config, wrong-type config, missing/empty/non-positive/non-integer fields, extra fields). Closes the last gap in the IPC-hardening series begun in #61/#62/#63. (#203)
+
 ## v0.49.6 (2026-05-08)
 
 ### IPC

--- a/apps/desktop/src/main/ipc/chatroom.test.ts
+++ b/apps/desktop/src/main/ipc/chatroom.test.ts
@@ -30,6 +30,7 @@ describe('Chatroom IPC', () => {
     getHistory: ReturnType<typeof vi.fn>;
     clearHistory: ReturnType<typeof vi.fn>;
     stopAll: ReturnType<typeof vi.fn>;
+    setOrchestration: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -40,6 +41,7 @@ describe('Chatroom IPC', () => {
       getHistory: vi.fn().mockReturnValue([]),
       clearHistory: vi.fn().mockResolvedValue(undefined),
       stopAll: vi.fn(),
+      setOrchestration: vi.fn(),
     });
     setupChatroomIPC(mockService as unknown as ChatroomService);
   });
@@ -146,6 +148,206 @@ describe('Chatroom IPC', () => {
       await expect(handler(EVT, '')).rejects.toThrow(/message/);
       await expect(handler(EVT, 'hello', 7)).rejects.toThrow(/model/);
       await expect(handler(EVT, 'hello', undefined, '')).rejects.toThrow(/roundId/);
+    });
+  });
+
+  describe('chatroom:set-orchestration input validation', () => {
+    it('accepts concurrent mode without config', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await handler(EVT, 'concurrent');
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('concurrent', undefined);
+    });
+
+    it('accepts sequential mode without config', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await handler(EVT, 'sequential');
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('sequential', undefined);
+    });
+
+    it('accepts group-chat mode without config (renderer fires this on first mode switch)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await handler(EVT, 'group-chat');
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('group-chat', undefined);
+    });
+
+    it('accepts handoff mode without config (renderer fires this on first mode switch)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await handler(EVT, 'handoff');
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('handoff', undefined);
+    });
+
+    it('accepts magentic mode without config (renderer fires this on first mode switch)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await handler(EVT, 'magentic');
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('magentic', undefined);
+    });
+
+    it('accepts group-chat mode with a valid config', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      const config = { moderatorMindId: 'mod-1', maxTurns: 10, minRounds: 1, maxSpeakerRepeats: 3 };
+      await handler(EVT, 'group-chat', config);
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('group-chat', config);
+    });
+
+    it('accepts handoff mode with a valid config (no initialMindId)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      const config = { maxHandoffHops: 5 };
+      await handler(EVT, 'handoff', config);
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('handoff', config);
+    });
+
+    it('accepts handoff mode with a valid config (with initialMindId)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      const config = { initialMindId: 'agent-a', maxHandoffHops: 5 };
+      await handler(EVT, 'handoff', config);
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('handoff', config);
+    });
+
+    it('accepts magentic mode with a valid config (no allowedMindIds)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      const config = { managerMindId: 'mgr-1', maxSteps: 10 };
+      await handler(EVT, 'magentic', config);
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('magentic', config);
+    });
+
+    it('accepts magentic mode with a valid config (with allowedMindIds)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      const config = { managerMindId: 'mgr-1', maxSteps: 10, allowedMindIds: ['a', 'b'] };
+      await handler(EVT, 'magentic', config);
+      expect(mockService.setOrchestration).toHaveBeenCalledWith('magentic', config);
+    });
+
+    it('rejects unknown mode without invoking the service', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'broadcast')).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-string mode without invoking the service', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 42)).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects concurrent mode with any non-undefined config (object)', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'concurrent', {})).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects concurrent mode with null config', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'concurrent', null)).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects sequential mode with any non-undefined config', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'sequential', { maxTurns: 5 })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects group-chat mode with null config', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'group-chat', null)).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects group-chat mode when config is the wrong type entirely', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'group-chat', 42)).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects group-chat mode missing required fields', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'group-chat', { moderatorMindId: 'mod-1' })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects group-chat mode with empty moderatorMindId', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'group-chat', {
+        moderatorMindId: '',
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects group-chat mode with non-positive maxTurns', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'group-chat', {
+        moderatorMindId: 'mod-1',
+        maxTurns: 0,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+      })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects group-chat mode with extra fields', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'group-chat', {
+        moderatorMindId: 'mod-1',
+        maxTurns: 10,
+        minRounds: 1,
+        maxSpeakerRepeats: 3,
+        extra: 'nope',
+      })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects handoff mode missing maxHandoffHops', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'handoff', { initialMindId: 'a' })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects handoff mode with zero maxHandoffHops', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'handoff', { maxHandoffHops: 0 })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects handoff mode with non-integer maxHandoffHops', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'handoff', { maxHandoffHops: 1.5 })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects magentic mode missing managerMindId', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'magentic', { maxSteps: 10 })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects magentic mode with zero maxSteps', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'magentic', { managerMindId: 'mgr-1', maxSteps: 0 })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('rejects magentic mode with empty-string entry in allowedMindIds', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'magentic', {
+        managerMindId: 'mgr-1',
+        maxSteps: 10,
+        allowedMindIds: ['a', ''],
+      })).rejects.toThrow(TypeError);
+      expect(mockService.setOrchestration).not.toHaveBeenCalled();
+    });
+
+    it('TypeError message names the channel for an unknown mode', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'broadcast')).rejects.toThrow(/chatroom:set-orchestration/);
+    });
+
+    it('TypeError message names the bad field for a malformed group-chat config', async () => {
+      const handler = getHandler('chatroom:set-orchestration');
+      await expect(handler(EVT, 'group-chat', { moderatorMindId: '', maxTurns: 10, minRounds: 1, maxSpeakerRepeats: 3 }))
+        .rejects.toThrow(/moderatorMindId/);
     });
   });
 

--- a/apps/desktop/src/main/ipc/chatroom.ts
+++ b/apps/desktop/src/main/ipc/chatroom.ts
@@ -2,7 +2,7 @@ import { ipcMain, BrowserWindow } from 'electron';
 import { z } from 'zod';
 import { IPC, parseIpcArgs } from '@chamber/shared';
 import type { ChatroomService } from '@chamber/services';
-import type { OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig, ChatroomStateChange } from '@chamber/shared/chatroom-types';
+import type { ChatroomStateChange } from '@chamber/shared/chatroom-types';
 
 const MAX_ROUND_ID_LENGTH = 128;
 
@@ -15,6 +15,45 @@ const sendArgsSchema = z.object({
     .max(MAX_ROUND_ID_LENGTH, `must be at most ${MAX_ROUND_ID_LENGTH} characters`)
     .optional(),
 });
+
+const groupChatConfigSchema = z
+  .object({
+    moderatorMindId: z.string().min(1),
+    maxTurns: z.number().int().positive(),
+    minRounds: z.number().int().nonnegative(),
+    maxSpeakerRepeats: z.number().int().positive(),
+  })
+  .strict();
+
+const handoffConfigSchema = z
+  .object({
+    initialMindId: z.string().min(1).optional(),
+    maxHandoffHops: z.number().int().positive(),
+  })
+  .strict();
+
+const magenticConfigSchema = z
+  .object({
+    managerMindId: z.string().min(1),
+    maxSteps: z.number().int().positive(),
+    allowedMindIds: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+// `chatroom:set-orchestration` is dispatched as two positional args
+// `(mode, config?)`. Mode is one of five string literals; config is
+// discriminated by mode. `concurrent` and `sequential` carry no config;
+// the other three modes accept their respective per-mode config or
+// nothing (the renderer fires the IPC call with `undefined` first when
+// switching modes, then a second time with the auto-default config —
+// see apps/web/src/renderer/components/chatroom/OrchestrationPicker.tsx).
+const setOrchestrationArgsSchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('concurrent'), config: z.undefined() }),
+  z.object({ mode: z.literal('sequential'), config: z.undefined() }),
+  z.object({ mode: z.literal('group-chat'), config: groupChatConfigSchema.optional() }),
+  z.object({ mode: z.literal('handoff'), config: handoffConfigSchema.optional() }),
+  z.object({ mode: z.literal('magentic'), config: magenticConfigSchema.optional() }),
+]);
 
 export function setupChatroomIPC(chatroomService: ChatroomService): void {
   ipcMain.handle(IPC.CHATROOM.SEND, async (_event, message: unknown, model?: unknown, roundId?: unknown) => {
@@ -42,8 +81,13 @@ export function setupChatroomIPC(chatroomService: ChatroomService): void {
     chatroomService.stopAll();
   });
 
-  ipcMain.handle(IPC.CHATROOM.SET_ORCHESTRATION, async (_event, mode: OrchestrationMode, config?: GroupChatConfig | HandoffConfig | MagenticConfig) => {
-    chatroomService.setOrchestration(mode, config);
+  ipcMain.handle(IPC.CHATROOM.SET_ORCHESTRATION, async (_event, mode: unknown, config?: unknown) => {
+    const parsed = parseIpcArgs(
+      IPC.CHATROOM.SET_ORCHESTRATION,
+      setOrchestrationArgsSchema,
+      { mode, config },
+    );
+    chatroomService.setOrchestration(parsed.mode, parsed.config);
   });
 
   ipcMain.handle(IPC.CHATROOM.GET_ORCHESTRATION, async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.49.6",
+  "version": "0.49.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.49.6",
+      "version": "0.49.7",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.49.6",
+  "version": "0.49.7",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
Closes #203.

Final PR in the IPC-hardening stack rooted at master:

- #234 — IPC channel constants (#61)
- #235 — Shared ElectronAPI type and typed createIpcListener (#62)
- #236 — Zod IPC validation framework (#63) `parseIpcArgs` + first two channels
- **this PR** — Zod validation for chatroom:set-orchestration

## What this changes

Before, chatroom:set-orchestration in pps/desktop/src/main/ipc/chatroom.ts forwarded the renderer-supplied mode and config straight into ChatroomService with no validation. Now it parses the payload through parseIpcArgs (#63) using a z.discriminatedUnion('mode', …) schema with five variants — one per OrchestrationMode literal.

Because the schema is a discriminated union, the inferred type is a proper sum type and there are no `as` casts at the call site:

`ts
chatroomService.setOrchestration(parsed.mode, parsed.config);
`

### Per-mode shape

| Mode | config |
| --- | --- |
| concurrent | z.undefined() — any non-undefined value rejected |
| sequential | z.undefined() — any non-undefined value rejected |
| group-chat | .optional() strict `{ moderatorMindId, maxTurns: positive int, minRounds: non-negative int, maxSpeakerRepeats: positive int }` |
| handoff | .optional() strict `{ initialMindId?, maxHandoffHops: positive int }` |
| magentic | .optional() strict `{ managerMindId, maxSteps: positive int, allowedMindIds?: string[] }` |

The three per-mode configs are .optional() (not required) because the existing renderer at pps/web/src/renderer/components/chatroom/OrchestrationPicker.tsx fires the IPC call twice when a user switches into a non-trivial mode for the first time:

1. setOrchestration(mode, undefined) — from onModeChange, before any auto-default exists.
2. setOrchestration(mode, defaultConfig) — from the picker's auto-default code, immediately after.

A schema that required config would have rejected the first call as a runtime regression. Caught by Uncle Bob review before merge.

### Error path

Failures surface as TypeError whose message names the channel and every Zod issue path under config.<field>, consistent with parseIpcArgs in #63.

## Tests

29 new tests in pps/desktop/src/main/ipc/chatroom.test.ts:

- Happy path for every mode, with and without config.
- Unknown mode, non-string mode.
- Non-undefined config on concurrent / sequential (object, `null`).
- `null` config / wrong-type config on group-chat.
- Missing required fields, empty strings, non-positive numbers, non-integer numbers, extra fields, empty-string entries inside `allowedMindIds`.
- Error-message shape: channel name and bad-field name asserted in two separate it blocks.

Verification: `npm run lint` clean (tsc + eslint + deps:check), `npm test` 1315/1315 passing locally.

## Follow-up debt

packages/services/src/chatroom/ChatroomService.setOrchestration still does its own shape sniffing via `'moderatorMindId' in config && 'maxTurns' in config` because the IPC layer used to be permissive. Now that IPC is the authority on shape, those service-side guards are redundant belt-and-suspenders. Left in place here for scope discipline; should be cleaned up in a follow-up along with tightening the service signature to a discriminated union derived from this schema.

That follow-up plus typed wrappers for the other three IPC verbs (`ipcRenderer.invoke/send`, `ipcMain.handle/on`, `webContents.send`) is the natural next slice once this stack lands.