### PR TITLE
feat(sdk): drop --allow-all-tools for explicit --allow-tool list (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.54.0 (2026-05-10)
+
+### SDK
+
+- **Replace broad SDK tool auto-approval with explicit tool kinds** — Primary Copilot SDK sessions now drop `--allow-all-tools` and pass only the side-effect tool kinds Chamber intentionally auto-approves at the CLI layer, leaving other tool permission requests to the SDK handler. (#131)
+
 ## v0.53.0 (2026-05-10)
 
 ### SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -69,16 +69,31 @@ describe('CopilotClientFactory', () => {
       );
     });
 
-    it('passes allow-all flags so SDK 0.3.0 server-side rules defer to onPermissionRequest', async () => {
+    it('declares an explicit --allow-tool list instead of --allow-all-tools (issue #131)', async () => {
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      const cliArgs = client.options.cliArgs as string[];
+
+      expect(cliArgs).not.toContain('--allow-all-tools');
+
+      // Explicit auto-approval list: only the side-effect kinds Chamber
+      // intentionally auto-approves at the CLI layer. Read-only model
+      // tools (view, ask_user, str_replace, etc.) do not fire permission
+      // prompts so they need no entry. URL access is handled separately
+      // by --allow-url (issue #131 checklist 3).
+      expect(cliArgs).toEqual(expect.arrayContaining([
+        '--allow-tool=shell',
+        '--allow-tool=write',
+      ]));
+    });
+
+    it('keeps --allow-all-paths and --allow-all-urls until later checklist items drop them', async () => {
       const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
       const cliArgs = client.options.cliArgs as string[];
 
       expect(cliArgs).toEqual(expect.arrayContaining([
-        '--allow-all-tools',
         '--allow-all-paths',
         '--allow-all-urls',
       ]));
-      expect(cliArgs).not.toContain(expect.stringMatching(/npm-loader\.js$/));
     });
 
     it('declares the mind cwd and the Chamber config root as --add-dir entries (issue #131)', async () => {

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -80,10 +80,11 @@ describe('CopilotClientFactory', () => {
       // tools (view, ask_user, str_replace, etc.) do not fire permission
       // prompts so they need no entry. URL access is handled separately
       // by --allow-url (issue #131 checklist 3).
-      expect(cliArgs).toEqual(expect.arrayContaining([
+      const allowToolArgs = cliArgs.filter((arg) => arg.startsWith('--allow-tool='));
+      expect(allowToolArgs).toEqual([
         '--allow-tool=shell',
         '--allow-tool=write',
-      ]));
+      ]);
     });
 
     it('keeps --allow-all-paths and --allow-all-urls until later checklist items drop them', async () => {

--- a/packages/services/src/sdk/CopilotClientFactory.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.ts
@@ -15,6 +15,16 @@ export interface CopilotClientFactoryOptions {
   env?: Record<string, string | undefined>;
 }
 
+// Side-effect tool kinds Chamber auto-approves at the CLI layer. The list
+// is intentionally narrow: only the patterns that the Copilot CLI exposes
+// as kinds requiring approval (see `copilot help permissions`):
+//   - `shell` — all shell commands (incl. git, gh, npm, pwsh, cmd)
+//   - `write` — all file create/modify operations
+// MCP-server tool kinds (`<server>(tool?)`) are not pre-approved — they
+// fall through to `onPermissionRequest`. URL access is controlled
+// separately by `--allow-url` / `--allow-all-urls`.
+export const TOOLS_AUTO_APPROVED: readonly string[] = ['shell', 'write'];
+
 export class CopilotClientFactory {
   private sdkModule: typeof import('@github/copilot-sdk') | null = null;
 
@@ -39,8 +49,8 @@ export class CopilotClientFactory {
     // SDK 0.3.0 enforces server-side permission rules (path verification, tool
     // gates, URL gates) that fire before our `onPermissionRequest` handler.
     // Chamber owns the security boundary itself (Electron sandbox + the
-    // chatroom ApprovalGate), so we tell the underlying CLI to defer all
-    // permission decisions to the SDK handler — which auto-approves.
+    // chatroom ApprovalGate), so anything not auto-approved at the CLI
+    // layer is forwarded to the SDK handler — which auto-approves today.
     // See: https://github.com/github/copilot-sdk/releases/tag/v0.3.0
     //
     // `--add-dir` is declared explicitly per-session for the mind cwd and
@@ -48,11 +58,17 @@ export class CopilotClientFactory {
     // scopes file access today, but listing it intentionally keeps the
     // allowed-paths surface visible in one place and prepares for a
     // follow-up that drops `--allow-all-paths`.
+    //
+    // `--allow-tool` is declared explicitly per-side-effect kind
+    // (issue #131 checklist 2). Read-only model tools (view, ask_user,
+    // str_replace, etc.) do not fire permission prompts so they need no
+    // entry. URL access is handled separately by --allow-url
+    // (issue #131 checklist 3).
     const cliArgs = [
       '--log-dir', logDir,
       '--add-dir', mindPath,
       '--add-dir', chamberRoot,
-      '--allow-all-tools',
+      ...TOOLS_AUTO_APPROVED.map((kind) => `--allow-tool=${kind}`),
       '--allow-all-paths',
       '--allow-all-urls',
     ];


### PR DESCRIPTION
## Summary

Replaces broad SDK CLI tool auto-approval with an explicit side-effect tool allowlist for primary Copilot SDK sessions.

## Changes

- Drop `--allow-all-tools` from SDK CLI args.
- Add explicit `--allow-tool=shell` and `--allow-tool=write` entries.
- Keep `--allow-all-paths` and `--allow-all-urls` for later #131 stack steps.
- Tighten tests so the exact auto-approved tool list is enforced.
- Bump Chamber to `0.54.0` and add the changelog entry.

## Test evidence

- `npm run lint` — passed.
- `npm test -- packages/services/src/sdk/CopilotClientFactory.test.ts` — 12/12 passed.
- `npm run smoke:sdk` — passed.
- `gh pr checks 265 --watch --interval 10` — required before merge.

## Skipped smoke

- Full local `npm test` is blocked in this Windows shell by the known unrelated `MindProfileService.test.ts` symlink privilege failure; GitHub CI is used for the full-suite gate.
- `npm run package` — not run; no packaging, installer, runtime materialization, or first-launch path changed.

Refs #131.