### PR TITLE
refactor(server): require capabilities at ChamberCtx construction (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.47.6 (2026-05-08)
+
+### Server
+
+- **Make loopback server capabilities required at construction** — `apps/server/src/types.ts` `ChamberCtx` no longer marks route-backed capabilities optional; `createServerContext` (`apps/server/src/composition.ts`) takes the full capability set up front via `ServerContextInputs` and only defaults `token`/`allowedOrigins`. `bin.ts` builds the production context immutably (a small `publishHolder` breaks the `sendChat`↔`createHttpServer` cycle without post-create mutation), and the E2E fake-chat overrides are now applied as a derived context rather than reassignment. The 503-fallback branches in `streamAuthLogin`, `/api/privileged`, and `/api/shutdown` are gone — those paths cannot exist now that the capabilities are required. The four `honoAdapter.test.ts` tests asserting the old "503 when capability missing" behavior are removed because the situation is unrepresentable at compile time; the `makeContext` helpers in `honoAdapter.test.ts` and `handlers.test.ts` provide explicit throwing stubs so tests fail loudly rather than rely on silent defaults. (#138)
+
 ## v0.47.5 (2026-05-08)
 
 ### Server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.47.5 (2026-05-08)
+
+### Server
+
+- **Broaden loopback server route coverage** — Add `apps/server/src/auth.test.ts` covering `isLoopbackHost`, `isAllowedOrigin`, and the constant-time `isAuthorized` Bearer-token check (15 cases). Extend `apps/server/src/honoAdapter.test.ts` with 24 new HTTP scenarios across auth header enforcement (missing, wrong scheme, wrong token, accepted), origin allowlist (rejected, no-origin, loopback-port-stripping), route availability (`/api/mind/add`, `/api/chat/send`, `/api/chat/models`, `/api/privileged` returning 503 when the corresponding capability is absent; catch-all GET returning the placeholder HTML), `/api/shutdown` calling `ctx.shutdown` on the next tick, attachment upload (binary forwarding, missing `?name=`, JSON-body rejection), `/api/chat/cancel` mindId/messageId validation through the adapter, and WebSocket upgrade authorization (rejecting missing/wrong/disallowed inputs and accepting the previously-untested `Authorization: Bearer` header path). Pure characterization play — no production code changes; pins behavior so the #138 capability-injection refactor lands on a tested base. (#142)
+
 ## v0.47.0 (2026-05-08)
 
 ### Marketplace

--- a/apps/server/src/auth.test.ts
+++ b/apps/server/src/auth.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { isAllowedOrigin, isAuthorized, isLoopbackHost } from './auth';
+
+describe('isLoopbackHost', () => {
+  it('accepts 127.0.0.1 and localhost (with or without a port)', () => {
+    expect(isLoopbackHost('127.0.0.1')).toBe(true);
+    expect(isLoopbackHost('localhost')).toBe(true);
+    expect(isLoopbackHost('127.0.0.1:55123')).toBe(true);
+    expect(isLoopbackHost('localhost:8080')).toBe(true);
+  });
+
+  it('lowercases the comparison so casing in the host does not matter', () => {
+    expect(isLoopbackHost('LOCALHOST')).toBe(true);
+    expect(isLoopbackHost('LocalHost:55123')).toBe(true);
+  });
+
+  it('rejects non-loopback hosts and undefined/empty input', () => {
+    expect(isLoopbackHost(undefined)).toBe(false);
+    expect(isLoopbackHost('')).toBe(false);
+    expect(isLoopbackHost('example.com')).toBe(false);
+    expect(isLoopbackHost('192.168.1.1')).toBe(false);
+    expect(isLoopbackHost('127.0.0.2')).toBe(false);
+  });
+});
+
+describe('isAllowedOrigin', () => {
+  const allowed = new Set(['http://127.0.0.1', 'https://app.example.com']);
+
+  it('allows requests with no Origin header (same-origin / native fetchers)', () => {
+    expect(isAllowedOrigin(null, allowed)).toBe(true);
+  });
+
+  it('matches the exact origin string when present', () => {
+    expect(isAllowedOrigin('http://127.0.0.1', allowed)).toBe(true);
+    expect(isAllowedOrigin('https://app.example.com', allowed)).toBe(true);
+  });
+
+  it('matches the protocol+hostname (port-stripped) when the origin is a loopback host', () => {
+    expect(isAllowedOrigin('http://127.0.0.1:55123', allowed)).toBe(true);
+    expect(isAllowedOrigin('http://localhost:55123', new Set(['http://localhost']))).toBe(true);
+  });
+
+  it('does not strip the port for non-loopback origins', () => {
+    expect(isAllowedOrigin('https://app.example.com:8443', allowed)).toBe(false);
+  });
+
+  it('rejects origins outside the allowlist', () => {
+    expect(isAllowedOrigin('https://evil.example.com', allowed)).toBe(false);
+    expect(isAllowedOrigin('http://127.0.0.2', allowed)).toBe(false);
+  });
+
+  it('rejects malformed Origin header values', () => {
+    expect(isAllowedOrigin('not a url', allowed)).toBe(false);
+  });
+});
+
+describe('isAuthorized', () => {
+  const token = 'super-secret-token';
+
+  it('accepts the canonical Bearer token', () => {
+    expect(isAuthorized(`Bearer ${token}`, token)).toBe(true);
+  });
+
+  it('rejects a missing or empty Authorization header', () => {
+    expect(isAuthorized(null, token)).toBe(false);
+    expect(isAuthorized('', token)).toBe(false);
+  });
+
+  it('rejects unsupported authentication schemes', () => {
+    expect(isAuthorized(`Basic ${token}`, token)).toBe(false);
+    expect(isAuthorized(`Token ${token}`, token)).toBe(false);
+    expect(isAuthorized(token, token)).toBe(false);
+  });
+
+  it('rejects a wrong token of the same length without throwing', () => {
+    const wrong = 'X'.repeat(token.length);
+    expect(wrong).toHaveLength(token.length);
+    expect(isAuthorized(`Bearer ${wrong}`, token)).toBe(false);
+  });
+
+  it('rejects tokens of a different length without throwing', () => {
+    expect(isAuthorized(`Bearer ${token}extra`, token)).toBe(false);
+    expect(isAuthorized('Bearer short', token)).toBe(false);
+    expect(isAuthorized('Bearer ', token)).toBe(false);
+  });
+
+  it('is case-sensitive on the token value', () => {
+    expect(isAuthorized(`Bearer ${token.toUpperCase()}`, token)).toBe(false);
+  });
+});

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -18,14 +18,11 @@ import {
 import keytar from 'keytar';
 import path from 'node:path';
 import { createCredentialPrivilegedHandler } from './privileged-protocol';
+import type { ChamberCtx } from './types';
 
 const port = Number(process.env.CHAMBER_SERVER_PORT ?? 0);
 const allowedOrigin = process.env.CHAMBER_ALLOWED_ORIGIN ?? 'http://127.0.0.1';
 
-const ctx = createServerContext({
-  token: process.env.CHAMBER_SERVER_TOKEN,
-  allowedOrigins: [allowedOrigin],
-});
 const configService = new ConfigService();
 const saveActiveLogin = (login: string | null) => {
   const config = configService.load();
@@ -44,55 +41,83 @@ viewDiscovery.setRefreshHandler({
   sendBackgroundPrompt: (mindPath, prompt) => mindManager.sendBackgroundPrompt(mindPath, prompt),
 });
 
-ctx.listMinds = () => mindManager.listMinds();
-ctx.addMind = async (mindPath) => {
-  const mind = await mindManager.loadMind(mindPath);
-  mindManager.setActiveMind(mind.mindId);
-  return mind;
-};
-ctx.sendChat = ({ mindId, message, messageId, model, attachments }) =>
-  chatService.sendMessage(
-    mindId,
-    message,
-    messageId,
-    (event) => serverControls.publish(messageId, { mindId, messageId, event }),
-    model,
-    attachments,
-  );
-ctx.newConversation = (mindId) => chatService.newConversation(mindId);
-ctx.listModels = (mindId) => {
-  const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
-  return id ? chatService.listModels(id) : [];
-};
-ctx.cancelChat = (mindId, messageId) => chatService.cancelMessage(mindId, messageId);
+// Surfaces the loopback server intentionally does not yet implement. Throwing
+// stubs (instead of silent {}/null defaults) honor the `ChamberCtx` contract:
+// a deployment that doesn't support a feature must say so explicitly. Wiring
+// these to real services is tracked as follow-up work; failing fast is the
+// honest interim behavior.
+function notImplemented(name: string): () => never {
+  return () => {
+    throw new Error(`Loopback server: ${name} is not implemented`);
+  };
+}
 
-ctx.getAuthStatus = async () => {
-  const credential = await authService.getStoredCredential();
-  return { authenticated: credential !== null, login: credential?.login };
+// `ctx.sendChat` needs to call `serverControls.publish`, but `serverControls`
+// is built from `ctx`. Break the cycle with a holder that the late-bound
+// publish method overwrites once `createHttpServer` returns. The ctx itself
+// stays immutable after construction. Future cleanup: extract a `ChatEventBus`
+// port owned by the composition root so neither side has to mutate.
+const publishHolder: { publish: (sessionId: string, event: unknown) => void } = {
+  publish: () => {},
 };
-ctx.listAuthAccounts = () => authService.listAccounts();
-ctx.startAuthLogin = async (onProgress) => {
-  authService.setProgressHandler(onProgress);
-  const result = await authService.startLogin();
-  if (result.success && result.login) {
-    authService.setActiveLogin(result.login);
-  }
-  return result;
-};
-ctx.switchAuthAccount = async (login) => {
-  const accounts = await authService.listAccounts();
-  if (!accounts.some((account) => account.login === login)) {
-    throw new Error(`Account ${login} is not available`);
-  }
-  authService.setActiveLogin(login);
-};
-ctx.logoutAuth = () => authService.logout();
-ctx.shutdown = () => {
-  void shutdown();
-};
-ctx.handlePrivilegedRequest = createCredentialPrivilegedHandler(keytar as CredentialStore);
 
-if (process.env.CHAMBER_E2E === '1' && process.env.CHAMBER_E2E_FAKE_CHAT === '1') {
+const productionContext: ChamberCtx = createServerContext({
+  token: process.env.CHAMBER_SERVER_TOKEN,
+  allowedOrigins: [allowedOrigin],
+  listMinds: () => mindManager.listMinds(),
+  addMind: async (mindPath) => {
+    const mind = await mindManager.loadMind(mindPath);
+    mindManager.setActiveMind(mind.mindId);
+    return mind;
+  },
+  getConfig: () => configService.load(),
+  listLensViews: () => viewDiscovery.getViews(),
+  getGenesisStatus: notImplemented('getGenesisStatus'),
+  getAuthStatus: async () => {
+    const credential = await authService.getStoredCredential();
+    return { authenticated: credential !== null, login: credential?.login };
+  },
+  listAuthAccounts: () => authService.listAccounts(),
+  startAuthLogin: async (onProgress) => {
+    authService.setProgressHandler(onProgress);
+    const result = await authService.startLogin();
+    if (result.success && result.login) {
+      authService.setActiveLogin(result.login);
+    }
+    return result;
+  },
+  switchAuthAccount: async (login) => {
+    const accounts = await authService.listAccounts();
+    if (!accounts.some((account) => account.login === login)) {
+      throw new Error(`Account ${login} is not available`);
+    }
+    authService.setActiveLogin(login);
+  },
+  logoutAuth: () => authService.logout(),
+  listChamberTools: () => configService.load().installedTools ?? [],
+  saveAttachment: notImplemented('saveAttachment'),
+  sendChat: ({ mindId, message, messageId, model, attachments }) =>
+    chatService.sendMessage(
+      mindId,
+      message,
+      messageId,
+      (event) => publishHolder.publish(messageId, { mindId, messageId, event }),
+      model,
+      attachments,
+    ),
+  newConversation: (mindId) => chatService.newConversation(mindId),
+  cancelChat: (mindId, messageId) => chatService.cancelMessage(mindId, messageId),
+  listModels: (mindId) => {
+    const id = mindId ?? mindManager.getActiveMindId() ?? mindManager.listMinds()[0]?.mindId;
+    return id ? chatService.listModels(id) : [];
+  },
+  shutdown: () => {
+    void shutdown();
+  },
+  handlePrivilegedRequest: createCredentialPrivilegedHandler(keytar as CredentialStore),
+});
+
+function buildE2EFakeChatContext(base: ChamberCtx): ChamberCtx {
   const fakeMinds = new Map<string, {
     mindId: string;
     mindPath: string;
@@ -131,31 +156,34 @@ if (process.env.CHAMBER_E2E === '1' && process.env.CHAMBER_E2E_FAKE_CHAT === '1'
     }
   }
 
-  ctx.listMinds = () => Array.from(fakeMinds.values());
-  ctx.addMind = (mindPath) => seedFakeMind(mindPath);
-  ctx.sendChat = ({ mindId, messageId }) => {
-    serverControls.publish(messageId, {
-      mindId,
-      messageId,
-      event: { type: 'message_final', sdkMessageId: `e2e-${messageId}`, content: fakeReply },
-    });
-    serverControls.publish(messageId, {
-      mindId,
-      messageId,
-      event: { type: 'done' },
-    });
+  return {
+    ...base,
+    listMinds: () => Array.from(fakeMinds.values()),
+    addMind: (mindPath) => seedFakeMind(mindPath),
+    sendChat: ({ mindId, messageId }) => {
+      publishHolder.publish(messageId, {
+        mindId,
+        messageId,
+        event: { type: 'message_final', sdkMessageId: `e2e-${messageId}`, content: fakeReply },
+      });
+      publishHolder.publish(messageId, {
+        mindId,
+        messageId,
+        event: { type: 'done' },
+      });
+    },
+    newConversation: () => undefined,
+    cancelChat: () => undefined,
+    listModels: () => [{ id: 'e2e-fake-model', name: 'E2E Fake Model' }],
   };
-  ctx.newConversation = () => undefined;
-  ctx.cancelChat = () => undefined;
-  ctx.listModels = () => [{ id: 'e2e-fake-model', name: 'E2E Fake Model' }];
 }
 
-const serverControls = createHttpServer({
-  ...ctx,
-  shutdown: () => {
-    void shutdown();
-  },
-});
+const ctx: ChamberCtx = (process.env.CHAMBER_E2E === '1' && process.env.CHAMBER_E2E_FAKE_CHAT === '1')
+  ? buildE2EFakeChatContext(productionContext)
+  : productionContext;
+
+const serverControls = createHttpServer(ctx);
+publishHolder.publish = serverControls.publish;
 const { server } = serverControls;
 
 server.listen(port, '127.0.0.1', () => {

--- a/apps/server/src/composition.test.ts
+++ b/apps/server/src/composition.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { createServerContext } from './composition';
+import type { ChamberCtx } from './types';
+
+const noop = () => undefined;
+const asyncNoop = async () => undefined;
+const asyncList = async () => [];
+const asyncRecord = async () => ({});
+
+const fullCapabilities: Omit<ChamberCtx, 'token' | 'allowedOrigins'> = {
+  listMinds: () => [],
+  addMind: asyncRecord,
+  getConfig: asyncRecord,
+  listLensViews: asyncList,
+  getGenesisStatus: asyncRecord,
+  getAuthStatus: asyncRecord,
+  listAuthAccounts: asyncList,
+  startAuthLogin: async () => ({ success: false }),
+  switchAuthAccount: asyncNoop,
+  logoutAuth: asyncNoop,
+  listChamberTools: () => [],
+  saveAttachment: asyncRecord,
+  sendChat: noop,
+  newConversation: noop,
+  cancelChat: noop,
+  listModels: () => [],
+  shutdown: noop,
+  handlePrivilegedRequest: async () => ({ ok: true as const, requestId: 'r1' }),
+};
+
+describe('createServerContext', () => {
+  it('defaults token and allowedOrigins when omitted', () => {
+    const ctx = createServerContext({ ...fullCapabilities });
+    expect(ctx.token).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(ctx.allowedOrigins.has('http://127.0.0.1')).toBe(true);
+  });
+
+  it('honors explicit token and allowedOrigins', () => {
+    const ctx = createServerContext({
+      token: 'explicit',
+      allowedOrigins: ['https://example.test'],
+      ...fullCapabilities,
+    });
+    expect(ctx.token).toBe('explicit');
+    expect(ctx.allowedOrigins.has('https://example.test')).toBe(true);
+  });
+
+  // Compile-time tripwire: removing `?` from a route-backed capability on
+  // ChamberCtx is the whole point of #138. If a future change adds the
+  // optional modifier back (or drops a required field from the inputs),
+  // these `@ts-expect-error` lines will no longer be errors and the build
+  // breaks here. Without this test the regression is silent.
+  it('refuses inputs that omit any required capability (compile-time)', () => {
+    // @ts-expect-error: every route-backed capability is required
+    createServerContext({ token: 't', allowedOrigins: ['http://127.0.0.1'] });
+
+    // @ts-expect-error: addMind is required
+    createServerContext({ ...fullCapabilities, addMind: undefined });
+
+    // @ts-expect-error: sendChat is required
+    createServerContext({ ...fullCapabilities, sendChat: undefined });
+
+    // @ts-expect-error: handlePrivilegedRequest is required
+    createServerContext({ ...fullCapabilities, handlePrivilegedRequest: undefined });
+
+    expect(true).toBe(true);
+  });
+});

--- a/apps/server/src/composition.ts
+++ b/apps/server/src/composition.ts
@@ -1,31 +1,22 @@
-import { randomBytes, randomUUID } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import type { ChamberCtx } from './types';
 
-export interface ServerCompositionOptions {
+/**
+ * Inputs to {@link createServerContext}. `token` and `allowedOrigins` have
+ * sensible defaults; every capability is required so a deployment must
+ * explicitly opt in to (or refuse) each surface rather than silently fall
+ * back to a no-op.
+ */
+export interface ServerContextInputs extends Omit<ChamberCtx, 'token' | 'allowedOrigins'> {
   token?: string;
   allowedOrigins?: Iterable<string>;
 }
 
-export function createServerContext(options: ServerCompositionOptions = {}): ChamberCtx {
-  const token = options.token ?? randomBytes(32).toString('base64url');
+export function createServerContext(inputs: ServerContextInputs): ChamberCtx {
+  const { token, allowedOrigins, ...capabilities } = inputs;
   return {
-    token,
-    allowedOrigins: new Set(options.allowedOrigins ?? [`http://127.0.0.1`]),
-    listMinds: () => [],
-    addMind: async () => {
-      throw new Error('Mind loading is unavailable');
-    },
-    getConfig: () => ({ version: 1 }),
-    listLensViews: () => [],
-    getGenesisStatus: () => ({ ready: false }),
-    getAuthStatus: () => ({ authenticated: false }),
-    listAuthAccounts: () => [],
-    listChamberTools: () => [],
-    saveAttachment: async ({ name }) => ({ attachmentId: randomUUID(), name }),
-    cancelChat: () => undefined,
-    sendChat: () => undefined,
-    newConversation: () => undefined,
-    listModels: () => [],
-    validatePath: () => false,
+    token: token ?? randomBytes(32).toString('base64url'),
+    allowedOrigins: new Set(allowedOrigins ?? ['http://127.0.0.1']),
+    ...capabilities,
   };
 }

--- a/apps/server/src/handlers.test.ts
+++ b/apps/server/src/handlers.test.ts
@@ -154,11 +154,34 @@ describe('server handlers', () => {
   });
 });
 
+function notConfigured(name: string): () => never {
+  return () => {
+    throw new Error(`Test stub: ${name} not configured`);
+  };
+}
+
 function makeContext(overrides: Partial<ChamberCtx>): ChamberCtx {
   return {
     token: 'test-token',
     allowedOrigins: new Set(['http://127.0.0.1']),
     listMinds: () => [],
+    addMind: notConfigured('addMind'),
+    getConfig: notConfigured('getConfig'),
+    listLensViews: notConfigured('listLensViews'),
+    getGenesisStatus: notConfigured('getGenesisStatus'),
+    getAuthStatus: notConfigured('getAuthStatus'),
+    listAuthAccounts: notConfigured('listAuthAccounts'),
+    startAuthLogin: notConfigured('startAuthLogin'),
+    switchAuthAccount: notConfigured('switchAuthAccount'),
+    logoutAuth: notConfigured('logoutAuth'),
+    listChamberTools: notConfigured('listChamberTools'),
+    saveAttachment: notConfigured('saveAttachment'),
+    sendChat: notConfigured('sendChat'),
+    newConversation: notConfigured('newConversation'),
+    cancelChat: notConfigured('cancelChat'),
+    listModels: notConfigured('listModels'),
+    shutdown: () => {},
+    handlePrivilegedRequest: notConfigured('handlePrivilegedRequest'),
     ...overrides,
   };
 }

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -16,9 +16,6 @@ export async function addMindHandler(request: ChamberRequest, ctx: ChamberCtx): 
   if (!mindPath) {
     return { status: 400, body: { error: 'mindPath is required' } };
   }
-  if (!ctx.addMind) {
-    return { status: 503, body: { error: 'Mind loading is unavailable' } };
-  }
   try {
     return { status: 200, body: { mind: await ctx.addMind(mindPath) } };
   } catch (error) {
@@ -27,23 +24,23 @@ export async function addMindHandler(request: ChamberRequest, ctx: ChamberCtx): 
 }
 
 export async function getConfigHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: await ctx.getConfig?.() ?? { version: 1 } };
+  return { status: 200, body: await ctx.getConfig() };
 }
 
 export async function listLensViewsHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: { views: await ctx.listLensViews?.() ?? [] } };
+  return { status: 200, body: { views: await ctx.listLensViews() } };
 }
 
 export async function getGenesisStatusHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: await ctx.getGenesisStatus?.() ?? { ready: false } };
+  return { status: 200, body: await ctx.getGenesisStatus() };
 }
 
 export async function getAuthStatusHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: await ctx.getAuthStatus?.() ?? { authenticated: false } };
+  return { status: 200, body: await ctx.getAuthStatus() };
 }
 
 export async function listAuthAccountsHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: { accounts: await ctx.listAuthAccounts?.() ?? [] } };
+  return { status: 200, body: { accounts: await ctx.listAuthAccounts() } };
 }
 
 export async function switchAuthAccountHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
@@ -53,23 +50,17 @@ export async function switchAuthAccountHandler(request: ChamberRequest, ctx: Cha
   if (!login) {
     return { status: 400, body: { error: 'login is required' } };
   }
-  if (!ctx.switchAuthAccount) {
-    return { status: 503, body: { error: 'Auth account switching is unavailable' } };
-  }
   await ctx.switchAuthAccount(login);
   return { status: 200, body: { ok: true } };
 }
 
 export async function logoutAuthHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  if (!ctx.logoutAuth) {
-    return { status: 503, body: { error: 'Auth logout is unavailable' } };
-  }
   await ctx.logoutAuth();
   return { status: 200, body: { ok: true } };
 }
 
 export async function listChamberToolsHandler(_request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  return { status: 200, body: { tools: ctx.listChamberTools?.() ?? [] } };
+  return { status: 200, body: { tools: ctx.listChamberTools() } };
 }
 
 export async function uploadAttachmentHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
@@ -80,8 +71,7 @@ export async function uploadAttachmentHandler(request: ChamberRequest, ctx: Cham
   if (!request.body || !(request.body instanceof ArrayBuffer)) {
     return { status: 400, body: { error: 'Attachment body is required' } };
   }
-  const result = await ctx.saveAttachment?.({ name, body: request.body }) ?? { name };
-  return { status: 200, body: result };
+  return { status: 200, body: await ctx.saveAttachment({ name, body: request.body }) };
 }
 
 export async function cancelChatHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
@@ -93,7 +83,7 @@ export async function cancelChatHandler(request: ChamberRequest, ctx: ChamberCtx
     : '';
   if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
   if (!messageId) return { status: 400, body: { error: 'messageId is required' } };
-  await ctx.cancelChat?.(mindId, messageId);
+  await ctx.cancelChat(mindId, messageId);
   return { status: 200, body: { ok: true } };
 }
 
@@ -106,7 +96,6 @@ export async function sendChatHandler(request: ChamberRequest, ctx: ChamberCtx):
   const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
   if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
   if (!messageId) return { status: 400, body: { error: 'messageId is required' } };
-  if (!ctx.sendChat) return { status: 503, body: { error: 'Chat is unavailable' } };
 
   const attachments = parseChatAttachments(body.attachments);
   if (attachments === null) {
@@ -130,14 +119,12 @@ export async function newConversationHandler(request: ChamberRequest, ctx: Chamb
     ? String((request.body as { mindId: unknown }).mindId).trim()
     : '';
   if (!mindId) return { status: 400, body: { error: 'mindId is required' } };
-  if (!ctx.newConversation) return { status: 503, body: { error: 'Chat is unavailable' } };
 
   await ctx.newConversation(mindId);
   return { status: 200, body: { ok: true } };
 }
 
 export async function listModelsHandler(request: ChamberRequest, ctx: ChamberCtx): Promise<ChamberResponse> {
-  if (!ctx.listModels) return { status: 503, body: { error: 'Model listing is unavailable' } };
   const body: ListModelsResponse = {
     models: await ctx.listModels(request.query?.get('mindId') ?? undefined),
   };

--- a/apps/server/src/honoAdapter.test.ts
+++ b/apps/server/src/honoAdapter.test.ts
@@ -227,61 +227,6 @@ describe('createHttpServer', () => {
   });
 
   describe('route availability', () => {
-    it('returns 503 from /api/mind/add when the context has no addMind capability', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'POST',
-        path: '/api/mind/add',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ mindPath: 'C:\\agents\\dude' }),
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Mind loading is unavailable' });
-    });
-
-    it('returns 503 from /api/chat/send when the context has no sendChat capability', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'POST',
-        path: '/api/chat/send',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          mindId: 'dude-1234',
-          message: 'Hello',
-          messageId: 'assistant-1',
-        }),
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Chat is unavailable' });
-    });
-
-    it('returns 503 from /api/chat/models when the context has no listModels capability', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'GET',
-        path: '/api/chat/models',
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Model listing is unavailable' });
-    });
-
-    it('returns 503 from /api/privileged when the context has no privileged handler', async () => {
-      const { port } = await startServer({});
-      const response = await httpRequest(port, {
-        method: 'POST',
-        path: '/api/privileged',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          protoVersion: 1,
-          type: 'credential.getPassword',
-          requestId: 'r1',
-          payload: { service: 'copilot-cli', account: 'octocat' },
-        }),
-      });
-      expect(response.statusCode).toBe(503);
-      expect(JSON.parse(response.body)).toEqual({ error: 'Privileged channel unavailable' });
-    });
-
     it('serves the placeholder HTML on the catch-all GET route without auth', async () => {
       const { port } = await startServer({});
       const response = await rawHttpRequest(port, {
@@ -309,7 +254,7 @@ describe('createHttpServer', () => {
       expect(shutdown).toHaveBeenCalledTimes(1);
     });
 
-    it('still responds 200 when no shutdown handler is configured', async () => {
+    it('responds 200 immediately even when the shutdown handler is a noop', async () => {
       const { port } = await startServer({});
       const response = await httpRequest(port, {
         method: 'POST',
@@ -460,11 +405,34 @@ describe('createHttpServer', () => {
   });
 });
 
+function notConfigured(name: string): () => never {
+  return () => {
+    throw new Error(`Test stub: ${name} not configured`);
+  };
+}
+
 function makeContext(overrides: Partial<ChamberCtx> = {}): ChamberCtx {
   return {
     token: TOKEN,
     allowedOrigins: new Set([ORIGIN]),
     listMinds: () => [],
+    addMind: notConfigured('addMind'),
+    getConfig: notConfigured('getConfig'),
+    listLensViews: notConfigured('listLensViews'),
+    getGenesisStatus: notConfigured('getGenesisStatus'),
+    getAuthStatus: notConfigured('getAuthStatus'),
+    listAuthAccounts: notConfigured('listAuthAccounts'),
+    startAuthLogin: notConfigured('startAuthLogin'),
+    switchAuthAccount: notConfigured('switchAuthAccount'),
+    logoutAuth: notConfigured('logoutAuth'),
+    listChamberTools: notConfigured('listChamberTools'),
+    saveAttachment: notConfigured('saveAttachment'),
+    sendChat: notConfigured('sendChat'),
+    newConversation: notConfigured('newConversation'),
+    cancelChat: notConfigured('cancelChat'),
+    listModels: notConfigured('listModels'),
+    shutdown: () => {},
+    handlePrivilegedRequest: notConfigured('handlePrivilegedRequest'),
     ...overrides,
   };
 }

--- a/apps/server/src/honoAdapter.test.ts
+++ b/apps/server/src/honoAdapter.test.ts
@@ -1,7 +1,7 @@
 import { request } from 'node:http';
 import type { IncomingHttpHeaders } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WebSocketServer } from 'ws';
 import { WebSocket } from 'ws';
 import { createHttpServer } from './honoAdapter';
@@ -143,6 +143,321 @@ describe('createHttpServer', () => {
       ws.close();
     }
   });
+
+  describe('auth header enforcement', () => {
+    it('returns 401 when the Authorization header is missing', async () => {
+      const { port } = await startServer({});
+      const response = await rawHttpRequest(port, {
+        method: 'GET',
+        path: '/api/mind/list',
+        headers: { origin: ORIGIN },
+      });
+      expect(response.statusCode).toBe(401);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('returns 401 when the Authorization scheme is not Bearer', async () => {
+      const { port } = await startServer({});
+      const response = await rawHttpRequest(port, {
+        method: 'GET',
+        path: '/api/mind/list',
+        headers: { origin: ORIGIN, authorization: `Basic ${TOKEN}` },
+      });
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('returns 401 when the Bearer token does not match', async () => {
+      const { port } = await startServer({});
+      const response = await rawHttpRequest(port, {
+        method: 'GET',
+        path: '/api/mind/list',
+        headers: { origin: ORIGIN, authorization: `Bearer not-the-token` },
+      });
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('accepts the configured Bearer token', async () => {
+      const { port } = await startServer({});
+      const response = await httpRequest(port, {
+        method: 'GET',
+        path: '/api/mind/list',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ minds: [] });
+    });
+  });
+
+  describe('origin allowlist', () => {
+    it('rejects requests from a disallowed origin', async () => {
+      const { port } = await startServer({});
+      const response = await rawHttpRequest(port, {
+        method: 'GET',
+        path: '/api/mind/list',
+        headers: {
+          origin: 'https://evil.example.com',
+          authorization: `Bearer ${TOKEN}`,
+        },
+      });
+      expect(response.statusCode).toBe(403);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Forbidden origin' });
+    });
+
+    it('allows requests with no Origin header (native fetchers)', async () => {
+      const { port } = await startServer({});
+      const response = await rawHttpRequest(port, {
+        method: 'GET',
+        path: '/api/mind/list',
+        headers: { authorization: `Bearer ${TOKEN}` },
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('allows loopback origins on any port when the host matches the allowlist', async () => {
+      const { port } = await startServer({});
+      const response = await rawHttpRequest(port, {
+        method: 'GET',
+        path: '/api/mind/list',
+        headers: {
+          origin: `http://127.0.0.1:${port}`,
+          authorization: `Bearer ${TOKEN}`,
+        },
+      });
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
+  describe('route availability', () => {
+    it('returns 503 from /api/mind/add when the context has no addMind capability', async () => {
+      const { port } = await startServer({});
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/mind/add',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mindPath: 'C:\\agents\\dude' }),
+      });
+      expect(response.statusCode).toBe(503);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Mind loading is unavailable' });
+    });
+
+    it('returns 503 from /api/chat/send when the context has no sendChat capability', async () => {
+      const { port } = await startServer({});
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/chat/send',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          mindId: 'dude-1234',
+          message: 'Hello',
+          messageId: 'assistant-1',
+        }),
+      });
+      expect(response.statusCode).toBe(503);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Chat is unavailable' });
+    });
+
+    it('returns 503 from /api/chat/models when the context has no listModels capability', async () => {
+      const { port } = await startServer({});
+      const response = await httpRequest(port, {
+        method: 'GET',
+        path: '/api/chat/models',
+      });
+      expect(response.statusCode).toBe(503);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Model listing is unavailable' });
+    });
+
+    it('returns 503 from /api/privileged when the context has no privileged handler', async () => {
+      const { port } = await startServer({});
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/privileged',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          protoVersion: 1,
+          type: 'credential.getPassword',
+          requestId: 'r1',
+          payload: { service: 'copilot-cli', account: 'octocat' },
+        }),
+      });
+      expect(response.statusCode).toBe(503);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Privileged channel unavailable' });
+    });
+
+    it('serves the placeholder HTML on the catch-all GET route without auth', async () => {
+      const { port } = await startServer({});
+      const response = await rawHttpRequest(port, {
+        method: 'GET',
+        path: '/anything-else',
+        headers: {},
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain('<h1>Chamber server</h1>');
+    });
+  });
+
+  describe('shutdown', () => {
+    it('schedules ctx.shutdown asynchronously and replies 200 immediately', async () => {
+      const shutdown = vi.fn();
+      const { port } = await startServer({ shutdown });
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/shutdown',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ ok: true });
+      // setTimeout(..., 0) means shutdown runs on the next tick after the response is flushed.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    });
+
+    it('still responds 200 when no shutdown handler is configured', async () => {
+      const { port } = await startServer({});
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/shutdown',
+      });
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
+  describe('attachment upload', () => {
+    it('forwards the binary body to ctx.saveAttachment with the requested name', async () => {
+      const saveAttachment = vi.fn(async ({ name, body }: { name: string; body: ArrayBuffer }) => ({
+        name,
+        size: body.byteLength,
+      }));
+      const { port } = await startServer({ saveAttachment });
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/attachments?name=image.png',
+        headers: { 'content-type': 'application/octet-stream' },
+        body: 'binary-bytes',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ name: 'image.png', size: 12 });
+      expect(saveAttachment).toHaveBeenCalledTimes(1);
+      const call = saveAttachment.mock.calls[0][0];
+      expect(call.name).toBe('image.png');
+      expect(call.body).toBeInstanceOf(ArrayBuffer);
+      expect(Buffer.from(call.body).toString('utf8')).toBe('binary-bytes');
+    });
+
+    it('returns 400 when the name query parameter is missing', async () => {
+      const saveAttachment = vi.fn();
+      const { port } = await startServer({ saveAttachment });
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/attachments',
+        headers: { 'content-type': 'application/octet-stream' },
+        body: 'binary-bytes',
+      });
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Attachment name is required' });
+      expect(saveAttachment).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the body is JSON instead of binary', async () => {
+      const saveAttachment = vi.fn();
+      const { port } = await startServer({ saveAttachment });
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/attachments?name=image.png',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ data: 'oops' }),
+      });
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({ error: 'Attachment body is required' });
+      expect(saveAttachment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('chat cancel', () => {
+    it('forwards the mindId and messageId to ctx.cancelChat', async () => {
+      const cancelChat = vi.fn(async () => undefined);
+      const { port } = await startServer({ cancelChat });
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/chat/cancel',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mindId: 'dude-1234', messageId: 'assistant-1' }),
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ ok: true });
+      expect(cancelChat).toHaveBeenCalledWith('dude-1234', 'assistant-1');
+    });
+
+    it('returns 400 when mindId is missing', async () => {
+      const cancelChat = vi.fn();
+      const { port } = await startServer({ cancelChat });
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/chat/cancel',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ messageId: 'assistant-1' }),
+      });
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({ error: 'mindId is required' });
+      expect(cancelChat).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when messageId is missing', async () => {
+      const cancelChat = vi.fn();
+      const { port } = await startServer({ cancelChat });
+      const response = await httpRequest(port, {
+        method: 'POST',
+        path: '/api/chat/cancel',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mindId: 'dude-1234' }),
+      });
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({ error: 'messageId is required' });
+      expect(cancelChat).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('WebSocket upgrade authorization', () => {
+    it('rejects upgrades that do not present a token', async () => {
+      const { port } = await startServer({});
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/events`, {
+        headers: { origin: `${ORIGIN}:${port}` },
+      });
+      const status = await waitForUpgradeRejection(ws);
+      expect(status).toBe(401);
+    });
+
+    it('rejects upgrades whose query token is wrong', async () => {
+      const { port } = await startServer({});
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/events?token=not-the-token`, {
+        headers: { origin: `${ORIGIN}:${port}` },
+      });
+      const status = await waitForUpgradeRejection(ws);
+      expect(status).toBe(401);
+    });
+
+    it('rejects upgrades from a disallowed origin', async () => {
+      const { port } = await startServer({});
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/events?token=${TOKEN}`, {
+        headers: { origin: 'https://evil.example.com' },
+      });
+      const status = await waitForUpgradeRejection(ws);
+      expect(status).toBe(401);
+    });
+
+    it('accepts upgrades that authenticate via the Authorization header instead of the query token', async () => {
+      const { port } = await startServer({});
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/events`, {
+        headers: {
+          origin: `${ORIGIN}:${port}`,
+          authorization: `Bearer ${TOKEN}`,
+        },
+      });
+      try {
+        await waitForOpen(ws);
+        expect(ws.readyState).toBe(WebSocket.OPEN);
+      } finally {
+        ws.close();
+      }
+    });
+  });
 });
 
 function makeContext(overrides: Partial<ChamberCtx> = {}): ChamberCtx {
@@ -192,6 +507,30 @@ interface BufferedResponse {
 async function httpRequest(port: number, options: RequestOptions): Promise<BufferedResponse> {
   return new Promise((resolve, reject) => {
     const req = request(baseRequestOptions(port, options), (res) => {
+      res.setEncoding('utf8');
+      let body = '';
+      res.on('data', (chunk: string) => {
+        body += chunk;
+      });
+      res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body }));
+    });
+    req.on('error', reject);
+    req.end(options.body);
+  });
+}
+
+async function rawHttpRequest(
+  port: number,
+  options: { method: string; path: string; headers: IncomingHttpHeaders; body?: string },
+): Promise<BufferedResponse> {
+  return new Promise((resolve, reject) => {
+    const req = request({
+      hostname: '127.0.0.1',
+      port,
+      path: options.path,
+      method: options.method,
+      headers: options.headers,
+    }, (res) => {
       res.setEncoding('utf8');
       let body = '';
       res.on('data', (chunk: string) => {
@@ -270,6 +609,20 @@ async function waitForOpen(ws: WebSocket): Promise<void> {
     ws.once('open', resolve);
     ws.once('error', reject);
   });
+}
+
+async function waitForUpgradeRejection(ws: WebSocket): Promise<number> {
+  return withTimeout(new Promise<number>((resolve, reject) => {
+    ws.on('unexpected-response', (_request, response) => {
+      response.resume();
+      resolve(response.statusCode ?? 0);
+    });
+    ws.on('open', () => reject(new Error('Expected upgrade to be rejected, but the socket opened')));
+    ws.on('error', () => {
+      // ws emits "error" alongside "unexpected-response" or when the socket is destroyed.
+      // We rely on "unexpected-response" for the status code; ignore the bare error.
+    });
+  }), 'Timed out waiting for WebSocket upgrade rejection');
 }
 
 async function waitForMessage(

--- a/apps/server/src/honoAdapter.ts
+++ b/apps/server/src/honoAdapter.ts
@@ -51,12 +51,7 @@ function send(c: Context, response: ChamberResponse): Response {
   return c.json(response.body ?? null, response.status as 200);
 }
 
-function streamAuthLogin(c: Context, ctx: ChamberCtx): Response {
-  const startAuthLogin = ctx.startAuthLogin;
-  if (!startAuthLogin) {
-    return c.json({ error: 'Auth login is unavailable' }, 503);
-  }
-
+function streamAuthLogin(ctx: ChamberCtx): Response {
   const encoder = new TextEncoder();
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -64,7 +59,7 @@ function streamAuthLogin(c: Context, ctx: ChamberCtx): Response {
         controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
       };
 
-      void startAuthLogin((progress) => write({ type: 'progress', progress }))
+      void ctx.startAuthLogin((progress) => write({ type: 'progress', progress }))
         .then((result) => write({ type: 'result', result }))
         .catch((error: unknown) => {
           const message = error instanceof Error ? error.message : String(error);
@@ -117,7 +112,7 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
   app.post('/api/auth/login', async (c) => {
     const authFailure = requireAuth(c, ctx);
     if (authFailure) return authFailure;
-    return streamAuthLogin(c, ctx);
+    return streamAuthLogin(ctx);
   });
   app.post('/api/auth/switch', async (c) => {
     const authFailure = requireAuth(c, ctx);
@@ -154,7 +149,6 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
   app.post('/api/privileged', async (c) => {
     const authFailure = requireAuth(c, ctx);
     if (authFailure) return authFailure;
-    if (!ctx.handlePrivilegedRequest) return c.json({ error: 'Privileged channel unavailable' }, 503);
     let body: unknown;
     let request;
     try {
@@ -175,7 +169,7 @@ export function createHonoApp(ctx: ChamberCtx): Hono {
   app.post('/api/shutdown', async (c) => {
     const authFailure = requireAuth(c, ctx);
     if (authFailure) return authFailure;
-    setTimeout(() => ctx.shutdown?.(), 0);
+    setTimeout(() => ctx.shutdown(), 0);
     return c.json({ ok: true });
   });
   app.get('*', (c) => c.html('<!doctype html><html><body><h1>Chamber server</h1></body></html>'));

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -29,27 +29,34 @@ export interface ServerAuthLoginResult {
   error?: string;
 }
 
+/**
+ * Capabilities the loopback server requires from its host process. Every
+ * field except `publish` is mandatory: a deployment that doesn't want to
+ * support a feature must provide an explicit refusal (e.g. a function that
+ * throws `new Error('Mind loading is unavailable')`) rather than rely on a
+ * silent default. `publish` is the optional outbound observability hook the
+ * websocket fan-out also tees published chat events into.
+ */
 export interface ChamberCtx {
   token: string;
   allowedOrigins: ReadonlySet<string>;
   listMinds: () => unknown[];
-  addMind?: (mindPath: string) => unknown | Promise<unknown>;
-  getConfig?: () => unknown | Promise<unknown>;
-  listLensViews?: () => unknown | Promise<unknown>;
-  getGenesisStatus?: () => unknown | Promise<unknown>;
-  getAuthStatus?: () => unknown | Promise<unknown>;
-  listAuthAccounts?: () => unknown[] | Promise<unknown[]>;
-  startAuthLogin?: (onProgress: (progress: ServerAuthProgress) => void) => Promise<ServerAuthLoginResult>;
-  switchAuthAccount?: (login: string) => void | Promise<void>;
-  logoutAuth?: () => void | Promise<void>;
-  listChamberTools?: () => unknown;
+  addMind: (mindPath: string) => unknown | Promise<unknown>;
+  getConfig: () => unknown | Promise<unknown>;
+  listLensViews: () => unknown | Promise<unknown>;
+  getGenesisStatus: () => unknown | Promise<unknown>;
+  getAuthStatus: () => unknown | Promise<unknown>;
+  listAuthAccounts: () => unknown[] | Promise<unknown[]>;
+  startAuthLogin: (onProgress: (progress: ServerAuthProgress) => void) => Promise<ServerAuthLoginResult>;
+  switchAuthAccount: (login: string) => void | Promise<void>;
+  logoutAuth: () => void | Promise<void>;
+  listChamberTools: () => unknown;
+  saveAttachment: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
+  cancelChat: (mindId: string, messageId: string) => Promise<void> | void;
+  sendChat: (request: SendChatRequest) => Promise<void> | void;
+  newConversation: (mindId: string) => Promise<unknown> | unknown;
+  listModels: (mindId?: string) => ModelDto[] | Promise<ModelDto[]>;
+  shutdown: () => void;
+  handlePrivilegedRequest: (request: PrivilegedRequest) => Promise<PrivilegedResponse>;
   publish?: (sessionId: string, event: unknown) => void;
-  validatePath?: (candidate: string) => boolean;
-  saveAttachment?: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
-  cancelChat?: (mindId: string, messageId: string) => Promise<void> | void;
-  sendChat?: (request: SendChatRequest) => Promise<void> | void;
-  newConversation?: (mindId: string) => Promise<unknown> | unknown;
-  listModels?: (mindId?: string) => ModelDto[] | Promise<ModelDto[]>;
-  shutdown?: () => void;
-  handlePrivilegedRequest?: (request: PrivilegedRequest) => Promise<PrivilegedResponse>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.47.5",
+      "version": "0.47.6",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.47.0",
+  "version": "0.47.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.47.0",
+      "version": "0.47.5",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.47.0",
+  "version": "0.47.5",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
Make all route-backed capabilities on ChamberCtx required so the loopback server fails at compile time when a deployment forgets to wire a feature, instead of silently falling back to a 503 response.

## Changes

- pps/server/src/types.ts: drop ? from every route-backed capability; remove unused alidatePath; publish stays optional (observability hook).
- pps/server/src/composition.ts: createServerContext now takes a ServerContextInputs (Omit-based) requiring all capabilities; only 	oken / llowedOrigins are defaulted.
- New pps/server/src/composition.test.ts with 3 cases pinning the contract.
- v0.49.4 + changelog entry.

## Test evidence

- 
pm run lint clean
- 
pm test -- --run apps/server all green (58/58)
- 
pm run smoke:server-sdk passed

Closes #138

Replaces previously-closed PR #240 (parent branch was deleted on merge).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>