### PR TITLE
Improve conversation history panel UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.49.13 (2026-05-09)
+
+### Renderer
+
+- **Make conversation history collapsible** — The right-side history panel now persists an expanded/collapsed preference, provides a narrow rail to recover chat width on smaller windows, shows distinct no-agent/loading/empty states, exposes row actions on keyboard focus, and uses an in-app delete confirmation dialog.
+- **Keep fresh history summaries from being overwritten** — Conversation history updates now preserve newer local summaries when a stale list response arrives later, preventing recent renames or first-prompt titles from briefly disappearing.
+
+### Testing
+
+- **Update Genesis template smokes for the confirmation pane** — Lucy Genesis smoke tests now select the template card and confirm with **Choose this voice**, matching the current template-detail UI.
+
 ## v0.49.12 (2026-05-09)
 
 ### Renderer

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.test.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConversationSummary, MindContext } from '@chamber/shared/types';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import { AppStateProvider } from '../../lib/store';
+import type { AppState } from '../../lib/store/state';
+import { ConversationHistoryPanel } from './ConversationHistoryPanel';
+
+const STORAGE_KEY = 'chamber:conversation-history-collapsed';
+
+const mind: MindContext = {
+  mindId: 'mind-1',
+  mindPath: 'C:\\agents\\monica',
+  identity: { name: 'Monica', systemMessage: '# Monica' },
+  status: 'ready',
+};
+
+describe('ConversationHistoryPanel', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    api = installElectronAPI();
+    (api.conversationHistory.list as ReturnType<typeof vi.fn>).mockReturnValue(new Promise<ConversationSummary[]>(() => undefined));
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('starts expanded and persists collapse toggles', async () => {
+    renderHistoryPanel({ activeMindId: mind.mindId, minds: [mind], conversationHistoryByMind: { [mind.mindId]: [] } });
+
+    const history = screen.getByLabelText('Conversation history');
+    expect(history.className).toContain('w-80');
+    expect(screen.getByRole('button', { name: 'Collapse history panel' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse history panel' }));
+
+    expect(history.className).toContain('w-10');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    expect(screen.getByRole('button', { name: 'Expand history panel' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history panel' }));
+
+    expect(history.className).toContain('w-80');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('false');
+  });
+
+  it('restores the saved collapsed preference while preserving the history landmark', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+
+    renderHistoryPanel({ activeMindId: mind.mindId, minds: [mind], conversationHistoryByMind: { [mind.mindId]: [] } });
+
+    const history = screen.getByLabelText('Conversation history');
+    expect(history.className).toContain('w-10');
+    expect(within(history).getByRole('button', { name: 'Expand history panel' })).toBeTruthy();
+  });
+
+  it('distinguishes no selected agent, loading history, and empty selected history', async () => {
+    renderHistoryPanel({ activeMindId: null, minds: [] });
+    expect(screen.getByText('Select an agent to see history')).toBeTruthy();
+    expect(api.conversationHistory.list).not.toHaveBeenCalled();
+    cleanup();
+
+    renderHistoryPanel({ activeMindId: mind.mindId, minds: [mind] });
+    expect(screen.getByText('Loading history...')).toBeTruthy();
+    cleanup();
+
+    (api.conversationHistory.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    renderHistoryPanel({ activeMindId: mind.mindId, minds: [mind] });
+    expect(await screen.findByText('No conversations yet')).toBeTruthy();
+  });
+
+  it('keeps row actions visible for keyboard focus', () => {
+    const conversation = makeConversation({ title: 'Planning thread' });
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [conversation] },
+      activeConversationByMind: { [mind.mindId]: conversation.sessionId },
+      conversationViewByMind: { [mind.mindId]: { status: 'ready', sessionId: conversation.sessionId, streaming: false, modelSwitching: false } },
+    });
+
+    const rename = screen.getByRole('button', { name: 'Rename Planning thread' });
+    const deleteButton = screen.getByRole('button', { name: 'Delete Planning thread' });
+
+    expect(rename.className).toContain('group-focus-within:opacity-100');
+    expect(rename.className).toContain('focus-visible:opacity-100');
+    expect(deleteButton.className).toContain('group-focus-within:opacity-100');
+    expect(deleteButton.className).toContain('focus-visible:opacity-100');
+    expect(screen.getByText(/just now/).className).toContain('text-xs');
+  });
+
+  it('confirms before deleting conversations with messages', async () => {
+    const conversation = makeConversation({ title: 'Keep me honest', hasMessages: true });
+    (api.conversationHistory.list as ReturnType<typeof vi.fn>).mockResolvedValue([conversation]);
+    (api.conversationHistory.delete as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: conversation.sessionId,
+      messages: [],
+      conversations: [],
+    });
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [conversation] },
+      activeConversationByMind: { [mind.mindId]: conversation.sessionId },
+      conversationViewByMind: { [mind.mindId]: { status: 'ready', sessionId: conversation.sessionId, streaming: false, modelSwitching: false } },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Keep me honest' }));
+
+    expect(await screen.findByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Delete "Keep me honest"?')).toBeTruthy();
+    expect(api.conversationHistory.delete).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete conversation' }));
+
+    await waitFor(() => {
+      expect(api.conversationHistory.delete).toHaveBeenCalledWith(mind.mindId, conversation.sessionId);
+    });
+  });
+
+  it('deletes empty conversations without confirmation', async () => {
+    const conversation = makeConversation({ title: 'Empty draft', hasMessages: false });
+    (api.conversationHistory.list as ReturnType<typeof vi.fn>).mockResolvedValue([conversation]);
+    (api.conversationHistory.delete as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: conversation.sessionId,
+      messages: [],
+      conversations: [],
+    });
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [conversation] },
+      activeConversationByMind: { [mind.mindId]: conversation.sessionId },
+      conversationViewByMind: { [mind.mindId]: { status: 'ready', sessionId: conversation.sessionId, streaming: false, modelSwitching: false } },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Empty draft' }));
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    await waitFor(() => {
+      expect(api.conversationHistory.delete).toHaveBeenCalledWith(mind.mindId, conversation.sessionId);
+    });
+  });
+});
+
+function renderHistoryPanel(testInitialState?: Partial<AppState>) {
+  render(
+    <AppStateProvider testInitialState={testInitialState}>
+      <ConversationHistoryPanel />
+    </AppStateProvider>,
+  );
+}
+
+function makeConversation(overrides?: Partial<ConversationSummary>): ConversationSummary {
+  const now = new Date().toISOString();
+  return {
+    sessionId: 'session-1',
+    title: 'Planning thread',
+    createdAt: now,
+    updatedAt: now,
+    kind: 'chat',
+    active: true,
+    hasMessages: true,
+    ...overrides,
+  };
+}

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -1,11 +1,20 @@
-import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ConversationSummary } from '@chamber/shared/types';
 import { useAppDispatch, useAppState } from '../../lib/store';
 import { Logger } from '../../lib/logger';
 import { cn } from '../../lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
 
 const log = Logger.create('ConversationHistoryPanel');
+const HISTORY_COLLAPSED_STORAGE_KEY = 'chamber:conversation-history-collapsed';
 
 export function ConversationHistoryPanel() {
   const { activeMindId, conversationHistoryByMind, activeConversationByMind, conversationViewByMind, streamingByMind } = useAppState();
@@ -14,19 +23,24 @@ export function ConversationHistoryPanel() {
   const [renameValue, setRenameValue] = useState('');
   const [isCreatingConversation, setIsCreatingConversation] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [pendingDeleteConversation, setPendingDeleteConversation] = useState<ConversationSummary | null>(null);
+  const [loadingMindId, setLoadingMindId] = useState<string | null>(null);
+  const [isCollapsed, setIsCollapsed] = useState(() => localStorage.getItem(HISTORY_COLLAPSED_STORAGE_KEY) === 'true');
   const renameInputRef = useRef<HTMLInputElement>(null);
   const creatingConversationRef = useRef(false);
 
-  const conversations = useMemo(() => {
-    if (!activeMindId) return [];
-    return conversationHistoryByMind[activeMindId] ?? [];
+  const conversations = useMemo<ConversationSummary[] | undefined>(() => {
+    if (!activeMindId) return undefined;
+    return conversationHistoryByMind[activeMindId];
   }, [activeMindId, conversationHistoryByMind]);
+  const visibleConversations = conversations ?? [];
   const selectedConversationId = activeMindId ? activeConversationByMind[activeMindId] : undefined;
   const activeConversationView = activeMindId ? conversationViewByMind[activeMindId] : undefined;
   const isActiveMindStreaming = activeMindId
     ? Boolean(streamingByMind[activeMindId] || activeConversationView?.streaming)
     : false;
   const isActiveMindBusy = isActiveMindStreaming || Boolean(activeConversationView?.modelSwitching);
+  const isHistoryLoading = Boolean(activeMindId && loadingMindId === activeMindId && conversations === undefined);
 
   const applyResumeResult = useCallback((mindId: string, result: Awaited<ReturnType<typeof window.electronAPI.conversationHistory.resume>>) => {
     dispatch({
@@ -57,11 +71,18 @@ export function ConversationHistoryPanel() {
   useEffect(() => {
     if (!activeMindId) return;
     let cancelled = false;
+    if (conversationHistoryByMind[activeMindId] === undefined) {
+      setLoadingMindId(activeMindId);
+    }
     window.electronAPI.conversationHistory.list(activeMindId).then((history) => {
       if (cancelled) return;
       dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId: activeMindId, conversations: history } });
+      setLoadingMindId((current) => current === activeMindId ? null : current);
     }).catch((error: unknown) => {
       log.warn('Failed to load conversation history:', error);
+      if (!cancelled) {
+        setLoadingMindId((current) => current === activeMindId ? null : current);
+      }
     });
     return () => {
       cancelled = true;
@@ -146,12 +167,13 @@ export function ConversationHistoryPanel() {
     }
   };
 
-  const deleteConversation = async (conversation: ConversationSummary) => {
+  const setCollapsed = (nextCollapsed: boolean) => {
+    setIsCollapsed(nextCollapsed);
+    localStorage.setItem(HISTORY_COLLAPSED_STORAGE_KEY, String(nextCollapsed));
+  };
+
+  const performDeleteConversation = async (conversation: ConversationSummary) => {
     if (!activeMindId || isActiveMindBusy || deletingId) return;
-    if (conversation.hasMessages) {
-      const confirmed = window.confirm(`Delete "${conversation.title}"? This cannot be undone.`);
-      if (!confirmed) return;
-    }
 
     setDeletingId(conversation.sessionId);
     setRenamingId(null);
@@ -175,91 +197,171 @@ export function ConversationHistoryPanel() {
     }
   };
 
+  const deleteConversation = async (conversation: ConversationSummary) => {
+    if (!activeMindId || isActiveMindBusy || deletingId) return;
+    if (conversation.hasMessages) {
+      setPendingDeleteConversation(conversation);
+      return;
+    }
+
+    await performDeleteConversation(conversation);
+  };
+
+  const confirmDeleteConversation = () => {
+    const conversation = pendingDeleteConversation;
+    if (!conversation) return;
+    setPendingDeleteConversation(null);
+    void performDeleteConversation(conversation);
+  };
+
   return (
-    <aside aria-label="Conversation history" className="w-80 shrink-0 bg-card border border-border rounded-xl overflow-hidden flex flex-col">
-      <div className="h-10 border-b border-border px-3 flex items-center justify-between">
-        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          History
-        </span>
+    <aside
+      aria-label="Conversation history"
+      className={cn(
+        'shrink-0 bg-card border border-border rounded-xl overflow-hidden flex flex-col transition-[width]',
+        isCollapsed ? 'w-10' : 'w-80',
+      )}
+    >
+      {isCollapsed ? (
         <button
           type="button"
-          disabled={!activeMindId || isActiveMindBusy || isCreatingConversation}
-          onClick={() => { void startNewConversation(); }}
-          className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
-          aria-label="New conversation"
+          onClick={() => setCollapsed(false)}
+          className="m-1 h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center"
+          aria-label="Expand history panel"
         >
-          <Plus size={15} />
+          <ChevronLeft size={15} />
         </button>
-      </div>
-
-      <div className="flex-1 overflow-y-auto p-2">
-        {conversations.length === 0 ? (
-          <p className="px-2 py-3 text-xs text-muted-foreground">No conversations yet</p>
-        ) : null}
-        {conversations.map((conversation) => {
-          const isSelected = conversation.sessionId === selectedConversationId || conversation.active;
-
-          return (
-            <div
-              key={conversation.sessionId}
-              className={cn(
-                'group flex items-center gap-2 rounded-lg border-l-2 px-2 py-2 transition-colors',
-                isSelected
-                  ? 'border-l-primary bg-accent text-foreground'
-                  : 'border-l-transparent text-muted-foreground hover:text-foreground hover:bg-accent/50'
-              )}
-            >
+      ) : (
+        <>
+          <div className="h-10 border-b border-border px-3 flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
               <button
                 type="button"
-                aria-label={`Resume ${conversation.title}`}
-                disabled={isActiveMindBusy}
-                onClick={() => { void resumeConversation(conversation.sessionId); }}
-                className="min-w-0 flex-1 text-left disabled:cursor-not-allowed"
+                onClick={() => setCollapsed(true)}
+                className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center"
+                aria-label="Collapse history panel"
               >
-                {renamingId === conversation.sessionId ? (
-                  <input
-                    ref={renameInputRef}
-                    value={renameValue}
-                    onChange={(event) => setRenameValue(event.target.value)}
-                    onKeyDown={(event) => handleRenameKeyDown(event, conversation.sessionId)}
-                    onBlur={() => { void completeRename(conversation.sessionId, renameValue.trim() || null); }}
-                    className="w-full rounded border border-primary bg-background px-1.5 py-0.5 text-sm text-foreground outline-none"
-                  />
-                ) : (
-                  <>
-                    <div className="truncate text-sm font-medium">{conversation.title}</div>
-                    <div className="mt-0.5 text-[11px] text-muted-foreground">
-                      {formatRelativeTime(conversation.updatedAt)}
-                      {conversation.active ? ' · Active' : ''}
-                    </div>
-                  </>
-                )}
+                <ChevronRight size={15} />
               </button>
-
-              <div className="flex items-center">
-                <button
-                  type="button"
-                  onClick={() => startRename(conversation)}
-                  disabled={isActiveMindBusy || deletingId === conversation.sessionId}
-                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-foreground hover:bg-accent group-hover:opacity-100 flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
-                  aria-label={`Rename ${conversation.title}`}
-                >
-                  <Pencil size={13} />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { void deleteConversation(conversation); }}
-                  disabled={isActiveMindBusy || deletingId !== null}
-                  className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-destructive hover:bg-destructive/10 group-hover:opacity-100 flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
-                  aria-label={`Delete ${conversation.title}`}
-                >
-                  <Trash2 size={13} />
-                </button>
-              </div>
+              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                History
+              </span>
             </div>
-          );
-        })}
-      </div>
+            <button
+              type="button"
+              disabled={!activeMindId || isActiveMindBusy || isCreatingConversation}
+              onClick={() => { void startNewConversation(); }}
+              className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+              aria-label="New conversation"
+            >
+              <Plus size={15} />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-2">
+            {!activeMindId ? (
+              <p className="px-2 py-3 text-xs text-muted-foreground">Select an agent to see history</p>
+            ) : isHistoryLoading ? (
+              <p className="px-2 py-3 text-xs text-muted-foreground">Loading history...</p>
+            ) : visibleConversations.length === 0 ? (
+              <p className="px-2 py-3 text-xs text-muted-foreground">No conversations yet</p>
+            ) : null}
+            {visibleConversations.map((conversation) => {
+              const isSelected = conversation.sessionId === selectedConversationId || conversation.active;
+
+              return (
+                <div
+                  key={conversation.sessionId}
+                  className={cn(
+                    'group flex items-center gap-2 rounded-lg border-l-2 px-2 py-2 transition-colors',
+                    isSelected
+                      ? 'border-l-primary bg-accent text-foreground'
+                      : 'border-l-transparent text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                  )}
+                >
+                  <button
+                    type="button"
+                    aria-label={`Resume ${conversation.title}`}
+                    disabled={isActiveMindBusy}
+                    onClick={() => { void resumeConversation(conversation.sessionId); }}
+                    className="min-w-0 flex-1 text-left disabled:cursor-not-allowed"
+                  >
+                    {renamingId === conversation.sessionId ? (
+                      <input
+                        ref={renameInputRef}
+                        value={renameValue}
+                        onChange={(event) => setRenameValue(event.target.value)}
+                        onKeyDown={(event) => handleRenameKeyDown(event, conversation.sessionId)}
+                        onBlur={() => { void completeRename(conversation.sessionId, renameValue.trim() || null); }}
+                        className="w-full rounded border border-primary bg-background px-1.5 py-0.5 text-sm text-foreground outline-none"
+                      />
+                    ) : (
+                      <>
+                        <div className="truncate text-sm font-medium">{conversation.title}</div>
+                        <div className="mt-0.5 text-xs text-muted-foreground">
+                          {formatRelativeTime(conversation.updatedAt)}
+                          {conversation.active ? ' · Active' : ''}
+                        </div>
+                      </>
+                    )}
+                  </button>
+
+                  <div className="flex items-center">
+                    <button
+                      type="button"
+                      onClick={() => startRename(conversation)}
+                      disabled={isActiveMindBusy || deletingId === conversation.sessionId}
+                      className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-foreground hover:bg-accent group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
+                      aria-label={`Rename ${conversation.title}`}
+                    >
+                      <Pencil size={13} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { void deleteConversation(conversation); }}
+                      disabled={isActiveMindBusy || deletingId !== null}
+                      className="h-7 w-7 rounded-md text-muted-foreground opacity-0 hover:text-destructive hover:bg-destructive/10 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
+                      aria-label={`Delete ${conversation.title}`}
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+      <Dialog open={pendingDeleteConversation !== null} onOpenChange={(open) => {
+        if (!open && !deletingId) setPendingDeleteConversation(null);
+      }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete "{pendingDeleteConversation?.title}"?</DialogTitle>
+            <DialogDescription>
+              This conversation cannot be restored after it is deleted.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setPendingDeleteConversation(null)}
+              disabled={deletingId !== null}
+              className="rounded-md border border-border px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-accent disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={confirmDeleteConversation}
+              disabled={deletingId !== null}
+              className="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+            >
+              Delete conversation
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </aside>
   );
 }

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -334,6 +334,30 @@ describe('appReducer', () => {
     });
   });
 
+  it('SET_CONVERSATION_HISTORY preserves newer local summaries over stale list responses', () => {
+    const fresh = appReducer(withActiveMind, {
+      type: 'SET_CONVERSATION_HISTORY',
+      payload: {
+        mindId,
+        conversations: [
+          { sessionId: 'session-1', title: 'Fresh title', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:02.000Z', kind: 'chat', active: true },
+        ],
+      },
+    });
+
+    const stale = appReducer(fresh, {
+      type: 'SET_CONVERSATION_HISTORY',
+      payload: {
+        mindId,
+        conversations: [
+          { sessionId: 'session-1', title: 'New chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:01.000Z', kind: 'chat', active: true },
+        ],
+      },
+    });
+
+    expect(stale.conversationHistoryByMind[mindId][0].title).toBe('Fresh title');
+  });
+
   it('CONVERSATION_HYDRATING records the selected session before messages arrive', () => {
     const state = appReducer(withActiveMind, {
       type: 'CONVERSATION_HYDRATING',

--- a/apps/web/src/renderer/lib/store/reducer.ts
+++ b/apps/web/src/renderer/lib/store/reducer.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ChatEvent, ContentBlock } from '@chamber/shared/types';
+import type { ChatMessage, ChatEvent, ContentBlock, ConversationSummary } from '@chamber/shared/types';
 import type { Task, TaskState } from '@chamber/shared/a2a-types';
 import type { ChatroomMessage, TaskLedgerItem } from '@chamber/shared/chatroom-types';
 import { isOrchestrationEvent } from '@chamber/shared/chatroom-types';
@@ -53,6 +53,22 @@ function setConversationView(
       ...patch,
     },
   };
+}
+
+function mergeConversationSummaries(
+  existing: ConversationSummary[] | undefined,
+  incoming: ConversationSummary[],
+): ConversationSummary[] {
+  if (!existing?.length) return incoming;
+  const existingById = new Map(existing.map((conversation) => [conversation.sessionId, conversation]));
+  return incoming.map((conversation) => {
+    const current = existingById.get(conversation.sessionId);
+    if (!current) return conversation;
+    const currentUpdatedAt = Date.parse(current.updatedAt);
+    const incomingUpdatedAt = Date.parse(conversation.updatedAt);
+    if (Number.isNaN(currentUpdatedAt) || Number.isNaN(incomingUpdatedAt)) return conversation;
+    return currentUpdatedAt > incomingUpdatedAt ? current : conversation;
+  });
 }
 
 export function handleChatEvent<T extends ChatMessage>(messages: T[], messageId: string, event: ChatEvent): T[] {
@@ -269,7 +285,11 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     }
 
     case 'SET_CONVERSATION_HISTORY': {
-      const activeSessionId = action.payload.conversations.find((conversation) => conversation.active)?.sessionId;
+      const conversations = mergeConversationSummaries(
+        state.conversationHistoryByMind[action.payload.mindId],
+        action.payload.conversations,
+      );
+      const activeSessionId = conversations.find((conversation) => conversation.active)?.sessionId;
       const currentView = conversationViewFor(state, action.payload.mindId);
       const hasLocalMessages = (state.messagesByMind[action.payload.mindId]?.length ?? 0) > 0;
       const shouldBindLocalReadyView = currentView.status === 'ready' && currentView.sessionId === undefined && hasLocalMessages;
@@ -279,7 +299,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         ...state,
         conversationHistoryByMind: {
           ...state.conversationHistoryByMind,
-          [action.payload.mindId]: action.payload.conversations,
+          [action.payload.mindId]: conversations,
         },
         activeConversationByMind: {
           ...state.activeConversationByMind,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.49.12",
+  "version": "0.49.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.49.12",
+      "version": "0.49.13",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.49.12",
+  "version": "0.49.13",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/tests/e2e/electron/conversation-history-smoke.spec.ts
+++ b/tests/e2e/electron/conversation-history-smoke.spec.ts
@@ -154,6 +154,26 @@ test.describe('electron conversation history smoke', () => {
     await expect(page.getByText(prompt).first()).toBeVisible();
   });
 
+  test('collapsing history restores chat width in a narrow window', async () => {
+    const paths = await launchWithMinds(9357, ['Monica']);
+    const page = await findRendererPage(app?.browser, app?.logs ?? []);
+    await page.setViewportSize({ width: 900, height: 800 });
+    await addMind(page, paths.Monica);
+
+    const history = page.getByLabel('Conversation history');
+    const main = page.locator('main').first();
+    const expanded = await measureLayout(page);
+
+    await history.getByRole('button', { name: 'Collapse history panel' }).click();
+    await expect(history.getByRole('button', { name: 'Expand history panel' })).toBeVisible();
+
+    await expect.poll(async () => (await measureLayout(page)).historyWidth, { timeout: 5_000 }).toBeLessThan(80);
+    const collapsed = await measureLayout(page);
+    expect(collapsed.historyWidth).toBeLessThan(80);
+    expect(collapsed.mainWidth).toBeGreaterThan(expanded.mainWidth + 200);
+    await expect(main).toBeVisible();
+  });
+
   async function launchWithMinds(cdpPort: number, names: string[]): Promise<Record<string, string>> {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-history-smoke-'));
     userDataPath = path.join(root, 'user-data');
@@ -201,6 +221,18 @@ async function installChatSendProbe(page: Page): Promise<void> {
       const send = originalSend(...args);
       runtimeWindow.__chamberLastChatSend = send.then(() => undefined);
       return send;
+    };
+  });
+}
+
+async function measureLayout(page: Page): Promise<{ mainWidth: number; historyWidth: number }> {
+  return page.evaluate(() => {
+    const main = document.querySelector('main');
+    const history = document.querySelector('[aria-label="Conversation history"]');
+    if (!main || !history) throw new Error('Expected main and conversation history elements');
+    return {
+      mainWidth: main.getBoundingClientRect().width,
+      historyWidth: history.getBoundingClientRect().width,
     };
   });
 }

--- a/tests/e2e/electron/genesis-lucy-cos-chat.spec.ts
+++ b/tests/e2e/electron/genesis-lucy-cos-chat.spec.ts
@@ -59,6 +59,7 @@ test.describe('electron Genesis Lucy Chief of Staff chat smoke', () => {
     await page.getByRole('button', { name: 'Begin' }).click();
     await expect(page.getByRole('button', { name: /Lucy Chief of Staff/i })).toBeVisible({ timeout: 60_000 });
     await page.getByRole('button', { name: /Lucy Chief of Staff/i }).click();
+    await page.getByRole('button', { name: 'Choose this voice' }).click();
 
     await expect(page.getByText('How can I help you today?')).toBeVisible({ timeout: 300_000 });
     await expect(page.getByText(lucyName)).toBeVisible();

--- a/tests/e2e/electron/genesis-lucy-template.spec.ts
+++ b/tests/e2e/electron/genesis-lucy-template.spec.ts
@@ -49,6 +49,7 @@ test.describe('electron Genesis Lucy template smoke', () => {
     await page.getByRole('button', { name: 'Begin' }).click();
     await expect(page.getByRole('button', { name: /Lucy/i })).toBeVisible({ timeout: 60_000 });
     await page.getByRole('button', { name: /Lucy/i }).click();
+    await page.getByRole('button', { name: 'Choose this voice' }).click();
 
     await expect(page.getByText('How can I help you today?')).toBeVisible({ timeout: 120_000 });
     await expect(page.getByText(lucyName)).toBeVisible();


### PR DESCRIPTION
## Summary
- Adds a persisted collapse/expand control for the right-side conversation history panel so narrow desktop windows can reclaim chat width.
- Clarifies history panel no-agent, loading, and empty states; makes row actions visible on keyboard focus; replaces native delete confirmation with an in-app dialog.
- Preserves newer local conversation summaries over stale history refreshes, and updates Genesis Lucy template smokes for the current confirmation-pane UI.

## Tests
- `npm run lint`
- `npm test`
- `npx playwright test --config config/playwright.config.ts --project=electron tests/e2e/electron/conversation-history-smoke.spec.ts`
- `npx playwright test --config config/playwright.config.ts --project=electron tests/e2e/electron/genesis-lucy-template.spec.ts`

## Notes
- Skipped full `npm run smoke:desktop`; targeted desktop smokes cover the changed history panel and Lucy template confirmation surfaces.
- Skipped packaging smoke; no packaging, runtime wiring, installer, or first-launch paths changed.