### PR TITLE
feat(sdk): switch primary sessions to approve-for-session decisions (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.56.0 (2026-05-10)
+
+### SDK
+
+- **Use session-scoped SDK permission approvals where supported** — Primary mind and Genesis SDK sessions now rely on `approveForSessionCompat`, returning session-wide approvals for read, write, and memory requests while preserving approve-once behavior for permission kinds that need richer request data. (#131)
+
 ## v0.55.0 (2026-05-10)
 
 ### SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/genesis/MindScaffold.generateSoul.test.ts
+++ b/packages/services/src/genesis/MindScaffold.generateSoul.test.ts
@@ -57,6 +57,7 @@ vi.mock('./genesisPrompt', () => ({
 }));
 
 import { MindScaffold } from './MindScaffold';
+import { approveForSessionCompat } from '../sdk/approveForSessionCompat';
 
 describe('MindScaffold.generateSoul — CopilotClientFactory integration', () => {
   beforeEach(() => {
@@ -152,5 +153,25 @@ describe('MindScaffold.generateSoul — CopilotClientFactory integration', () =>
     const execCalls = vi.mocked(execSync).mock.calls
       .map(([command]) => String(command));
     expect(execCalls.some((command) => command.includes('install --all'))).toBe(false);
+  });
+
+  it('wires approveForSessionCompat for genesis sessions and does not short-circuit via setApproveAll (issue #131)', async () => {
+    const scaffold = new MindScaffold(undefined, fakeFactory as unknown as CopilotClientFactory);
+
+    await scaffold.create({
+      name: 'echo',
+      role: 'assistant',
+      voice: 'neutral',
+      voiceDescription: 'measured',
+      basePath: 'C:\\agents',
+    });
+
+    const sessionConfig = (mockCreateSession.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]?.[0];
+    expect(sessionConfig?.onPermissionRequest).toBe(approveForSessionCompat);
+
+    const session = await mockCreateSession.mock.results[0].value as {
+      rpc: { permissions: { setApproveAll: ReturnType<typeof vi.fn> } };
+    };
+    expect(session.rpc.permissions.setApproveAll).not.toHaveBeenCalled();
   });
 });

--- a/packages/services/src/genesis/MindScaffold.test.ts
+++ b/packages/services/src/genesis/MindScaffold.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MindScaffold } from './MindScaffold';
+import { approveForSessionCompat } from '../sdk/approveForSessionCompat';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -109,6 +110,43 @@ describe('MindScaffold.create', () => {
     expect(sentPrompt).toEqual(expect.stringContaining('<current_datetime>'));
     expect(sentPrompt).toEqual(expect.stringContaining('<timezone>'));
     expect(sentPrompt).toEqual(expect.stringContaining('Bob'));
+  });
+
+  it('wires approveForSessionCompat for genesis sessions and does not short-circuit via setApproveAll (issue #131)', async () => {
+    const session = {
+      send: vi.fn<(_: { prompt: string }) => Promise<void>>(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+      on: vi.fn((event: string, callback: () => void) => {
+        if (event === 'session.idle') setTimeout(callback, 0);
+        return vi.fn();
+      }),
+      rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
+    };
+    const createSession = vi.fn<(_: Record<string, unknown>) => Promise<typeof session>>(async () => session);
+    const client = { createSession };
+    const clientFactory = {
+      createClient: vi.fn(async () => client),
+      destroyClient: vi.fn(async () => undefined),
+    } as unknown as CopilotClientFactory;
+    const scaffold = new MindScaffold(
+      {} as unknown as GitHubRegistryClient,
+      clientFactory,
+    );
+
+    const generateSoul = scaffold as unknown as {
+      generateSoul(mindPath: string, config: Parameters<MindScaffold['create']>[0], slug: string): Promise<void>;
+    };
+    await generateSoul.generateSoul('/tmp/minds/zed', {
+      name: 'Zed',
+      role: 'reviewer',
+      voice: 'direct',
+      voiceDescription: 'direct',
+      basePath: '/tmp/minds',
+    }, 'zed');
+
+    const sessionConfig = createSession.mock.calls[0]?.[0] as { onPermissionRequest?: unknown } | undefined;
+    expect(sessionConfig?.onPermissionRequest).toBe(approveForSessionCompat);
+    expect(session.rpc.permissions.setApproveAll).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/services/src/genesis/MindScaffold.ts
+++ b/packages/services/src/genesis/MindScaffold.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import { execSync } from 'child_process';
 import { Logger } from '../logger';
 import { CopilotClientFactory } from '../sdk/CopilotClientFactory';
-import { approveAllCompat } from '../sdk/approveAllCompat';
+import { approveForSessionCompat } from '../sdk/approveForSessionCompat';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
 import { buildGenesisPrompt } from './genesisPrompt';
 import { GitHubRegistryClient } from './GitHubRegistryClient';
@@ -154,14 +154,18 @@ export class MindScaffold {
     const sessionConfig: Record<string, unknown> = {
       streaming: true,
       workingDirectory: mindPath,
-      onPermissionRequest: approveAllCompat,
+      onPermissionRequest: approveForSessionCompat,
     };
 
     const session = await client.createSession(
       sessionConfig as unknown as Parameters<typeof client.createSession>[0]
     );
 
-    await session.rpc.permissions.setApproveAll({ enabled: true });
+    // Issue #131 checklist 4: rely on `approveForSessionCompat` returning
+    // `approve-for-session` decisions for read/write/memory and `approve-once`
+    // for the rest, instead of short-circuiting through setApproveAll. The
+    // handler-driven path keeps genesis fully auto-approved while exposing
+    // the request stream so future PRs can surface activity to the UI.
 
     try {
       await session.send({ prompt: injectCurrentDateTimeContext(prompt, getCurrentDateTimeContext()) });

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MindManager } from './MindManager';
+import { approveForSessionCompat } from '../sdk/approveForSessionCompat';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import type { IdentityLoader } from '../chat/IdentityLoader';
 import type { ChamberToolProvider } from '../chamberTools';
@@ -464,6 +465,15 @@ describe('MindManager', () => {
       await manager.loadMind('/tmp/agents/q');
       expect(listener).toHaveBeenCalledWith(expect.objectContaining({ mindPath: '/tmp/agents/q' }));
     });
+
+    it('wires approveForSessionCompat and does not short-circuit via setApproveAll (issue #131)', async () => {
+      const created = createSessionStub();
+      mockCreateSession.mockResolvedValueOnce(created);
+      await manager.loadMind('/tmp/agents/q');
+      const sessionConfig = mockCreateSession.mock.calls[0][0] as { onPermissionRequest?: unknown };
+      expect(sessionConfig.onPermissionRequest).toBe(approveForSessionCompat);
+      expect(created.rpc.permissions.setApproveAll).not.toHaveBeenCalled();
+    });
   });
 
   describe('unloadMind', () => {
@@ -753,6 +763,22 @@ describe('MindManager', () => {
       expect(result.conversations.map((conversation) => conversation.sessionId)).toEqual(
         historyBeforeResume.map((conversation) => conversation.sessionId),
       );
+    });
+
+    it('wires approveForSessionCompat on resumed sessions and does not short-circuit via setApproveAll (issue #131)', async () => {
+      const resumedSession = createSessionStub();
+      resumedSession.getMessages.mockResolvedValue([]);
+      mockResumeSession.mockResolvedValueOnce(resumedSession);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Prior chat');
+      await manager.recreateSession(mind.mindId);
+      const target = manager.listConversationHistory(mind.mindId)[1];
+
+      await manager.resumeConversation(mind.mindId, target.sessionId);
+
+      const resumeConfig = mockResumeSession.mock.calls[0][1] as { onPermissionRequest?: unknown };
+      expect(resumeConfig.onPermissionRequest).toBe(approveForSessionCompat);
+      expect(resumedSession.rpc.permissions.setApproveAll).not.toHaveBeenCalled();
     });
 
     it('hydrates the already-active conversation without resuming the SDK session again', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -13,7 +13,7 @@ import type { InternalMindContext, CopilotClient, CopilotSession, Tool, UserInpu
 import { generateMindId } from './generateMindId';
 import { loadMcpServersFromMindPath } from './mcpConfig';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
-import { approveAllCompat } from '../sdk/approveAllCompat';
+import { approveForSessionCompat } from '../sdk/approveForSessionCompat';
 import type { IdentityLoader } from '../chat/IdentityLoader';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext, stripInjectedCurrentDateTimeContext } from '../chat/currentDateTimeContext';
 import type { ChamberToolProvider } from '../chamberTools';
@@ -116,8 +116,8 @@ export class MindManager extends EventEmitter {
         identity.systemMessage,
         sessionTools,
         undefined,
-        approveAllCompat,
-        true,
+        approveForSessionCompat,
+        false,
         selectedModel,
         activeSessionId,
       );
@@ -357,8 +357,8 @@ export class MindManager extends EventEmitter {
       context.identity.systemMessage,
       sessionTools,
       undefined,
-      approveAllCompat,
-      true,
+      approveForSessionCompat,
+      false,
       context.selectedModel,
       conversation.sessionId,
     );
@@ -739,7 +739,7 @@ export class MindManager extends EventEmitter {
       sessionTools,
       undefined,
       onPermissionRequest,
-      !onPermissionRequest,
+      false,
     );
   }
 
@@ -749,8 +749,8 @@ export class MindManager extends EventEmitter {
     systemMessage: string,
     tools: Tool[],
     onUserInputRequest?: UserInputHandler,
-    onPermissionRequest: PermissionHandler = approveAllCompat,
-    approveAll = true,
+    onPermissionRequest: PermissionHandler = approveForSessionCompat,
+    useSetApproveAllShortcut = false,
     model?: string,
     sessionId?: string,
   ): Promise<CopilotSession> {
@@ -774,7 +774,13 @@ export class MindManager extends EventEmitter {
     };
     const session = await client.createSession(sessionConfig);
 
-    if (approveAll) {
+    // Issue #131 checklist 4: stop short-circuiting per-session approval
+    // through `setApproveAll`. The handler-driven `approve-for-session`
+    // path now owns the auto-approval decision, which lets B5 surface
+    // requests in the chat UI without losing chamber's existing safe
+    // defaults. The shortcut remains opt-in for legacy callers that
+    // still want the server-side flag.
+    if (useSetApproveAllShortcut) {
       await session.rpc.permissions.setApproveAll({ enabled: true });
     }
 
@@ -788,8 +794,8 @@ export class MindManager extends EventEmitter {
     systemMessage: string,
     tools: Tool[],
     onUserInputRequest?: UserInputHandler,
-    onPermissionRequest: PermissionHandler = approveAllCompat,
-    approveAll = true,
+    onPermissionRequest: PermissionHandler = approveForSessionCompat,
+    useSetApproveAllShortcut = false,
     model?: string,
   ): Promise<CopilotSession> {
     const mcpServers = loadMcpServersFromMindPath(mindPath);
@@ -810,7 +816,7 @@ export class MindManager extends EventEmitter {
       ...(onUserInputRequest ? { onUserInputRequest } : {}),
     };
     const session = await client.resumeSession(sessionId, sessionConfig);
-    if (approveAll) {
+    if (useSetApproveAllShortcut) {
       await session.rpc.permissions.setApproveAll({ enabled: true });
     }
     return session;
@@ -832,8 +838,8 @@ export class MindManager extends EventEmitter {
         systemMessage,
         tools,
         undefined,
-        approveAllCompat,
-        true,
+        approveForSessionCompat,
+        false,
         model,
       );
     } catch (error) {
@@ -845,8 +851,8 @@ export class MindManager extends EventEmitter {
         systemMessage,
         tools,
         undefined,
-        approveAllCompat,
-        true,
+        approveForSessionCompat,
+        false,
         model,
         conversationSessionId,
       );

--- a/packages/services/src/sdk/approveAllCompat.ts
+++ b/packages/services/src/sdk/approveAllCompat.ts
@@ -1,3 +1,0 @@
-import type { PermissionHandler } from '@github/copilot-sdk';
-
-export const approveAllCompat: PermissionHandler = async () => ({ kind: 'approve-once' });

--- a/packages/services/src/sdk/approveForSessionCompat.test.ts
+++ b/packages/services/src/sdk/approveForSessionCompat.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { approveForSessionCompat } from './approveForSessionCompat';
+
+const invocation = { sessionId: 'session-1' };
+
+describe('approveForSessionCompat (issue #131 checklist 4)', () => {
+  describe('approve-for-session decisions', () => {
+    it('approves read for the rest of the session', async () => {
+      const decision = await approveForSessionCompat({ kind: 'read', toolCallId: 'r1' }, invocation);
+      expect(decision).toEqual({
+        kind: 'approve-for-session',
+        approval: { kind: 'read' },
+      });
+    });
+
+    it('approves write for the rest of the session', async () => {
+      const decision = await approveForSessionCompat({ kind: 'write', toolCallId: 'w1' }, invocation);
+      expect(decision).toEqual({
+        kind: 'approve-for-session',
+        approval: { kind: 'write' },
+      });
+    });
+
+    it('approves memory for the rest of the session', async () => {
+      const decision = await approveForSessionCompat({ kind: 'memory', toolCallId: 'm1' }, invocation);
+      expect(decision).toEqual({
+        kind: 'approve-for-session',
+        approval: { kind: 'memory' },
+      });
+    });
+  });
+
+  describe('approve-once fallback for kinds without per-session decisions', () => {
+    // shell would need PermissionDecisionApproveForSessionApprovalCommands.commandIdentifiers,
+    // but the handler-side PermissionRequest only carries { kind, toolCallId? }. Until the
+    // handler is wired to the richer permission.requested event, fall back to approve-once.
+    // In practice --allow-tool=shell auto-approves at the CLI layer so this branch is mostly
+    // defensive coverage.
+    it('approves shell once (no commandIdentifiers available in the handler-side request)', async () => {
+      const decision = await approveForSessionCompat({ kind: 'shell', toolCallId: 's1' }, invocation);
+      expect(decision).toEqual({ kind: 'approve-once' });
+    });
+
+    it('approves mcp once (no serverName available in the handler-side request)', async () => {
+      const decision = await approveForSessionCompat({ kind: 'mcp', toolCallId: 'mcp1' }, invocation);
+      expect(decision).toEqual({ kind: 'approve-once' });
+    });
+
+    it('approves custom-tool once (no toolName available in the handler-side request)', async () => {
+      const decision = await approveForSessionCompat({ kind: 'custom-tool', toolCallId: 'ct1' }, invocation);
+      expect(decision).toEqual({ kind: 'approve-once' });
+    });
+
+    it('approves url once (no per-session variant in the SDK)', async () => {
+      const decision = await approveForSessionCompat({ kind: 'url', toolCallId: 'u1' }, invocation);
+      expect(decision).toEqual({ kind: 'approve-once' });
+    });
+
+    it('approves hook once (no per-session variant in the SDK)', async () => {
+      const decision = await approveForSessionCompat({ kind: 'hook', toolCallId: 'h1' }, invocation);
+      expect(decision).toEqual({ kind: 'approve-once' });
+    });
+  });
+
+  describe('end-to-end auto-approve preserved', () => {
+    it('never returns reject', async () => {
+      const kinds: Array<'shell' | 'write' | 'mcp' | 'read' | 'url' | 'custom-tool' | 'memory' | 'hook'> = [
+        'shell', 'write', 'mcp', 'read', 'url', 'custom-tool', 'memory', 'hook',
+      ];
+      for (const kind of kinds) {
+        const decision = await approveForSessionCompat({ kind }, invocation);
+        expect(decision.kind).not.toBe('reject');
+        expect(decision.kind).not.toBe('user-not-available');
+      }
+    });
+  });
+});

--- a/packages/services/src/sdk/approveForSessionCompat.ts
+++ b/packages/services/src/sdk/approveForSessionCompat.ts
@@ -5,9 +5,9 @@ import type { PermissionHandler, PermissionRequest, PermissionRequestResult } fr
 // every kind in the SDK protocol, but several variants require detail
 // fields the handler-side request does not expose:
 //
-//   - `commands` requires `commandIdentifiers: string[]` (shell)
-//   - `mcp` and `mcp-sampling` require `serverName` (mcp / mcp-sampling)
-//   - `custom-tool` requires `toolName` (custom-tool)
+//   - `shell` requires `commandIdentifiers: string[]`
+//   - `mcp` requires `serverName`
+//   - `custom-tool` requires `toolName`
 //   - `url` and `hook` have no `approve-for-session` variant in the protocol
 //
 // For those kinds we fall back to `approve-once` until a future PR

--- a/packages/services/src/sdk/approveForSessionCompat.ts
+++ b/packages/services/src/sdk/approveForSessionCompat.ts
@@ -1,0 +1,40 @@
+import type { PermissionHandler, PermissionRequest, PermissionRequestResult } from '@github/copilot-sdk';
+
+// SDK 0.3.0 PermissionRequest carries only `{ kind, toolCallId? }` on the
+// handler side. Decisions of kind `approve-for-session` are available for
+// every kind in the SDK protocol, but several variants require detail
+// fields the handler-side request does not expose:
+//
+//   - `commands` requires `commandIdentifiers: string[]` (shell)
+//   - `mcp` and `mcp-sampling` require `serverName` (mcp / mcp-sampling)
+//   - `custom-tool` requires `toolName` (custom-tool)
+//   - `url` and `hook` have no `approve-for-session` variant in the protocol
+//
+// For those kinds we fall back to `approve-once` until a future PR
+// (issue #131 checklist 5) wires the richer `permission.requested`
+// session event so the handler can see command identifiers, server
+// names, etc.
+//
+// Read / write / memory have unconditional `approve-for-session`
+// variants, so we use them — that means the SDK stops re-invoking the
+// handler for the rest of the session for those kinds, which is the
+// whole point of issue #131 checklist 4.
+export const approveForSessionCompat: PermissionHandler = (
+  request: PermissionRequest,
+): PermissionRequestResult => {
+  switch (request.kind) {
+    case 'read':
+      return { kind: 'approve-for-session', approval: { kind: 'read' } };
+    case 'write':
+      return { kind: 'approve-for-session', approval: { kind: 'write' } };
+    case 'memory':
+      return { kind: 'approve-for-session', approval: { kind: 'memory' } };
+    case 'shell':
+    case 'mcp':
+    case 'custom-tool':
+    case 'url':
+    case 'hook':
+    default:
+      return { kind: 'approve-once' };
+  }
+};


### PR DESCRIPTION
## Summary

Fourth PR in the SDK 0.3.0 permission scoping stack for issue #131. Replaces the catch-all `approveAllCompat` handler + `setApproveAll(true)` shortcut with a real handler that returns `approve-for-session` decisions for the kinds the SDK 0.3.0 protocol supports without extra request data, falling back to `approve-once` for the rest.

## What changed

### New: `packages/services/src/sdk/approveForSessionCompat.ts`

Maps each `PermissionRequest.kind` to a decision:

| kind | decision |
|---|---|
| `read` | `{ kind: 'approve-for-session', approval: { kind: 'read' } }` |
| `write` | `{ kind: 'approve-for-session', approval: { kind: 'write' } }` |
| `memory` | `{ kind: 'approve-for-session', approval: { kind: 'memory' } }` |
| `shell` | `{ kind: 'approve-once' }` (needs `commandIdentifiers`, not in handler-side request) |
| `mcp` | `{ kind: 'approve-once' }` (needs `serverName`) |
| `custom-tool` | `{ kind: 'approve-once' }` (needs `toolName`) |
| `url` | `{ kind: 'approve-once' }` (no per-session protocol variant) |
| `hook` | `{ kind: 'approve-once' }` (no per-session protocol variant) |

The `approve-once` branches will graduate to `approve-for-session` in B5 once the handler is wired to the richer `permission.requested` event and can read the missing fields.

### `packages/services/src/mind/MindManager.ts`

- Replace `approveAllCompat` import + every primary session use with `approveForSessionCompat` (initial mind load, conversation reset, session resume, stale-session fallback create — 4 sites).
- Rename internal `approveAll` parameter on `createSessionForMind` and `resumeSessionForMind` to `useSetApproveAllShortcut` and default it to `false`.
- Stop calling `session.rpc.permissions.setApproveAll({ enabled: true })` on chamber-controlled paths, so the new handler actually fires.

### `packages/services/src/genesis/MindScaffold.ts`

- Same handler swap (1 site, the genesis bootstrap session).
- Stop calling `setApproveAll(true)` on the genesis session.

### Cleanup

- Delete `packages/services/src/sdk/approveAllCompat.ts` — orphaned after this PR; nothing imports it.

## Behavior

- **End-to-end auto-approve preserved.** The new handler still approves every kind; nothing is rejected.
- **Protocol change**: the SDK now stops re-invoking the handler for `read` / `write` / `memory` after the first approval in a session. For other kinds (`shell`, `mcp`, `custom-tool`, `url`, `hook`) the handler is invoked per call (each still auto-approves). This is a deliberate trade-off pending B5 — those kinds need richer request data to be safely scoped to a session, so the cost of an extra in-process RPC per call is preferable to a permanent process-wide bypass via `setApproveAll`.
- **Chatroom approval gate is unchanged.** The chatroom still passes its own approval-gate handler through `createChatroomSession`; that handler owns the side-effect security boundary at the chatroom layer.

## Stack context

Built on top of #266 (which is built on #265, #264). Subsequent PRs:

- B5 — surface denials + permission events in chat UI; wire richer `permission.requested` data so shell/mcp/url/custom-tool can also use `approve-for-session`.
- B6 — per-agent `excludedTools` (closes #131).

## Test evidence

- `packages/services/src/sdk/approveForSessionCompat.test.ts` — covers every `PermissionRequest.kind` in the SDK 0.3.0 protocol and asserts decisions never `reject` or `user-not-available`.
- New regression-locking assertions in `MindManager.test.ts` (loadMind + resumeConversation) and the two `MindScaffold` test files: assert `sessionConfig.onPermissionRequest === approveForSessionCompat` and that `rpc.permissions.setApproveAll` is never called for primary sessions or genesis sessions.
- `npm run lint` — clean.
- `npm run smoke:sdk` — green.
- Targeted vitest run for the four affected files: 108/108 pass.

## Release metadata

- Bumps `package.json` / `package-lock.json` to `0.56.0`.
- Adds the matching `CHANGELOG.md` entry.

Refs #131
