### PR TITLE
feat(sdk): declare --add-dir for mind cwd and chamber root (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.53.0 (2026-05-10)
+
+### SDK
+
+- **Declare explicit SDK CLI add-dir entries** — Primary Copilot SDK sessions now pass `--add-dir` for the active mind cwd and the shared `~/.chamber` root, making the allowed-path surface explicit ahead of removing broad path allowances. Closes #131.
+
 ## v0.52.2 (2026-05-10)
 
 ### Reliability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.52.2",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.52.2",
+      "version": "0.53.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.52.2",
+  "version": "0.53.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -81,6 +81,25 @@ describe('CopilotClientFactory', () => {
       expect(cliArgs).not.toContain(expect.stringMatching(/npm-loader\.js$/));
     });
 
+    it('declares the mind cwd and the Chamber config root as --add-dir entries (issue #131)', async () => {
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      const cliArgs = client.options.cliArgs as string[];
+
+      // Per-session mind cwd. cwd already scopes today, but listing it
+      // explicitly under --add-dir keeps the allowed-paths source of
+      // truth in the same place as the chamber-shared dirs and prepares
+      // for dropping --allow-all-paths in a follow-up.
+      const addDirIndices = cliArgs
+        .map((arg, i) => (arg === '--add-dir' ? i : -1))
+        .filter((i) => i >= 0);
+      const addDirValues = addDirIndices.map((i) => cliArgs[i + 1]);
+
+      expect(addDirValues).toContain('C:\\agents\\q');
+      // The Chamber config root (~/.chamber). Resolved via os.homedir so
+      // we just check the tail; the home prefix varies by user/CI runner.
+      expect(addDirValues.some((v) => v.endsWith('.chamber'))).toBe(true);
+    });
+
     it('prepends the Chamber tools bin directory to the CLI PATH when configured', async () => {
       factory = new CopilotClientFactory({ toolsBinDir: 'C:\\Users\\ianphil\\AppData\\Roaming\\Chamber\\tools\\bin' });
       const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;

--- a/packages/services/src/sdk/CopilotClientFactory.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.ts
@@ -28,14 +28,30 @@ export class CopilotClientFactory {
     const logDir = path.join(os.homedir(), '.chamber', 'logs');
     fs.mkdirSync(logDir, { recursive: true });
 
+    // Chamber config root. Listed under --add-dir so that --mcp servers,
+    // mind credential lookups, cron job state, and other shared chamber
+    // assets remain accessible to the CLI even after `--allow-all-paths`
+    // is dropped in a follow-up. Today this is a no-op (`--allow-all-paths`
+    // overrides per-directory entries) but it keeps the explicit
+    // allowed-paths list as the source of truth in one place.
+    const chamberRoot = path.join(os.homedir(), '.chamber');
+
     // SDK 0.3.0 enforces server-side permission rules (path verification, tool
     // gates, URL gates) that fire before our `onPermissionRequest` handler.
     // Chamber owns the security boundary itself (Electron sandbox + the
     // chatroom ApprovalGate), so we tell the underlying CLI to defer all
     // permission decisions to the SDK handler — which auto-approves.
     // See: https://github.com/github/copilot-sdk/releases/tag/v0.3.0
+    //
+    // `--add-dir` is declared explicitly per-session for the mind cwd and
+    // the Chamber config root (issue #131 checklist 1). cwd already
+    // scopes file access today, but listing it intentionally keeps the
+    // allowed-paths surface visible in one place and prepares for a
+    // follow-up that drops `--allow-all-paths`.
     const cliArgs = [
       '--log-dir', logDir,
+      '--add-dir', mindPath,
+      '--add-dir', chamberRoot,
       '--allow-all-tools',
       '--allow-all-paths',
       '--allow-all-urls',


### PR DESCRIPTION
## Summary

Adds explicit Copilot SDK `--add-dir` entries for the active mind cwd and the shared `~/.chamber` root. This keeps the allowed-path surface visible before later #131 stack PRs remove broad path allowances.

## Changes

- Pass `--add-dir <mindPath>` for the per-mind working directory.
- Pass `--add-dir ~/.chamber` for shared Chamber config, MCP, credential, and job state access.
- Preserve the existing broad allow flags in this transitional PR.
- Bump Chamber to `0.53.0` and add the changelog entry.

## Test evidence

- `npm run lint` — passed.
- `npm test -- packages/services/src/sdk/CopilotClientFactory.test.ts` — 11/11 passed.
- `npm run smoke:sdk` — passed.
- `gh pr checks 264 --watch --interval 10` — required before merge.

## Skipped smoke

- Full local `npm test` is blocked in this Windows shell by the known unrelated `MindProfileService.test.ts` symlink privilege failure; GitHub CI is used for the full-suite gate.
- `npm run package` — not run; no packaging, installer, runtime materialization, or first-launch path changed.

Closes #131.