### PR TITLE
fix(chat): revert model refresh subprocess recycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.59.7 (2026-05-12)
+
+### Fixes
+
+- **Revert the Refresh models subprocess recycle affordance** — Removes the `chat:refreshModels` IPC path, model-picker refresh button, `MindManager.recycleClientForMind`, and chatroom `mind:client-recycled` listener added in #271. The cache diagnosis from #270 remains, but Chamber no longer restarts a mind's Copilot CLI subprocess from the chat UI while #287 verifies the conversation-context risk. Closes #287.
+
 ## v0.59.6 (2026-05-11)
 
 ### Refactoring

--- a/apps/desktop/src/main/ipc/chat.ts
+++ b/apps/desktop/src/main/ipc/chat.ts
@@ -20,13 +20,6 @@ export function setupChatIPC(chatService: ChatService, mindManager: MindManager)
     return chatService.listModels(id);
   });
 
-  ipcMain.handle(IPC.CHAT.REFRESH_MODELS, async (_event, mindId: string) => {
-    if (!mindId) {
-      throw new Error('refreshModels requires an explicit mindId — cannot reload "any" mind.');
-    }
-    return chatService.refreshModels(mindId);
-  });
-
   ipcMain.handle(IPC.CHAT.STOP, async (event, mindId: string, messageId: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     await chatService.cancelMessage(mindId, messageId);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -13,7 +13,6 @@ const electronAPI: ElectronAPI = {
     newConversation: (mindId) =>
       ipcRenderer.invoke(IPC.CHAT.NEW_CONVERSATION, mindId),
     listModels: (mindId?) => ipcRenderer.invoke(IPC.CHAT.LIST_MODELS, mindId),
-    refreshModels: (mindId) => ipcRenderer.invoke(IPC.CHAT.REFRESH_MODELS, mindId),
     onEvent: (callback) => createIpcListener(ipcRenderer, IPC.CHAT.EVENT, callback),
   },
   conversationHistory: {

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -139,11 +139,6 @@ export function installBrowserApi(): void {
         return { sessionId: '', messages: [], conversations: [] };
       },
       listModels: (): Promise<ModelInfo[]> => client.listModels(),
-      refreshModels: async (): Promise<ModelInfo[]> => {
-        throw new Error(
-          'Refreshing the model cache requires restarting the underlying CLI subprocess and is only supported by the Chamber desktop app.',
-        );
-      },
       onEvent: (callback) => {
         chatEventHandlers.add(callback);
         void openEventSocket();

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useCallback, Suspense, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { RefreshCw } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import type { ModelInfo, ChatImageAttachment } from '@chamber/shared/types';
 import {
@@ -20,14 +19,6 @@ import {
   CommandList,
   CommandItem,
 } from '../ui/command';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '../ui/dialog';
 import { pushRecentEmoji } from '../../lib/emoji-recents';
 import { loadEmojiData, type EmojiRecord } from '../../lib/emoji-data';
 import { getTextareaCaretCoords } from '../../lib/textarea-caret';
@@ -44,14 +35,6 @@ interface Props {
   availableModels: ModelInfo[];
   selectedModel: string | null;
   onModelChange: (model: string) => void;
-  /**
-   * Optional handler that restarts the underlying CLI subprocess and
-   * returns a fresh model catalog. The renderer surfaces a confirmation
-   * dialog before invoking this because the operation tears down the
-   * in-flight conversation. See `docs/model-cache-investigation.md`
-   * (issue #90).
-   */
-  onRefreshModels?: () => Promise<void>;
   placeholder?: string;
   /**
    * When provided, the textarea is controlled — `value` drives display and
@@ -170,7 +153,7 @@ function getShortcodePopoverPlacement(anchor: ShortcodeAnchor): ShortcodePopover
   };
 }
 
-export function ChatInput({ onSend, onStop, isStreaming, disabled, availableModels, selectedModel, onModelChange, onRefreshModels, placeholder, value, onValueChange }: Props) {
+export function ChatInput({ onSend, onStop, isStreaming, disabled, availableModels, selectedModel, onModelChange, placeholder, value, onValueChange }: Props) {
   const isControlled = value !== undefined;
   const [internalInput, setInternalInput] = useState('');
   const input = isControlled ? value : internalInput;
@@ -185,9 +168,6 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   const [shortcodeResults, setShortcodeResults] = useState<EmojiRecord[]>([]);
   const [shortcodeIndex, setShortcodeIndex] = useState(0);
   const [shortcodeAnchor, setShortcodeAnchor] = useState<ShortcodeAnchor | null>(null);
-  const [refreshDialogOpen, setRefreshDialogOpen] = useState(false);
-  const [refreshingModels, setRefreshingModels] = useState(false);
-  const [refreshError, setRefreshError] = useState<string | null>(null);
   const isComposingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const pastedSeq = useRef(0);
@@ -498,36 +478,22 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
               </Popover>
 
               {availableModels.length > 0 ? (
-                <div className="flex items-center gap-1">
-                  <Select
-                    value={selectedModel ?? undefined}
-                    onValueChange={onModelChange}
-                    disabled={isStreaming || disabled}
-                  >
-                    <SelectTrigger className="h-6 w-auto gap-1.5 border-none bg-transparent px-0 text-xs text-muted-foreground shadow-none hover:text-foreground focus:ring-0">
-                      <SelectValue placeholder="Select model" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableModels.map((model) => (
-                        <SelectItem key={model.id} value={model.id} className="text-xs">
-                          {model.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {onRefreshModels ? (
-                    <button
-                      type="button"
-                      onClick={() => setRefreshDialogOpen(true)}
-                      disabled={isStreaming || disabled || refreshingModels}
-                      aria-label="Refresh model list"
-                      title="Refresh model list (restarts the agent — ends the current conversation)"
-                      className="h-5 w-5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
-                    >
-                      <RefreshCw size={11} className={cn(refreshingModels && 'animate-spin')} />
-                    </button>
-                  ) : null}
-                </div>
+                <Select
+                  value={selectedModel ?? undefined}
+                  onValueChange={onModelChange}
+                  disabled={isStreaming || disabled}
+                >
+                  <SelectTrigger className="h-6 w-auto gap-1.5 border-none bg-transparent px-0 text-xs text-muted-foreground shadow-none hover:text-foreground focus:ring-0">
+                    <SelectValue placeholder="Select model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableModels.map((model) => (
+                      <SelectItem key={model.id} value={model.id} className="text-xs">
+                        {model.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               ) : (
                 <span className="text-xs text-muted-foreground">
                   {disabled ? '' : 'Loading models…'}
@@ -601,72 +567,6 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
             document.body,
           )
         : null}
-      <Dialog open={refreshDialogOpen} onOpenChange={(open) => {
-        if (refreshingModels) return;
-        setRefreshDialogOpen(open);
-        if (!open) setRefreshError(null);
-      }}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Refresh model list?</DialogTitle>
-            <DialogDescription>
-              The Copilot CLI caches its model catalog for 30 minutes. Refreshing
-              restarts this agent's CLI subprocess so the next request fetches the
-              live list. The active conversation is preserved; any reply that is
-              still streaming must finish first.
-            </DialogDescription>
-          </DialogHeader>
-          {refreshError ? (
-            <div
-              role="alert"
-              className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-            >
-              {refreshError}
-            </div>
-          ) : null}
-          <DialogFooter>
-            <button
-              type="button"
-              onClick={() => {
-                setRefreshDialogOpen(false);
-                setRefreshError(null);
-              }}
-              disabled={refreshingModels}
-              className="px-3 py-1.5 text-sm rounded-md border border-input bg-background hover:bg-accent disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={async () => {
-                if (!onRefreshModels) {
-                  setRefreshDialogOpen(false);
-                  return;
-                }
-                setRefreshError(null);
-                setRefreshingModels(true);
-                try {
-                  await onRefreshModels();
-                  setRefreshDialogOpen(false);
-                } catch (err) {
-                  // Keep the dialog open so the user can retry or cancel
-                  // after seeing why the refresh did not happen (e.g. a
-                  // turn was still streaming, or the CLI failed to
-                  // restart). Errors that escape `onRefreshModels` are
-                  // surfaced inline rather than silently dismissed.
-                  setRefreshError(err instanceof Error ? err.message : String(err));
-                } finally {
-                  setRefreshingModels(false);
-                }
-              }}
-              disabled={refreshingModels}
-              className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50"
-            >
-              {refreshingModels ? 'Refreshing…' : 'Refresh models'}
-            </button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/web/src/renderer/components/chat/ChatPanel.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { useChatStreaming } from '../../hooks/useChatStreaming';
 import { MessageList } from './MessageList';
@@ -45,22 +44,6 @@ export function ChatPanel() {
       });
   };
 
-  // Force-refresh the model catalog (#90). Restarts the underlying CLI
-  // subprocess via ChatService.refreshModels — the Copilot CLI keeps its
-  // model list in process memory for 30 minutes (LIST_MODELS_CACHE_TTL_MS),
-  // so a reload is the only way to bust it. The destructive part is gated
-  // behind a confirm dialog inside ChatInput.
-  const handleRefreshModels = useCallback(async () => {
-    if (!activeMindId) return;
-    try {
-      const fresh = await window.electronAPI.chat.refreshModels(activeMindId);
-      dispatch({ type: 'SET_AVAILABLE_MODELS', payload: fresh });
-    } catch (error) {
-      log.error('Failed to refresh models:', error);
-      throw error;
-    }
-  }, [activeMindId, dispatch]);
-
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {isConversationHydrating ? (
@@ -85,7 +68,6 @@ export function ChatPanel() {
         availableModels={availableModels}
         selectedModel={selectedModel}
         onModelChange={handleModelChange}
-        onRefreshModels={activeMindId ? handleRefreshModels : undefined}
         placeholder={isModelSwitching ? 'Switching model…' : undefined}
         value={draft}
         onValueChange={handleDraftChange}

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -117,7 +117,6 @@ export function mockElectronAPI(): ElectronAPI {
       stop: vi.fn().mockResolvedValue(undefined),
       newConversation: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
       listModels: vi.fn().mockResolvedValue([]),
-      refreshModels: vi.fn().mockResolvedValue([]),
       onEvent: vi.fn().mockReturnValue(vi.fn()),
     },
     conversationHistory: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.59.6",
+  "version": "0.59.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.59.6",
+      "version": "0.59.7",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.59.6",
+  "version": "0.59.7",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -38,8 +38,6 @@ const mockMindManager = {
   deleteConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
   renameConversation: vi.fn(() => []),
   setMindModel: vi.fn(async () => null),
-  reloadMind: vi.fn(async () => ({ mindId: 'valid-mind' })),
-  recycleClientForMind: vi.fn(async () => ({ mindId: 'valid-mind' })),
 };
 
 describe('ChatService', () => {
@@ -242,97 +240,6 @@ describe('ChatService', () => {
       await expect(svc.listModels('drifted-models')).rejects.toThrow(
         'SDK contract mismatch for client.listModels',
       );
-    });
-  });
-
-  describe('refreshModels', () => {
-    it('recycles the SDK client to bust the CLI cache, then returns the fresh model list', async () => {
-      const fresh = [{ id: 'gpt-7-vision', name: 'GPT-7 Vision' }];
-      const recycledClient = {
-        modelsCache: {} as unknown,
-        listModels: vi.fn(async () => fresh.map((m) => ({ ...m, extra: true }))),
-      };
-      mockMindManager.recycleClientForMind.mockResolvedValueOnce({ mindId: 'valid-mind' });
-      // refreshModels does not call getMind in its precondition check; the
-      // single getMind call comes from listModels, AFTER the client recycle ran.
-      mockMindManager.getMind.mockReturnValueOnce({
-        session: mockSession,
-        client: recycledClient,
-      });
-
-      const result = await svc.refreshModels('valid-mind');
-
-      expect(mockMindManager.recycleClientForMind).toHaveBeenCalledWith('valid-mind');
-      expect(mockMindManager.reloadMind).not.toHaveBeenCalled();
-      expect(result).toEqual(fresh);
-      expect(recycledClient.modelsCache).toBeNull();
-    });
-
-    it('propagates a missing-mind error from recycleClientForMind', async () => {
-      mockMindManager.recycleClientForMind.mockRejectedValueOnce(
-        new Error('Mind nonexistent not found'),
-      );
-
-      await expect(svc.refreshModels('nonexistent')).rejects.toThrow('Mind nonexistent not found');
-    });
-
-    it('refuses to recycle a mind whose conversation is mid-stream', async () => {
-      // Drive a real send that parks on a never-fired session.idle event,
-      // mirroring how ChatService.sendMessage installs an AbortController
-      // for the duration of the streamTurn call. This proves the
-      // assertion fires on the real lifecycle, not just on a hand-set
-      // entry in the private map.
-      mockSession.on.mockImplementation(() => vi.fn());
-      const sendPromise = svc.sendMessage('valid-mind', 'hello', 'msg-park', vi.fn());
-      // Yield so the queued send body installs its AbortController before
-      // we race against it.
-      await new Promise<void>((resolve) => setImmediate(resolve));
-
-      try {
-        await expect(svc.refreshModels('valid-mind')).rejects.toThrow(
-          /streaming|in progress|active turn/i,
-        );
-        expect(mockMindManager.recycleClientForMind).not.toHaveBeenCalled();
-        expect(mockMindManager.reloadMind).not.toHaveBeenCalled();
-      } finally {
-        // Unblock the parked send so the test runner exits cleanly.
-        await svc.cancelMessage('valid-mind', 'msg-park');
-        await sendPromise.catch(() => { /* aborted */ });
-      }
-    });
-
-    it('serializes refresh against a queued send, even if the assertion would pass at call time', async () => {
-      // Reproduces the queue-race that the assertion alone cannot close:
-      // sendMessage is enqueued first, but its body has not executed yet,
-      // so no AbortController exists in the map. refreshModels would pass
-      // its precondition check and race the queued send. With both calls
-      // routed through TurnQueue.enqueue(mindId, ...), the refresh waits
-      // until the send body has finished before recycling the client.
-      const sendOrder: string[] = [];
-      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
-        if (eventOrCb === 'session.idle' && cb) {
-          setTimeout(() => {
-            sendOrder.push('send-completed');
-            cb();
-          }, 10);
-        }
-        return vi.fn();
-      });
-      mockMindManager.recycleClientForMind.mockImplementationOnce(async () => {
-        sendOrder.push('recycle-started');
-        return { mindId: 'valid-mind' };
-      });
-      mockMindManager.getMind.mockReturnValue({
-        session: mockSession,
-        client: validModelClient,
-      });
-
-      const sendPromise = svc.sendMessage('valid-mind', 'hello', 'msg-queued', vi.fn());
-      const refreshPromise = svc.refreshModels('valid-mind');
-
-      await Promise.all([sendPromise, refreshPromise]);
-
-      expect(sendOrder).toEqual(['send-completed', 'recycle-started']);
     });
   });
 

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -289,37 +289,6 @@ export class ChatService {
     return mapSdkModelList(models);
   }
 
-  async refreshModels(mindId: string): Promise<ModelInfo[]> {
-    // The CLI server process holds a 30-min in-memory model cache that
-    // cannot be busted in-place — see docs/model-cache-investigation.md
-    // (issue #90). The only way to force a fresh `/models` fetch is to
-    // restart the CLI subprocess, so we recycle the SDK client + active
-    // session in place via MindManager.recycleClientForMind. This keeps
-    // chatroom orchestration intact (no mind:unloaded teardown).
-    //
-    // Refusing mid-stream serves two purposes: (1) we don't yank the rug
-    // out from under an executing turn, and (2) routing the recycle call
-    // through TurnQueue.enqueue serializes it against any send that has
-    // already been enqueued but not yet pulled off the chain — so the
-    // assertion below is fast-fail UX, and the queue is the real lock.
-    this.assertCanRefreshModels(mindId);
-    return this.turnQueue.enqueue(mindId, async () => {
-      // Re-check inside the queue: a different actor could have parked an
-      // AbortController between our assertion and the queue acquiring the
-      // lock. With TurnQueue serializing all sends and refreshes for this
-      // mind, this branch is defensive but cheap.
-      this.assertCanRefreshModels(mindId);
-      await this.mindManager.recycleClientForMind(mindId);
-      return this.listModels(mindId);
-    });
-  }
-
-  private assertCanRefreshModels(mindId: string): void {
-    if (this.abortControllers.has(mindId)) {
-      throw new Error('Cannot refresh models while a message is still streaming.');
-    }
-  }
-
   private assertCanSwitchConversation(mindId: string): void {
     if (this.abortControllers.has(mindId)) {
       throw new Error('Cannot switch conversations while a message is still streaming.');

--- a/packages/services/src/chatroom/ChatroomService.ts
+++ b/packages/services/src/chatroom/ChatroomService.ts
@@ -522,16 +522,6 @@ export class ChatroomService extends EventEmitter {
       this.sessionFactory.on('mind:unloaded', (...args: unknown[]) => {
         this.handleMindUnloaded(args[0] as string);
       });
-      // mind:client-recycled is fired by `MindManager.recycleClientForMind`
-      // (issue #90 refresh-models). The mind is still loaded and still in
-      // the chatroom; only its underlying SDK client + session were
-      // restarted to bust the CLI's model cache. We must drop our cached
-      // SessionGroup session for this mind so the next chatroom turn binds
-      // to the fresh client, but we MUST NOT cancel the active orchestrator
-      // or clear `disabledMindIds` — those belong to a true unload.
-      this.sessionFactory.on('mind:client-recycled', (...args: unknown[]) => {
-        this.handleMindClientRecycled(args[0] as string);
-      });
     }
   }
 
@@ -549,15 +539,5 @@ export class ChatroomService extends EventEmitter {
       this.persist();
       this.emitStateChanged();
     }
-  }
-
-  private handleMindClientRecycled(mindId: string): void {
-    // Drop the cached chatroom session for this mind only; the next
-    // chatroom turn will rebind to the freshly-created client. Leave
-    // `disabledMindIds` and any active orchestrator alone — refresh is
-    // gated by ChatService to refuse mid-stream, so there is nothing
-    // in-flight to cancel for this mind, and nothing about the
-    // chatroom's per-mind toggles changed.
-    this.sessionGroup.destroySession(mindId);
   }
 }

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -239,59 +239,6 @@ export class MindManager extends EventEmitter {
     return reloaded;
   }
 
-  /**
-   * Recycle the SDK client and active session for a mind in place. This is
-   * the narrow primitive behind issue #90's "Refresh models" affordance:
-   * the only way to bust the Copilot CLI's 30-min in-memory model cache is
-   * to restart the CLI subprocess (see `docs/model-cache-investigation.md`).
-   *
-   * Unlike `reloadMind`, this does NOT emit `mind:unloaded` / `mind:loaded`,
-   * so chatroom orchestration is not torn down and per-mind toggles like
-   * `disabledMindIds` survive. A separate `mind:client-recycled` event lets
-   * the chatroom drop its cached `SessionGroup` session for this mind only.
-   *
-   * Caller must guarantee no turn is in flight (the chamber wiring serializes
-   * this through `TurnQueue` in `ChatService.refreshModels`).
-   */
-  async recycleClientForMind(mindId: string): Promise<MindContext> {
-    const context = this.minds.get(mindId);
-    if (!context) throw new Error(`Mind ${mindId} not found`);
-
-    const oldSession = context.session;
-    const oldClient = context.client;
-
-    await oldSession?.disconnect().catch(() => { /* session already disconnected */ });
-    await this.clientFactory.destroyClient(oldClient);
-
-    const newClient = await this.clientFactory.createClient(context.mindPath);
-    const sessionTools = this.getSessionTools(mindId, context.mindPath);
-    const newSession = context.activeSessionId
-      ? await this.loadConversationSession(
-        newClient,
-        context.mindPath,
-        context.identity.systemMessage,
-        sessionTools,
-        context.activeSessionId,
-        context.selectedModel,
-      )
-      : await this.createSessionForMind(
-        newClient,
-        context.mindPath,
-        context.identity.systemMessage,
-        sessionTools,
-        undefined,
-        approveForSessionCompat,
-        false,
-        context.selectedModel,
-      );
-
-    context.client = newClient;
-    context.session = newSession;
-
-    this.emit('mind:client-recycled', mindId);
-    return this.toExternalContext(context);
-  }
-
   listMinds(): MindContext[] {
     return Array.from(this.minds.values()).map(m => this.toExternalContext(m));
   }

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -49,7 +49,6 @@ export interface ElectronAPI {
     stop: (mindId: string, messageId: string) => Promise<void>;
     newConversation: (mindId: string) => Promise<ConversationResumeResult>;
     listModels: (mindId?: string) => Promise<ModelInfo[]>;
-    refreshModels: (mindId: string) => Promise<ModelInfo[]>;
     onEvent: (callback: (mindId: string, messageId: string, event: ChatEvent) => void) => () => void;
   };
   conversationHistory: {

--- a/packages/shared/src/ipc-channels.test.ts
+++ b/packages/shared/src/ipc-channels.test.ts
@@ -7,7 +7,6 @@ describe('IPC channel constants', () => {
     expect(IPC.CHAT.STOP).toBe('chat:stop');
     expect(IPC.CHAT.NEW_CONVERSATION).toBe('chat:newConversation');
     expect(IPC.CHAT.LIST_MODELS).toBe('chat:listModels');
-    expect(IPC.CHAT.REFRESH_MODELS).toBe('chat:refreshModels');
     expect(IPC.CHAT.EVENT).toBe('chat:event');
 
     expect(IPC.CONVERSATION_HISTORY.LIST).toBe('conversationHistory:list');

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -17,7 +17,6 @@ export const IPC = {
     STOP: 'chat:stop',
     NEW_CONVERSATION: 'chat:newConversation',
     LIST_MODELS: 'chat:listModels',
-    REFRESH_MODELS: 'chat:refreshModels',
     EVENT: 'chat:event',
   },
   CONVERSATION_HISTORY: {


### PR DESCRIPTION
## Summary

Reverts PR #271's "Refresh models" affordance and subprocess recycle path. The existing active-mind model-list refresh remains intact, while the risky SDK client/session recreation path is removed pending #287's context-preservation concern.

## Notable changes

- Removes the `chat:refreshModels` IPC/preload/browser API contract and shared channel/type entries.
- Removes `ChatService.refreshModels`, `MindManager.recycleClientForMind`, and chatroom `mind:client-recycled` handling.
- Removes the model-picker refresh button/dialog and associated tests/helpers.
- Bumps Chamber to `0.59.7` with a changelog entry for the revert.

Closes #287

## Test evidence

- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npm run smoke:desktop -- tests/e2e/electron/per-agent-model-persistence.spec.ts tests/e2e/electron/model-switch-context-smoke.spec.ts`
- Uncle Bob focused review: no blocking findings

## Skipped smoke

- `npm run package`: skipped because this does not touch packaging/runtime-resolution/installer startup paths.