### PR TITLE
fix(testing): unblock desktop smoke on Windows and fix #244 sidebar selectors (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.49.11 (2026-05-09)
+
+### Testing
+
+- **Unblock `npm run smoke:desktop` on Windows** — The Playwright `webServer` (`apps/server/dist/bin.mjs`) and the shared Electron test helper (`tests/e2e/electron/electronApp.ts`) were both eagerly importing `keytar` at module load. Windows holds an exclusive lock on a loaded `.node` native addon, so when `electron-forge start` next ran `@electron/rebuild` to swap `keytar.node` to Electron's ABI it failed with `EPERM: operation not permitted, unlink 'keytar.node'` and 0 of 22 desktop smoke tests could even start. Both call sites now lazy-load keytar (`bin.ts` exposes a `CredentialStore` proxy that calls `require('keytar')` only when a credential operation actually fires; `electronApp.ts` inlines the require inside `canAccessRepo`). Linux/macOS were unaffected (POSIX allows unlinking open files). (#250)
+
+### Renderer
+
+- **Fix three `MindSidebar` selector regressions from #244** — PR #244 intentionally added three `role="button"` accessibility controls per mind row (Edit profile / Open in window / Remove) nested inside the outer `<button>`. Eight desktop smoke tests using `getByRole('button', { name: /MindName/ })` then matched four elements and tripped Playwright's strict-mode guard. Switched the affected selectors in `monica-open-existing.spec.ts`, `lens-hotload.spec.ts`, and `desktop-navigation-popout.spec.ts` to `page.locator('button').filter({ hasText: /\bMindName\b/ })`, which restricts to real `<button>` elements (excluding the new `role="button"` `<span>`s) and uses word boundaries so `Inactive Lens Smoke Mind` cannot collide with `Active Lens Smoke Mind`. The `MindSidebar` accessibility additions are unchanged. (#250)
+- **`ProfileMarkdownEditor` Save button stays in the viewport on small windows** — The new modal added in #244 wrapped its 420px-min textarea + header + footer in a `DialogContent` with no `max-height`, so on the default 800px Electron window the Save button rendered below the visible area and could not be reached by clicking, scrolling, or `scrollIntoViewIfNeeded` (the dialog is `position: fixed`, not part of the page scroll). `DialogContent` is now `flex max-h-[88vh] flex-col` and the textarea is `flex-1 min-h-[200px]`, matching the outer `AgentProfileModal` pattern: header/footer pinned, textarea scrolls internally. Save is now reachable in any reasonable window size. (#250)
+
 ## v0.49.10 (2026-05-08)
 
 ### Mind

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -15,7 +15,6 @@ import {
   ViewDiscovery,
   type CredentialStore,
 } from '@chamber/services';
-import keytar from 'keytar';
 import path from 'node:path';
 import { createCredentialPrivilegedHandler } from './privileged-protocol';
 import type { ChamberCtx } from './types';
@@ -23,12 +22,29 @@ import type { ChamberCtx } from './types';
 const port = Number(process.env.CHAMBER_SERVER_PORT ?? 0);
 const allowedOrigin = process.env.CHAMBER_ALLOWED_ORIGIN ?? 'http://127.0.0.1';
 
+// Defer loading the keytar native addon until an auth method is actually
+// invoked. On Windows, keytar.node is locked the moment Node loads it, which
+// breaks `electron-forge start`'s rebuild step (it can't unlink keytar.node
+// to swap it for Electron's ABI). The loopback server runs as part of
+// Playwright's webServer during desktop smoke runs and never exercises auth
+// in CHAMBER_E2E mode, so deferring the load keeps Forge's rebuild unblocked.
+async function loadKeytar(): Promise<CredentialStore> {
+  const mod = await import('keytar');
+  return ((mod as { default?: CredentialStore }).default ?? (mod as unknown as CredentialStore));
+}
+const credentialStore: CredentialStore = {
+  findCredentials: async (service) => (await loadKeytar()).findCredentials(service),
+  setPassword: async (service, account, password) =>
+    (await loadKeytar()).setPassword(service, account, password),
+  deletePassword: async (service, account) => (await loadKeytar()).deletePassword(service, account),
+};
+
 const configService = new ConfigService();
 const saveActiveLogin = (login: string | null) => {
   const config = configService.load();
   configService.save({ ...config, activeLogin: login });
 };
-const authService = new AuthService(keytar as CredentialStore, () => configService.load().activeLogin, saveActiveLogin);
+const authService = new AuthService(credentialStore, () => configService.load().activeLogin, saveActiveLogin);
 const viewDiscovery = new ViewDiscovery();
 const mindManager = new MindManager(
   new CopilotClientFactory({ toolsBinDir: getChamberToolsBinDir() }),
@@ -112,7 +128,7 @@ const productionContext: ChamberCtx = createServerContext({
   shutdown: () => {
     void shutdown();
   },
-  handlePrivilegedRequest: createCredentialPrivilegedHandler(keytar as CredentialStore),
+  handlePrivilegedRequest: createCredentialPrivilegedHandler(credentialStore),
 });
 
 function buildE2EFakeChatContext(base: ChamberCtx): ChamberCtx {

--- a/apps/web/src/renderer/components/profile/AgentProfileModal.tsx
+++ b/apps/web/src/renderer/components/profile/AgentProfileModal.tsx
@@ -307,7 +307,7 @@ function ProfileMarkdownEditor({
 
   return (
     <Dialog open={Boolean(file)} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="max-w-4xl bg-slate-950 text-slate-100">
+      <DialogContent className="flex max-h-[88vh] max-w-4xl flex-col bg-slate-950 text-slate-100">
         <DialogHeader>
           <DialogTitle>{file?.label ?? 'Profile file'}</DialogTitle>
           <DialogDescription>{file?.relativePath}</DialogDescription>
@@ -317,7 +317,7 @@ function ProfileMarkdownEditor({
           value={value}
           onChange={(event) => setValue(event.target.value)}
           spellCheck={false}
-          className="min-h-[420px] w-full resize-none rounded-xl border border-border bg-background p-4 font-mono text-sm leading-6 text-foreground outline-none focus:border-primary"
+          className="min-h-[200px] w-full flex-1 resize-none rounded-xl border border-border bg-background p-4 font-mono text-sm leading-6 text-foreground outline-none focus:border-primary"
         />
         <DialogFooter>
           {dirty ? <span className="mr-auto self-center text-xs text-amber-300">Unsaved edits</span> : null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.49.10",
+  "version": "0.49.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.49.10",
+      "version": "0.49.11",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.49.10",
+  "version": "0.49.11",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/tests/e2e/electron/desktop-navigation-popout.spec.ts
+++ b/tests/e2e/electron/desktop-navigation-popout.spec.ts
@@ -46,7 +46,7 @@ test.describe('electron desktop navigation and popout smoke', () => {
   test('keeps Chamber focused when an agent message opens an external link', async () => {
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await page.waitForLoadState('domcontentloaded');
-    const mind = await loadMindInRenderer(page, externalMindPath, /External Link Smoke Mind/);
+    const mind = await loadMindInRenderer(page, externalMindPath, 'External Link Smoke Mind');
     const initialUrl = page.url();
 
     await hydrateChatState(page, mind.mindId, 'external-link-message', 'Open [external smoke link](https://example.com/chamber-smoke) please.');
@@ -64,7 +64,7 @@ test.describe('electron desktop navigation and popout smoke', () => {
   test('keeps chat messages visible in a popout and after it closes', async () => {
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await page.waitForLoadState('domcontentloaded');
-    const mind = await loadMindInRenderer(page, popoutMindPath, /Popout Continuity Smoke Mind/);
+    const mind = await loadMindInRenderer(page, popoutMindPath, 'Popout Continuity Smoke Mind');
     const message = 'Popout continuity smoke transcript';
 
     await hydrateChatState(page, mind.mindId, 'popout-continuity-message', message);
@@ -108,13 +108,14 @@ test.describe('electron desktop navigation and popout smoke', () => {
   }
 });
 
-async function loadMindInRenderer(page: Page, mindPath: string, buttonName: RegExp) {
+async function loadMindInRenderer(page: Page, mindPath: string, mindName: string) {
   const mind = await page.evaluate(async (pathToMind) => {
     const loaded = await window.electronAPI.mind.add(pathToMind);
     await window.electronAPI.mind.setActive(loaded.mindId);
     return loaded;
   }, mindPath);
-  await page.getByRole('button', { name: buttonName }).click();
+  const escaped = mindName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  await page.locator('button').filter({ hasText: new RegExp(`\\b${escaped}\\b`) }).click();
   await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
   return mind;
 }

--- a/tests/e2e/electron/electronApp.ts
+++ b/tests/e2e/electron/electronApp.ts
@@ -2,7 +2,6 @@ import { chromium, type Browser, type Page } from '@playwright/test';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
-import keytar from 'keytar';
 
 export const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
@@ -100,10 +99,18 @@ function logsPreview(logs: string[]): string {
 /**
  * Returns true when Chamber's public GitHub API access or stored credentials can access the given repo.
  * Use with `test.skip()` to skip marketplace tests that need a private repo.
+ *
+ * Loads keytar lazily so the Playwright runner process doesn't hold the
+ * keytar.node native addon open. On Windows, an open keytar.node prevents
+ * `electron-forge start` from rebuilding it for Electron's ABI (EPERM on
+ * unlink), which breaks every Electron spec.
  */
 export async function canAccessRepo(nwo: string): Promise<boolean> {
   if (await canFetchRepo(nwo, null)) return true;
 
+  const keytarModule = await import('keytar');
+  const keytar = ((keytarModule as { default?: typeof import('keytar') }).default
+    ?? (keytarModule as unknown as typeof import('keytar')));
   const credentials = await keytar.findCredentials('copilot-cli');
   for (const credential of credentials) {
     if (credential.password && await canFetchRepo(nwo, credential.password)) {

--- a/tests/e2e/electron/lens-hotload.spec.ts
+++ b/tests/e2e/electron/lens-hotload.spec.ts
@@ -58,7 +58,7 @@ test.describe('electron Lens hot-load smoke', () => {
       return loaded;
     }, { pathToMind: mindPath, pathToInactiveMind: inactiveMindPath });
 
-    await page.getByRole('button', { name: /Active Lens Smoke Mind/ }).click();
+    await page.locator('button').filter({ hasText: /\bActive Lens Smoke Mind\b/ }).click();
 
     await page.evaluate(() => {
       const target = window as typeof window & { __lensHotloadEvents?: string[][] };
@@ -140,7 +140,7 @@ test.describe('electron Lens hot-load smoke', () => {
       }, { mindId: mind.mindId, viewId: refreshViewId }),
       { timeout: 10_000 },
     ).toBe(true);
-    await page.getByRole('button', { name: /Active Lens Smoke Mind/ }).click();
+    await page.locator('button').filter({ hasText: /\bActive Lens Smoke Mind\b/ }).click();
     await expect(page.getByRole('button', { name: 'Smoke Refresh Continuity' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Smoke Refresh Continuity' }).click();

--- a/tests/e2e/electron/monica-open-existing.spec.ts
+++ b/tests/e2e/electron/monica-open-existing.spec.ts
@@ -68,8 +68,9 @@ test.describe('electron Monica existing mind smoke', () => {
     ).toEqual(['Monica']);
 
     expect(sameMind.mindId).toBe(mind.mindId);
-    await expect(page.getByRole('button', { name: 'Monica' })).toHaveCount(1);
-    await page.getByRole('button', { name: 'Monica' }).first().click();
+    const monicaSidebarButton = page.locator('button').filter({ hasText: /\bMonica\b/ });
+    await expect(monicaSidebarButton).toHaveCount(1);
+    await monicaSidebarButton.click();
     await expect(page.getByText('How can I help you today?')).toBeVisible();
     await expect(page.getByPlaceholder('Message your agent… (paste an image to attach)')).toBeEnabled();
     expect(mind.identity.name).toBe('Monica');


### PR DESCRIPTION
## Summary

Three independent problems were preventing `npm run smoke:desktop` from completing on Windows. This PR fixes all of them and bumps to v0.49.11.

### 1. Windows: keytar lock prevented `electron-forge start` rebuild
The Playwright `webServer` (`apps/server/dist/bin.mjs`) and the shared Electron test helper (`tests/e2e/electron/electronApp.ts`) were eagerly importing `keytar` at module load. Windows holds an exclusive lock on a loaded `.node` native addon, so when Forge next ran `@electron/rebuild` to swap `keytar.node` to Electron's ABI it failed with `EPERM: operation not permitted, unlink 'keytar.node'` — and 0 of 22 desktop smoke tests could even start. POSIX hosts allow unlinking open files, so Linux/macOS were unaffected.

Both call sites now lazy-load via `await import('keytar')` only when an actual credential operation fires.

### 2. PR #244 broke 8 desktop smoke selectors
PR #244 intentionally added three `role="button"` accessibility controls per mind row in `MindSidebar.tsx` (Edit / Open in window / Remove), nested INSIDE the outer `<button>`. Eight smoke tests using `getByRole('button', { name: /MindName/ })` then matched 4 elements and tripped Playwright's strict-mode guard.

Switched the affected selectors in `monica-open-existing.spec.ts`, `lens-hotload.spec.ts`, and `desktop-navigation-popout.spec.ts` to:

`page.locator('button').filter({ hasText: /\bMindName\b/ })`

This restricts to real `<button>` elements (excluding the new `role="button"` `<span>`s) and uses word boundaries so `Inactive Lens Smoke Mind` cannot collide with `Active Lens Smoke Mind`. The `MindSidebar` accessibility additions are unchanged.

### 3. ProfileMarkdownEditor Save button was outside the viewport
The new modal added in #244 had no `max-height` constraint on its `DialogContent`. With a 420px-min textarea + header + footer, the Save button rendered below the default 800px Electron window and could not be reached by clicking, scrolling, or `scrollIntoViewIfNeeded` — the dialog is `position: fixed`, not part of the page scroll. This was a real UX bug on small windows, not just a test issue.

`DialogContent` is now `flex max-h-[88vh] flex-col` and the textarea is `flex-1 min-h-[200px]`, matching the outer `AgentProfileModal` pattern: header/footer pinned, textarea scrolls internally.

## Test evidence (Windows, local)

| Step | Result |
|---|---|
| `npm run lint` | clean |
| `npm test` | 1384/1385 — the 1 failure is the pre-existing Windows symlink-permission test (`MindProfileService > rejects symlinked profile files`); same baseline as `master` |
| `npm run smoke:web` | 4/4 |
| `npm run smoke:desktop` | 27/28 — see note below |

### About the 1 remaining `smoke:desktop` failure
`genesis-lucy-template.spec.ts:44` times out waiting for `"How can I help you today?"`. This is **not** a #244 regression and **not** caused by anything in this PR:
- The spec was last touched in #163 (long before yesterday's merges)
- None of #244, #242, or #235 touched `apps/web/src/renderer/components/genesis/*`
- Failure mode is timeout on welcome screen, not strict-mode selector violation
- Reproduced identically across every desktop-smoke run today

Tracking it separately rather than bundling into this PR.

## Out of scope (deliberately)

- Adding `smoke:desktop` to CI (`.github/workflows/ci.yml` does not run it). Worth a separate decision — it adds ~18m to a Windows CI run.
- Investigating `genesis-lucy-template.spec.ts`.

## Reviewer notes

Uncle Bob reviewed and signed off; suggested converting `require('keytar')` to `await import('keytar')` for consistency with the 8+ other dynamic-import sites in the repo. Applied before the commit landed.

Closes #250