### PR TITLE
refactor(auth): per-request AuthService.startLogin and instance user agent (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.49.9 (2026-05-08)
+
+### Auth
+
+- **Per-request `AuthService.startLogin`** — `AuthService` no longer stores `onProgress` and abort state on the instance; `startLogin({ onProgress, signal })` accepts a per-attempt callback and an `AbortSignal`. Concurrent login attempts (browser + server, or two browser tabs) now have isolated progress streams and cancellation. The desktop IPC handler tracks an `AbortController` per in-flight `auth:startLogin` and aborts all of them on `auth:cancelLogin`. Removes `setProgressHandler` and `abort()` from the public surface. (#139)
+- **Instance-scoped GitHub user agent** — Removed the static `AuthService.userAgent` global. `AuthService`, `GitHubRegistryClient`, and `GitHubReleaseAssetClient` each accept a `userAgent` constructor option (default `'Chamber'`). The desktop and server composition roots thread the same `Chamber/${version}` string through all three. Eliminates an order-dependent module-level mutation that could leak the wrong user agent between processes. (#139)
+
 ## v0.49.8 (2026-05-08)
 
 ### Server

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -146,12 +146,13 @@ const saveActiveLogin = (login: string | null) => {
 };
 const credentialStore = loadKeytar();
 const sharp = loadSharp();
-const githubRegistryClient = GitHubRegistryClient.withCredentialStore(credentialStore);
+const userAgent = `Chamber/${app.getVersion()}`;
+const githubRegistryClient = GitHubRegistryClient.withCredentialStore(credentialStore, userAgent);
 const authService = new AuthService(
   credentialStore,
   () => configService.load().activeLogin,
   saveActiveLogin,
-  `Chamber/${app.getVersion()}`,
+  userAgent,
 );
 const scaffold = new MindScaffold();
 const genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(githubRegistryClient, getGenesisMarketplaceSources);
@@ -162,7 +163,7 @@ const toolsService = new ToolsService(
   marketplaceToolCatalog,
   new ToolInstaller(
     new ChildProcessRunner(),
-    GitHubReleaseAssetClient.withCredentialStore(credentialStore),
+    GitHubReleaseAssetClient.withCredentialStore(credentialStore, userAgent),
     chamberToolsBinDir,
   ),
   configService,

--- a/apps/desktop/src/main/ipc/auth.test.ts
+++ b/apps/desktop/src/main/ipc/auth.test.ts
@@ -15,11 +15,9 @@ function createFakeAuth() {
   return {
     getStoredCredential: vi.fn().mockResolvedValue(null),
     listAccounts: vi.fn().mockResolvedValue([]),
-    setProgressHandler: vi.fn(),
     startLogin: vi.fn().mockResolvedValue({ success: true }),
     logout: vi.fn().mockResolvedValue(undefined),
     setActiveLogin: vi.fn(),
-    abort: vi.fn(),
   } as unknown as AuthService;
 }
 
@@ -143,14 +141,95 @@ describe('setupAuthIPC', () => {
     expect(mockSend).toHaveBeenCalledTimes(2);
   });
 
-  it('BVT-13: auth:cancelLogin handler calls authService.abort()', async () => {
+  it('BVT-13: auth:cancelLogin handler aborts the in-flight startLogin AbortSignal', async () => {
     const fakeAuth = createFakeAuth();
+    // Resolve startLogin only when its signal aborts, so we can prove the
+    // cancel handler delivered the abort to the per-attempt controller (#139).
+    fakeAuth.startLogin = vi.fn().mockImplementation(({ signal }: { signal?: AbortSignal }) =>
+      new Promise<{ success: boolean }>((resolve) => {
+        signal?.addEventListener('abort', () => resolve({ success: false }));
+      }),
+    ) as unknown as AuthService['startLogin'];
     setupAuthIPC(fakeAuth, createFakeMindManager());
 
+    const startCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:startLogin');
     const cancelCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:cancelLogin');
+    expect(startCall).toBeDefined();
     expect(cancelCall).toBeDefined();
+
+    const startPromise = startCall![1]({ sender: {} } as never, ...([] as unknown[]));
+    await Promise.resolve();
     await cancelCall![1]({} as never, ...([] as unknown[]));
-    expect(fakeAuth.abort).toHaveBeenCalled();
+
+    await expect(startPromise).resolves.toEqual({ success: false });
+    const startArgs = vi.mocked(fakeAuth.startLogin).mock.calls[0]![0] as { signal?: AbortSignal };
+    expect(startArgs.signal?.aborted).toBe(true);
+  });
+
+  it('BVT-13a: concurrent auth:startLogin invocations each get an isolated AbortController; cancel aborts all of them (#139)', async () => {
+    const fakeAuth = createFakeAuth();
+    // Each startLogin call resolves only when its OWN signal aborts. If the
+    // IPC handler accidentally shares one controller across attempts (the
+    // pre-#139 bug), the second call would inherit the first call's signal
+    // and either both signals would point at the same instance or only one
+    // would abort.
+    fakeAuth.startLogin = vi.fn().mockImplementation(({ signal }: { signal?: AbortSignal }) =>
+      new Promise<{ success: boolean }>((resolve) => {
+        signal?.addEventListener('abort', () => resolve({ success: false }));
+      }),
+    ) as unknown as AuthService['startLogin'];
+    setupAuthIPC(fakeAuth, createFakeMindManager());
+
+    const startCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:startLogin');
+    const cancelCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:cancelLogin');
+    expect(startCall).toBeDefined();
+    expect(cancelCall).toBeDefined();
+
+    const first = startCall![1]({ sender: {} } as never, ...([] as unknown[]));
+    const second = startCall![1]({ sender: {} } as never, ...([] as unknown[]));
+    await Promise.resolve();
+
+    const calls = vi.mocked(fakeAuth.startLogin).mock.calls;
+    expect(calls.length).toBe(2);
+    const firstSignal = (calls[0]![0] as { signal?: AbortSignal }).signal;
+    const secondSignal = (calls[1]![0] as { signal?: AbortSignal }).signal;
+    expect(firstSignal).toBeDefined();
+    expect(secondSignal).toBeDefined();
+    // Per-attempt isolation: each invocation owns a distinct signal.
+    expect(firstSignal).not.toBe(secondSignal);
+    expect(firstSignal!.aborted).toBe(false);
+    expect(secondSignal!.aborted).toBe(false);
+
+    await cancelCall![1]({} as never, ...([] as unknown[]));
+
+    await expect(first).resolves.toEqual({ success: false });
+    await expect(second).resolves.toEqual({ success: false });
+    expect(firstSignal!.aborted).toBe(true);
+    expect(secondSignal!.aborted).toBe(true);
+  });
+
+  it('BVT-13b: auth:cancelLogin after a successful startLogin does NOT abort the already-finished signal (no inflight leak) (#139)', async () => {
+    const fakeAuth = createFakeAuth();
+    fakeAuth.startLogin = vi.fn().mockResolvedValue({ success: true, login: 'alice' });
+    setupAuthIPC(fakeAuth, createFakeMindManager());
+
+    const startCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:startLogin');
+    const cancelCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:cancelLogin');
+    expect(startCall).toBeDefined();
+    expect(cancelCall).toBeDefined();
+
+    await expect(
+      startCall![1]({ sender: {} } as never, ...([] as unknown[])),
+    ).resolves.toEqual({ success: true, login: 'alice' });
+
+    const finishedSignal = (vi.mocked(fakeAuth.startLogin).mock.calls[0]![0] as { signal?: AbortSignal }).signal;
+    expect(finishedSignal).toBeDefined();
+    expect(finishedSignal!.aborted).toBe(false);
+
+    // Cancel should be a no-op once the controller is removed from the
+    // inflight set in the handler's `finally` clause.
+    await cancelCall![1]({} as never, ...([] as unknown[]));
+    expect(finishedSignal!.aborted).toBe(false);
   });
 
   it('BVT-14: e2e:auth handlers are NOT registered when CHAMBER_E2E is unset', async () => {

--- a/apps/desktop/src/main/ipc/auth.ts
+++ b/apps/desktop/src/main/ipc/auth.ts
@@ -41,6 +41,11 @@ export function setupAuthIPC(
 
   ipcMain.handle(IPC.AUTH.LIST_ACCOUNTS, async () => authService.listAccounts());
 
+  // Tracks in-flight login attempts so auth:cancelLogin can abort them.
+  // Each call to auth:startLogin gets its own AbortController, isolating
+  // progress + abort state per request (#139).
+  const inflightLoginControllers = new Set<AbortController>();
+
   // E2E short-circuit: when CHAMBER_E2E=1, do not hit the real GitHub device flow.
   // Tests drive auth:progress via e2e:auth:emit-progress and resolve startLogin
   // via e2e:auth:complete-login, exercising the full renderer lifecycle without
@@ -71,41 +76,51 @@ export function setupAuthIPC(
     }
 
     const win = BrowserWindow.fromWebContents(event.sender);
+    const controller = new AbortController();
+    inflightLoginControllers.add(controller);
 
-    authService.setProgressHandler((progress) => {
-      if (win) {
-        win.webContents.send(IPC.AUTH.PROGRESS, progress);
+    try {
+      const result = await authService.startLogin({
+        onProgress: (progress) => {
+          if (win) {
+            win.webContents.send(IPC.AUTH.PROGRESS, progress);
+          }
+          if (progress.step === 'device_code' && progress.verificationUri) {
+            shell.openExternal(progress.verificationUri);
+          }
+        },
+        signal: controller.signal,
+      });
+      if (result.success && result.login) {
+        authService.setActiveLogin(result.login);
+        broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login: result.login });
+        try {
+          await mindManager.reloadAllMinds();
+        } catch (err) {
+          log.error('Failed to reload minds after login:', err);
+        }
+        broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login: result.login });
       }
-      if (progress.step === 'device_code' && progress.verificationUri) {
-        shell.openExternal(progress.verificationUri);
-      }
-    });
 
-    const result = await authService.startLogin();
-    if (result.success && result.login) {
-      authService.setActiveLogin(result.login);
-      broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login: result.login });
-      try {
-        await mindManager.reloadAllMinds();
-      } catch (err) {
-        log.error('Failed to reload minds after login:', err);
-      }
-      broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login: result.login });
+      return result;
+    } finally {
+      inflightLoginControllers.delete(controller);
     }
-
-    return result;
   });
 
-  // Lets the renderer abort a pending device-code login (e.g. user cancels the
-  // Add Account modal). Maps onto AuthService.abort() which trips the polling
-  // loop's exit flag. In E2E mode it short-circuits the stub resolver instead.
+  // Lets the renderer abort all in-flight device-code logins (e.g. user cancels
+  // the Add Account modal). Each in-flight startLogin owns its own
+  // AbortController; aborting them trips the polling loop's exit condition.
+  // In E2E mode it short-circuits the stub resolver instead.
   ipcMain.handle(IPC.AUTH.CANCEL_LOGIN, async () => {
     if (E2E_ENABLED && e2eStartLoginResolver) {
       e2eStartLoginResolver({ success: false });
       e2eStartLoginResolver = null;
       return;
     }
-    authService.abort();
+    for (const controller of inflightLoginControllers) {
+      controller.abort();
+    }
   });
 
   ipcMain.handle(IPC.AUTH.SWITCH_ACCOUNT, async (_event, login: string) => {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -60,7 +60,6 @@ function notImplemented(name: string): () => never {
 const publishHolder: { publish: (sessionId: string, event: unknown) => void } = {
   publish: () => {},
 };
-
 const productionContext: ChamberCtx = createServerContext({
   token: process.env.CHAMBER_SERVER_TOKEN,
   allowedOrigins: [allowedOrigin],
@@ -79,8 +78,7 @@ const productionContext: ChamberCtx = createServerContext({
   },
   listAuthAccounts: () => authService.listAccounts(),
   startAuthLogin: async (onProgress) => {
-    authService.setProgressHandler(onProgress);
-    const result = await authService.startLogin();
+    const result = await authService.startLogin({ onProgress });
     if (result.success && result.login) {
       authService.setActiveLogin(result.login);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.49.8",
+      "version": "0.49.9",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/auth/AuthService.test.ts
+++ b/packages/services/src/auth/AuthService.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 
 // Mock electron's app module before importing AuthService helpers
 vi.mock('electron', () => ({
@@ -11,6 +13,44 @@ vi.mock('keytar', () => ({
   setPassword: vi.fn().mockResolvedValue(undefined),
   deletePassword: vi.fn().mockResolvedValue(true),
 }));
+
+// Per-test programmable https mock. Tests push fixtures onto httpsResponses
+// before invoking startLogin; each https.request consumes one fixture FIFO.
+// Default behavior (no fixtures queued) is to error immediately so tests
+// that don't care about the network path still complete fast.
+type HttpsFixture =
+  | { kind: 'json'; status?: number; body: Record<string, unknown> }
+  | { kind: 'error'; error: Error }
+  | { kind: 'never' };
+const httpsResponses: HttpsFixture[] = [];
+const httpsCalls: Array<{ host: string; path: string }> = [];
+
+vi.mock('https', () => {
+  const request = vi.fn((options: { hostname: string; path: string }, callback?: (res: Readable) => void) => {
+    httpsCalls.push({ host: options.hostname, path: options.path });
+    const req = new EventEmitter() as EventEmitter & {
+      write: () => void;
+      end: () => void;
+    };
+    req.write = () => undefined;
+    req.end = () => undefined;
+    const fixture = httpsResponses.shift() ?? { kind: 'error', error: new Error('Test fixture: no https fixture queued') };
+    if (fixture.kind === 'never') return req;
+    queueMicrotask(() => {
+      if (fixture.kind === 'error') {
+        req.emit('error', fixture.error);
+        return;
+      }
+      const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+      res.statusCode = fixture.status ?? 200;
+      callback?.(res as unknown as Readable);
+      res.emit('data', JSON.stringify(fixture.body));
+      res.emit('end');
+    });
+    return req;
+  });
+  return { default: { request }, request };
+});
 
 import { getCredentialAccount, getLoginFromAccount, AuthService } from './AuthService';
 
@@ -161,5 +201,97 @@ describe('AuthService multi-account', () => {
 
     expect(mockKeytar.deletePassword).toHaveBeenCalledWith('copilot-cli', 'https://github.com:bob');
     expect(setActiveLogin).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('AuthService.startLogin per-attempt isolation (#139)', () => {
+  beforeEach(() => {
+    httpsResponses.length = 0;
+    httpsCalls.length = 0;
+  });
+
+  it('routes progress to the per-attempt onProgress callback only', async () => {
+    const service = new AuthService(createMockKeytar());
+    const progressA: Array<{ step: string }> = [];
+    const progressB: Array<{ step: string }> = [];
+
+    // Each startLogin makes one https call (device-code POST) which we error
+    // out so the catch path runs onProgress with step:'error'. Two queued
+    // errors, two attempts in parallel.
+    httpsResponses.push({ kind: 'error', error: new Error('A') });
+    httpsResponses.push({ kind: 'error', error: new Error('B') });
+
+    const [resultA, resultB] = await Promise.all([
+      service.startLogin({ onProgress: (p) => progressA.push({ step: p.step }) }),
+      service.startLogin({ onProgress: (p) => progressB.push({ step: p.step }) }),
+    ]);
+
+    expect(resultA.success).toBe(false);
+    expect(resultB.success).toBe(false);
+    // Each callback received exactly its own attempt's error event,
+    // proving onProgress state is no longer shared across the instance.
+    expect(progressA).toEqual([{ step: 'error' }]);
+    expect(progressB).toEqual([{ step: 'error' }]);
+  });
+
+  it('treats an already-aborted signal at entry as a clean no-op (no network)', async () => {
+    const service = new AuthService(createMockKeytar());
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await service.startLogin({ signal: controller.signal });
+
+    expect(result.success).toBe(false);
+    // Entry-level abort short-circuits before any https.request runs. If a
+    // future change moves the abort check below the device-code POST, this
+    // assertion fails — pinning the contract.
+    expect(httpsCalls).toEqual([]);
+  });
+
+  it('honors an AbortSignal aborted mid-poll: stops the loop and skips token POSTs', async () => {
+    // This is the regression test that pins the contract Uncle Bob flagged
+    // as untested. Without the `isAborted()` checks inside startLogin's
+    // polling loop, the test fails because the loop proceeds to a second
+    // https.request (the access-token POST) which is queued as 'never'
+    // (a request that hangs forever) — startLogin would never resolve.
+    vi.useFakeTimers();
+    try {
+      const service = new AuthService(createMockKeytar());
+      const controller = new AbortController();
+
+      httpsResponses.push({
+        kind: 'json',
+        body: {
+          user_code: 'TEST-CODE',
+          verification_uri: 'https://example.test/device',
+          device_code: 'devcode-1',
+          interval: 1,
+          expires_in: 900,
+        },
+      });
+      // If the loop ever reaches the access-token POST after the abort,
+      // it will hang on this fixture and the test times out.
+      httpsResponses.push({ kind: 'never' });
+
+      const promise = service.startLogin({ signal: controller.signal });
+
+      // Drain the device-code microtasks so the polling loop is parked
+      // inside its setTimeout-based sleep with the ACCESS_TOKEN fixture
+      // still queued.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(httpsCalls.map((c) => c.path)).toEqual(['/login/device/code']);
+
+      controller.abort();
+      // Walk the timers past the 1s polling interval. With both abort
+      // checks intact, the loop body wakes, sees isAborted(), and returns
+      // before issuing the access-token POST.
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      const result = await promise;
+      expect(result).toEqual({ success: false });
+      expect(httpsCalls.map((c) => c.path)).toEqual(['/login/device/code']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/services/src/auth/AuthService.ts
+++ b/packages/services/src/auth/AuthService.ts
@@ -15,6 +15,7 @@ const AUTH_SCOPE = 'read:user,read:org,repo,gist';
 // so existing Windows credentials remain readable after the switch to keytar.
 export const GITHUB_CREDENTIAL_SERVICE = 'copilot-cli';
 export const GITHUB_ACCOUNT_PREFIX = 'https://github.com:';
+export const DEFAULT_USER_AGENT = 'Chamber';
 
 export interface StoredGitHubCredential {
   login: string;
@@ -51,7 +52,12 @@ export interface AuthProgress {
   error?: string;
 }
 
-function postJson(url: string, body: Record<string, string>): Promise<Record<string, unknown>> {
+export interface StartLoginOptions {
+  onProgress?: (progress: AuthProgress) => void;
+  signal?: AbortSignal;
+}
+
+function postJson(url: string, body: Record<string, string>, userAgent: string): Promise<Record<string, unknown>> {
   return new Promise((resolve, reject) => {
     const data = JSON.stringify(body);
     const parsed = new URL(url);
@@ -63,7 +69,7 @@ function postJson(url: string, body: Record<string, string>): Promise<Record<str
         'Accept': 'application/json',
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(data),
-        'User-Agent': AuthService.userAgent,
+        'User-Agent': userAgent,
       },
     };
 
@@ -81,7 +87,7 @@ function postJson(url: string, body: Record<string, string>): Promise<Record<str
   });
 }
 
-function getJson(url: string, token: string): Promise<Record<string, unknown>> {
+function getJson(url: string, token: string, userAgent: string): Promise<Record<string, unknown>> {
   return new Promise((resolve, reject) => {
     const parsed = new URL(url);
     const options = {
@@ -91,7 +97,7 @@ function getJson(url: string, token: string): Promise<Record<string, unknown>> {
       headers: {
         'Accept': 'application/json',
         'Authorization': `Bearer ${token}`,
-        'User-Agent': AuthService.userAgent,
+        'User-Agent': userAgent,
       },
     };
 
@@ -109,28 +115,15 @@ function getJson(url: string, token: string): Promise<Record<string, unknown>> {
 }
 
 export class AuthService {
-  static userAgent = 'Chamber/dev';
-
-  private onProgress?: (progress: AuthProgress) => void;
-  private aborted = false;
+  private readonly userAgent: string;
 
   constructor(
     private readonly credentials: CredentialStore,
     private readonly getActiveLogin: () => string | null = () => null,
     readonly setActiveLogin: (login: string | null) => void = () => undefined,
-    userAgent?: string,
+    userAgent: string = DEFAULT_USER_AGENT,
   ) {
-    if (userAgent) {
-      AuthService.userAgent = userAgent;
-    }
-  }
-
-  setProgressHandler(handler: (progress: AuthProgress) => void): void {
-    this.onProgress = handler;
-  }
-
-  abort(): void {
-    this.aborted = true;
+    this.userAgent = userAgent;
   }
 
   async listAccounts(): Promise<Array<{ login: string }>> {
@@ -154,8 +147,6 @@ export class AuthService {
   }
 
   async logout(): Promise<void> {
-    this.abort();
-
     try {
       const credential = await this.getStoredCredentialEntry();
       if (!credential) return;
@@ -191,15 +182,20 @@ export class AuthService {
     log.info(`Stored credential for ${login} via keytar`);
   }
 
-  async startLogin(): Promise<{ success: boolean; login?: string }> {
-    this.aborted = false;
+  async startLogin(options: StartLoginOptions = {}): Promise<{ success: boolean; login?: string }> {
+    const { onProgress, signal } = options;
+    const isAborted = (): boolean => signal?.aborted === true;
+
+    // Honor an already-aborted signal as a clean no-op so the public contract
+    // is "an aborted signal at entry never makes a network request."
+    if (isAborted()) return { success: false };
 
     try {
       // 1. Start device flow
       const deviceResp = await postJson(DEVICE_CODE_URL, {
         client_id: CLIENT_ID,
         scope: AUTH_SCOPE,
-      });
+      }, this.userAgent);
 
       const userCode = String(deviceResp.user_code);
       const verificationUri = String(deviceResp.verification_uri_complete ?? deviceResp.verification_uri);
@@ -207,21 +203,21 @@ export class AuthService {
       let interval = Number(deviceResp.interval) || 5;
       const expiresIn = Number(deviceResp.expires_in) || 900;
 
-      this.onProgress?.({ step: 'device_code', userCode, verificationUri });
+      onProgress?.({ step: 'device_code', userCode, verificationUri });
 
       // 2. Poll for access token
-      this.onProgress?.({ step: 'polling', userCode, verificationUri });
+      onProgress?.({ step: 'polling', userCode, verificationUri });
       const deadline = Date.now() + expiresIn * 1000;
 
-      while (Date.now() < deadline && !this.aborted) {
+      while (Date.now() < deadline && !isAborted()) {
         await new Promise(r => setTimeout(r, interval * 1000));
-        if (this.aborted) return { success: false };
+        if (isAborted()) return { success: false };
 
         const tokenResp = await postJson(ACCESS_TOKEN_URL, {
           client_id: CLIENT_ID,
           device_code: deviceCode,
           grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-        });
+        }, this.userAgent);
 
         if (tokenResp.access_token) {
           const token = String(tokenResp.access_token);
@@ -229,7 +225,7 @@ export class AuthService {
           // Get user login
           let login = 'user';
           try {
-            const user = await getJson('https://api.github.com/user', token);
+            const user = await getJson('https://api.github.com/user', token, this.userAgent);
             login = String(user.login);
           } catch (err) {
             log.warn('Failed to fetch user login, using default account name:', err);
@@ -237,7 +233,7 @@ export class AuthService {
 
           await this.storeCredential(login, token);
 
-          this.onProgress?.({ step: 'authenticated', login });
+          onProgress?.({ step: 'authenticated', login });
           return { success: true, login };
         }
 
@@ -248,16 +244,16 @@ export class AuthService {
           continue;
         }
 
-        this.onProgress?.({ step: 'error', error: `Auth failed: ${error}` });
+        onProgress?.({ step: 'error', error: `Auth failed: ${error}` });
         return { success: false };
       }
 
-      if (this.aborted) return { success: false };
-      this.onProgress?.({ step: 'error', error: 'Timed out waiting for authorization' });
+      if (isAborted()) return { success: false };
+      onProgress?.({ step: 'error', error: 'Timed out waiting for authorization' });
       return { success: false };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      this.onProgress?.({ step: 'error', error: message });
+      onProgress?.({ step: 'error', error: message });
       return { success: false };
     }
   }

--- a/packages/services/src/auth/index.ts
+++ b/packages/services/src/auth/index.ts
@@ -1,9 +1,10 @@
 export {
   AuthService,
+  DEFAULT_USER_AGENT,
   GITHUB_ACCOUNT_PREFIX,
   GITHUB_CREDENTIAL_SERVICE,
   getCredentialAccount,
   getLoginFromAccount,
   listStoredGitHubCredentials,
 } from './AuthService';
-export type { AuthProgress, StoredGitHubCredential } from './AuthService';
+export type { AuthProgress, StartLoginOptions, StoredGitHubCredential } from './AuthService';

--- a/packages/services/src/genesis/GitHubRegistryClient.test.ts
+++ b/packages/services/src/genesis/GitHubRegistryClient.test.ts
@@ -84,6 +84,24 @@ describe('GitHubRegistryClient', () => {
       await expect(client.fetchTree('agency-microsoft', 'genesis-minds', 'main'))
         .rejects.toThrow('GitHub API request failed anonymously: 404 Not Found');
     });
+
+    it('uses the configured user agent in request headers', async () => {
+      // Pins #139: removing the static AuthService.userAgent means the user
+      // agent must be threaded through this client's options. If a future
+      // change goes back to a global, this test will fail because the option
+      // path is no longer honored.
+      client = new GitHubRegistryClient({ fetch: fetchMock, userAgent: 'Chamber/test-1.2.3' });
+      fetchMock.mockResolvedValueOnce(jsonResponse({ tree: [] }));
+
+      await client.fetchTree('o', 'r', 'main');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'User-Agent': 'Chamber/test-1.2.3' }),
+        }),
+      );
+    });
   });
 
   describe('fetchBlob', () => {

--- a/packages/services/src/genesis/GitHubRegistryClient.ts
+++ b/packages/services/src/genesis/GitHubRegistryClient.ts
@@ -1,4 +1,4 @@
-import { AuthService, listStoredGitHubCredentials } from '../auth';
+import { listStoredGitHubCredentials, DEFAULT_USER_AGENT } from '../auth';
 import type { CredentialStore } from '../ports';
 
 export interface TreeEntry {
@@ -19,6 +19,7 @@ export interface GitHubRegistryClientOptions {
   credentialProvider?: GitHubRegistryCredentialProvider;
   requestTimeoutMs?: number;
   maxBlobBytes?: number;
+  userAgent?: string;
 }
 
 interface GitHubTreeResponse {
@@ -38,18 +39,21 @@ export class GitHubRegistryClient {
   private readonly credentialProvider: GitHubRegistryCredentialProvider;
   private readonly requestTimeoutMs: number;
   private readonly maxBlobBytes: number;
+  private readonly userAgent: string;
 
   constructor(options: GitHubRegistryClientOptions = {}) {
     this.fetchImpl = options.fetch ?? globalThis.fetch;
     this.credentialProvider = options.credentialProvider ?? (() => Promise.resolve([]));
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.maxBlobBytes = options.maxBlobBytes ?? DEFAULT_MAX_BLOB_BYTES;
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
   }
 
-  static withCredentialStore(credentials: CredentialStore): GitHubRegistryClient {
+  static withCredentialStore(credentials: CredentialStore, userAgent?: string): GitHubRegistryClient {
     return new GitHubRegistryClient({
       credentialProvider: async () => (await listStoredGitHubCredentials(credentials))
         .map((credential) => ({ login: credential.login, token: credential.password })),
+      userAgent,
     });
   }
 
@@ -118,7 +122,7 @@ export class GitHubRegistryClient {
     const timeout = setTimeout(() => abort.abort(), this.requestTimeoutMs);
     try {
       const response = await this.fetchImpl(`https://api.github.com${pathAndQuery}`, {
-        headers: requestHeaders(token),
+        headers: this.requestHeaders(token),
         signal: abort.signal,
       });
       if (response.ok) {
@@ -143,18 +147,18 @@ export class GitHubRegistryClient {
       return [];
     }
   }
+
+  private requestHeaders(token: string | null): HeadersInit {
+    return {
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': this.userAgent,
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+    };
+  }
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BLOB_BYTES = 10 * 1024 * 1024;
-
-function requestHeaders(token: string | null): HeadersInit {
-  return {
-    'Accept': 'application/vnd.github+json',
-    'User-Agent': AuthService.userAgent,
-    ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-  };
-}
 
 function maxBase64Length(maxBytes: number): number {
   return Math.ceil(maxBytes / 3) * 4;

--- a/packages/services/src/tools/GitHubReleaseAssetClient.ts
+++ b/packages/services/src/tools/GitHubReleaseAssetClient.ts
@@ -1,4 +1,4 @@
-import { AuthService, listStoredGitHubCredentials } from '../auth';
+import { listStoredGitHubCredentials, DEFAULT_USER_AGENT } from '../auth';
 import type { CredentialStore } from '../ports';
 import type { GitHubRegistryCredential, GitHubRegistryCredentialProvider } from '../genesis/GitHubRegistryClient';
 
@@ -6,6 +6,7 @@ export interface GitHubReleaseAssetClientOptions {
   fetch?: typeof fetch;
   credentialProvider?: GitHubRegistryCredentialProvider;
   requestTimeoutMs?: number;
+  userAgent?: string;
 }
 
 export interface DownloadReleaseAssetRequest {
@@ -28,17 +29,20 @@ export class GitHubReleaseAssetClient {
   private readonly fetchImpl: typeof fetch;
   private readonly credentialProvider: GitHubRegistryCredentialProvider;
   private readonly requestTimeoutMs: number;
+  private readonly userAgent: string;
 
   constructor(options: GitHubReleaseAssetClientOptions = {}) {
     this.fetchImpl = options.fetch ?? globalThis.fetch;
     this.credentialProvider = options.credentialProvider ?? (() => Promise.resolve([]));
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
   }
 
-  static withCredentialStore(credentials: CredentialStore): GitHubReleaseAssetClient {
+  static withCredentialStore(credentials: CredentialStore, userAgent?: string): GitHubReleaseAssetClient {
     return new GitHubReleaseAssetClient({
       credentialProvider: async () => (await listStoredGitHubCredentials(credentials))
         .map((credential) => ({ login: credential.login, token: credential.password })),
+      userAgent,
     });
   }
 
@@ -82,7 +86,7 @@ export class GitHubReleaseAssetClient {
     repo: string,
   ): Promise<{ ok: true; value: T } | { ok: false; error: Error }> {
     const response = await this.fetchWithTimeout(`https://api.github.com${pathAndQuery}`, {
-      headers: jsonHeaders(token),
+      headers: this.jsonHeaders(token),
     });
     if (response.ok) {
       return { ok: true, value: await response.json() as T };
@@ -112,7 +116,7 @@ export class GitHubReleaseAssetClient {
     repo: string,
   ): Promise<{ ok: true; value: Buffer } | { ok: false; error: Error }> {
     const response = await this.fetchWithTimeout(`https://api.github.com${pathAndQuery}`, {
-      headers: assetHeaders(token),
+      headers: this.assetHeaders(token),
       redirect: 'manual',
     });
     if (response.status >= 300 && response.status < 400) {
@@ -121,7 +125,7 @@ export class GitHubReleaseAssetClient {
         return { ok: false, error: new Error(`GitHub release asset redirect for ${owner}/${repo} did not include a location`) };
       }
       const redirected = await this.fetchWithTimeout(location, {
-        headers: { 'User-Agent': AuthService.userAgent },
+        headers: { 'User-Agent': this.userAgent },
       });
       if (!redirected.ok) {
         return { ok: false, error: await githubRequestError(redirected, null, owner, repo) };
@@ -153,6 +157,22 @@ export class GitHubReleaseAssetClient {
       return [];
     }
   }
+
+  private jsonHeaders(token: string | null): HeadersInit {
+    return {
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': this.userAgent,
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+    };
+  }
+
+  private assetHeaders(token: string | null): HeadersInit {
+    return {
+      'Accept': 'application/octet-stream',
+      'User-Agent': this.userAgent,
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+    };
+  }
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -162,22 +182,6 @@ function releasePath(owner: string, repo: string, tag: string): string {
     return `/repos/${encodePath(owner)}/${encodePath(repo)}/releases/latest`;
   }
   return `/repos/${encodePath(owner)}/${encodePath(repo)}/releases/tags/${encodePath(tag)}`;
-}
-
-function jsonHeaders(token: string | null): HeadersInit {
-  return {
-    'Accept': 'application/vnd.github+json',
-    'User-Agent': AuthService.userAgent,
-    ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-  };
-}
-
-function assetHeaders(token: string | null): HeadersInit {
-  return {
-    'Accept': 'application/octet-stream',
-    'User-Agent': AuthService.userAgent,
-    ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-  };
 }
 
 async function githubRequestError(response: Response, login: string | null, owner: string, repo: string): Promise<Error> {


### PR DESCRIPTION
Follow-up from PR #136. `AuthService` stored login progress and abort state on the service instance, which is unsound when concurrent logins can arrive (browser/server, or two simultaneous tabs). Switch to a per-attempt API and remove the static user-agent global.

## Changes

### Per-request `startLogin`

```ts
authService.startLogin({ onProgress, signal })
```

- Progress callback and `AbortSignal` are owned per-call. Nothing is stored on the instance during a login.
- An already-aborted signal at entry returns `{ success: false }` immediately — no network request is made.
- The polling loop checks `signal?.aborted` at both loop boundaries, so a mid-poll abort stops cleanly without issuing the access-token POST.
- `setProgressHandler()` and `abort()` are removed from the public surface.

### Instance-scoped user agent

- The static `AuthService.userAgent` global is gone. `AuthService`, `GitHubRegistryClient`, and `GitHubReleaseAssetClient` each accept a `userAgent` constructor option (default `'Chamber'`).
- Desktop composition root (`apps/desktop/src/main.ts`) threads one `Chamber/${app.getVersion()}` string through all three clients explicitly.
- `withCredentialStore(credentials, userAgent?)` accepts the user agent as a second argument.

### IPC handler

- `apps/desktop/src/main/ipc/auth.ts`: `auth:startLogin` allocates an `AbortController` per request and tracks them in a `Set`. `auth:cancelLogin` aborts every in-flight controller.
- `apps/server/src/bin.ts`: `startAuthLogin` passes `onProgress` through `startLogin({ onProgress })`.

## Test evidence

- `npm run lint` — clean (352 modules, 700 deps).
- `npx vitest run packages/services/src/auth apps/desktop/src/main/ipc/auth.test.ts packages/services/src/genesis/GitHubRegistryClient.test.ts` — 38/38 passing.
- Full Vitest suite green (one unrelated `JobStore` Windows `EPERM` rename flake that passes on rerun).

New tests pin the contract:
- **Per-attempt isolation**: two concurrent `startLogin` calls each receive only their own `onProgress` events.
- **Entry-level abort**: an already-aborted signal returns `success:false` before any `https.request` runs (asserted via the per-call programmable https mock — the queued fixtures stay untouched).
- **Mid-poll abort** (Uncle Bob B1 fix): the test queues a `'never'`-resolving second `https.request`. With the abort checks intact, the polling loop wakes from sleep, sees `isAborted()`, and returns. Without the checks, the test would hang on the never-fixture instead of silently passing — the AbortSignal polling-loop contract is genuinely pinned.
- **User-agent option propagation**: `GitHubRegistryClient` test asserts the configured `userAgent` shows up in fetch headers.

## Uncle Bob review

Critical finding **B1** (test didn't actually pin the polling-loop AbortSignal contract) addressed in the third bullet above. **N1** (already-aborted signal at entry should skip the device-code POST) addressed by adding an entry-level `isAborted()` check. Non-blocking observations deferred:

- **N2** — `auth:cancelLogin` aborts every in-flight controller globally. Acceptable today (matches old behavior) but worth scoping per-`WebContents` if multi-window concurrent logins become a real flow.
- **N3** — `logout()` no longer aborts in-flight logins (intentional; pre-existing race between abort and `storeCredential` would need its own UX decision).
- **N4** — Server `bin.ts` constructs `AuthService` without a custom user agent, falling back to `'Chamber'` (no version). Worth threading the package version through if the loopback server reaches GitHub's user-agent rate-limit lane.
- **N5** — `https.request` and `setTimeout` aren't abort-aware, so cancellation only takes effect at the next loop boundary (~5s). UX wart, not a correctness bug.

Closes #139