### PR TITLE
feat(sdk): per-mind excludedTools via .chamber.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.58.0 (2026-05-10)
+
+### SDK
+
+- **Per-mind tool exclusion via `.chamber.json`** — Mind authors can drop a `.chamber.json` at the mind root with `"excludedTools": ["shell", "str_replace"]` to remove specific tool names from the agent's toolset on every session create + resume. Missing file, missing key, malformed JSON, and empty arrays are all treated as no exclusions so a typo never bricks the mind. Closes #131.
+
 ## v0.57.0 (2026-05-10)
 
 ### SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.57.0",
+      "version": "0.58.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -156,10 +156,14 @@ describe('MindManager', () => {
       void sessionId;
     });
     vi.mocked(fs.existsSync).mockImplementation((candidate) => {
-      // Default: every checked path exists EXCEPT `.mcp.json`. Tests that
-      // need MindManager to discover an `.mcp.json` opt in by overriding
-      // existsSync + readFileSync per test (#199).
-      return !String(candidate).endsWith('.mcp.json');
+      // Default: every checked path exists EXCEPT `.mcp.json` and
+      // `.chamber.json`. Tests that need MindManager to discover either
+      // file opt in by overriding existsSync + readFileSync per test
+      // (#199 / #131). Without the chamber.json exclusion, the default
+      // readFileSync stub ('# TestAgent\nSome content') fails JSON.parse
+      // and pollutes every test with a chamberMindConfig warn.
+      const s = String(candidate);
+      return !s.endsWith('.mcp.json') && !s.endsWith('.chamber.json');
     });
     vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
     vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => String(candidate));
@@ -1316,6 +1320,28 @@ describe('MindManager', () => {
       const config = mockCreateSession.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
       expect(config).toBeDefined();
       expect(Object.prototype.hasOwnProperty.call(config, 'excludedTools')).toBe(false);
+    });
+
+    it('passes excludedTools through to resumeSession when resuming a prior conversation', async () => {
+      const chamberJson = JSON.stringify({ excludedTools: ['shell'] });
+      vi.mocked(fs.existsSync).mockImplementation(() => true);
+      vi.mocked(fs.readFileSync).mockImplementation((candidate) => {
+        return String(candidate).endsWith('.chamber.json')
+          ? chamberJson
+          : '# TestAgent\nSome content';
+      });
+      const resumedSession = createSessionStub();
+      resumedSession.getMessages.mockResolvedValue([]);
+      mockResumeSession.mockResolvedValueOnce(resumedSession);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Prior chat');
+      await manager.recreateSession(mind.mindId);
+      const target = manager.listConversationHistory(mind.mindId)[1];
+
+      await manager.resumeConversation(mind.mindId, target.sessionId);
+
+      const resumeConfig = mockResumeSession.mock.calls[0][1] as Record<string, unknown>;
+      expect(resumeConfig.excludedTools).toEqual(['shell']);
     });
   });
 

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -1275,6 +1275,50 @@ describe('MindManager', () => {
     });
   });
 
+  describe('chamber mind config (#131 — per-mind excludedTools)', () => {
+    it('passes excludedTools through to createSession when .chamber.json declares them', async () => {
+      const chamberJson = JSON.stringify({ excludedTools: ['shell', 'str_replace'] });
+      vi.mocked(fs.existsSync).mockImplementation(() => true);
+      vi.mocked(fs.readFileSync).mockImplementation((candidate) => {
+        return String(candidate).endsWith('.chamber.json')
+          ? chamberJson
+          : '# TestAgent\nSome content';
+      });
+
+      await manager.loadMind('/tmp/agents/q');
+
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludedTools: ['shell', 'str_replace'],
+        }),
+      );
+    });
+
+    it('omits excludedTools from session config when .chamber.json is absent', async () => {
+      await manager.loadMind('/tmp/agents/q');
+
+      const config = mockCreateSession.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect(config).toBeDefined();
+      expect(Object.prototype.hasOwnProperty.call(config, 'excludedTools')).toBe(false);
+    });
+
+    it('omits excludedTools from session config when .chamber.json declares an empty array', async () => {
+      const chamberJson = JSON.stringify({ excludedTools: [] });
+      vi.mocked(fs.existsSync).mockImplementation(() => true);
+      vi.mocked(fs.readFileSync).mockImplementation((candidate) => {
+        return String(candidate).endsWith('.chamber.json')
+          ? chamberJson
+          : '# TestAgent\nSome content';
+      });
+
+      await manager.loadMind('/tmp/agents/q');
+
+      const config = mockCreateSession.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect(config).toBeDefined();
+      expect(Object.prototype.hasOwnProperty.call(config, 'excludedTools')).toBe(false);
+    });
+  });
+
   describe('provider integration', () => {
     it('activates providers after creating a mind session', async () => {
       await manager.loadMind('/tmp/agents/q');

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -12,6 +12,7 @@ import { Logger } from '../logger';
 import type { InternalMindContext, CopilotClient, CopilotSession, Tool, UserInputHandler } from './types';
 import { generateMindId } from './generateMindId';
 import { loadMcpServersFromMindPath } from './mcpConfig';
+import { loadChamberMindConfig } from './chamberMindConfig';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import { approveForSessionCompat } from '../sdk/approveForSessionCompat';
 import type { IdentityLoader } from '../chat/IdentityLoader';
@@ -755,6 +756,7 @@ export class MindManager extends EventEmitter {
     sessionId?: string,
   ): Promise<CopilotSession> {
     const mcpServers = loadMcpServersFromMindPath(mindPath);
+    const chamberMindConfig = loadChamberMindConfig(mindPath);
     const sessionConfig: SessionConfig = {
       workingDirectory: mindPath,
       enableConfigDiscovery: true,
@@ -768,6 +770,9 @@ export class MindManager extends EventEmitter {
       },
       onPermissionRequest,
       ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+      ...(chamberMindConfig.excludedTools && chamberMindConfig.excludedTools.length > 0
+        ? { excludedTools: chamberMindConfig.excludedTools }
+        : {}),
       ...(sessionId ? { sessionId } : {}),
       ...(model ? { model } : {}),
       ...(onUserInputRequest ? { onUserInputRequest } : {}),
@@ -799,6 +804,7 @@ export class MindManager extends EventEmitter {
     model?: string,
   ): Promise<CopilotSession> {
     const mcpServers = loadMcpServersFromMindPath(mindPath);
+    const chamberMindConfig = loadChamberMindConfig(mindPath);
     const sessionConfig: ResumeSessionConfig = {
       workingDirectory: mindPath,
       enableConfigDiscovery: true,
@@ -812,6 +818,9 @@ export class MindManager extends EventEmitter {
       },
       onPermissionRequest,
       ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+      ...(chamberMindConfig.excludedTools && chamberMindConfig.excludedTools.length > 0
+        ? { excludedTools: chamberMindConfig.excludedTools }
+        : {}),
       ...(model ? { model } : {}),
       ...(onUserInputRequest ? { onUserInputRequest } : {}),
     };

--- a/packages/services/src/mind/chamberMindConfig.test.ts
+++ b/packages/services/src/mind/chamberMindConfig.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadChamberMindConfig, CHAMBER_MIND_CONFIG_FILENAME } from './chamberMindConfig';
+
+describe('loadChamberMindConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-mind-config-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns an empty config when no .chamber.json file is present', () => {
+    expect(loadChamberMindConfig(tmpDir)).toEqual({});
+  });
+
+  it('reads excludedTools when present', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, CHAMBER_MIND_CONFIG_FILENAME),
+      JSON.stringify({ excludedTools: ['shell', 'str_replace'] }),
+    );
+    expect(loadChamberMindConfig(tmpDir)).toEqual({
+      excludedTools: ['shell', 'str_replace'],
+    });
+  });
+
+  it('omits excludedTools when the array is empty so the SDK sees no key', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, CHAMBER_MIND_CONFIG_FILENAME),
+      JSON.stringify({ excludedTools: [] }),
+    );
+    expect(loadChamberMindConfig(tmpDir)).toEqual({});
+  });
+
+  it('returns empty config for invalid JSON without throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fs.writeFileSync(path.join(tmpDir, CHAMBER_MIND_CONFIG_FILENAME), '{ not valid json');
+    expect(loadChamberMindConfig(tmpDir)).toEqual({});
+    warn.mockRestore();
+  });
+
+  it('rejects an excludedTools entry that is not a string array', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fs.writeFileSync(
+      path.join(tmpDir, CHAMBER_MIND_CONFIG_FILENAME),
+      JSON.stringify({ excludedTools: [1, 2, 3] }),
+    );
+    expect(loadChamberMindConfig(tmpDir)).toEqual({});
+    warn.mockRestore();
+  });
+
+  it('ignores extra unknown keys to stay forward-compatible', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, CHAMBER_MIND_CONFIG_FILENAME),
+      JSON.stringify({
+        excludedTools: ['shell'],
+        somethingFromAFutureVersion: { ignored: true },
+      }),
+    );
+    expect(loadChamberMindConfig(tmpDir)).toEqual({
+      excludedTools: ['shell'],
+    });
+  });
+});

--- a/packages/services/src/mind/chamberMindConfig.test.ts
+++ b/packages/services/src/mind/chamberMindConfig.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { loadChamberMindConfig, CHAMBER_MIND_CONFIG_FILENAME } from './chamberMindConfig';
 
 describe('loadChamberMindConfig', () => {

--- a/packages/services/src/mind/chamberMindConfig.ts
+++ b/packages/services/src/mind/chamberMindConfig.ts
@@ -1,0 +1,66 @@
+// Reads a mind's `.chamber.json` and returns the chamber-managed slice of
+// session config that needs per-mind customization. Missing file → empty
+// config; invalid JSON / failing schema → warn + empty (consistent with
+// `mcpConfig.ts`, so a typo in one file never bricks a mind).
+//
+// Schema (intentionally small — extend additively):
+//   {
+//     "excludedTools": ["shell", "str_replace"]
+//   }
+//
+// `excludedTools` maps directly onto `SessionConfig.excludedTools`
+// (SDK 0.3.0). Names match the tool names the CLI registers — see
+// `copilot help tools` for the full list. This is per-agent in chamber
+// terms because each mind runs its own CopilotClient + session.
+//
+// Issue #131 checklist 6.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { z } from 'zod';
+import { Logger } from '../logger';
+
+const log = Logger.create('chamberMindConfig');
+
+const chamberMindConfigSchema = z.object({
+  excludedTools: z.array(z.string().min(1)).optional(),
+}).passthrough();
+
+export const CHAMBER_MIND_CONFIG_FILENAME = '.chamber.json';
+
+export interface ChamberMindConfig {
+  excludedTools?: string[];
+}
+
+export function loadChamberMindConfig(mindPath: string): ChamberMindConfig {
+  const filePath = path.join(mindPath, CHAMBER_MIND_CONFIG_FILENAME);
+  if (!fs.existsSync(filePath)) return {};
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    log.warn(`Failed to read ${filePath}; skipping chamber mind config:`, err);
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn(`Invalid JSON in ${filePath}; skipping chamber mind config:`, err);
+    return {};
+  }
+
+  const result = chamberMindConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    log.warn(`Schema validation failed for ${filePath}; skipping chamber mind config:`, result.error.issues);
+    return {};
+  }
+
+  const out: ChamberMindConfig = {};
+  if (result.data.excludedTools && result.data.excludedTools.length > 0) {
+    out.excludedTools = [...result.data.excludedTools];
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

**Closes #131** — final PR in the SDK 0.3.0 permission scoping stack.

SDK 0.3.0 added session-level `excludedTools`: a list of tool names that the default agent cannot see. In chamber terms each mind already runs its own `CopilotClient` and session, so wiring this through gives us per-mind tool exclusion without inventing any new abstraction.

Mind authors can now drop a `.chamber.json` at the mind root:

```json
{
  "excludedTools": ["shell", "str_replace"]
}
```

…and those tool names will be removed from the agent's toolset on every session create + resume.

## Notable changes

- **New** `packages/services/src/mind/chamberMindConfig.ts` — `loadChamberMindConfig(mindPath)` reads `.chamber.json`, validates with zod, returns `{ excludedTools?: string[] }`. Missing file, missing key, or empty array all behave as "no exclusions" so the SDK never sees an empty list.
- Mirrors the established `mcpConfig.ts` pattern: missing file → empty config, malformed JSON → warn + empty (a typo never bricks the mind). Schema is intentionally small and forward-compatible (`.passthrough()`).
- **`MindManager`**: both `createSessionForMind` and `resumeSessionForMind` load the chamber mind config and spread `excludedTools` into the `SessionConfig` only when present and non-empty.
- **Test hygiene**: the default `fs.existsSync` mock in `MindManager.test.ts` now also excludes `.chamber.json` so the "absent" test truly exercises the missing-file branch (not the malformed-JSON branch via the default agent-markdown stub), and every pre-existing MindManager test stops emitting chamberMindConfig warnings on every run.

## Closes / refs

**Closes #131**

Wraps the SDK 0.3.0 permission scoping stack:

- #264 — `--add-dir` per session
- #265 — `--allow-tool` instead of `--allow-all-tools`
- #266 — `--allow-url` instead of `--allow-all-urls`
- #267 — `approve-for-session` decisions instead of `setApproveAll`
- #268 — surface permission requests + denials in chat UI
- **#269** (this PR) — per-mind `excludedTools`

## Tests

- 6 `chamberMindConfig` tests covering the missing-file fast path, presence, the empty-array no-op, JSON parse failure, schema rejection for non-string entries, and forward-compat passthrough.
- 4 `MindManager` tests covering passthrough into `createSession`, into `resumeSession`, absence when no `.chamber.json`, and absence when an empty array is declared.
- `npm run lint` clean.
- `npm run smoke:sdk` passes.
- Targeted vitest run for the affected files: 89/89.

## Skipped smoke

- `npm run smoke:web` / `npm run smoke:desktop`: no chat routing or UI behavior changed.
- `npm run package` / `npm run make:sandbox`: packaging path untouched.

## Release metadata

- Bumps `package.json` / `package-lock.json` to `0.58.0`.
- Adds the matching `CHANGELOG.md` entry.

## Stack

Final child in the #131 stack; rebased onto `master` after #268 merged.
