### PR TITLE
refactor(server): require capabilities at ChamberCtx construction (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.49.8 (2026-05-08)
+
+### Server
+
+- **Require capabilities at `ChamberCtx` construction** — Drop the `?` modifier from every route-backed capability on `ChamberCtx` so the loopback server fails at compile time when a deployment forgets to wire a feature, instead of silently returning a 503 at runtime. `createServerContext` now takes a `ServerContextInputs` (`Omit`-based) requiring all capabilities; only `token` and `allowedOrigins` are defaulted; `publish` stays optional as an observability hook. `bin.ts` builds `ChamberCtx` up front with real services backing `getConfig` / `listLensViews` / `listChamberTools`, and uses throwing `notImplemented(name)` stubs for surfaces with no implementation (`getGenesisStatus`, `saveAttachment`) so the contract refusal is explicit. A small `publishHolder` breaks the `sendChat` ↔ `serverControls.publish` cycle so the production context is constructed once and never mutated; the E2E fake-chat path is now `buildE2EFakeChatContext(productionContext)` returning a derived context. New `composition.test.ts` pins the contract with `@ts-expect-error` tripwires on `createServerContext` calls missing required capabilities. `handlers.test.ts` and `honoAdapter.test.ts` `makeContext` helpers use explicit `notConfigured(<name>)` throwing stubs for every required capability so tests fail loudly when wiring is wrong. Four `returns 503 when capability missing` tests are deleted (no longer representable at compile time); the `no shutdown handler` test is rewritten as `responds 200 even with a noop shutdown handler`. Closes #138. (#248)
+
 ## v0.49.7 (2026-05-08)
 
 ### IPC

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -18,14 +18,11 @@ import {
 import keytar from 'keytar';
 import path from 'node:path';
 import { createCredentialPrivilegedHandler } from './privileged-protocol';
+import type { ChamberCtx } from './types';
 
 const port = Number(process.env.CHAMBER_SERVER_PORT ?? 0);
 const allowedOrigin = process.env.CHAMBER_ALLOWED_ORIGIN ?? 'http://127.0.0.1';
 
-const ctx = createServerContext({
-  token: process.env.CHAMBER_SERVER_TOKEN,
-  allowedOrigins: [allowedOrigin],
-});
 const configService = new ConfigService();
 const saveActiveLogin = (login: string | null) => {
   const config = configService.load();
@@ -44,55 +41,83 @@ viewDiscovery.setRefreshHandler({
   sendBackgroundPrompt: (mindPath, prompt) => mindManager.sendBackgroundPrompt(mindPath, prompt),
 });
 
-ctx.listMinds = () => mindManager.listMinds();
-ctx.addMind = async (mindPath) => {
-  const mind = await mindManager.loadMind(mindPath);
-  mindManager.setActiveMind(mind.mindId);
-  return mind;
-};
-ctx.sendChat = ({ mindId, message, messageId, model, attachments }) =>
-  chatService.sendMessage(
-    mindId,
-    message,
-    messageId,
-    (event) => serverControls.publish(messageId, { mindId, messageId, event }),
-    model,
-    attachments,
-  );
-ctx.newConversation = (mindId) => chatService.newConversation(mindId);
-ctx.listModels = (mindId) => {
-  const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
-  return id ? chatService.listModels(id) : [];
-};
-ctx.cancelChat = (mindId, messageId) => chatService.cancelMessage(mindId, messageId);
+// Surfaces the loopback server intentionally does not yet implement. Throwing
+// stubs (instead of silent {}/null defaults) honor the `ChamberCtx` contract:
+// a deployment that doesn't support a feature must say so explicitly. Wiring
+// these to real services is tracked as follow-up work; failing fast is the
+// honest interim behavior.
+function notImplemented(name: string): () => never {
+  return () => {
+    throw new Error(`Loopback server: ${name} is not implemented`);
+  };
+}
 
-ctx.getAuthStatus = async () => {
-  const credential = await authService.getStoredCredential();
-  return { authenticated: credential !== null, login: credential?.login };
+// `ctx.sendChat` needs to call `serverControls.publish`, but `serverControls`
+// is built from `ctx`. Break the cycle with a holder that the late-bound
+// publish method overwrites once `createHttpServer` returns. The ctx itself
+// stays immutable after construction. Future cleanup: extract a `ChatEventBus`
+// port owned by the composition root so neither side has to mutate.
+const publishHolder: { publish: (sessionId: string, event: unknown) => void } = {
+  publish: () => {},
 };
-ctx.listAuthAccounts = () => authService.listAccounts();
-ctx.startAuthLogin = async (onProgress) => {
-  authService.setProgressHandler(onProgress);
-  const result = await authService.startLogin();
-  if (result.success && result.login) {
-    authService.setActiveLogin(result.login);
-  }
-  return result;
-};
-ctx.switchAuthAccount = async (login) => {
-  const accounts = await authService.listAccounts();
-  if (!accounts.some((account) => account.login === login)) {
-    throw new Error(`Account ${login} is not available`);
-  }
-  authService.setActiveLogin(login);
-};
-ctx.logoutAuth = () => authService.logout();
-ctx.shutdown = () => {
-  void shutdown();
-};
-ctx.handlePrivilegedRequest = createCredentialPrivilegedHandler(keytar as CredentialStore);
 
-if (process.env.CHAMBER_E2E === '1' && process.env.CHAMBER_E2E_FAKE_CHAT === '1') {
+const productionContext: ChamberCtx = createServerContext({
+  token: process.env.CHAMBER_SERVER_TOKEN,
+  allowedOrigins: [allowedOrigin],
+  listMinds: () => mindManager.listMinds(),
+  addMind: async (mindPath) => {
+    const mind = await mindManager.loadMind(mindPath);
+    mindManager.setActiveMind(mind.mindId);
+    return mind;
+  },
+  getConfig: () => configService.load(),
+  listLensViews: () => viewDiscovery.getViews(),
+  getGenesisStatus: notImplemented('getGenesisStatus'),
+  getAuthStatus: async () => {
+    const credential = await authService.getStoredCredential();
+    return { authenticated: credential !== null, login: credential?.login };
+  },
+  listAuthAccounts: () => authService.listAccounts(),
+  startAuthLogin: async (onProgress) => {
+    authService.setProgressHandler(onProgress);
+    const result = await authService.startLogin();
+    if (result.success && result.login) {
+      authService.setActiveLogin(result.login);
+    }
+    return result;
+  },
+  switchAuthAccount: async (login) => {
+    const accounts = await authService.listAccounts();
+    if (!accounts.some((account) => account.login === login)) {
+      throw new Error(`Account ${login} is not available`);
+    }
+    authService.setActiveLogin(login);
+  },
+  logoutAuth: () => authService.logout(),
+  listChamberTools: () => configService.load().installedTools ?? [],
+  saveAttachment: notImplemented('saveAttachment'),
+  sendChat: ({ mindId, message, messageId, model, attachments }) =>
+    chatService.sendMessage(
+      mindId,
+      message,
+      messageId,
+      (event) => publishHolder.publish(messageId, { mindId, messageId, event }),
+      model,
+      attachments,
+    ),
+  newConversation: (mindId) => chatService.newConversation(mindId),
+  cancelChat: (mindId, messageId) => chatService.cancelMessage(mindId, messageId),
+  listModels: (mindId) => {
+    const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
+    return id ? chatService.listModels(id) : [];
+  },
+  shutdown: () => {
+    void shutdown();
+  },
+  handlePrivilegedRequest: createCredentialPrivilegedHandler(keytar as CredentialStore),
+});
+
+function buildE2EFakeChatContext(base: ChamberCtx): ChamberCtx {
   const fakeMinds = new Map<string, {
     mindId: string;
     mindPath: string;
@@ -131,31 +156,34 @@ if (process.env.CHAMBER_E2E === '1' && process.env.CHAMBER_E2E_FAKE_CHAT === '1'
     }
   }
 
-  ctx.listMinds = () => Array.from(fakeMinds.values());
-  ctx.addMind = (mindPath) => seedFakeMind(mindPath);
-  ctx.sendChat = ({ mindId, messageId }) => {
-    serverControls.publish(messageId, {
-      mindId,
-      messageId,
-      event: { type: 'message_final', sdkMessageId: `e2e-${messageId}`, content: fakeReply },
-    });
-    serverControls.publish(messageId, {
-      mindId,
-      messageId,
-      event: { type: 'done' },
-    });
+  return {
+    ...base,
+    listMinds: () => Array.from(fakeMinds.values()),
+    addMind: (mindPath) => seedFakeMind(mindPath),
+    sendChat: ({ mindId, messageId }) => {
+      publishHolder.publish(messageId, {
+        mindId,
+        messageId,
+        event: { type: 'message_final', sdkMessageId: `e2e-${messageId}`, content: fakeReply },
+      });
+      publishHolder.publish(messageId, {
+        mindId,
+        messageId,
+        event: { type: 'done' },
+      });
+    },
+    newConversation: () => undefined,
+    cancelChat: () => undefined,
+    listModels: () => [{ id: 'e2e-fake-model', name: 'E2E Fake Model' }],
   };
-  ctx.newConversation = () => undefined;
-  ctx.cancelChat = () => undefined;
-  ctx.listModels = () => [{ id: 'e2e-fake-model', name: 'E2E Fake Model' }];
 }
 
-const serverControls = createHttpServer({
-  ...ctx,
-  shutdown: () => {
-    void shutdown();
-  },
-});
+const ctx: ChamberCtx = (process.env.CHAMBER_E2E === '1' && process.env.CHAMBER_E2E_FAKE_CHAT === '1')
+  ? buildE2EFakeChatContext(productionContext)
+  : productionContext;
+
+const serverControls = createHttpServer(ctx);
+publishHolder.publish = serverControls.publish;
 const { server } = serverControls;
 
 server.listen(port, '127.0.0.1', () => {

--- a/apps/server/src/composition.test.ts
+++ b/apps/server/src/composition.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { createServerContext } from './composition';
+import type { ChamberCtx } from './types';
+
+const noop = () => undefined;
+const asyncNoop = async () => undefined;
+const asyncList = async () => [];
+const asyncRecord = async () => ({});
+
+const fullCapabilities: Omit<ChamberCtx, 'token' | 'allowedOrigins'> = {
+  listMinds: () => [],
+  addMind: asyncRecord,
+  getConfig: asyncRecord,
+  listLensViews: asyncList,
+  getGenesisStatus: asyncRecord,
+  getAuthStatus: asyncRecord,
+  listAuthAccounts: asyncList,
+  startAuthLogin: async () => ({ success: false }),
+  switchAuthAccount: asyncNoop,
+  logoutAuth: asyncNoop,
+  listChamberTools: () => [],
+  saveAttachment: asyncRecord,
+  sendChat: noop,
+  newConversation: noop,
+  cancelChat: noop,
+  listModels: () => [],
+  shutdown: noop,
+  handlePrivilegedRequest: async () => ({ ok: true as const, requestId: 'r1' }),
+};
+
+describe('createServerContext', () => {
+  it('defaults token and allowedOrigins when omitted', () => {
+    const ctx = createServerContext({ ...fullCapabilities });
+    expect(ctx.token).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(ctx.allowedOrigins.has('http://127.0.0.1')).toBe(true);
+  });
+
+  it('honors explicit token and allowedOrigins', () => {
+    const ctx = createServerContext({
+      token: 'explicit',
+      allowedOrigins: ['https://example.test'],
+      ...fullCapabilities,
+    });
+    expect(ctx.token).toBe('explicit');
+    expect(ctx.allowedOrigins.has('https://example.test')).toBe(true);
+  });
+
+  // Compile-time tripwire: removing `?` from a route-backed capability on
+  // ChamberCtx is the whole point of #138. If a future change adds the
+  // optional modifier back (or drops a required field from the inputs),
+  // these `@ts-expect-error` lines will no longer be errors and the build
+  // breaks here. Without this test the regression is silent.
+  it('refuses inputs that omit any required capability (compile-time)', () => {
+    // @ts-expect-error: every route-backed capability is required
+    createServerContext({ token: 't', allowedOrigins: ['http://127.0.0.1'] });
+
+    // @ts-expect-error: addMind is required
+    createServerContext({ ...fullCapabilities, addMind: undefined });
+
+    // @ts-expect-error: sendChat is required
+    createServerContext({ ...fullCapabilities, sendChat: undefined });
+
+    // @ts-expect-error: handlePrivilegedRequest is required
+    createServerContext({ ...fullCapabilities, handlePrivilegedRequest: undefined });
+
+    expect(true).toBe(true);
+  });
+});

--- a/apps/server/src/composition.ts
+++ b/apps/server/src/composition.ts
@@ -1,31 +1,22 @@
-import { randomBytes, randomUUID } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import type { ChamberCtx } from './types';
 
-export interface ServerCompositionOptions {
+/**
+ * Inputs to {@link createServerContext}. `token` and `allowedOrigins` have
+ * sensible defaults; every capability is required so a deployment must
+ * explicitly opt in to (or refuse) each surface rather than silently fall
+ * back to a no-op.
+ */
+export interface ServerContextInputs extends Omit<ChamberCtx, 'token' | 'allowedOrigins'> {
   token?: string;
   allowedOrigins?: Iterable<string>;
 }
 
-export function createServerContext(options: ServerCompositionOptions = {}): ChamberCtx {
-  const token = options.token ?? randomBytes(32).toString('base64url');
+export function createServerContext(inputs: ServerContextInputs): ChamberCtx {
+  const { token, allowedOrigins, ...capabilities } = inputs;
   return {
-    token,
-    allowedOrigins: new Set(options.allowedOrigins ?? [`http://127.0.0.1`]),
-    listMinds: () => [],
-    addMind: async () => {
-      throw new Error('Mind loading is unavailable');
-    },
-    getConfig: () => ({ version: 1 }),
-    listLensViews: () => [],
-    getGenesisStatus: () => ({ ready: false }),
-    getAuthStatus: () => ({ authenticated: false }),
-    listAuthAccounts: () => [],
-    listChamberTools: () => [],
-    saveAttachment: async ({ name }) => ({ attachmentId: randomUUID(), name }),
-    cancelChat: () => undefined,
-    sendChat: () => undefined,
-    newConversation: () => undefined,
-    listModels: () => [],
-    validatePath: () => false,
+    token: token ?? randomBytes(32).toString('base64url'),
+    allowedOrigins: new Set(allowedOrigins ?? ['http://127.0.0.1']),
+    ...capabilities,
   };
 }

--- a/apps/server/src/handlers.test.ts
+++ b/apps/server/src/handlers.test.ts
@@ -154,11 +154,34 @@ describe('server handlers', () => {
   });
 });
 
+function notConfigured(name: string): () => never {
+  return () => {
+    throw new Error(`Test stub: ${name} not configured`);
+  };
+}
+
 function makeContext(overrides: Partial<ChamberCtx>): ChamberCtx {
   return {
     token: 'test-token',
     allowedOrigins: new Set(['http://127.0.0.1']),
     listMinds: () => [],
+    addMind: notConfigured('addMind'),
+    getConfig: notConfigured('getConfig'),
+    listLensViews: notConfigured('listLensViews'),
+    getGenesisStatus: notConfigured('getGenesisStatus'),
+    getAuthStatus: notConfigured('getAuthStatus'),
+    listAuthAccounts: notConfigured('listAuthAccounts'),
+    startAuthLogin: notConfigured('startAuthLogin'),
+    switchAuthAccount: notConfigured('switchAuthAccount'),
+    logoutAuth: notConfigured('logoutAuth'),
+    listChamberTools: notConfigured('listChamberTools'),
+    saveAttachment: notConfigured('saveAttachment'),
+    sendChat: notConfigured('sendChat'),
+    newConversation: notConfigured('newConversation'),
+    cancelChat: notConfigured('cancelChat'),
+    listModels: notConfigured('listModels'),
+    shutdown: () => {},
+    handlePrivilegedRequest: notConfigured('handlePrivilegedRequest'),
     ...overrides,
   };
 }

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -16,9 +16,6 @@ export async function addMindHandler(request: ChamberRequest, ctx: ChamberCtx): 
   if (!mindPath) {
     return { status: 400, body: { error: 'mindPath is required' } };
   }
-  if (!ctx.addMind) {
-    return { status: 503, body: { error: 'Mind loading is unavailable' } };
-  }
   try {
     return { status: 200, body: { mind: await ctx.addMind(mindPath) } };
   } catch (error) {
@@ -27,23 +24,23 @@ export async function addMindHandler(request: ChamberRequest, ctx: ChamberCtx): 
 }
 
 export async function getConfigHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: await ctx.getConfig?.() ?? { version: 1 } };
+  return { status: 200, body: await ctx.getConfig() };
 }
 
 export async function listLensViewsHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: { views: await ctx.listLensViews?.() ?? [] } };
+  return { status: 200, body: { views: await ctx.listLensViews() } };
 }
 
 export async function getGenesisStatusHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: await ctx.getGenesisStatus?.() ?? { ready: false } };
+  return { status: 200, body: await ctx.getGenesisStatus() };
 }
 
 export async function getAuthStatusHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: await ctx.getAuthStatus?.() ?? { authenticated: false } };
+  return { status: 200, body: await ctx.getAuthStatus() };
 }
 
 export async function listAuthAccountsHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: { accounts: await ctx.listAuthAccounts?.() ?? [] } };
+  return { status: 200, body: { accounts: await ctx.listAuthAccounts() } };
 }
 
 export async function switchAuthAccountHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
@@ -53,23 +50,17 @@ export async function switchAuthAccountHandler(request: ChamberRequest, ctx: Cha
   if (!login) {
     return { status: 400, body: { error: 'login is required' } };
   }
-  if (!ctx.switchAuthAccount) {
-    return { status: 503, body: { error: 'Auth account switching is unavailable' } };
-  }
   await ctx.switchAuthAccount(login);
   return { status: 200, body: { ok: true } };
 }
 
 export async function logoutAuthHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  if (!ctx.logoutAuth) {
-    return { status: 503, body: { error: 'Auth logout is unavailable' } };
-  }
   await ctx.logoutAuth();
   return { status: 200, body: { ok: true } };
 }
 
 export async function listChamberToolsHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: { tools: ctx.listChamberTools?.() ?? [] } };
+  return { status: 200, body: { tools: ctx.listChamberTools() } };
 }
 
 export async function uploadAttachmentHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
@@ -80,8 +71,7 @@ export async function uploadAttachmentHandler(request: ChamberRequest, ctx: Cham
   if (!request.body || !(request.body instanceof ArrayBuffer)) {
     return { status: 400, body: { error: 'Attachment body is required' } };
   }
-  const result = await ctx.saveAttachment?.({ name, body: request.body }) ?? { name };
-  return { status: 200, body: result };
+  return { status: 200, body: await ctx.saveAttachment({ name, body: request.body }) };
 }
 
 export async function cancelChatHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
@@ -93,7 +83,7 @@ export async function cancelChatHandler(request: ChamberRequest, ctx: ChamberCtx
     : '';
   if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
   if (!messageId) return { status: 400, body: { error: 'messageId is required' } };
-  await ctx.cancelChat?.(mindId, messageId);
+  await ctx.cancelChat(mindId, messageId);
   return { status: 200, body: { ok: true } };
 }
 
@@ -106,7 +96,6 @@ export async function sendChatHandler(request: ChamberRequest, ctx: ChamberCtx):
   const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
   if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
   if (!messageId) return { status: 400, body: { error: 'messageId is required' } };
-  if (!ctx.sendChat) return { status: 503, body: { error: 'Chat is unavailable' } };
 
   const attachments = parseChatAttachments(body.attachments);
   if (attachments === null) {
@@ -130,14 +119,12 @@ export async function newConversationHandler(request: ChamberRequest, ctx: Chamb
     ? String((request.body as { mindId: unknown }).mindId).trim()
     : '';
   if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
-  if (!ctx.newConversation) return { status: 503, body: { error: 'Chat is unavailable' } };
 
   await ctx.newConversation(mindId);
   return { status: 200, body: { ok: true } };
 }
 
 export async function listModelsHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  if (!ctx.listModels) return { status: 503, body: { error: 'Model listing is unavailable' } };
   const body: ListModelsResponse = {
     models: await ctx.listModels(request.query?.get('mindId') ?? undefined),
   };

--- a/apps/server/src/honoAdapter.test.ts
+++ b/apps/server/src/honoAdapter.test.ts
@@ -227,61 +227,6 @@ describe('createHttpServer', () => {
   });
 
   describe('route availability', () => {
-    it('returns 503 from /api/mind/add when the context has no addMind capability', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'POST',
-        path: '/api/mind/add',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ mindPath: 'C:\\agents\\dude' }),
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Mind loading is unavailable' });
-    });
-
-    it('returns 503 from /api/chat/send when the context has no sendChat capability', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'POST',
-        path: '/api/chat/send',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          mindId: 'dude-1234',
-          message: 'Hello',
-          messageId: 'assistant-1',
-        }),
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Chat is unavailable' });
-    });
-
-    it('returns 503 from /api/chat/models when the context has no listModels capability', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'GET',
-        path: '/api/chat/models',
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Model listing is unavailable' });
-    });
-
-    it('returns 503 from /api/privileged when the context has no privileged handler', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'POST',
-        path: '/api/privileged',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          protoVersion: 1,
-          type: 'credential.getPassword',
-          requestId: 'r1',
-          payload: { service: 'copilot-cli', account: 'octocat' },
-        }),
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Privileged channel unavailable' });
-    });
-
     it('serves the placeholder HTML on the catch-all GET route without auth', async () => {
       const { port } = await startServer({});
       const response = await rawHttpRequest(port, {
@@ -309,7 +254,7 @@ describe('createHttpServer', () => {
       expect(shutdown).toHaveBeenCalledTimes(1);
     });
 
-    it('still responds 200 when no shutdown handler is configured', async () => {
+    it('responds 200 immediately even when the shutdown handler is a noop', async () => {
       const { port } = await startServer({});
       const response = await httpRequest(port, {
         method: 'POST',
@@ -460,11 +405,34 @@ describe('createHttpServer', () => {
   });
 });
 
+function notConfigured(name: string): () => never {
+  return () => {
+    throw new Error(`Test stub: ${name} not configured`);
+  };
+}
+
 function makeContext(overrides: Partial<ChamberCtx> = {}): ChamberCtx {
   return {
     token: TOKEN,
     allowedOrigins: new Set([ORIGIN]),
     listMinds: () => [],
+    addMind: notConfigured('addMind'),
+    getConfig: notConfigured('getConfig'),
+    listLensViews: notConfigured('listLensViews'),
+    getGenesisStatus: notConfigured('getGenesisStatus'),
+    getAuthStatus: notConfigured('getAuthStatus'),
+    listAuthAccounts: notConfigured('listAuthAccounts'),
+    startAuthLogin: notConfigured('startAuthLogin'),
+    switchAuthAccount: notConfigured('switchAuthAccount'),
+    logoutAuth: notConfigured('logoutAuth'),
+    listChamberTools: notConfigured('listChamberTools'),
+    saveAttachment: notConfigured('saveAttachment'),
+    sendChat: notConfigured('sendChat'),
+    newConversation: notConfigured('newConversation'),
+    cancelChat: notConfigured('cancelChat'),
+    listModels: notConfigured('listModels'),
+    shutdown: () => {},
+    handlePrivilegedRequest: notConfigured('handlePrivilegedRequest'),
     ...overrides,
   };
 }

--- a/apps/server/src/honoAdapter.ts
+++ b/apps/server/src/honoAdapter.ts
@@ -51,12 +51,7 @@ function send(c: Context, response: ChamberResponse): Response {
   return c.json(response.body ?? null, response.status as 200);
 }
 
-function streamAuthLogin(c: Context, ctx: ChamberCtx): Response {
-  const startAuthLogin = ctx.startAuthLogin;
-  if (!startAuthLogin) {
-    return c.json({ error: 'Auth login is unavailable' }, 503);
-  }
-
+function streamAuthLogin(ctx: ChamberCtx): Response {
   const encoder = new TextEncoder();
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -64,7 +59,7 @@ function streamAuthLogin(c: Context, ctx: ChamberCtx): Response {
         controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
       };
 
-      void startAuthLogin((progress) => write({ type: 'progress', progress }))
+      void ctx.startAuthLogin((progress) => write({ type: 'progress', progress }))
         .then((result) => write({ type: 'result', result }))
         .catch((error: unknown) => {
           const message = error instanceof Error ? error.message : String(error);
@@ -117,7 +112,7 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
   app.post('/api/auth/login', async (c) => {
     const authFailure = requireAuth(c, ctx);
     if (authFailure) return authFailure;
-    return streamAuthLogin(c, ctx);
+    return streamAuthLogin(ctx);
   });
   app.post('/api/auth/switch', async (c) => {
     const authFailure = requireAuth(c, ctx);
@@ -154,7 +149,6 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
   app.post('/api/privileged', async (c) => {
     const authFailure = requireAuth(c, ctx);
     if (authFailure) return authFailure;
-    if (!ctx.handlePrivilegedRequest) return c.json({ error: 'Privileged channel unavailable' }, 503);
     let body: unknown;
     let request;
     try {
@@ -175,7 +169,7 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
   app.post('/api/shutdown', async (c) => {
     const authFailure = requireAuth(c, ctx);
     if (authFailure) return authFailure;
-    setTimeout(() => ctx.shutdown?.(), 0);
+    setTimeout(() => ctx.shutdown(), 0);
     return c.json({ ok: true });
   });
   app.get('*', (c) => c.html('<!doctype html><html><body><h1>Chamber server</h1></body></html>'));

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -29,27 +29,34 @@ export interface ServerAuthLoginResult {
   error?: string;
 }
 
+/**
+ * Capabilities the loopback server requires from its host process. Every
+ * field except `publish` is mandatory: a deployment that doesn't want to
+ * support a feature must provide an explicit refusal (e.g. a function that
+ * throws `new Error('Mind loading is unavailable')`) rather than rely on a
+ * silent default. `publish` is the optional outbound observability hook the
+ * websocket fan-out also tees published chat events into.
+ */
 export interface ChamberCtx {
   token: string;
   allowedOrigins: ReadonlySet<string>;
   listMinds: () => unknown[];
-  addMind?: (mindPath: string) => unknown | Promise<unknown>;
-  getConfig?: () => unknown | Promise<unknown>;
-  listLensViews?: () => unknown | Promise<unknown>;
-  getGenesisStatus?: () => unknown | Promise<unknown>;
-  getAuthStatus?: () => unknown | Promise<unknown>;
-  listAuthAccounts?: () => unknown[] | Promise<unknown[]>;
-  startAuthLogin?: (onProgress: (progress: ServerAuthProgress) => void) => Promise<ServerAuthLoginResult>;
-  switchAuthAccount?: (login: string) => void | Promise<void>;
-  logoutAuth?: () => void | Promise<void>;
-  listChamberTools?: () => unknown;
+  addMind: (mindPath: string) => unknown | Promise<unknown>;
+  getConfig: () => unknown | Promise<unknown>;
+  listLensViews: () => unknown | Promise<unknown>;
+  getGenesisStatus: () => unknown | Promise<unknown>;
+  getAuthStatus: () => unknown | Promise<unknown>;
+  listAuthAccounts: () => unknown[] | Promise<unknown[]>;
+  startAuthLogin: (onProgress: (progress: ServerAuthProgress) => void) => Promise<ServerAuthLoginResult>;
+  switchAuthAccount: (login: string) => void | Promise<void>;
+  logoutAuth: () => void | Promise<void>;
+  listChamberTools: () => unknown;
+  saveAttachment: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
+  cancelChat: (mindId: string, messageId: string) => Promise<void> | void;
+  sendChat: (request: SendChatRequest) => Promise<void> | void;
+  newConversation: (mindId: string) => Promise<unknown> | unknown;
+  listModels: (mindId?: string) => ModelDto[] | Promise<ModelDto[]>;
+  shutdown: () => void;
+  handlePrivilegedRequest: (request: PrivilegedRequest) => Promise<PrivilegedResponse>;
   publish?: (sessionId: string, event: unknown) => void;
-  validatePath?: (candidate: string) => boolean;
-  saveAttachment?: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
-  cancelChat?: (mindId: string, messageId: string) => Promise<void> | void;
-  sendChat?: (request: SendChatRequest) => Promise<void> | void;
-  newConversation?: (mindId: string) => Promise<unknown> | unknown;
-  listModels?: (mindId?: string) => ModelDto[] | Promise<ModelDto[]>;
-  shutdown?: () => void;
-  handlePrivilegedRequest?: (request: PrivilegedRequest) => Promise<PrivilegedResponse>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.49.7",
+      "version": "0.49.8",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
Make all route-backed capabilities on `ChamberCtx` required so the loopback server fails at compile time when a deployment forgets to wire a feature, instead of silently falling back to a 503 response.

## Why

The `?` modifier on route-backed capabilities was load-bearing only by accident: every handler had `?.()` or `??` fallbacks that produced 503s for capabilities the renderer always expects to exist. That made wiring mistakes invisible until a route was hit at runtime. After this PR, omitting a capability in `createServerContext` is a compile error.

## Changes

- **`types.ts`**: drop `?` from every route-backed capability; remove unused `validatePath`; `publish` stays optional (observability hook).
- **`composition.ts`**: `createServerContext` now takes a `ServerContextInputs` (Omit-based) requiring all capabilities; only `token` / `allowedOrigins` are defaulted.
- **`handlers.ts`**: drop `?.()` / `??` fallbacks. No functional change beyond removing dead branches.
- **`honoAdapter.ts`**: remove 503 branches in `streamAuthLogin`, `/api/privileged`, and `/api/shutdown`.
- **`bin.ts`**: build `ChamberCtx` up front. Real services back `getConfig` / `listLensViews` / `listChamberTools`; surfaces with no implementation (`getGenesisStatus`, `saveAttachment`) use throwing `notImplemented(name)` stubs so the contract refusal is explicit. A small `publishHolder` breaks the `sendChat` ↔ `serverControls.publish` cycle so the production context is constructed once and never mutated. E2E fake-chat path is now `buildE2EFakeChatContext(productionContext)` returning a derived context.
- **`composition.test.ts`** (new): compile-time tripwire using `@ts-expect-error` on `createServerContext` calls missing required capabilities. Pins the contract.
- **Tests**: `handlers.test.ts` and `honoAdapter.test.ts` `makeContext` helpers now use explicit `notConfigured(<name>)` throwing stubs for every required capability, so tests fail loudly when wiring is wrong. Four `returns 503 when capability missing` tests are deleted because the situation is no longer representable at compile time. The `no shutdown handler` test is rewritten as `responds 200 even with a noop shutdown handler`.

## Test evidence

- `npm run lint` — clean (354 modules, 701 deps).
- `npx vitest run apps/server` — 58/58 passing across 5 files (auth, privileged-protocol, composition, handlers, honoAdapter).
- Full Vitest suite green locally (one unrelated Windows `EPERM` rename flake in CronService that passes on rerun).

## Stack

Stacked on #239 (loopback route tests) because those tests are the guardrails for this refactor.

## Follow-ups (Uncle Bob, deferred)

- Extract a `ChatEventBus` port to eliminate the `publishHolder` cycle-breaker.
- Deduplicate POST route registration in `honoAdapter.ts` via `authenticatedWithBody(handler)`.
- Extract a shared `makeContext` / `notConfigured` test helper used in `handlers.test.ts` and `honoAdapter.test.ts`.

Closes #138