### PR TITLE
feat(sdk): drop --allow-all-urls for explicit --allow-url list (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.55.0 (2026-05-10)
+
+### SDK
+
+- **Replace broad SDK URL auto-approval with explicit GitHub hosts** — Primary Copilot SDK sessions now drop `--allow-all-urls` and pass only the default first-party GitHub URL allowlist, leaving other URL permission requests to the SDK handler. (#131)
+
 ## v0.54.0 (2026-05-10)
 
 ### SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -98,10 +98,11 @@ describe('CopilotClientFactory', () => {
       // outside this list flows through onPermissionRequest where the
       // SDK handler currently auto-approves. B5 (#131 checklist 5) will
       // surface those denials in the chat UI.
-      expect(cliArgs).toEqual(expect.arrayContaining([
+      const allowUrlArgs = cliArgs.filter((arg) => arg.startsWith('--allow-url='));
+      expect(allowUrlArgs).toEqual([
         '--allow-url=github.com',
         '--allow-url=*.github.com',
-      ]));
+      ]);
     });
 
     it('keeps --allow-all-paths until a later checklist item drops it', async () => {

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -87,14 +87,28 @@ describe('CopilotClientFactory', () => {
       ]);
     });
 
-    it('keeps --allow-all-paths and --allow-all-urls until later checklist items drop them', async () => {
+    it('declares an explicit --allow-url list instead of --allow-all-urls (issue #131)', async () => {
       const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
       const cliArgs = client.options.cliArgs as string[];
 
+      expect(cliArgs).not.toContain('--allow-all-urls');
+
+      // Default first-party allow-list: github.com bare and the *.github.com
+      // wildcard that covers api., raw., gist., codeload., etc. Anything
+      // outside this list flows through onPermissionRequest where the
+      // SDK handler currently auto-approves. B5 (#131 checklist 5) will
+      // surface those denials in the chat UI.
       expect(cliArgs).toEqual(expect.arrayContaining([
-        '--allow-all-paths',
-        '--allow-all-urls',
+        '--allow-url=github.com',
+        '--allow-url=*.github.com',
       ]));
+    });
+
+    it('keeps --allow-all-paths until a later checklist item drops it', async () => {
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      const cliArgs = client.options.cliArgs as string[];
+
+      expect(cliArgs).toContain('--allow-all-paths');
     });
 
     it('declares the mind cwd and the Chamber config root as --add-dir entries (issue #131)', async () => {

--- a/packages/services/src/sdk/CopilotClientFactory.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.ts
@@ -25,6 +25,14 @@ export interface CopilotClientFactoryOptions {
 // separately by `--allow-url` / `--allow-all-urls`.
 export const TOOLS_AUTO_APPROVED: readonly string[] = ['shell', 'write'];
 
+// Default URL allow-list for the CLI's shell + web-fetch tools. Anything
+// outside this list flows through onPermissionRequest where the SDK
+// handler currently auto-approves. Patterns are protocol-aware and
+// default to https:// when no scheme is given (per the CLI permissions
+// docs). Subdomain coverage requires the `*.host` pattern in addition
+// to the bare host.
+export const URLS_ALLOWED: readonly string[] = ['github.com', '*.github.com'];
+
 export class CopilotClientFactory {
   private sdkModule: typeof import('@github/copilot-sdk') | null = null;
 
@@ -64,13 +72,18 @@ export class CopilotClientFactory {
     // str_replace, etc.) do not fire permission prompts so they need no
     // entry. URL access is handled separately by --allow-url
     // (issue #131 checklist 3).
+    //
+    // `--allow-url` is declared explicitly per first-party host
+    // (issue #131 checklist 3). Anything not in URLS_ALLOWED falls
+    // through to onPermissionRequest, where the SDK handler still
+    // auto-approves — B5 will surface those denials in the chat UI.
     const cliArgs = [
       '--log-dir', logDir,
       '--add-dir', mindPath,
       '--add-dir', chamberRoot,
       ...TOOLS_AUTO_APPROVED.map((kind) => `--allow-tool=${kind}`),
       '--allow-all-paths',
-      '--allow-all-urls',
+      ...URLS_ALLOWED.map((host) => `--allow-url=${host}`),
     ];
 
     const client = new sdk.CopilotClient({


### PR DESCRIPTION
## Summary

Replaces broad SDK CLI URL auto-approval with an explicit first-party GitHub host allowlist for primary Copilot SDK sessions.

## Changes

- Drop `--allow-all-urls` from SDK CLI args.
- Add explicit `--allow-url=github.com` and `--allow-url=*.github.com` entries.
- Keep `--allow-all-paths` for the later #131 stack step.
- Tighten tests so the exact URL allowlist is enforced.
- Bump Chamber to `0.55.0` and add the changelog entry.

## Test evidence

- `npm run lint` — passed.
- `npm test -- packages/services/src/sdk/CopilotClientFactory.test.ts` — 13/13 passed.
- `npm run smoke:sdk` — passed.
- `gh pr checks 266 --watch --interval 10` — required before merge.

## Skipped smoke

- Full local `npm test` is blocked in this Windows shell by the known unrelated `MindProfileService.test.ts` symlink privilege failure; GitHub CI is used for the full-suite gate.
- `npm run package` — not run; no packaging, installer, runtime materialization, or first-launch path changed.

Refs #131.