### PR TITLE
Make Chamber agents A2A-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.51.0 (2026-05-09)
+
+### Agents
+
+- **Make Chamber minds Chamber-aware by default** - Minds now receive concise Chamber operating context in their system message, including where to find Chamber docs and source guidance so they can help users use the app. Closes #256.
+
+### Documentation
+
+- **Put A2A at the center of Chamber docs** - The README now leads with Agent-to-Agent collaboration, and the user guide adds A2A concepts plus a built-in Chamber tool directory covering A2A, Canvas, cron, Lens, and marketplace CLI tools. (#256)
+
 ## v0.50.0 (2026-05-09)
 
 ### Profile

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center">
-  <strong>Where AI agents are born and operate.</strong>
+  <strong>Where AI agents meet, delegate, and operate.</strong>
 </p>
 
 <p align="center">
-  Chamber is a desktop workspace for creating, running, and coordinating AI agents powered by GitHub Copilot.
+  Chamber is an A2A-first desktop workspace for creating, running, and coordinating AI agents powered by GitHub Copilot.
 </p>
 
 <p align="center">
@@ -26,15 +26,30 @@
 
 ## What is Chamber?
 
-Chamber is an Electron desktop app for AI agents that act as your Chief of Staff. A Chamber agent, called a **mind**, has identity, memory, tools, scheduled work, and a UI that can grow with the tasks you give it.
+Chamber is an Electron desktop app for A2A-style agent collaboration. A Chamber agent, called a **mind**, has identity, memory, tools, scheduled work, and a UI that can grow with the tasks you give it.
 
-Instead of treating chat as the whole product, Chamber gives agents a full operating room: a persistent workspace, dynamic views, multi-agent chatrooms, canvases, cron jobs, and marketplace-installed Genesis minds.
+Instead of treating chat as the whole product, Chamber gives agents a shared operating room where they can discover each other, exchange messages, delegate stateful tasks, track artifacts, and still use practical desktop tools like Lens views, Canvas pages, cron jobs, and marketplace-installed Genesis minds.
+
+## A2A first
+
+Chamber puts Agent-to-Agent (A2A) collaboration front and center. Minds are not just tool wrappers; they are peer agents that can describe what they do, talk to each other, and hand off durable work.
+
+In Chamber, A2A means:
+
+- **Agent discovery** — minds expose Agent Card-style metadata with names, descriptions, skills, and capabilities so other minds know who can help.
+- **Direct messages** — a mind can send another mind a message when the user asks for another perspective or specialist input.
+- **Tracked tasks** — a mind can create a stateful task for another mind, then check progress, list related tasks, or cancel work that is no longer needed.
+- **Shared context** — related messages and tasks can stay grouped with a context ID so collaboration keeps continuity across turns.
+- **Artifacts and handoffs** — task results can become concrete outputs that another mind can review, refine, or build on.
+
+A2A complements tools. MCP-style tools and marketplace CLIs give a mind access to resources; A2A lets minds collaborate as autonomous agents on larger goals.
 
 ## Why use it?
 
 | Need | Chamber gives you |
 | --- | --- |
-| A personal AI operator | Minds with personality, memory, and GitHub Copilot-powered turns |
+| A personal AI operator | Minds with personality, memory, Agent Card-style skills, and GitHub Copilot-powered turns |
+| Agent-to-agent delegation | A2A messages, stateful tasks, task history, cancellation, and cross-mind coordination |
 | More than a chat box | Lens views, tables, briefings, status boards, timelines, forms, and editors |
 | Multi-agent collaboration | Chatrooms with concurrent, sequential, moderated, handoff, and manager-led modes |
 | Durable operations | Built-in cron jobs, conversation history, model selection, and desktop notifications |
@@ -43,7 +58,8 @@ Instead of treating chat as the whole product, Chamber gives agents a full opera
 
 ## Features
 
-- **Minds** — Load or create Genesis agent directories with identity, memory, and tool access.
+- **A2A tools** — Let minds list available agents, send peer messages, create tracked tasks, check task status, list tasks, and cancel in-flight work.
+- **Minds** — Load or create Genesis agent directories with identity, memory, Agent Card-style skills, and tool access.
 - **Chat** — Stream Copilot-powered turns with markdown, reasoning blocks, tool-call display, attachments, stop controls, and conversation history.
 - **Lens** — Drop a `view.json` into `.github/lens/` and Chamber renders a form, table, briefing, detail view, status board, timeline, editor, or canvas.
 - **Chatroom** — Coordinate multiple minds in concurrent, round-robin, moderated, handoff, or manager-led orchestration modes.

--- a/docs/user-docs/a2a.html
+++ b/docs/user-docs/a2a.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Plain-language guide to Chamber A2A, agent discovery, messages, tasks, context, and artifacts."
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/app.svg" />
+    <link rel="stylesheet" href="user-guide.css" />
+    <title>A2A Collaboration | Chamber User Guide</title>
+  </head>
+  <body>
+    <main class="guide-shell" aria-label="Chamber A2A guide">
+      <header class="site-header">
+        <a class="brand" href="../index.html" aria-label="Chamber home">
+          <img class="brand-mark" src="../assets/app.svg" alt="" />
+          <span class="brand-word">CHAMBER</span>
+        </a>
+        <nav class="nav" aria-label="Primary navigation">
+          <a href="index.html">Guide Home</a>
+          <a href="getting-started.html">Start</a>
+          <a href="a2a.html">A2A</a>
+          <a href="chat.html">Chat</a>
+          <a href="privacy-safety-troubleshooting.html">Safety</a>
+        </nav>
+        <a class="github-link" href="https://github.com/ianphil/chamber">GitHub</a>
+      </header>
+
+      <section class="hero">
+        <div>
+          <p class="eyebrow">A2A</p>
+          <h1>Agent-to-agent collaboration</h1>
+          <div class="divider" aria-hidden="true"></div>
+          <p class="hero-copy">
+            A2A lets minds work together as agents, not just as tools. A mind can discover
+            other minds, send them messages, delegate stateful tasks, track progress, and
+            use results from one agent as input for another.
+          </p>
+        </div>
+        <aside class="hero-card" aria-label="A2A in one sentence">
+          <h2>The big idea</h2>
+          <p>
+            Use A2A when one mind should ask another mind for help, not when it only needs
+            a simple data lookup or one-off command.
+          </p>
+        </aside>
+      </section>
+
+      <div class="guide-layout">
+        <nav class="side-nav" aria-label="On this page">
+          <strong>On this page</strong>
+          <a aria-current="page" href="#why">Why A2A matters</a>
+          <a href="#concepts">Core concepts</a>
+          <a href="#tools">A2A tools</a>
+          <a href="#examples">When to use it</a>
+          <a href="#mcp">A2A vs tools</a>
+          <a href="#safety">Safety note</a>
+          <a href="#related">Related guides</a>
+        </nav>
+
+        <section class="guide-content">
+          <article class="content-card" id="why">
+            <h2>Why A2A matters in Chamber</h2>
+            <p>
+              Chamber is built around minds that can act like specialists. A2A gives those
+              specialists a common way to collaborate: one mind can identify another mind's
+              skills, ask for help, hand off a task, and keep track of the result.
+            </p>
+            <ul>
+              <li><strong>Discovery:</strong> minds can list other available agents and see what they are good at.</li>
+              <li><strong>Delegation:</strong> a mind can ask another mind to take on a piece of work.</li>
+              <li><strong>Continuity:</strong> related messages and tasks can share context instead of becoming disconnected chats.</li>
+              <li><strong>Accountability:</strong> tracked tasks have status, history, and results you can review.</li>
+            </ul>
+          </article>
+
+          <article class="content-card" id="concepts">
+            <h2>Core A2A concepts</h2>
+            <table class="info-table">
+              <tbody>
+                <tr>
+                  <th>Agent Card</th>
+                  <td>A description of an agent's identity, skills, capabilities, and how other agents can interact with it.</td>
+                </tr>
+                <tr>
+                  <th>Message</th>
+                  <td>A single turn between agents. Use it for quick questions, context sharing, or lightweight collaboration.</td>
+                </tr>
+                <tr>
+                  <th>Task</th>
+                  <td>A stateful unit of work. Use it when another mind should work asynchronously, report status, and produce results.</td>
+                </tr>
+                <tr>
+                  <th>Context ID</th>
+                  <td>A way to group related messages and tasks so a multi-step collaboration stays connected.</td>
+                </tr>
+                <tr>
+                  <th>Artifact</th>
+                  <td>A concrete result from a task, such as a summary, plan, document, dataset, image, or structured output.</td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+
+          <article class="content-card" id="tools">
+            <h2>A2A tools available to minds</h2>
+            <p>
+              These are model-facing Chamber tools. You usually do not call them by name;
+              you ask naturally, and the mind decides whether A2A is the right path.
+            </p>
+            <table class="info-table">
+              <tbody>
+                <tr>
+                  <th><code>a2a_list_agents</code></th>
+                  <td>Lists other minds in the workspace with their names, descriptions, and skills.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_send_message</code></th>
+                  <td>Sends a message to another mind for quick peer input or context sharing.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_send_task</code></th>
+                  <td>Creates a tracked asynchronous task for another mind to work on.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_get_task</code></th>
+                  <td>Checks one task's state, history, artifacts, and latest result.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_list_tasks</code></th>
+                  <td>Lists tasks, optionally filtered by shared context or status.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_cancel_task</code></th>
+                  <td>Cancels an in-progress task that is no longer needed.</td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+
+          <article class="content-card" id="examples">
+            <h2>When to use A2A</h2>
+            <ul>
+              <li>Ask a research mind to gather background while a writing mind drafts the response.</li>
+              <li>Have a planner mind create tasks for specialist minds, then summarize their outputs.</li>
+              <li>Send a quick peer review request from one mind to another before making a decision.</li>
+              <li>Keep several related work items tied together with shared context and task history.</li>
+            </ul>
+          </article>
+
+          <article class="content-card" id="mcp">
+            <h2>A2A vs tools</h2>
+            <p>
+              Tools and A2A solve different problems. Tools are good for specific actions:
+              search, read, write, open a Canvas, schedule a job, or call a service. A2A is
+              for working with another agent that can reason, plan, ask clarifying questions,
+              use its own tools, and produce durable work.
+            </p>
+          </article>
+
+          <aside class="callout" id="safety">
+            <strong>Safety note</strong>
+            <p>
+              A2A can multiply work quickly because more than one mind may use tools or ask
+              for follow-up actions. Review approvals based on the action and target, not
+              just the mind that requested them.
+            </p>
+          </aside>
+
+          <article class="content-card" id="related">
+            <h2>Related guides</h2>
+            <div class="related">
+              <a href="chatrooms.html">Chatrooms</a>
+              <a href="tools-and-approvals.html">Tools and approvals</a>
+              <a href="minds.html">Work with Minds</a>
+              <a href="scheduled-work.html">Scheduled work</a>
+            </div>
+          </article>
+        </section>
+      </div>
+
+      <footer class="page-footer">Chamber user documentation</footer>
+    </main>
+  </body>
+</html>

--- a/docs/user-docs/chatrooms.html
+++ b/docs/user-docs/chatrooms.html
@@ -21,6 +21,7 @@
         <nav class="nav" aria-label="Primary navigation">
           <a href="index.html">Guide Home</a>
           <a href="getting-started.html">Start</a>
+          <a href="a2a.html">A2A</a>
           <a href="chat.html">Chat</a>
           <a href="lens-and-canvas.html">Lens</a>
           <a href="privacy-safety-troubleshooting.html">Safety</a>
@@ -50,6 +51,7 @@
       <div class="guide-layout">
         <nav class="side-nav" aria-label="Guide pages">
           <strong>Guides</strong>
+          <a href="a2a.html">A2A collaboration</a>
           <a href="tools-and-approvals.html">Tools and approvals</a>
           <a href="lens-and-canvas.html">Lens and canvas</a>
           <a href="scheduled-work.html">Scheduled work</a>
@@ -91,6 +93,10 @@
               <li><strong>Handoff:</strong> one mind can pass work to another mind when the task changes.</li>
               <li><strong>Manager-led:</strong> a manager mind breaks the goal into tasks and tracks progress.</li>
             </ul>
+            <p>
+              Behind the scenes, A2A gives minds a way to discover each other, send peer
+              messages, and create tracked tasks when one mind should hand durable work to another.
+            </p>
           </article>
 
           <article class="content-card" id="steps">
@@ -133,6 +139,7 @@
             <p>Chatrooms often use tools, views, scheduled follow-ups, and marketplace minds.</p>
             <div class="related">
               <a href="tools-and-approvals.html">Tools and approvals</a>
+              <a href="a2a.html">A2A collaboration</a>
               <a href="lens-and-canvas.html">Lens and canvas</a>
               <a href="scheduled-work.html">Scheduled work</a>
               <a href="marketplace.html">Marketplace</a>

--- a/docs/user-docs/index.html
+++ b/docs/user-docs/index.html
@@ -20,6 +20,7 @@
         </a>
         <nav class="nav" aria-label="Primary navigation">
           <a href="getting-started.html">Start</a>
+          <a href="a2a.html">A2A</a>
           <a href="chat.html">Chat</a>
           <a href="lens-and-canvas.html">Lens</a>
           <a href="privacy-safety-troubleshooting.html">Safety</a>
@@ -33,8 +34,8 @@
           <h1>Use Chamber without learning the machinery</h1>
           <div class="divider" aria-hidden="true"></div>
           <p class="hero-copy">
-            These guides explain Chamber in plain language: how to create minds, chat with
-            them, review their work, automate follow-ups, and stay in control of what they do.
+            These guides explain Chamber in plain language: how to create minds, let agents
+            collaborate through A2A, review their tools, automate follow-ups, and stay in control.
           </p>
         </div>
         <aside class="hero-card" aria-label="Best starting point">
@@ -65,6 +66,11 @@
           <span>Chat</span>
           <h2>Talk to a Mind</h2>
           <p>Send messages, paste images, stop long work, choose models, and read results.</p>
+        </a>
+        <a class="link-card" href="a2a.html">
+          <span>A2A</span>
+          <h2>Agent-to-Agent Collaboration</h2>
+          <p>Use agent discovery, peer messages, tracked tasks, context, and artifacts across minds.</p>
         </a>
         <a class="link-card" href="conversation-history.html">
           <span>History</span>

--- a/docs/user-docs/tools-and-approvals.html
+++ b/docs/user-docs/tools-and-approvals.html
@@ -21,6 +21,7 @@
         <nav class="nav" aria-label="Primary navigation">
           <a href="index.html">Guide Home</a>
           <a href="getting-started.html">Start</a>
+          <a href="a2a.html">A2A</a>
           <a href="chat.html">Chat</a>
           <a href="lens-and-canvas.html">Lens</a>
           <a href="privacy-safety-troubleshooting.html">Safety</a>
@@ -50,6 +51,7 @@
       <div class="guide-layout">
         <nav class="side-nav" aria-label="Guide pages">
           <strong>Guides</strong>
+          <a href="a2a.html">A2A collaboration</a>
           <a aria-current="page" href="tools-and-approvals.html">Tools and approvals</a>
           <a href="lens-and-canvas.html">Lens and canvas</a>
           <a href="scheduled-work.html">Scheduled work</a>
@@ -63,7 +65,8 @@
             <p>
               A tool call is a request from a mind to do something outside a normal chat
               reply. It may read a file, search a source, create a Lens view, open a Canvas
-              dashboard, schedule work, or perform another action Chamber supports.
+              dashboard, schedule work, talk to another mind through A2A, or perform another
+              action Chamber supports.
             </p>
             <ul>
               <li>Reading tools gather information so the mind can answer better.</li>
@@ -71,6 +74,111 @@
               <li>External tools may contact a service or use an account you connected.</li>
               <li>Scheduled tools can run later, even when you are not watching the chat.</li>
             </ul>
+          </article>
+
+          <article class="content-card" id="built-in-tools">
+            <h2>Built-in Chamber tools</h2>
+            <p>
+              Chamber gives minds several built-in tool groups. Marketplace tools can add
+              more, but these are the core Chamber-managed tools users are most likely to see.
+            </p>
+            <table class="info-table">
+              <tbody>
+                <tr>
+                  <th>A2A collaboration</th>
+                  <td><code>a2a_list_agents</code>, <code>a2a_send_message</code>, <code>a2a_send_task</code>, <code>a2a_get_task</code>, <code>a2a_list_tasks</code>, and <code>a2a_cancel_task</code> let minds discover each other, exchange messages, delegate tracked tasks, check status, and stop in-flight work.</td>
+                </tr>
+                <tr>
+                  <th>Canvas</th>
+                  <td><code>canvas_show</code>, <code>canvas_update</code>, <code>canvas_close</code>, and <code>canvas_list</code> create, refresh, close, and list browser-based HTML canvases for dashboards, reports, forms, and rich visual output.</td>
+                </tr>
+                <tr>
+                  <th>Scheduled work</th>
+                  <td><code>cron_create</code>, <code>cron_list</code>, <code>cron_remove</code>, <code>cron_enable</code>, <code>cron_disable</code>, <code>cron_run_now</code>, and <code>cron_history</code> create and manage recurring prompts, process jobs, webhooks, notifications, and run history.</td>
+                </tr>
+                <tr>
+                  <th>Lens views</th>
+                  <td>Lens uses validated <code>view.json</code> files to render forms, tables, briefings, detail views, status boards, timelines, editors, and canvas-backed views inside Chamber.</td>
+                </tr>
+                <tr>
+                  <th>Marketplace CLI tools</th>
+                  <td>Marketplace sources can install npm-global or GitHub release asset tools. Chamber advertises each installed tool to minds with its command name, description, help command, and agent instructions.</td>
+                </tr>
+              </tbody>
+            </table>
+            <h3>Tool name directory</h3>
+            <table class="info-table">
+              <tbody>
+                <tr>
+                  <th><code>a2a_list_agents</code></th>
+                  <td>Finds other available minds and their skills before delegating work.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_send_message</code></th>
+                  <td>Sends a quick peer message to another mind.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_send_task</code></th>
+                  <td>Creates a tracked asynchronous task for another mind.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_get_task</code></th>
+                  <td>Checks one task's state, history, artifacts, and result.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_list_tasks</code></th>
+                  <td>Lists tasks, optionally by shared context or status.</td>
+                </tr>
+                <tr>
+                  <th><code>a2a_cancel_task</code></th>
+                  <td>Cancels an in-progress A2A task.</td>
+                </tr>
+                <tr>
+                  <th><code>canvas_show</code></th>
+                  <td>Creates or opens a browser canvas from HTML content or an existing HTML file.</td>
+                </tr>
+                <tr>
+                  <th><code>canvas_update</code></th>
+                  <td>Updates an existing canvas and live-reloads the browser page.</td>
+                </tr>
+                <tr>
+                  <th><code>canvas_close</code></th>
+                  <td>Closes one canvas or all canvases for a mind.</td>
+                </tr>
+                <tr>
+                  <th><code>canvas_list</code></th>
+                  <td>Lists currently open canvases for the active mind.</td>
+                </tr>
+                <tr>
+                  <th><code>cron_create</code></th>
+                  <td>Creates a scheduled prompt, process, webhook, or notification job.</td>
+                </tr>
+                <tr>
+                  <th><code>cron_list</code></th>
+                  <td>Shows scheduled jobs with next run and recent run details.</td>
+                </tr>
+                <tr>
+                  <th><code>cron_remove</code></th>
+                  <td>Deletes a scheduled job and its stored run history.</td>
+                </tr>
+                <tr>
+                  <th><code>cron_enable</code></th>
+                  <td>Turns a paused job back on.</td>
+                </tr>
+                <tr>
+                  <th><code>cron_disable</code></th>
+                  <td>Pauses a job without deleting it.</td>
+                </tr>
+                <tr>
+                  <th><code>cron_run_now</code></th>
+                  <td>Runs a scheduled job immediately and records the result.</td>
+                </tr>
+                <tr>
+                  <th><code>cron_history</code></th>
+                  <td>Shows recent run history, optionally for one job.</td>
+                </tr>
+              </tbody>
+            </table>
           </article>
 
           <article class="content-card" id="approval-prompts">
@@ -132,6 +240,7 @@
             <p>Learn where tool results appear and how to review work from several minds.</p>
             <div class="related">
               <a href="lens-and-canvas.html">Lens and canvas</a>
+              <a href="a2a.html">A2A collaboration</a>
               <a href="scheduled-work.html">Scheduled work</a>
               <a href="chatrooms.html">Chatrooms</a>
               <a href="privacy-safety-troubleshooting.html">Safety help</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chat/IdentityLoader.test.ts
+++ b/packages/services/src/chat/IdentityLoader.test.ts
@@ -26,8 +26,11 @@ describe('IdentityLoader', () => {
       const result = loader.load('/tmp/test');
       expect(result).toEqual({
         name: 'Q',
-        systemMessage: '# Q\nI am an agent.',
+        systemMessage: expect.stringContaining('# Q\nI am an agent.'),
       });
+      expect(result?.systemMessage).toContain('## Chamber');
+      expect(result?.systemMessage).toContain('operating inside Chamber as a Chamber agent');
+      expect(result?.systemMessage).toContain('https://github.com/ianphil/chamber');
     });
 
     it('extracts name from first H1 heading', () => {
@@ -155,6 +158,29 @@ describe('IdentityLoader', () => {
       vi.mocked(fs.readdirSync).mockReturnValue([]);
       const result = new IdentityLoader(() => []).load('/tmp/test');
       expect(result?.systemMessage).not.toContain('## Tools');
+      expect(result?.systemMessage).toContain('## Chamber');
+    });
+
+    it('appends Chamber guidance before installed tool guidance', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('# Q\nI am an agent.');
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+      const tools: InstalledTool[] = [{
+        id: 'workiq',
+        package: '@microsoft/workiq',
+        version: 'latest',
+        bin: 'workiq',
+        displayName: 'Microsoft Work IQ',
+        description: 'Query M365 data.',
+        source: { marketplaceId: 'github:ianphil/genesis-minds', pluginId: 'genesis-minds' },
+        installedAt: '2026-05-07T21:00:00.000Z',
+      }];
+
+      const result = new IdentityLoader(() => tools).load('/tmp/test');
+      const systemMessage = result?.systemMessage ?? '';
+
+      expect(systemMessage.indexOf('## Chamber')).toBeGreaterThan(systemMessage.indexOf('# Q'));
+      expect(systemMessage.indexOf('## Tools')).toBeGreaterThan(systemMessage.indexOf('## Chamber'));
     });
   });
 });

--- a/packages/services/src/chat/IdentityLoader.ts
+++ b/packages/services/src/chat/IdentityLoader.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { InstalledTool, MindIdentity } from '@chamber/shared/types';
 import { buildToolsSection } from '../tools/toolsSystemMessage';
+import { buildChamberSection } from './chamberSystemMessage';
 
 const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 const H1_RE = /^#\s+(.+)$/m;
@@ -53,6 +54,8 @@ export class IdentityLoader {
 
     const parts = [...identityParts, ...memoryParts];
     if (parts.length === 0) return null;
+
+    parts.push(buildChamberSection());
 
     const toolsSection = buildToolsSection(this.getInstalledTools());
     if (toolsSection) parts.push(toolsSection);

--- a/packages/services/src/chat/chamberSystemMessage.test.ts
+++ b/packages/services/src/chat/chamberSystemMessage.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { buildChamberSection } from './chamberSystemMessage';
+
+describe('buildChamberSection', () => {
+  it('renders Chamber identity and documentation guidance', () => {
+    const section = buildChamberSection();
+
+    expect(section).toContain('## Chamber');
+    expect(section).toContain('operating inside Chamber as a Chamber agent');
+    expect(section).toContain('https://github.com/ianphil/chamber');
+    expect(section).toContain('README.md');
+    expect(section).toContain('ai-docs/');
+    expect(section).toContain('local desktop auto-update testing');
+    expect(section).toContain('CONTRIBUTING.md');
+    expect(section).toContain('AGENTS.md');
+    expect(section).toContain('.github/copilot-instructions.md');
+    expect(section).toContain('search the repository docs/source first');
+    expect(section).toContain('cite or link the most relevant doc path');
+  });
+});

--- a/packages/services/src/chat/chamberSystemMessage.ts
+++ b/packages/services/src/chat/chamberSystemMessage.ts
@@ -1,0 +1,21 @@
+/**
+ * Renders Chamber-specific operating context for minds.
+ *
+ * Keep this concise: each mind still owns its personality and role through
+ * SOUL.md and agent files, while this section teaches the shared Chamber host.
+ */
+export function buildChamberSection(): string {
+  return [
+    '## Chamber',
+    '',
+    'You are operating inside Chamber as a Chamber agent. Help users use Chamber when they ask about the app, its minds, chatrooms, tools, Lens views, Canvas, cron jobs, or agent setup.',
+    '',
+    'Chamber documentation and source of truth:',
+    '- GitHub repository: https://github.com/ianphil/chamber',
+    '- Start with README.md for user-facing capabilities.',
+    '- Check ai-docs/ for runbooks and feature-specific operational docs, including local desktop auto-update testing.',
+    '- Use CONTRIBUTING.md, AGENTS.md, and .github/copilot-instructions.md for development, architecture, and safety guidance when relevant.',
+    '',
+    'When answering Chamber-specific questions, search the repository docs/source first when available, follow markdown cross-references, and cite or link the most relevant doc path before falling back to general release or README information.',
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary
- Injects Chamber identity and documentation guidance into every mind system message.
- Adds an A2A-focused user guide and expands the tools documentation with the built-in Chamber tool directory.
- Reframes the README around Agent-to-Agent collaboration while preserving the rest of Chamber's feature overview.
- Bumps Chamber to v0.51.0 with a changelog entry.

## Tests
- npm run lint
- npm test (1414 tests, 139 files)

## Smoke
- Packaging smoke skipped locally; CI packages this PR because the minor version changed.

Closes #256