### PR TITLE
fix(chat): stop chat box memory leak on long streaming replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.59.2 (2026-05-10)
+
+### Fixes
+
+- **Stop the chat box from leaking memory on long replies** — Two compounding causes during streaming addressed in the renderer: (1) `react-markdown` was re-parsing the entire growing assistant message on every token because `remarkPlugins` and `rehypePlugins` were declared as inline array literals (defeating the library's internal memoization) and `TextChunk` was not memoized; (2) the `BroadcastChannel` cross-window sync effect re-published the entire `messagesByMind` map on every reducer change, structured-cloning every block of every mind per token. Plugin arrays are now module-level constants, `TextChunk` is wrapped in `React.memo`, and the `BroadcastChannel` post is coalesced via `requestAnimationFrame` so a burst of streaming chunks results in at most one cross-window post per frame. Closes #273.
+
 ## v0.59.0 (2026-05-10)
 
 ### Chat

--- a/apps/web/src/renderer/components/chat/StreamingMessage.test.tsx
+++ b/apps/web/src/renderer/components/chat/StreamingMessage.test.tsx
@@ -1,16 +1,21 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { StreamingMessage } from './StreamingMessage';
 import { makeTextBlock, makeToolCallBlock, makeReasoningBlock } from '@/test/helpers';
 
+const markdownMock = vi.fn(({ children }: { children: string }) => <div data-testid="markdown">{children}</div>);
+
 vi.mock('react-markdown', () => ({
-  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+  default: (props: { children: string }) => markdownMock(props),
 }));
 vi.mock('remark-gfm', () => ({ default: vi.fn() }));
 
 describe('StreamingMessage', () => {
+  beforeEach(() => {
+    markdownMock.mockClear();
+  });
   it('shows thinking dots when empty blocks and streaming', () => {
     render(<StreamingMessage blocks={[]} isStreaming={true} />);
     expect(screen.getByText('Thinking…')).toBeTruthy();
@@ -70,5 +75,31 @@ describe('StreamingMessage', () => {
     const { container } = render(<StreamingMessage blocks={[]} isStreaming={false} />);
     expect(container.querySelector('.animate-bounce')).toBeNull();
     expect(screen.queryByText('Thinking…')).toBeNull();
+  });
+
+  it('does not re-render Markdown for an unchanged text block when a sibling block updates', () => {
+    const stableText = makeTextBlock('alpha');
+    const initialTool = makeToolCallBlock({ toolCallId: 'tc-1', toolName: 'grep', status: 'running' });
+    const { rerender } = render(<StreamingMessage blocks={[stableText, initialTool]} isStreaming={true} />);
+    const callsAfterInitialRender = markdownMock.mock.calls.length;
+    expect(callsAfterInitialRender).toBeGreaterThanOrEqual(1);
+
+    const updatedTool = { ...initialTool, status: 'done' as const, output: 'finished' };
+    rerender(<StreamingMessage blocks={[stableText, updatedTool]} isStreaming={true} />);
+
+    expect(markdownMock.mock.calls.length).toBe(callsAfterInitialRender);
+  });
+
+  it('re-renders Markdown only for the changed text block when one of two text blocks updates', () => {
+    const stableText = makeTextBlock('alpha');
+    const growingTextV1 = makeTextBlock('beta');
+    const tool = makeToolCallBlock({ toolCallId: 'tc-1', toolName: 'grep', status: 'done' });
+    const { rerender } = render(<StreamingMessage blocks={[stableText, tool, growingTextV1]} isStreaming={true} />);
+    const callsAfterInitialRender = markdownMock.mock.calls.length;
+
+    const growingTextV2 = { ...growingTextV1, content: 'beta-extended' };
+    rerender(<StreamingMessage blocks={[stableText, tool, growingTextV2]} isStreaming={true} />);
+
+    expect(markdownMock.mock.calls.length).toBe(callsAfterInitialRender + 1);
   });
 });

--- a/apps/web/src/renderer/components/chat/StreamingMessage.tsx
+++ b/apps/web/src/renderer/components/chat/StreamingMessage.tsx
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { memo } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
+import type { PluggableList } from 'unified';
+import type { Components } from 'react-markdown';
 import { cn } from '../../lib/utils';
 import { WorkGroup, hasRunningTool } from './WorkGroup';
 import { groupBlocksIntoChunks } from './WorkGroup.logic';
 import type { ContentBlock, TextBlock } from '@chamber/shared/types';
+
+const REMARK_PLUGINS: PluggableList = [remarkGfm];
+const REHYPE_PLUGINS: PluggableList = [[rehypeHighlight, { detect: true, ignoreMissing: true }]];
+const MARKDOWN_COMPONENTS: Components = {
+  a: (props) => <a {...props} target="_blank" rel="noopener noreferrer" />,
+};
 
 interface Props {
   blocks: ContentBlock[];
@@ -65,7 +73,7 @@ export function StreamingMessage({ blocks, isStreaming }: Props) {
   );
 }
 
-function TextChunk({ block, streaming }: { block: TextBlock; streaming: boolean }) {
+const TextChunk = memo(function TextChunk({ block, streaming }: { block: TextBlock; streaming: boolean }) {
   return (
     <div
       className={cn(
@@ -74,11 +82,9 @@ function TextChunk({ block, streaming }: { block: TextBlock; streaming: boolean 
       )}
     >
       <Markdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[[rehypeHighlight, { detect: true, ignoreMissing: true }]]}
-        components={{
-          a: (props) => <a {...props} target="_blank" rel="noopener noreferrer" />,
-        }}
+        remarkPlugins={REMARK_PLUGINS}
+        rehypePlugins={REHYPE_PLUGINS}
+        components={MARKDOWN_COMPONENTS}
       >
         {block.content}
       </Markdown>
@@ -87,7 +93,7 @@ function TextChunk({ block, streaming }: { block: TextBlock; streaming: boolean 
       )}
     </div>
   );
-}
+});
 
 function ThinkingDots({ label }: { label: string }) {
   return (

--- a/apps/web/src/renderer/lib/store/context.test.tsx
+++ b/apps/web/src/renderer/lib/store/context.test.tsx
@@ -4,11 +4,12 @@
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeMessage, makeTextBlock } from '../../../test/helpers';
-import { AppStateProvider, useAppState } from './context';
+import { AppStateProvider, useAppDispatch, useAppState } from './context';
 import { CHAT_STATE_CHANNEL, createChatStateSyncMessage } from './chatStateSync';
 
 class FakeBroadcastChannel {
   static channels = new Map<string, Set<FakeBroadcastChannel>>();
+  static postMessageCalls = 0;
 
   onmessage: ((event: MessageEvent) => void) | null = null;
 
@@ -19,6 +20,7 @@ class FakeBroadcastChannel {
   }
 
   postMessage(data: unknown): void {
+    FakeBroadcastChannel.postMessageCalls += 1;
     for (const channel of FakeBroadcastChannel.channels.get(this.name) ?? []) {
       if (channel === this) continue;
       channel.onmessage?.({ data } as MessageEvent);
@@ -37,9 +39,31 @@ function ChatStateProbe() {
   return <div>{text}</div>;
 }
 
+function ChunkAppender() {
+  const dispatch = useAppDispatch();
+  return (
+    <button
+      data-testid="append-chunk"
+      onClick={() => {
+        dispatch({
+          type: 'CHAT_EVENT',
+          payload: {
+            mindId: 'mind-1',
+            messageId: 'streaming-msg',
+            event: { type: 'chunk', sdkMessageId: 'sdk-1', content: 'x' },
+          },
+        });
+      }}
+    >
+      append
+    </button>
+  );
+}
+
 describe('AppStateProvider chat sync', () => {
   beforeEach(() => {
     FakeBroadcastChannel.channels.clear();
+    FakeBroadcastChannel.postMessageCalls = 0;
     vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
   });
 
@@ -84,5 +108,86 @@ describe('AppStateProvider chat sync', () => {
     await waitFor(() => {
       expect(screen.getByText('returned conversation')).toBeTruthy();
     });
+  });
+
+  it('coalesces a burst of chat-event dispatches into a single BroadcastChannel postMessage per animation frame', async () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    let nextRafId = 1;
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return nextRafId++;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+
+    render(
+      <AppStateProvider>
+        <ChunkAppender />
+      </AppStateProvider>,
+    );
+
+    await waitFor(() => {
+      const channels = FakeBroadcastChannel.channels.get(CHAT_STATE_CHANNEL);
+      expect(channels && channels.size).toBeGreaterThan(0);
+    });
+
+    FakeBroadcastChannel.postMessageCalls = 0;
+    rafCallbacks.length = 0;
+
+    const append = screen.getByTestId('append-chunk');
+    act(() => {
+      append.click();
+      append.click();
+      append.click();
+      append.click();
+      append.click();
+    });
+
+    expect(FakeBroadcastChannel.postMessageCalls).toBe(0);
+
+    act(() => {
+      const pending = rafCallbacks.splice(0);
+      for (const cb of pending) cb(performance.now());
+    });
+
+    expect(FakeBroadcastChannel.postMessageCalls).toBe(1);
+  });
+
+  it('flushes the pending state synchronously when the source window unmounts before the next animation frame', () => {
+    let pendingRaf: FrameRequestCallback | null = null;
+    let cancelled = false;
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      pendingRaf = cb;
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {
+      cancelled = true;
+      pendingRaf = null;
+    });
+
+    const peer = new BroadcastChannel(CHAT_STATE_CHANNEL);
+    let received: unknown = null;
+    peer.onmessage = (event) => {
+      if (event.data?.type === 'state') received = event.data;
+    };
+
+    const { unmount } = render(
+      <AppStateProvider>
+        <ChunkAppender />
+      </AppStateProvider>,
+    );
+
+    act(() => {
+      screen.getByTestId('append-chunk').click();
+    });
+
+    expect(pendingRaf).not.toBeNull();
+    received = null;
+
+    act(() => {
+      unmount();
+    });
+
+    expect(cancelled).toBe(true);
+    expect(received).not.toBeNull();
   });
 });

--- a/apps/web/src/renderer/lib/store/context.tsx
+++ b/apps/web/src/renderer/lib/store/context.tsx
@@ -13,6 +13,7 @@ export function AppStateProvider({ children, testInitialState }: { children: Rea
   const stateRef = useRef(state);
   const channelRef = useRef<BroadcastChannel | null>(null);
   const applyingRemoteState = useRef(false);
+  const pendingFlushRaf = useRef<number | null>(null);
 
   useEffect(() => {
     stateRef.current = state;
@@ -24,11 +25,23 @@ export function AppStateProvider({ children, testInitialState }: { children: Rea
       applyingRemoteState.current = false;
       return;
     }
-    channelRef.current.postMessage(createChatStateSyncMessage({
-      messagesByMind: state.messagesByMind,
-      streamingByMind: state.streamingByMind,
-      conversationViewByMind: state.conversationViewByMind,
-    }));
+    if (pendingFlushRaf.current !== null) return;
+    // The cleanup of the channel-lifecycle effect (below) deliberately does
+    // not cancel the pending rAF on every state change — that would defeat
+    // coalescing. Cancel-and-final-flush only happens on full unmount.
+    pendingFlushRaf.current = requestAnimationFrame(() => {
+      const channel = channelRef.current;
+      if (!channel) {
+        pendingFlushRaf.current = null;
+        return;
+      }
+      channel.postMessage(createChatStateSyncMessage({
+        messagesByMind: stateRef.current.messagesByMind,
+        streamingByMind: stateRef.current.streamingByMind,
+        conversationViewByMind: stateRef.current.conversationViewByMind,
+      }));
+      pendingFlushRaf.current = null;
+    });
   }, [state.conversationViewByMind, state.messagesByMind, state.streamingByMind, testInitialState]);
 
   useEffect(() => {
@@ -56,6 +69,17 @@ export function AppStateProvider({ children, testInitialState }: { children: Rea
     channel.postMessage({ type: 'request-state' } satisfies ChatStateSyncMessage);
 
     return () => {
+      if (pendingFlushRaf.current !== null) {
+        cancelAnimationFrame(pendingFlushRaf.current);
+        pendingFlushRaf.current = null;
+        // Final synchronous flush so peer windows do not lose the last
+        // delta when the source window unmounts mid-frame.
+        channel.postMessage(createChatStateSyncMessage({
+          messagesByMind: stateRef.current.messagesByMind,
+          streamingByMind: stateRef.current.streamingByMind,
+          conversationViewByMind: stateRef.current.conversationViewByMind,
+        }));
+      }
       channelRef.current = null;
       channel.close();
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.59.1",
+      "version": "0.59.2",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary

Fixes the user-reported chat-box memory leak that surfaces during long streaming replies. Two reinforcing causes addressed in the renderer.

Closes #273

## Changes

**M2 — react-markdown re-parsing the entire growing message per token**
- `apps/web/src/renderer/components/chat/StreamingMessage.tsx`
- `REMARK_PLUGINS`, `REHYPE_PLUGINS`, `MARKDOWN_COMPONENTS` hoisted to module-level constants. Inline plugin array literals were a fresh array identity per render, defeating react-markdown's internal memoization.
- `TextChunk` wrapped in `React.memo` so unchanged text blocks skip the markdown/AST/highlight pipeline when sibling blocks update.

**M1 — BroadcastChannel re-publishing the full transcript per token**
- `apps/web/src/renderer/lib/store/context.tsx`
- `BroadcastChannel.postMessage` from the state-sync effect is now coalesced via `requestAnimationFrame`: at most one post per frame, latest state read at flush time from a ref. Cancellation ownership lives on the channel-lifecycle effect, not the per-state-change effect, so coalescing is preserved.
- On unmount, the in-flight rAF is cancelled and a **synchronous final flush** runs so peer windows do not lose the last delta when the source window closes mid-frame (caught by Uncle Bob during review).

## Tests

Three new vitest cases (jsdom):
- `StreamingMessage` does not re-render Markdown when an unrelated sibling block updates.
- `StreamingMessage` re-renders Markdown only for the changed text block when one of two text blocks updates.
- `AppStateProvider` coalesces a 5-dispatch burst into 0 `postMessage` calls before rAF and exactly 1 after.
- `AppStateProvider` flushes pending state synchronously to peers when the source window unmounts before the next animation frame.

## Test evidence

- `npm run lint` — clean
- `npm test` — 141 files / **1452 tests** passing
- `npm run smoke:web` — **skipped**: pre-existing master regression tracked in #281 (`apps/server` ESM bundle uses `__filename`). Renderer behavior covered by the new vitest cases plus the existing test suite.

## Uncle Bob critique

Reviewed pre-amend; verdict: structurally correct, **one real defect** caught and fixed (loss-of-update on unmount; synchronous final flush + dedicated test added). Two optional polishes also applied: `markdownMock.mockClear()` in `beforeEach`, and a non-obvious-decision comment on the flush-effect cleanup ownership.

## Out of scope (separate cluster work)

- M3: virtualization in `MessageList`
- M4: cap on `messagesByMind` (compare `ChatroomService` MAX_MESSAGES=500)
- M5: reducer O(N²) string churn
- M6: chat IPC closure pinning `BrowserWindow` mid-turn
- M7: `MindManager.pushSystemPrompt` listener cleanup on timeout

## Note on version

Bumps to v0.52.1. PR #272 also bumps to v0.52.1 from master. Whichever PR merges second will need a rebase + re-bump to v0.52.2 — standard collision for parallel independent PRs.