### PR TITLE
Fix A2A task stale-session race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.61.0 (2026-05-12)
+
+### A2A
+
+- **Fix stale-session task retries** — Prevents a stale SDK `session.error` from marking an A2A task failed before the stale-session retry path can create a fresh task session and complete the work.
+
 ## v0.60.0 (2026-05-12)
 
 ### A2A

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/a2a/TaskManager.test.ts
+++ b/packages/services/src/a2a/TaskManager.test.ts
@@ -709,6 +709,30 @@ describe('TaskManager', () => {
       expect(artifactEvents.length).toBeGreaterThan(0);
     });
 
+    it('does not let stale session.error make a task terminal before send retry completes', async () => {
+      const staleSession = createMockSession();
+      staleSession.send.mockImplementationOnce(async () => {
+        staleSession._emit('session.error', { data: { message: 'Session not found: abc' } });
+        throw new Error('Session not found: abc');
+      });
+      mockMindManager.createTaskSession.mockResolvedValueOnce(staleSession);
+
+      const freshSession = createMockSession();
+      mockMindManager.createTaskSession.mockResolvedValueOnce(freshSession);
+
+      const task = await tm.sendTask(makeRequest('target-1', 'hello'));
+      await flushPromises();
+
+      freshSession._emit('assistant.message', { data: { content: 'Recovered' } });
+      freshSession._emit('session.idle');
+      await flushPromises();
+
+      const completedTask = tm.getTask(task.id);
+      if (!completedTask) throw new Error('Expected task to exist');
+      expect(completedTask.status.state).toBe('TASK_STATE_COMPLETED');
+      expect(completedTask.artifacts?.[0].parts[0].text).toBe('Recovered');
+    });
+
     it('does not loop — fails task when retry also throws stale error', async () => {
       const events: TaskStatusUpdateEvent[] = [];
       tm.on('task:status-update', (e) => events.push(e));

--- a/packages/services/src/a2a/TaskManager.ts
+++ b/packages/services/src/a2a/TaskManager.ts
@@ -13,6 +13,7 @@ import type {
 } from './types';
 import { isStaleSessionError } from '@chamber/shared/sessionErrors';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
+import { getSdkSessionErrorMessage } from '../sdk';
 
 const log = Logger.create('TaskManager');
 
@@ -290,8 +291,10 @@ export class TaskManager extends EventEmitter {
       this.taskTargets.delete(task.id);
     });
 
-    session.on('session.error', () => {
+    session.on('session.error', (event) => {
       if (TERMINAL_STATES.has(task.status.state)) return;
+      const errorMessage = getSessionErrorMessage(event);
+      if (isStaleSessionError(new Error(errorMessage))) return;
       this.transitionState(task, 'TASK_STATE_FAILED');
       this.sessions.delete(task.id);
       this.taskTargets.delete(task.id);
@@ -332,5 +335,13 @@ export class TaskManager extends EventEmitter {
       targetMindId: this.taskTargets.get(task.id) ?? '',
     };
     this.emit('task:status-update', event);
+  }
+}
+
+function getSessionErrorMessage(event: unknown): string {
+  try {
+    return getSdkSessionErrorMessage(event);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
   }
 }


### PR DESCRIPTION
## Summary
- Fixes a stale-session race where an SDK session.error could mark A2A tasks failed before retry recovery completed.
- Bumps Chamber to v0.61.0 and adds the changelog entry for release.

## Tests
- npm test -- --run packages/services/src/a2a/TaskManager.test.ts packages/services/src/a2a/a2a-task-flow.test.ts
- npm run typecheck
- npm run lint