### PR TITLE
fix(chamber-copilot): pin exact + add runtime surface check (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.52.1 (2026-05-10)
+
+### Dependencies
+
+- **Pin `chamber-copilot` exactly + add a runtime surface check** — `chamber-copilot` is now pinned to `0.5.11` (no caret) in root `package.json`, mirroring the discipline already enforced for `@github/copilot` in `chamber-copilot-runtime/package.json`. A new `packages/services/src/chamberCopilot/chamber-copilot-surface.test.ts` asserts every value-level symbol our hand-rolled `chamber-copilot.d.ts` shim declares exists at runtime, that `PERMISSION_MODES`, `DEFAULT_PERMISSION_MODE`, and `YOLO_ACP_ARGS` have the documented shapes, and that `MindScopedJobs.prototype` mirrors every shim-declared `JobStore.prototype` method — so the duck-typed `scoped as unknown as JobStore` cast in `ChamberCopilotService.getToolsForMind` cannot silently regress on a future bump. Closes #260.
+
 ## v0.52.0 (2026-05-09)
 
 ### Extensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -15,7 +15,7 @@
       "dependencies": {
         "@azure/msal-node": "^5.2.0",
         "@azure/msal-node-extensions": "^5.2.0",
-        "chamber-copilot": "^0.5.11",
+        "chamber-copilot": "0.5.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,
@@ -85,7 +85,7 @@
   "dependencies": {
     "@azure/msal-node": "^5.2.0",
     "@azure/msal-node-extensions": "^5.2.0",
-    "chamber-copilot": "^0.5.11",
+    "chamber-copilot": "0.5.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/services/src/chamberCopilot/chamber-copilot-surface.test.ts
+++ b/packages/services/src/chamberCopilot/chamber-copilot-surface.test.ts
@@ -1,0 +1,112 @@
+// Runtime surface check for the published `chamber-copilot` package.
+//
+// Why this test exists:
+//
+//   `chamber-copilot` ships pure ESM JavaScript with `"types": null`. We
+//   maintain a hand-rolled type shim at `chamber-copilot.d.ts` that mirrors
+//   only the symbols Chamber consumes directly. TypeScript will happily
+//   compile against the shim regardless of what the published package
+//   actually exports — so an upstream rename or removal that we don't
+//   notice during a version bump produces "TypeError: undefined is not a
+//   function" at runtime in production code paths.
+//
+//   The dependency is now pinned exactly (no caret) in root `package.json`
+//   to force every bump through PR review. This test is the second line of
+//   defense: it asserts every value-level symbol the shim declares exists
+//   at runtime, that the documented constants have the documented shapes,
+//   and — most importantly — that `MindScopedJobs.prototype` mirrors every
+//   `JobStore.prototype` method the shim declares. The duck-typed
+//   `scoped as unknown as JobStore` cast in `ChamberCopilotService.getToolsForMind`
+//   would otherwise let drift slip through silently.
+//
+//   If this test fails after a `chamber-copilot` bump, audit the shim and
+//   `MindScopedJobs` together — do not patch the test in isolation.
+
+import { describe, it, expect } from 'vitest';
+import * as chamberCopilot from 'chamber-copilot';
+import { MindScopedJobs } from './MindScopedJobs';
+
+// Methods the shim declares on `JobStore`. These are the only methods
+// chamber-copilot's own `createAcpTools` wires through to a `JobStore`
+// shape today; they are also the methods Chamber calls directly. Both
+// `JobStore.prototype` and `MindScopedJobs.prototype` must expose every
+// one of them.
+const SHIM_DECLARED_JOBSTORE_METHODS = [
+  'delegate',
+  'respond',
+  'approve',
+  'cancel',
+  'status',
+  'list',
+] as const;
+
+const SHIM_DECLARED_ACPCONNECTION_METHODS = ['start', 'stop'] as const;
+
+describe('chamber-copilot package surface', () => {
+  describe('value-level exports declared by chamber-copilot.d.ts', () => {
+    it('exports the expected runtime symbols with the expected typeof', () => {
+      expect(typeof chamberCopilot.AcpConnection).toBe('function');
+      expect(typeof chamberCopilot.JobStore).toBe('function');
+      expect(typeof chamberCopilot.UnsupportedPermissionModeError).toBe('function');
+      expect(typeof chamberCopilot.createAcpTools).toBe('function');
+      expect(typeof chamberCopilot.defaultAcpConnectionFactory).toBe('function');
+    });
+
+    it('PERMISSION_MODES is the documented set of {safe, yolo}', () => {
+      expect(chamberCopilot.PERMISSION_MODES).toBeInstanceOf(Set);
+      const modes = [...chamberCopilot.PERMISSION_MODES].sort();
+      expect(modes).toEqual(['safe', 'yolo']);
+    });
+
+    it("DEFAULT_PERMISSION_MODE is 'safe'", () => {
+      expect(chamberCopilot.DEFAULT_PERMISSION_MODE).toBe('safe');
+    });
+
+    it('YOLO_ACP_ARGS is a non-empty array including --yolo', () => {
+      expect(Array.isArray(chamberCopilot.YOLO_ACP_ARGS)).toBe(true);
+      expect(chamberCopilot.YOLO_ACP_ARGS.length).toBeGreaterThan(0);
+      expect(chamberCopilot.YOLO_ACP_ARGS).toContain('--yolo');
+    });
+
+    it('UnsupportedPermissionModeError is a subclass of Error', () => {
+      const instance = new chamberCopilot.UnsupportedPermissionModeError('yolo');
+      expect(instance).toBeInstanceOf(Error);
+      expect(instance.name).toBe('UnsupportedPermissionModeError');
+    });
+  });
+
+  describe('JobStore method surface', () => {
+    it.each(SHIM_DECLARED_JOBSTORE_METHODS)(
+      "JobStore.prototype.%s exists at runtime",
+      (method) => {
+        const proto = chamberCopilot.JobStore.prototype as unknown as Record<string, unknown>;
+        expect(typeof proto[method]).toBe('function');
+      },
+    );
+  });
+
+  describe('MindScopedJobs duck-typed mirror', () => {
+    // INVARIANT: MindScopedJobs is cast through `as unknown as JobStore`
+    // when handed to `createAcpTools`. If chamber-copilot adds a new
+    // method to `JobStore` AND declares it in our shim, this mirror must
+    // grow the same method or the cli_* tools that consume it will throw
+    // "is not a function" at runtime. This test traps that drift.
+    it.each(SHIM_DECLARED_JOBSTORE_METHODS)(
+      "MindScopedJobs.prototype.%s mirrors the shim-declared JobStore method",
+      (method) => {
+        const proto = MindScopedJobs.prototype as unknown as Record<string, unknown>;
+        expect(typeof proto[method]).toBe('function');
+      },
+    );
+  });
+
+  describe('AcpConnection method surface', () => {
+    it.each(SHIM_DECLARED_ACPCONNECTION_METHODS)(
+      "AcpConnection.prototype.%s exists at runtime",
+      (method) => {
+        const proto = chamberCopilot.AcpConnection.prototype as unknown as Record<string, unknown>;
+        expect(typeof proto[method]).toBe('function');
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Audit cleanup from PR #259 (chamber-copilot ACP integration). `chamber-copilot` is now pinned exactly in root `package.json` (no caret), and a new runtime surface test catches drift between the published package and our hand-rolled `chamber-copilot.d.ts` shim before it can regress at runtime.

## Why

The Uncle Bob audit on PR #259 (issue #260) flagged two related risks that this PR closes:

1. The dependency was pinned `"chamber-copilot": "^0.5.11"`, so any `0.5.x` minor bump could land via `npm ci` without a code review of the shim. If upstream changed a method signature or removed a symbol the shim declares, TypeScript would compile cleanly but production would throw at runtime.
2. `MindScopedJobs` does not `implements JobStore` — it is duck-typed. The bridge through the shim relies on the structural cast `scoped as unknown as JobStore` in `ChamberCopilotService.getToolsForMind`. If upstream adds a method that `createAcpTools` consumes, `MindScopedJobs` will not have it and the `cli_*` handler will hit `undefined is not a function` at runtime.

## Changes

- `package.json` / `package-lock.json` — drop the caret on `chamber-copilot` (`^0.5.11` → `0.5.11`). Mirrors the pinning discipline already enforced for `@github/copilot` in `chamber-copilot-runtime/package.json`.
- `packages/services/src/chamberCopilot/chamber-copilot-surface.test.ts` — new Vitest suite that:
  - Asserts every value-level symbol the shim declares (`AcpConnection`, `JobStore`, `UnsupportedPermissionModeError`, `createAcpTools`, `defaultAcpConnectionFactory`, `PERMISSION_MODES`, `DEFAULT_PERMISSION_MODE`, `YOLO_ACP_ARGS`) exists at runtime with the expected typeof.
  - Pins the documented constants (`PERMISSION_MODES = {safe, yolo}`, `DEFAULT_PERMISSION_MODE = 'safe'`, `YOLO_ACP_ARGS` includes `--yolo`).
  - Asserts `JobStore.prototype` exposes every method the shim declares (`delegate`, `respond`, `approve`, `cancel`, `status`, `list`).
  - Asserts `MindScopedJobs.prototype` mirrors every shim-declared `JobStore.prototype` method, so the duck-typed cast cannot silently regress.
- `CHANGELOG.md` — `v0.52.1` entry.
- `package.json` / `package-lock.json` — version bump `0.52.0` → `0.52.1`.

## Out of scope

The optional Uncle Bob suggestion of narrowing the cast through an explicit `AcpToolStore = Pick<JobStore, 'delegate'|'respond'|'approve'|'cancel'|'status'|'list'>` interface (so drift surfaces at compile time) is intentionally deferred. The runtime surface check provides the same drift signal, with no API churn for `MindScopedJobs` or `AcpToolFactory`.

## Test evidence

- `npx vitest run packages/services/src/chamberCopilot` — 53/53 pass (19 new surface tests + 22 `ChamberCopilotService` + 12 `MindScopedJobs`).
- `npm run lint` — clean.
- `npm test` — 1466/1467 pass. The single failure is a pre-existing Windows-only `EPERM: operation not permitted, symlink` in `packages/services/src/mindProfile/MindProfileService.test.ts:73` (`fs.symlinkSync` requires elevation on Windows). Reproduces on `master` without these changes.

## Skipped smoke

- `npm run smoke:sdk` — not run. Validates `@github/copilot-sdk` runtime; this PR does not change the SDK runtime path. The new surface test is the targeted coverage for the changed surface (`chamber-copilot`).
- `npm run package` — not run. No packaging, runtime wiring, or first-launch behavior changed.

Closes #260.
