### PR TITLE
feat(mind): pass mind .mcp.json into Copilot session config (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.49.10 (2026-05-08)
+
+### Mind
+
+- **Pass `.mcp.json` MCP servers from the mind folder into Copilot sessions** — `MindManager` now reads each mind's `<mindPath>/.mcp.json` and threads parsed `mcpServers` through `client.createSession`/`resumeSession`, working around an upstream `@github/copilot-sdk` bug where `enableConfigDiscovery: true` does not actually load workspace-scoped servers. Entries are validated against a Zod schema (stdio with `command` or HTTP/SSE with `url`); malformed JSON or schema-invalid entries warn-and-skip so a typo in one mind cannot break others. The `tools` field defaults to `["*"]` when omitted, matching the CLI's discovery behavior. (#199)
+
 ## v0.49.9 (2026-05-08)
 
 ### Auth

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.49.9",
+  "version": "0.49.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.49.9",
+      "version": "0.49.10",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.49.9",
+  "version": "0.49.10",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -154,7 +154,12 @@ describe('MindManager', () => {
     mockDeleteSession.mockImplementation(async (sessionId: string) => {
       void sessionId;
     });
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockImplementation((candidate) => {
+      // Default: every checked path exists EXCEPT `.mcp.json`. Tests that
+      // need MindManager to discover an `.mcp.json` opt in by overriding
+      // existsSync + readFileSync per test (#199).
+      return !String(candidate).endsWith('.mcp.json');
+    });
     vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
     vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => String(candidate));
     manager = new MindManager(
@@ -434,7 +439,9 @@ describe('MindManager', () => {
     });
 
     it('deduplicates filesystem aliases by realpath before creating another client', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.existsSync).mockImplementation((candidate) => {
+        return !String(candidate).endsWith('.mcp.json');
+      });
       vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => {
         const normalized = String(candidate).replace(/\\/g, '/');
         if (normalized.endsWith('/tmp/aliases/q-link')) {
@@ -1194,6 +1201,51 @@ describe('MindManager', () => {
       const [mind1, mind2] = await Promise.all([promise1, promise2]);
       expect(mind1.mindId).toBe(mind2.mindId);
       expect(mockClientFactory.createClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('mcp.json discovery (#199)', () => {
+    it('passes parsed mcpServers to createSession when .mcp.json is present', async () => {
+      const mcpJson = JSON.stringify({
+        mcpServers: {
+          memory: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-memory'],
+            env: { ROOT: '/tmp/mem' },
+          },
+        },
+      });
+      vi.mocked(fs.existsSync).mockImplementation(() => true);
+      vi.mocked(fs.readFileSync).mockImplementation((candidate) => {
+        return String(candidate).endsWith('.mcp.json')
+          ? mcpJson
+          : '# TestAgent\nSome content';
+      });
+
+      await manager.loadMind('/tmp/agents/q');
+
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mcpServers: {
+            memory: {
+              type: 'stdio',
+              command: 'npx',
+              args: ['-y', '@modelcontextprotocol/server-memory'],
+              env: { ROOT: '/tmp/mem' },
+              tools: ['*'],
+            },
+          },
+        }),
+      );
+    });
+
+    it('omits mcpServers from session config when .mcp.json is absent', async () => {
+      // Default beforeEach: existsSync returns false for `.mcp.json`.
+      await manager.loadMind('/tmp/agents/q');
+
+      const config = mockCreateSession.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect(config).toBeDefined();
+      expect(Object.prototype.hasOwnProperty.call(config, 'mcpServers')).toBe(false);
     });
   });
 

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -11,6 +11,7 @@ import type { AppConfig, ChamberConversationRecord, ChatMessage, ConversationRes
 import { Logger } from '../logger';
 import type { InternalMindContext, CopilotClient, CopilotSession, Tool, UserInputHandler } from './types';
 import { generateMindId } from './generateMindId';
+import { loadMcpServersFromMindPath } from './mcpConfig';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import { approveAllCompat } from '../sdk/approveAllCompat';
 import type { IdentityLoader } from '../chat/IdentityLoader';
@@ -753,6 +754,7 @@ export class MindManager extends EventEmitter {
     model?: string,
     sessionId?: string,
   ): Promise<CopilotSession> {
+    const mcpServers = loadMcpServersFromMindPath(mindPath);
     const sessionConfig: SessionConfig = {
       workingDirectory: mindPath,
       enableConfigDiscovery: true,
@@ -765,6 +767,7 @@ export class MindManager extends EventEmitter {
         },
       },
       onPermissionRequest,
+      ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
       ...(sessionId ? { sessionId } : {}),
       ...(model ? { model } : {}),
       ...(onUserInputRequest ? { onUserInputRequest } : {}),
@@ -789,6 +792,7 @@ export class MindManager extends EventEmitter {
     approveAll = true,
     model?: string,
   ): Promise<CopilotSession> {
+    const mcpServers = loadMcpServersFromMindPath(mindPath);
     const sessionConfig: ResumeSessionConfig = {
       workingDirectory: mindPath,
       enableConfigDiscovery: true,
@@ -801,6 +805,7 @@ export class MindManager extends EventEmitter {
         },
       },
       onPermissionRequest,
+      ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
       ...(model ? { model } : {}),
       ...(onUserInputRequest ? { onUserInputRequest } : {}),
     };

--- a/packages/services/src/mind/mcpConfig.test.ts
+++ b/packages/services/src/mind/mcpConfig.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadMcpServersFromMindPath, MCP_CONFIG_FILENAME } from './mcpConfig';
+
+describe('loadMcpServersFromMindPath', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-mcp-config-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(value: unknown): void {
+    fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), JSON.stringify(value), 'utf-8');
+  }
+
+  it('returns an empty object when .mcp.json does not exist', () => {
+    expect(loadMcpServersFromMindPath(tmpDir)).toEqual({});
+  });
+
+  it('reads stdio servers and defaults tools to ["*"]', () => {
+    writeConfig({
+      mcpServers: {
+        filesystem: {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-filesystem'],
+          env: { ROOT: '/tmp' },
+        },
+      },
+    });
+
+    expect(loadMcpServersFromMindPath(tmpDir)).toEqual({
+      filesystem: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem'],
+        env: { ROOT: '/tmp' },
+        tools: ['*'],
+      },
+    });
+  });
+
+  it('reads HTTP servers and preserves the type', () => {
+    writeConfig({
+      mcpServers: {
+        remote: {
+          type: 'http',
+          url: 'https://mcp.example.test/v1',
+          headers: { Authorization: 'Bearer abc' },
+          tools: ['ping', 'pong'],
+        },
+      },
+    });
+
+    expect(loadMcpServersFromMindPath(tmpDir)).toEqual({
+      remote: {
+        type: 'http',
+        url: 'https://mcp.example.test/v1',
+        headers: { Authorization: 'Bearer abc' },
+        tools: ['ping', 'pong'],
+      },
+    });
+  });
+
+  it('drops only the invalid entry and keeps valid ones (per-entry validation, #199)', () => {
+    writeConfig({
+      mcpServers: {
+        good: { command: 'real-cli' },
+        broken: { type: 'stdio' }, // missing command
+        alsoGood: {
+          type: 'http',
+          url: 'https://mcp.example.test/v2',
+        },
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const servers = loadMcpServersFromMindPath(tmpDir);
+      expect(Object.keys(servers).sort()).toEqual(['alsoGood', 'good']);
+      expect(servers.good).toMatchObject({ command: 'real-cli' });
+      expect(servers.alsoGood).toMatchObject({ url: 'https://mcp.example.test/v2' });
+      // The dropped entry must be named in the warning so authors know
+      // which key to fix. Logger prefixes with the tag so the message
+      // string lives at index 1.
+      expect(warn.mock.calls.some(args =>
+        args.some(arg => typeof arg === 'string' && arg.includes('"broken"')),
+      )).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('rejects entries that mix stdio and http keys (no silent union coercion)', () => {
+    writeConfig({
+      mcpServers: {
+        confused: {
+          command: 'evil',
+          url: 'http://attacker.example/',
+        },
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(loadMcpServersFromMindPath(tmpDir)).toEqual({});
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('returns empty without throwing when JSON is invalid', () => {
+    fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), '{not json', 'utf-8');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(loadMcpServersFromMindPath(tmpDir)).toEqual({});
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('returns empty when the only entry fails schema validation (e.g. missing command and url)', () => {
+    writeConfig({
+      mcpServers: {
+        broken: { type: 'stdio' },
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(loadMcpServersFromMindPath(tmpDir)).toEqual({});
+      // Per-entry validation: the warning must reference the entry name,
+      // not the file globally.
+      expect(warn.mock.calls.some(args =>
+        args.some(arg => typeof arg === 'string' && arg.includes('"broken"')),
+      )).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('returns empty when mcpServers is absent', () => {
+    writeConfig({});
+    expect(loadMcpServersFromMindPath(tmpDir)).toEqual({});
+  });
+
+  it('omits optional fields rather than passing undefined values', () => {
+    writeConfig({
+      mcpServers: {
+        bare: { command: 'cli' },
+      },
+    });
+
+    const servers = loadMcpServersFromMindPath(tmpDir);
+    expect(servers.bare).toEqual({
+      type: 'stdio',
+      command: 'cli',
+      args: [],
+      tools: ['*'],
+    });
+    expect(Object.prototype.hasOwnProperty.call(servers.bare, 'env')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(servers.bare, 'cwd')).toBe(false);
+  });
+});

--- a/packages/services/src/mind/mcpConfig.ts
+++ b/packages/services/src/mind/mcpConfig.ts
@@ -1,0 +1,121 @@
+// Reads a mind's `.mcp.json` and returns servers in the shape the Copilot
+// SDK's `SessionConfig.mcpServers` expects. Exists because the SDK's
+// `enableConfigDiscovery` path doesn't pass `includeWorkspaceSources: true`,
+// so workspace-level `.mcp.json` files are silently ignored. Chamber reads
+// them itself and threads the result through `client.createSession`.
+//
+// Schema (subset of the upstream MCP server config — the SDK validates the
+// rest):
+//   { "mcpServers": {
+//       "<name>": { "command": "...", "args": [...], "env": {...}, ... },
+//       "<name>": { "type": "http", "url": "...", "headers": {...} }
+//   } }
+//
+// The CLI's `tools` field is required by the SDK type (`MCPServerConfigBase`),
+// but real-world `.mcp.json` files almost never set it. We default to `["*"]`
+// (all tools allowed) when missing, matching the CLI's discovery behavior.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { MCPServerConfig } from '@github/copilot-sdk';
+import { Logger } from '../logger';
+
+const log = Logger.create('mcpConfig');
+
+// `.strict()` rejects unknown keys per arm so an entry that mixes `command`
+// AND `url` fails with a clear "unrecognized keys" error rather than being
+// silently coerced into one arm of the union.
+const stdioSchema = z.object({
+  type: z.enum(['stdio', 'local']).optional(),
+  command: z.string().min(1),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  cwd: z.string().optional(),
+  tools: z.array(z.string()).optional(),
+  timeout: z.number().optional(),
+}).strict();
+
+const httpSchema = z.object({
+  type: z.enum(['http', 'sse']),
+  url: z.url(),
+  headers: z.record(z.string(), z.string()).optional(),
+  tools: z.array(z.string()).optional(),
+  timeout: z.number().optional(),
+}).strict();
+
+const serverSchema = z.union([stdioSchema, httpSchema]);
+
+// Top-level shape: the file MUST be a valid JSON object whose `mcpServers` is
+// an object map. Each entry is validated independently below so a single typo
+// only drops that one server, not every server in the file (#199).
+const fileSchema = z.object({
+  mcpServers: z.record(z.string(), z.unknown()).optional(),
+}).passthrough();
+
+export const MCP_CONFIG_FILENAME = '.mcp.json';
+
+export function loadMcpServersFromMindPath(mindPath: string): Record<string, MCPServerConfig> {
+  const filePath = path.join(mindPath, MCP_CONFIG_FILENAME);
+  if (!fs.existsSync(filePath)) return {};
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    log.warn(`Failed to read ${filePath}; skipping MCP servers:`, err);
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn(`Invalid JSON in ${filePath}; skipping MCP servers:`, err);
+    return {};
+  }
+
+  const fileResult = fileSchema.safeParse(parsed);
+  if (!fileResult.success) {
+    log.warn(`Top-level schema validation failed for ${filePath}; skipping MCP servers:`, fileResult.error.issues);
+    return {};
+  }
+
+  const servers = fileResult.data.mcpServers ?? {};
+  const out: Record<string, MCPServerConfig> = {};
+  for (const [name, rawEntry] of Object.entries(servers)) {
+    // Per-entry validation: a bad entry only drops itself, not the whole
+    // file. Issue #199 explicitly asks to "warn or skip invalid entries".
+    const entry = serverSchema.safeParse(rawEntry);
+    if (!entry.success) {
+      log.warn(`MCP server "${name}" in ${filePath} failed validation; skipping:`, entry.error.issues);
+      continue;
+    }
+    const config = entry.data;
+    // Default tools to ["*"] (all) — the SDK's MCPServerConfigBase requires
+    // a tools array, but `.mcp.json` files generally omit it. Authors who
+    // want to scope server tool access can still set it explicitly.
+    const tools = config.tools ?? ['*'];
+    if ('command' in config) {
+      out[name] = {
+        type: config.type ?? 'stdio',
+        command: config.command,
+        args: config.args ?? [],
+        ...(config.env ? { env: config.env } : {}),
+        ...(config.cwd ? { cwd: config.cwd } : {}),
+        tools,
+        ...(config.timeout !== undefined ? { timeout: config.timeout } : {}),
+      };
+    } else {
+      out[name] = {
+        type: config.type,
+        url: config.url,
+        ...(config.headers ? { headers: config.headers } : {}),
+        tools,
+        ...(config.timeout !== undefined ? { timeout: config.timeout } : {}),
+      };
+    }
+  }
+  return out;
+}
+


### PR DESCRIPTION
## What

Chamber must read each mind's `<mindPath>/.mcp.json` and pass parsed servers into the Copilot SDK's `mcpServers` session config. The SDK's `enableConfigDiscovery: true` does not actually load workspace-scoped `.mcp.json` (it omits `includeWorkspaceSources: true` from the discovery call), so without this fix every mind's MCP servers are silently ignored.

## Why

Issue #199 — Chamber agents shipped with a `.mcp.json` (the standard location for workspace-scoped MCP server declarations) were getting zero MCP tools attached, with no error and no warning. Authors had no signal that their config was being dropped.

## How

- **New `packages/services/src/mind/mcpConfig.ts`** — Zod-validated reader exporting `loadMcpServersFromMindPath(mindPath)`.
- **Per-entry validation.** The file's top-level shape is validated first, then each entry independently. One bad entry only drops itself (warn-and-skip naming the offending key); a typo in one server does not silently disable every server in the file. This is what the issue body explicitly asks for.
- **Strict union arms.** Each arm of the discriminated union (`stdio`, `http`/`sse`) is `.strict()` so a config that mixes `command` and `url` fails with a clear validation error rather than being silently coerced into stdio.
- **`MindManager.createSessionForMind` and `resumeSessionForMind`** invoke the reader and conditionally include `mcpServers` in the SessionConfig.
- **`tools` defaults to `['*']`** when omitted, matching the CLI's discovery behavior (real `.mcp.json` files almost never set it).

## Tests

- **`mcpConfig.test.ts`** — 9 unit tests:
  - Reads valid stdio + HTTP servers.
  - Defaults `tools: ['*']` when missing.
  - Returns empty when file is absent / JSON is malformed / only entry fails schema.
  - **(N2 follow-up)** Drops only the invalid entry and keeps valid ones — names the offending key in the warning.
  - **(N3 follow-up)** Rejects entries that mix stdio and http keys.
  - Omits optional fields (no `undefined` leakage).
- **`MindManager.test.ts`** — 2 new tests:
  - Passes parsed `mcpServers` to `createSession` when `.mcp.json` is present.
  - Omits `mcpServers` from session config when `.mcp.json` is absent.
- Adjusted the global `fs.existsSync` mock to default `.mcp.json` to absent — tests that need it discovered opt in.

## Verification

- `npm run lint` clean.
- `npm test` — 1275/1275 pass.

## Review

Uncle Bob review applied:
- **N1 (deprecation):** `z.string().url()` → `z.url()` (Zod 4.4.3 marks the former deprecated; `tsconfig` keeps `ignoreDeprecations` disabled).
- **N2 (issue intent):** All-or-nothing schema validation replaced with per-entry validation so one typo doesn't drop every server.
- **N3 (defensive):** `.strict()` on each union arm closes the silent-coercion footgun where `{ command, url }` would have been parsed as stdio.
- **N4 (DRY):** `createSessionForMind` and `resumeSessionForMind` are 90% duplicate; this PR mildly worsens it. Deferred to a follow-up issue per scope discipline.

## Notes

- Versioned at v0.47.2. PR #241 (PR8) holds v0.47.1 against master; whichever lands first keeps its number, the other rebases.
- Mind directories are user-controlled and already trusted (their `SOUL.md` becomes the system prompt, the SDK runs with `--allow-all-tools`). MCP `command` strings ride the same trust frame.

Closes #199
