### PR TITLE
fix(chamber-copilot): split scoped job_id on the last separator (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.52.2 (2026-05-10)
+
+### Reliability
+
+- **Split chamber-copilot scoped job IDs at the last separator** — `MindScopedJobs` now preserves mind IDs that contain `:` when validating `cli_*` job ownership, while rejecting colon-containing raw job IDs at delegate time so scoping remains unambiguous. Closes #261.
+
 ## v0.52.1 (2026-05-10)
 
 ### Dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.52.1",
+      "version": "0.52.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chamberCopilot/MindScopedJobs.test.ts
+++ b/packages/services/src/chamberCopilot/MindScopedJobs.test.ts
@@ -141,6 +141,63 @@ describe('MindScopedJobs', () => {
     expect(() => scoped.status('')).toThrow(/Unknown job_id/);
   });
 
+  describe('separator robustness (issue #261)', () => {
+    // Real Chamber mindIds are derived from a directory basename plus a
+    // 4-char hex suffix (see generateMindId.ts). On Linux/macOS a basename
+    // can contain ':', so a mindId of the shape 'foo:bar-abcd' is not a
+    // theoretical concern. The scope/unscope split must therefore tolerate
+    // colons in the mindId portion. The complementary invariant — that
+    // the inner store never returns a colon-containing rawJobId — is now
+    // enforced at delegate time so a future custom JobStoreOptions.idFactory
+    // cannot regress the boundary silently.
+
+    it('round-trips a colon-containing mindId through scope/unscope', async () => {
+      const store = buildStore();
+      const scoped = new MindScopedJobs(asJobStore(store), 'mind:with:colons');
+
+      const { jobId } = await scoped.delegate({ cwd: '/repo', prompt: 'p' });
+      expect(jobId.startsWith('mind:with:colons:')).toBe(true);
+
+      // status must round-trip the same scoped jobId without throwing
+      // Unknown — i.e. the unscope split must recover ('mind:with:colons',
+      // 'job-1'), not ('mind', 'with:colons:job-1').
+      const snap = scoped.status(jobId);
+      expect(snap.jobId).toBe(jobId);
+    });
+
+    it('keeps cross-mind isolation when both mindIds contain colons', async () => {
+      const store = buildStore();
+      const scopedA = new MindScopedJobs(asJobStore(store), 'mind:a');
+      const scopedB = new MindScopedJobs(asJobStore(store), 'mind:b');
+
+      const { jobId: jobA } = await scopedA.delegate({ cwd: '/repo', prompt: 'p' });
+      // mindB must not be able to read mindA's job by reusing the same scoped id.
+      expect(() => scopedB.status(jobA)).toThrow(/Unknown job_id/);
+      // …or by spoofing the prefix.
+      const rawSuffix = jobA.slice('mind:a:'.length);
+      expect(() => scopedB.status(`mind:b:${rawSuffix}`)).toThrow(/Unknown job_id/);
+    });
+
+    it('rejects an inner JobStore.idFactory that returns colon-containing rawJobIds', async () => {
+      // A custom idFactory that produces ids carrying ':' would silently
+      // shift the unscope boundary on lastIndexOf. Reject it at the
+      // boundary so the failure mode is loud and immediate.
+      const evilStore = {
+        delegate: vi.fn(async () => ({ jobId: 'has:colon', sessionId: 'sess-1' })),
+        respond: vi.fn(),
+        approve: vi.fn(),
+        cancel: vi.fn(),
+        status: vi.fn(),
+        list: vi.fn(),
+      };
+      const scoped = new MindScopedJobs(asJobStore(evilStore as unknown as FakeStore), 'mind-a');
+
+      await expect(scoped.delegate({ cwd: '/repo', prompt: 'p' })).rejects.toThrow(
+        /MindScopedJobs invariant violated.*colon/i,
+      );
+    });
+  });
+
   it('releaseAll cancels every owned job and forgets ownership', async () => {
     const store = buildStore();
     const scoped = new MindScopedJobs(asJobStore(store), 'mind-a');

--- a/packages/services/src/chamberCopilot/MindScopedJobs.test.ts
+++ b/packages/services/src/chamberCopilot/MindScopedJobs.test.ts
@@ -186,15 +186,17 @@ describe('MindScopedJobs', () => {
         delegate: vi.fn(async () => ({ jobId: 'has:colon', sessionId: 'sess-1' })),
         respond: vi.fn(),
         approve: vi.fn(),
-        cancel: vi.fn(),
+        cancel: vi.fn(async () => {}),
         status: vi.fn(),
-        list: vi.fn(),
+        list: vi.fn(() => [snap('has:colon')]),
       };
       const scoped = new MindScopedJobs(asJobStore(evilStore as unknown as FakeStore), 'mind-a');
 
       await expect(scoped.delegate({ cwd: '/repo', prompt: 'p' })).rejects.toThrow(
         /MindScopedJobs invariant violated.*colon/i,
       );
+      expect(evilStore.cancel).toHaveBeenCalledWith('has:colon');
+      expect(scoped.list()).toEqual([]);
     });
   });
 

--- a/packages/services/src/chamberCopilot/MindScopedJobs.ts
+++ b/packages/services/src/chamberCopilot/MindScopedJobs.ts
@@ -40,6 +40,18 @@ function unknownJob(scopedJobId: string): Error {
   return new Error(`Unknown job_id: ${scopedJobId}`);
 }
 
+// Thrown when the inner JobStore.delegate returns a rawJobId that violates
+// the encoding invariant. Distinct error shape (NOT UnknownJob) so callers
+// can tell "I asked for a job that does not exist" apart from "the inner
+// store handed us a malformed id". See `unscope` below for why the
+// invariant matters.
+class MindScopedJobsInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MindScopedJobsInvariantError';
+  }
+}
+
 export class MindScopedJobs {
   private readonly ownedJobIds = new Set<string>();
 
@@ -54,6 +66,20 @@ export class MindScopedJobs {
     readonly permissionMode?: PermissionMode;
   }): Promise<{ readonly jobId: string; readonly sessionId: string }> {
     const result = await this.inner.delegate(params);
+    // INVARIANT (issue #261): the unscope split below uses
+    // `lastIndexOf(SCOPED_ID_SEPARATOR)`, which only recovers the
+    // (mindId, rawJobId) pair correctly if the rawJobId itself does not
+    // contain the separator. The default chamber-copilot JobStore uses
+    // `randomUUID()` (no colons) so this holds in production today, but
+    // `JobStoreOptions.idFactory` is a public extension point — a future
+    // custom factory that returns colon-containing ids would silently
+    // shift the unscope boundary. Reject at the boundary so the failure
+    // is loud and immediate, not a delayed "Unknown job_id" miles away.
+    if (result.jobId.includes(SCOPED_ID_SEPARATOR)) {
+      throw new MindScopedJobsInvariantError(
+        `MindScopedJobs invariant violated: inner JobStore returned a rawJobId containing the scope separator '${SCOPED_ID_SEPARATOR}' (jobId=${JSON.stringify(result.jobId)}). The scope/unscope split assumes rawJobIds do not contain '${SCOPED_ID_SEPARATOR}'. Use a different JobStoreOptions.idFactory.`,
+      );
+    }
     this.ownedJobIds.add(result.jobId);
     return { jobId: this.scope(result.jobId), sessionId: result.sessionId };
   }
@@ -116,7 +142,20 @@ export class MindScopedJobs {
     if (typeof scopedJobId !== 'string' || scopedJobId.length === 0) {
       throw unknownJob(scopedJobId);
     }
-    const sep = scopedJobId.indexOf(SCOPED_ID_SEPARATOR);
+    // INVARIANT (issue #261): split on the LAST separator, not the first.
+    //
+    //   Real Chamber mindIds are derived from a directory basename plus a
+    //   4-char hex suffix (see generateMindId.ts). On Linux/macOS a
+    //   basename can legally contain ':', so a mindId like
+    //   'foo:bar-abcd' is realistic. `indexOf(':')` would split that at
+    //   position 3 and reject every legitimate scoped id as foreign.
+    //
+    //   `lastIndexOf(':')` correctly recovers the (mindId, rawJobId) pair
+    //   under the complementary invariant that rawJobIds do not contain
+    //   ':'. That invariant is enforced eagerly in `delegate()` above, so
+    //   if a future `JobStoreOptions.idFactory` violates it the failure
+    //   surfaces at write time with a distinct error, not silently here.
+    const sep = scopedJobId.lastIndexOf(SCOPED_ID_SEPARATOR);
     if (sep <= 0 || sep === scopedJobId.length - 1) {
       throw unknownJob(scopedJobId);
     }

--- a/packages/services/src/chamberCopilot/MindScopedJobs.ts
+++ b/packages/services/src/chamberCopilot/MindScopedJobs.ts
@@ -46,8 +46,8 @@ function unknownJob(scopedJobId: string): Error {
 // store handed us a malformed id". See `unscope` below for why the
 // invariant matters.
 class MindScopedJobsInvariantError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'MindScopedJobsInvariantError';
   }
 }
@@ -76,8 +76,15 @@ export class MindScopedJobs {
     // shift the unscope boundary. Reject at the boundary so the failure
     // is loud and immediate, not a delayed "Unknown job_id" miles away.
     if (result.jobId.includes(SCOPED_ID_SEPARATOR)) {
+      let cancelFailure: unknown;
+      try {
+        await this.inner.cancel(result.jobId);
+      } catch (error) {
+        cancelFailure = error;
+      }
       throw new MindScopedJobsInvariantError(
         `MindScopedJobs invariant violated: inner JobStore returned a rawJobId containing the scope separator '${SCOPED_ID_SEPARATOR}' (jobId=${JSON.stringify(result.jobId)}). The scope/unscope split assumes rawJobIds do not contain '${SCOPED_ID_SEPARATOR}'. Use a different JobStoreOptions.idFactory.`,
+        cancelFailure === undefined ? undefined : { cause: cancelFailure },
       );
     }
     this.ownedJobIds.add(result.jobId);


### PR DESCRIPTION
## Summary

Audit cleanup from PR #259 (chamber-copilot ACP integration). `MindScopedJobs.unscope` now splits encoded scoped job IDs on the **last** separator so mind IDs containing `:` round-trip correctly, while `delegate()` rejects colon-containing raw inner job IDs and cancels the invalid delegated job before surfacing the invariant failure.

## Changes

- `packages/services/src/chamberCopilot/MindScopedJobs.ts`
  - `unscope`: switch `indexOf(SCOPED_ID_SEPARATOR)` to `lastIndexOf(SCOPED_ID_SEPARATOR)`.
  - `delegate`: throw `MindScopedJobsInvariantError` if the inner `JobStore` returns a raw job ID containing the scope separator.
  - `delegate`: cancel the invalid raw job before throwing so a rejected delegation cannot leave an orphaned child job behind.
  - INVARIANT comments document both halves of the encoding contract.
- `packages/services/src/chamberCopilot/MindScopedJobs.test.ts`
  - Covers colon-containing mind IDs, cross-mind isolation with colon-containing prefixes, invalid raw job ID rejection, and cleanup of invalid delegated jobs.
- Release metadata
  - Bumps Chamber to `0.52.2` and adds the `CHANGELOG.md` entry for #261.

## Test evidence

- `npm run lint` — clean.
- `npm test -- packages/services/src/chamberCopilot/MindScopedJobs.test.ts packages/services/src/chamberCopilot/chamber-copilot-surface.test.ts` — 34/34 pass.
- `COPILOT_REAL_CLI=1 npm run smoke:acp` — passed.
- `COPILOT_REAL_CLI=1 npm run smoke:acp-desktop` — passed.
- `gh pr checks 263 --watch --interval 10` — all GitHub checks passed, including `CI/validate`.
- Full local `npm test` was attempted; it is blocked in this Windows shell by an unrelated symlink privilege failure in `packages/services/src/mindProfile/MindProfileService.test.ts` (`EPERM: operation not permitted, symlink`). Proceeding was approved after the related tests and ACP smokes passed.

## Skipped smoke

- `npm run smoke:sdk` — not run. This PR changes the `chamber-copilot` ACP adapter boundary, not the `@github/copilot-sdk` runtime path.
- `npm run package` — not run. No packaging, runtime wiring, installer, or first-launch behavior changed.

Closes #261.