### PR TITLE
Sullivan: presentation-pedagogy tool provider (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.62.0 (2026-05-14)
+
+### Sullivan
+
+- **Add the Sullivan presentation-pedagogy tool provider** — Introduces a new in-process `ChamberToolProvider` (`SullivanToolsService` in `@chamber/services`) that exposes five pure presentation tools to any mind: `presentation_template`, `presentation_outline_validate`, `presentation_critique`, `presentation_contrast_check`, and `presentation_motion_budget`. Built on two deterministic primitives (WCAG contrast ratio plus per-transition and aggregate motion budgets) and a cross-step rubric, with full unit coverage and a barrel → service → handler → primitive integration smoke. Wired into both composition roots (`apps/desktop/src/main.ts` and `apps/server/src/bin.ts`) via the `@chamber/services` package barrel. Stateless v1: `activateMind` / `releaseMind` are intentional no-ops. (#6)
+
 ## v0.61.0 (2026-05-12)
 
 ### A2A

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,6 +35,7 @@ import {
   MindManager,
   MindProfileService,
   MindScaffold,
+  SullivanToolsService,
   TaskManager,
   ChildProcessRunner,
   ToolInstaller,
@@ -255,9 +256,10 @@ const cronService = new CronService({
   },
   notifier,
 });
+const sullivanService = new SullivanToolsService();
 const a2aToolProvider = new A2aToolProvider(messageRouter, activeA2AResolver, taskManager);
 
-const mindToolProviders: ChamberToolProvider[] = [cronService, canvasService, a2aToolProvider];
+const mindToolProviders: ChamberToolProvider[] = [cronService, canvasService, sullivanService, a2aToolProvider];
 let chamberCopilotService: ChamberCopilotService | null = null;
 
 if (configService.load().chamberCopilotEnabled === true) {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -16,6 +16,7 @@ import {
   IdentityLoader,
   MessageRouter,
   MindManager,
+  SullivanToolsService,
   TaskManager,
   TurnQueue,
   ViewDiscovery,
@@ -66,7 +67,10 @@ const mindManager = new MindManager(
 const taskManager = new TaskManager(mindManager, agentCardRegistry);
 const chatService = new ChatService(mindManager, new TurnQueue());
 const messageRouter = new MessageRouter(chatService, activeA2AResolver, a2aEventBus);
-mindManager.setProviders([new A2aToolProvider(messageRouter, activeA2AResolver, taskManager)]);
+mindManager.setProviders([
+  new A2aToolProvider(messageRouter, activeA2AResolver, taskManager),
+  new SullivanToolsService(),
+]);
 mindManager.on('mind:loaded', (mind) => {
   agentCardRegistry.register(mind);
   a2aRelayModeService.publishLocalCard(mind.mindId).catch((error: unknown) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.61.0",
+      "version": "0.62.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -14,5 +14,6 @@ export * from './mind';
 export * from './mindProfile';
 export * from './ports';
 export * from './sdk';
+export * from './sullivan';
 export * from './tools';
 export * from './userProfile';

--- a/packages/services/src/sullivan/SullivanToolsService.test.ts
+++ b/packages/services/src/sullivan/SullivanToolsService.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from 'vitest';
+import type { ChamberToolProvider } from '../chamberTools';
+import type { SessionTool } from '../a2a/tools';
+import type {
+  ContrastCheckResult,
+  CritiqueResult,
+  MotionBudgetResult,
+  OutlineValidateResult,
+  PresentationTemplateResult,
+} from './tools';
+import { SullivanToolsService } from './SullivanToolsService';
+
+// -----------------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------------
+
+const MIND_ID = 'mind-test';
+const MIND_PATH = '/tmp/mind-test';
+
+const TOOL_NAMES = [
+  'presentation_template',
+  'presentation_outline_validate',
+  'presentation_critique',
+  'presentation_contrast_check',
+  'presentation_motion_budget',
+] as const;
+
+function makeService(): SullivanToolsService {
+  return new SullivanToolsService();
+}
+
+/**
+ * Resolve a tool from the provider for runtime invocation. The provider
+ * returns SDK `Tool[]` (matching `ChamberToolProvider.getToolsForMind`'s
+ * signature). The runtime objects are `SessionTool` shape — same as
+ * `buildSullivanTools` produces — so we cast through `unknown` to drive
+ * the handler with the `(args)` signature the underlying tools use.
+ */
+function resolveSessionTool(
+  service: SullivanToolsService,
+  mindId: string,
+  mindPath: string,
+  name: string,
+): SessionTool {
+  const tools = service.getToolsForMind(mindId, mindPath) as unknown as SessionTool[];
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool "${name}" not found`);
+  return tool;
+}
+
+// -----------------------------------------------------------------------------
+// Provider contract — ChamberToolProvider shape
+// -----------------------------------------------------------------------------
+
+describe('SullivanToolsService — provider contract', () => {
+  it('is assignable to ChamberToolProvider', () => {
+    const service: ChamberToolProvider = new SullivanToolsService();
+    expect(typeof service.getToolsForMind).toBe('function');
+    expect(typeof service.activateMind).toBe('function');
+    expect(typeof service.releaseMind).toBe('function');
+  });
+
+  it('getToolsForMind returns an array', () => {
+    const service = makeService();
+    const tools = service.getToolsForMind(MIND_ID, MIND_PATH);
+    expect(Array.isArray(tools)).toBe(true);
+  });
+
+  it('returns exactly the five Sullivan tools in stable order', () => {
+    const service = makeService();
+    const tools = service.getToolsForMind(MIND_ID, MIND_PATH);
+    expect(tools).toHaveLength(5);
+    expect(tools.map((t) => t.name)).toEqual([...TOOL_NAMES]);
+  });
+
+  it('every returned tool has the SessionTool fields', () => {
+    const service = makeService();
+    const tools = service.getToolsForMind(MIND_ID, MIND_PATH) as unknown as SessionTool[];
+    for (const tool of tools) {
+      expect(typeof tool.name).toBe('string');
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.description).toBe('string');
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(typeof tool.parameters).toBe('object');
+      expect(tool.parameters).not.toBeNull();
+      expect(typeof tool.handler).toBe('function');
+    }
+  });
+
+  it('successive calls to getToolsForMind return independent array references', () => {
+    const service = makeService();
+    const first = service.getToolsForMind(MIND_ID, MIND_PATH);
+    const second = service.getToolsForMind(MIND_ID, MIND_PATH);
+    expect(first).not.toBe(second);
+    expect(first.map((t) => t.name)).toEqual(second.map((t) => t.name));
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Stateless lifecycle — activateMind / releaseMind are no-ops
+// -----------------------------------------------------------------------------
+
+describe('SullivanToolsService — stateless lifecycle', () => {
+  it('activateMind resolves without throwing', async () => {
+    const service = makeService();
+    await expect(service.activateMind('m1', '/tmp/m1')).resolves.toBeUndefined();
+  });
+
+  it('activateMind leaves getToolsForMind output unchanged', async () => {
+    const service = makeService();
+    const before = service.getToolsForMind('m1', '/tmp/m1').map((t) => t.name);
+    await service.activateMind('m1', '/tmp/m1');
+    const after = service.getToolsForMind('m1', '/tmp/m1').map((t) => t.name);
+    expect(after).toEqual(before);
+  });
+
+  it('releaseMind resolves without throwing', async () => {
+    const service = makeService();
+    await expect(service.releaseMind('m1')).resolves.toBeUndefined();
+  });
+
+  it('releaseMind is idempotent — repeated calls all resolve', async () => {
+    const service = makeService();
+    await service.releaseMind('m1');
+    await service.releaseMind('m1');
+    await expect(service.releaseMind('m1')).resolves.toBeUndefined();
+  });
+
+  it('releaseMind before activateMind resolves without throwing', async () => {
+    const service = makeService();
+    await expect(service.releaseMind('never-activated')).resolves.toBeUndefined();
+  });
+
+  it('does not retain per-mind state across getToolsForMind calls', () => {
+    const service = makeService();
+    const namesForA = service.getToolsForMind('m1', '/tmp/m1').map((t) => t.name);
+    const namesForB = service.getToolsForMind('m2', '/tmp/m2').map((t) => t.name);
+    expect(namesForA).toEqual([...TOOL_NAMES]);
+    expect(namesForB).toEqual([...TOOL_NAMES]);
+  });
+
+  it('two service instances produce equivalent tool lists', () => {
+    const a = new SullivanToolsService();
+    const b = new SullivanToolsService();
+    expect(a.getToolsForMind(MIND_ID, MIND_PATH).map((t) => t.name)).toEqual(
+      b.getToolsForMind(MIND_ID, MIND_PATH).map((t) => t.name),
+    );
+  });
+
+  it('activate/release in any order has no observable effect on tool output', async () => {
+    const service = makeService();
+    await service.releaseMind('m1');
+    await service.activateMind('m1', '/tmp/m1');
+    await service.activateMind('m1', '/tmp/m1');
+    await service.releaseMind('m1');
+    const names = service.getToolsForMind('m1', '/tmp/m1').map((t) => t.name);
+    expect(names).toEqual([...TOOL_NAMES]);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Integration smoke — invoke each handler through the provider
+// -----------------------------------------------------------------------------
+
+describe('SullivanToolsService — integration smoke through the provider', () => {
+  it('presentation_template handler returns the empty-scaffold shape', async () => {
+    const service = makeService();
+    const tool = resolveSessionTool(service, MIND_ID, MIND_PATH, 'presentation_template');
+    const result = (await tool.handler({
+      topic: 'Cell division',
+      audience: 'High school biology students',
+      learningObjective: 'Distinguish mitosis from meiosis.',
+    })) as PresentationTemplateResult;
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        thesis: '',
+        narrativeArc: [],
+        steps: [],
+      }),
+    );
+    expect(result.guidance.oneIdeaPerStep).toBe(true);
+    expect(typeof result.guidance.maxWordsPerSlide).toBe('number');
+    expect(result.guidance.timeBudgetTargetMinutes).toBeNull();
+  });
+
+  it('presentation_outline_validate handler returns findings + summary on a clean outline', async () => {
+    const service = makeService();
+    const tool = resolveSessionTool(
+      service,
+      MIND_ID,
+      MIND_PATH,
+      'presentation_outline_validate',
+    );
+    const result = (await tool.handler({
+      thesis: 'Photosynthesis converts light to chemical energy.',
+      narrativeArc: ['hook', 'body', 'close'],
+      steps: [
+        { id: 's1', title: 'Hook', content: 'Plants need sunlight.', oneIdea: true },
+        { id: 's2', title: 'Body', content: 'Chloroplasts capture photons.', oneIdea: true },
+        { id: 's3', title: 'Close', content: 'Energy flows to all life.', oneIdea: true },
+      ],
+    })) as OutlineValidateResult;
+
+    expect(Array.isArray(result.findings)).toBe(true);
+    expect(result.summary).toEqual(
+      expect.objectContaining({
+        blockCount: expect.any(Number),
+        warnCount: expect.any(Number),
+        noteCount: expect.any(Number),
+      }),
+    );
+  });
+
+  it('presentation_critique handler returns findings + perStep + summary', async () => {
+    const service = makeService();
+    const tool = resolveSessionTool(service, MIND_ID, MIND_PATH, 'presentation_critique');
+    const result = (await tool.handler({
+      steps: [
+        { id: 's1', title: 'Hook', content: 'Plants need sunlight.', oneIdea: true },
+        { id: 's2', title: 'Body', content: 'Chloroplasts capture photons.', oneIdea: true },
+        { id: 's3', title: 'Close', content: 'Energy flows to all life.', oneIdea: true },
+      ],
+    })) as CritiqueResult;
+
+    expect(Array.isArray(result.findings)).toBe(true);
+    expect(Array.isArray(result.perStep)).toBe(true);
+    expect(result.perStep).toHaveLength(3);
+    expect(result.perStep.map((s) => s.stepId)).toEqual(['s1', 's2', 's3']);
+    expect(result.summary).toEqual(
+      expect.objectContaining({
+        blockCount: expect.any(Number),
+        warnCount: expect.any(Number),
+        noteCount: expect.any(Number),
+      }),
+    );
+  });
+
+  it('presentation_contrast_check handler returns AA/AAA + recommendation per pair', async () => {
+    const service = makeService();
+    const tool = resolveSessionTool(
+      service,
+      MIND_ID,
+      MIND_PATH,
+      'presentation_contrast_check',
+    );
+    const result = (await tool.handler({
+      pairs: [
+        { foreground: '#000000', background: '#ffffff', label: 'body' },
+        { foreground: '#777777', background: '#ffffff', label: 'muted' },
+      ],
+    })) as readonly ContrastCheckResult[];
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(2);
+    for (const entry of result) {
+      expect(typeof entry.ratio).toBe('number');
+      expect(entry.AA).toEqual(
+        expect.objectContaining({
+          largeText: expect.any(Boolean),
+          normalText: expect.any(Boolean),
+        }),
+      );
+      expect(entry.AAA).toEqual(
+        expect.objectContaining({
+          largeText: expect.any(Boolean),
+          normalText: expect.any(Boolean),
+        }),
+      );
+      expect(typeof entry.recommendation).toBe('string');
+      expect(entry.recommendation.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('presentation_motion_budget handler returns perTransition + aggregate', async () => {
+    const service = makeService();
+    const tool = resolveSessionTool(
+      service,
+      MIND_ID,
+      MIND_PATH,
+      'presentation_motion_budget',
+    );
+    const result = (await tool.handler({
+      transitions: [
+        { id: 't1', durationMs: 300, type: 'fade' },
+        { id: 't2', durationMs: 500, type: 'zoom' },
+      ],
+    })) as MotionBudgetResult;
+
+    expect(Array.isArray(result.perTransition)).toBe(true);
+    expect(result.perTransition).toHaveLength(2);
+    for (const t of result.perTransition) {
+      expect(typeof t.withinPerTransitionBudget).toBe('boolean');
+      expect(typeof t.reducedMotionEquivalent).toBe('string');
+      expect(typeof t.recommendation).toBe('string');
+    }
+    expect(result.aggregate.totalDurationMs).toBe(800);
+    expect(typeof result.aggregate.withinAggregateBudget).toBe('boolean');
+    expect(typeof result.aggregate.recommendation).toBe('string');
+  });
+
+  it('handler errors on malformed input propagate as thrown errors (template)', async () => {
+    const service = makeService();
+    const tool = resolveSessionTool(service, MIND_ID, MIND_PATH, 'presentation_template');
+    await expect(tool.handler({})).rejects.toThrow(/topic/i);
+  });
+});

--- a/packages/services/src/sullivan/SullivanToolsService.ts
+++ b/packages/services/src/sullivan/SullivanToolsService.ts
@@ -1,0 +1,38 @@
+import type { ChamberToolProvider } from '../chamberTools';
+import type { Tool } from '../mind/types';
+import type { SullivanService } from './types';
+import { buildSullivanTools } from './tools';
+
+/**
+ * Provider for the five Sullivan presentation tools.
+ *
+ * v1 stance: this provider is stateless. The Phase 3 tools are pure
+ * functions over their declared inputs — they compose the Phase 1 /
+ * Phase 2 primitives (`./contrast`, `./motionLimits`, `./rubric`) with
+ * no fs / keytar / electron / network — so there is nothing to set up
+ * on activation or tear down on release. `activateMind` and
+ * `releaseMind` are therefore intentional no-ops; they exist to
+ * satisfy `ChamberToolProvider`'s optional contract and to leave a
+ * stable extension point for a future v2 that needs per-mind state.
+ *
+ * The cast `as Tool[]` mirrors `CanvasService.getToolsForMind`
+ * (`packages/services/src/canvas/CanvasService.ts`). `SessionTool` is
+ * structurally compatible with the SDK's `Tool<any>` — no runtime
+ * transform, no duck-type adapter.
+ */
+export class SullivanToolsService implements ChamberToolProvider, SullivanService {
+  getToolsForMind(mindId: string, mindPath: string): Tool[] {
+    return buildSullivanTools(mindId, mindPath, this) as Tool[];
+  }
+
+  async activateMind(_mindId: string, _mindPath: string): Promise<void> {
+    // stateless v1: no per-mind activation needed; see plan.md
+    void _mindId;
+    void _mindPath;
+  }
+
+  async releaseMind(_mindId: string): Promise<void> {
+    // stateless v1: no per-mind activation needed; see plan.md
+    void _mindId;
+  }
+}

--- a/packages/services/src/sullivan/contrast.test.ts
+++ b/packages/services/src/sullivan/contrast.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import {
+  contrastRatio,
+  parseHexColor,
+  passesAA,
+  passesAAA,
+  relativeLuminance,
+  srgbChannelToLinear,
+} from './contrast';
+
+describe('parseHexColor', () => {
+  it('accepts six-digit hex with leading hash', () => {
+    expect(parseHexColor('#ffffff')).toEqual([255, 255, 255]);
+  });
+
+  it('accepts six-digit hex without leading hash', () => {
+    expect(parseHexColor('000000')).toEqual([0, 0, 0]);
+  });
+
+  it('accepts three-digit shorthand and expands each nibble', () => {
+    expect(parseHexColor('#abc')).toEqual([0xaa, 0xbb, 0xcc]);
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseHexColor('#AaBbCc')).toEqual([0xaa, 0xbb, 0xcc]);
+  });
+
+  it('accepts all-uppercase hex', () => {
+    expect(parseHexColor('#FFFFFF')).toEqual([255, 255, 255]);
+  });
+
+  it('throws on malformed input', () => {
+    expect(() => parseHexColor('not-a-color')).toThrow(/invalid hex color/i);
+    expect(() => parseHexColor('#1234')).toThrow(/invalid hex color/i);
+    expect(() => parseHexColor('')).toThrow(/invalid hex color/i);
+  });
+});
+
+describe('srgbChannelToLinear', () => {
+  it('returns 0 for 0', () => {
+    expect(srgbChannelToLinear(0)).toBeCloseTo(0, 10);
+  });
+
+  it('returns 1 for 255', () => {
+    expect(srgbChannelToLinear(255)).toBeCloseTo(1, 10);
+  });
+
+  it('uses the linear branch for low values (c <= 0.03928)', () => {
+    // 10 / 255 ≈ 0.0392 — still in the linear branch
+    const value = 10;
+    const normalized = value / 255;
+    expect(srgbChannelToLinear(value)).toBeCloseTo(normalized / 12.92, 10);
+  });
+
+  it('uses the gamma branch for high values (c > 0.03928)', () => {
+    // 128 / 255 ≈ 0.502 — gamma branch
+    const value = 128;
+    const normalized = value / 255;
+    const expected = Math.pow((normalized + 0.055) / 1.055, 2.4);
+    expect(srgbChannelToLinear(value)).toBeCloseTo(expected, 10);
+  });
+});
+
+describe('relativeLuminance', () => {
+  it('returns 0 for black', () => {
+    expect(relativeLuminance([0, 0, 0])).toBeCloseTo(0, 10);
+  });
+
+  it('returns 1 for white', () => {
+    expect(relativeLuminance([255, 255, 255])).toBeCloseTo(1, 10);
+  });
+
+  it('weighted sum of RGB channels matches WCAG 2.1 formula', () => {
+    // Pure red at full intensity should have luminance ≈ 0.2126
+    expect(relativeLuminance([255, 0, 0])).toBeCloseTo(0.2126, 4);
+    // Pure green ≈ 0.7152
+    expect(relativeLuminance([0, 255, 0])).toBeCloseTo(0.7152, 4);
+    // Pure blue ≈ 0.0722
+    expect(relativeLuminance([0, 0, 255])).toBeCloseTo(0.0722, 4);
+  });
+});
+
+describe('contrastRatio', () => {
+  it('black on white is exactly 21.00', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 5);
+  });
+
+  it('white on white is exactly 1.00', () => {
+    expect(contrastRatio('#ffffff', '#ffffff')).toBeCloseTo(1, 5);
+  });
+
+  it('is symmetric — order of arguments does not matter', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(
+      contrastRatio('#ffffff', '#000000'),
+      5,
+    );
+  });
+
+  it('#777777 on #ffffff is just below the AA normal-text threshold', () => {
+    // Canonical WCAG example: medium gray vs white, ratio ≈ 4.48
+    const ratio = contrastRatio('#777777', '#ffffff');
+    expect(ratio).toBeGreaterThan(4.4);
+    expect(ratio).toBeLessThan(4.5);
+  });
+
+  it('#595959 on #ffffff meets AA normal-text threshold', () => {
+    // Canonical WCAG example: darker gray vs white, ratio ≈ 7.0
+    const ratio = contrastRatio('#595959', '#ffffff');
+    expect(ratio).toBeGreaterThan(6.9);
+    expect(ratio).toBeLessThan(7.1);
+  });
+});
+
+describe('passesAA', () => {
+  it('requires ratio >= 4.5 for normal text', () => {
+    expect(passesAA(4.5, false)).toBe(true);
+    expect(passesAA(4.49, false)).toBe(false);
+  });
+
+  it('requires ratio >= 3.0 for large text', () => {
+    expect(passesAA(3.0, true)).toBe(true);
+    expect(passesAA(2.99, true)).toBe(false);
+  });
+
+  it('treats undefined largeText as normal text', () => {
+    expect(passesAA(4.5)).toBe(true);
+    expect(passesAA(4.49)).toBe(false);
+  });
+});
+
+describe('passesAAA', () => {
+  it('requires ratio >= 7.0 for normal text', () => {
+    expect(passesAAA(7.0, false)).toBe(true);
+    expect(passesAAA(6.99, false)).toBe(false);
+  });
+
+  it('requires ratio >= 4.5 for large text', () => {
+    expect(passesAAA(4.5, true)).toBe(true);
+    expect(passesAAA(4.49, true)).toBe(false);
+  });
+
+  it('treats undefined largeText as normal text', () => {
+    expect(passesAAA(7.0)).toBe(true);
+    expect(passesAAA(6.99)).toBe(false);
+  });
+});

--- a/packages/services/src/sullivan/contrast.ts
+++ b/packages/services/src/sullivan/contrast.ts
@@ -1,0 +1,69 @@
+/**
+ * WCAG 2.1 contrast math.
+ *
+ * Formulas from:
+ *   - https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ *   - https://www.w3.org/TR/WCAG21/#contrast-minimum
+ *
+ * Kept as pure functions so they are trivially testable and reusable by any
+ * future Sullivan surface (and any other chamber service) without dragging
+ * the rest of the pedagogy provider in as a dependency.
+ */
+
+const HEX_FULL = /^#?([0-9a-f]{6})$/i;
+const HEX_SHORT = /^#?([0-9a-f]{3})$/i;
+
+export type Rgb = readonly [number, number, number];
+
+export function parseHexColor(hex: string): Rgb {
+  if (typeof hex !== 'string' || hex.length === 0) {
+    throw new Error(`Invalid hex color: ${JSON.stringify(hex)}`);
+  }
+  const fullMatch = HEX_FULL.exec(hex);
+  if (fullMatch) {
+    const hex6 = fullMatch[1];
+    return [
+      parseInt(hex6.slice(0, 2), 16),
+      parseInt(hex6.slice(2, 4), 16),
+      parseInt(hex6.slice(4, 6), 16),
+    ];
+  }
+  const shortMatch = HEX_SHORT.exec(hex);
+  if (shortMatch) {
+    const hex3 = shortMatch[1];
+    const expand = (digit: string): number => parseInt(`${digit}${digit}`, 16);
+    return [expand(hex3[0]), expand(hex3[1]), expand(hex3[2])];
+  }
+  throw new Error(`Invalid hex color: ${JSON.stringify(hex)}`);
+}
+
+export function srgbChannelToLinear(channel: number): number {
+  const normalized = channel / 255;
+  return normalized <= 0.03928
+    ? normalized / 12.92
+    : Math.pow((normalized + 0.055) / 1.055, 2.4);
+}
+
+export function relativeLuminance(rgb: Rgb): number {
+  const [r, g, b] = rgb;
+  const linearR = srgbChannelToLinear(r);
+  const linearG = srgbChannelToLinear(g);
+  const linearB = srgbChannelToLinear(b);
+  return 0.2126 * linearR + 0.7152 * linearG + 0.0722 * linearB;
+}
+
+export function contrastRatio(fg: string, bg: string): number {
+  const lFg = relativeLuminance(parseHexColor(fg));
+  const lBg = relativeLuminance(parseHexColor(bg));
+  const lighter = Math.max(lFg, lBg);
+  const darker = Math.min(lFg, lBg);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function passesAA(ratio: number, largeText: boolean = false): boolean {
+  return ratio >= (largeText ? 3.0 : 4.5);
+}
+
+export function passesAAA(ratio: number, largeText: boolean = false): boolean {
+  return ratio >= (largeText ? 4.5 : 7.0);
+}

--- a/packages/services/src/sullivan/index.ts
+++ b/packages/services/src/sullivan/index.ts
@@ -1,0 +1,3 @@
+export { SullivanToolsService } from './SullivanToolsService';
+export { buildSullivanTools } from './tools';
+export type * from './types';

--- a/packages/services/src/sullivan/integration.test.ts
+++ b/packages/services/src/sullivan/integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Sullivan end-to-end integration smoke (Phase 6).
+ *
+ * Exercises the full chain `@chamber/services` barrel →
+ * `SullivanToolsService` → `getToolsForMind()` → handler →
+ * structured return, the same way `apps/desktop/src/main.ts:38` and
+ * `apps/server/src/bin.ts:19` consume the service at runtime — without
+ * spinning up Electron and without spinning up the HTTP server.
+ *
+ * Importing via the package barrel (rather than the local
+ * `./SullivanToolsService`) is the whole point: this smoke catches a
+ * regression where the Phase 5 barrel export
+ * (`packages/services/src/index.ts:17`) silently drops Sullivan and the
+ * composition roots fail to resolve the class. The unit shape tests in
+ * `tools.test.ts` and `SullivanToolsService.test.ts` cover the internals;
+ * this file pins the public surface the apps actually consume.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { SullivanToolsService } from '@chamber/services';
+import type { SessionTool } from '../a2a/tools';
+import type { ContrastCheckResult, MotionBudgetResult } from './tools';
+
+const MIND_ID = 'mind-smoke';
+const MIND_PATH = '/tmp/mind-smoke';
+
+const TOOL_NAMES = [
+  'presentation_template',
+  'presentation_outline_validate',
+  'presentation_critique',
+  'presentation_contrast_check',
+  'presentation_motion_budget',
+] as const;
+
+function resolveSessionTool(
+  service: SullivanToolsService,
+  name: (typeof TOOL_NAMES)[number],
+): SessionTool {
+  const tools = service.getToolsForMind(MIND_ID, MIND_PATH) as unknown as SessionTool[];
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool "${name}" not found on provider`);
+  return tool;
+}
+
+describe('Sullivan tools end-to-end integration', () => {
+  it('SullivanToolsService is reachable through the @chamber/services barrel and constructs standalone', () => {
+    // The barrel re-export landed in Phase 5; without it the imports in
+    // apps/desktop/src/main.ts and apps/server/src/bin.ts would not
+    // resolve. Constructing via the barrel-imported class — with no
+    // arguments and no collaborators — is exactly what both composition
+    // roots do.
+    const service = new SullivanToolsService();
+    expect(typeof service.getToolsForMind).toBe('function');
+    expect(typeof service.activateMind).toBe('function');
+    expect(typeof service.releaseMind).toBe('function');
+  });
+
+  it('getToolsForMind returns the five Sullivan tools in stable, documented order', () => {
+    const service = new SullivanToolsService();
+    const tools = service.getToolsForMind(MIND_ID, MIND_PATH);
+    expect(tools).toHaveLength(5);
+    expect(tools.map((t) => t.name)).toEqual([...TOOL_NAMES]);
+  });
+
+  it('presentation_contrast_check composes barrel → service → handler → Phase 1 primitive', async () => {
+    const service = new SullivanToolsService();
+    const tool = resolveSessionTool(service, 'presentation_contrast_check');
+
+    const result = (await tool.handler({
+      pairs: [{ foreground: '#000000', background: '#ffffff', label: 'body' }],
+    })) as readonly ContrastCheckResult[];
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    // Black on white is the canonical maximum-contrast pair:
+    // (1 + 0.05) / (0 + 0.05) = 21.
+    expect(entry.ratio).toBe(21);
+    expect(entry.label).toBe('body');
+    expect(entry.foreground).toBe('#000000');
+    expect(entry.background).toBe('#ffffff');
+    expect(entry.AA).toEqual({ largeText: true, normalText: true });
+    expect(entry.AAA).toEqual({ largeText: true, normalText: true });
+    expect(typeof entry.recommendation).toBe('string');
+    expect(entry.recommendation.length).toBeGreaterThan(0);
+  });
+
+  it('presentation_motion_budget composes barrel → service → handler → Phase 2 primitive', async () => {
+    const service = new SullivanToolsService();
+    const tool = resolveSessionTool(service, 'presentation_motion_budget');
+
+    const result = (await tool.handler({
+      transitions: [{ id: 't1', durationMs: 400, type: 'fade' }],
+    })) as MotionBudgetResult;
+
+    expect(typeof result).not.toBe('string');
+    expect(result.perTransition).toHaveLength(1);
+    const [first] = result.perTransition;
+    expect(first.id).toBe('t1');
+    expect(first.durationMs).toBe(400);
+    expect(first.type).toBe('fade');
+    expect(first.withinPerTransitionBudget).toBe(true);
+    expect(typeof first.reducedMotionEquivalent).toBe('string');
+    expect(first.reducedMotionEquivalent.length).toBeGreaterThan(0);
+    expect(typeof first.recommendation).toBe('string');
+
+    expect(result.aggregate.totalDurationMs).toBe(400);
+    expect(result.aggregate.withinAggregateBudget).toBe(true);
+    expect(typeof result.aggregate.recommendation).toBe('string');
+  });
+
+  it('activateMind and releaseMind are idempotent no-ops (stateless v1 contract)', async () => {
+    const service = new SullivanToolsService();
+    await expect(service.activateMind(MIND_ID, MIND_PATH)).resolves.toBeUndefined();
+    await expect(service.activateMind(MIND_ID, MIND_PATH)).resolves.toBeUndefined();
+    await expect(service.releaseMind(MIND_ID)).resolves.toBeUndefined();
+    await expect(service.releaseMind(MIND_ID)).resolves.toBeUndefined();
+  });
+});

--- a/packages/services/src/sullivan/motionLimits.test.ts
+++ b/packages/services/src/sullivan/motionLimits.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_AGGREGATE_TRANSITION_DURATION_MS,
+  MAX_TRANSITION_DURATION_MS,
+  REDUCED_MOTION_EQUIVALENT,
+  VESTIBULAR_RISKY_TRANSITIONS,
+} from './motionLimits';
+
+describe('motionLimits constants', () => {
+  it('MAX_TRANSITION_DURATION_MS is a positive number under 1 second', () => {
+    expect(typeof MAX_TRANSITION_DURATION_MS).toBe('number');
+    expect(MAX_TRANSITION_DURATION_MS).toBeGreaterThan(0);
+    // WCAG 2.2.2 mandates pause-controls for motion > 5 seconds; Sullivan's
+    // per-transition ceiling stays well under that to keep cognitive load low.
+    expect(MAX_TRANSITION_DURATION_MS).toBeLessThan(1000);
+  });
+
+  it('MAX_TRANSITION_DURATION_MS is pinned to 800ms (Sullivan contract)', () => {
+    // Pin the exact value so a silent refactor (e.g. to 999ms) fails CI.
+    // This is the contract downstream rubrics rely on; the > 0 / < 1000
+    // soft bounds above protect against gross drift but not subtle drift.
+    expect(MAX_TRANSITION_DURATION_MS).toBe(800);
+  });
+
+  it('MAX_AGGREGATE_TRANSITION_DURATION_MS is a positive number and at least 2x per-transition', () => {
+    expect(typeof MAX_AGGREGATE_TRANSITION_DURATION_MS).toBe('number');
+    expect(MAX_AGGREGATE_TRANSITION_DURATION_MS).toBeGreaterThan(0);
+    expect(MAX_AGGREGATE_TRANSITION_DURATION_MS).toBeGreaterThanOrEqual(
+      MAX_TRANSITION_DURATION_MS * 2,
+    );
+  });
+
+  it('MAX_AGGREGATE_TRANSITION_DURATION_MS is pinned to 4000ms (Sullivan contract)', () => {
+    // Same rationale as the per-transition pin: protect against silent drift.
+    expect(MAX_AGGREGATE_TRANSITION_DURATION_MS).toBe(4000);
+  });
+
+  it('VESTIBULAR_RISKY_TRANSITIONS includes the canonical risky transition names', () => {
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has('zoom')).toBe(true);
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has('parallax')).toBe(true);
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has('spin')).toBe(true);
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has('flip')).toBe(true);
+  });
+
+  it('VESTIBULAR_RISKY_TRANSITIONS does NOT include vestibular-safe transitions', () => {
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has('fade')).toBe(false);
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has('none')).toBe(false);
+  });
+
+  it('REDUCED_MOTION_EQUIVALENT maps every risky transition to a safe one', () => {
+    for (const risky of VESTIBULAR_RISKY_TRANSITIONS) {
+      expect(REDUCED_MOTION_EQUIVALENT[risky]).toBeDefined();
+      expect(VESTIBULAR_RISKY_TRANSITIONS.has(REDUCED_MOTION_EQUIVALENT[risky])).toBe(false);
+    }
+  });
+});

--- a/packages/services/src/sullivan/motionLimits.ts
+++ b/packages/services/src/sullivan/motionLimits.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared motion thresholds for Sullivan's accessibility critiques.
+ *
+ * Each constant cites the WCAG success criterion that motivates it.
+ * Extracted to a single module so `presentation_motion_budget` (and any
+ * future Sullivan or chamber surface) consumes one source of truth
+ * instead of inline literals that can silently drift.
+ */
+
+/**
+ * Maximum duration of a single presentation transition, in milliseconds.
+ *
+ * WCAG 2.2.2 (Pause, Stop, Hide) requires pause-controls for motion
+ * lasting more than 5 seconds. Sullivan tightens this to 800ms per
+ * transition so individual step changes never approach the pause-control
+ * trigger, and so cognitive load per step stays low. The 400-800ms range
+ * is widely cited as a perceptual sweet spot for slide-style transitions
+ * — long enough to register, short enough to avoid interrupting flow.
+ */
+export const MAX_TRANSITION_DURATION_MS = 800;
+
+/**
+ * Maximum sum of all transition durations across a presentation, in
+ * milliseconds.
+ *
+ * Same WCAG anchors as the per-transition cap, applied to the total:
+ *   - WCAG 2.2.2 (Pause, Stop, Hide) — pause-controls are required for
+ *     any moving content lasting more than 5 seconds presented in
+ *     parallel with other content. Sullivan tightens this to a 4-second
+ *     aggregate across the whole presentation so the cumulative motion
+ *     budget stays comfortably under the WCAG floor without needing
+ *     per-transition pause UI in a slide deck.
+ *   - WCAG 2.3.3 (Animation from Interactions, AAA) — non-essential
+ *     motion should be minimised and disable-able; a small aggregate
+ *     budget makes that easier to honour and leaves headroom for
+ *     prefers-reduced-motion fallbacks.
+ *
+ * The specific 4-second value is a Sullivan editorial choice (~10% of a
+ * typical one-minute reading window) layered on top of those SCs, not a
+ * WCAG mandate.
+ */
+export const MAX_AGGREGATE_TRANSITION_DURATION_MS = 4000;
+
+/**
+ * Transition names known to trigger vestibular reactions (motion
+ * sickness, dizziness, disorientation) in some users.
+ *
+ * Source: WCAG 2.3.3 (Animation from Interactions, AAA) — large-scale
+ * movement, scaling, and rotation can trigger vestibular disorders.
+ * Sullivan flags any transition in this set that lacks a documented
+ * reduced-motion fallback.
+ */
+export const VESTIBULAR_RISKY_TRANSITIONS: ReadonlySet<string> = new Set([
+  'zoom',
+  'parallax',
+  'spin',
+  'flip',
+]);
+
+/**
+ * Map of risky transition names to their vestibular-safe equivalents.
+ *
+ * Used by `presentation_motion_budget` to suggest a drop-in alternative
+ * the author can apply for prefers-reduced-motion users (WCAG 2.3.3).
+ * Every entry's value MUST itself NOT be in
+ * {@link VESTIBULAR_RISKY_TRANSITIONS} — guaranteed by tests.
+ */
+export const REDUCED_MOTION_EQUIVALENT: Readonly<Record<string, string>> = {
+  zoom: 'fade',
+  parallax: 'fade',
+  spin: 'fade',
+  flip: 'fade',
+};

--- a/packages/services/src/sullivan/rubric.test.ts
+++ b/packages/services/src/sullivan/rubric.test.ts
@@ -1,0 +1,485 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_AGGREGATE_TRANSITION_DURATION_MS,
+  MAX_TRANSITION_DURATION_MS,
+} from './motionLimits';
+import {
+  RUBRIC,
+  type Finding,
+  type Rule,
+  type RubricContext,
+  type Severity,
+  type Step,
+} from './rubric';
+
+const ALLOWED_SEVERITIES: ReadonlyArray<Severity> = ['block', 'warn', 'note'];
+
+function getRule(id: string): Rule {
+  const rule = RUBRIC.find((r) => r.id === id);
+  if (!rule) {
+    throw new Error(`Rule "${id}" not found in RUBRIC`);
+  }
+  return rule;
+}
+
+function ctxAt(index: number, allSteps: readonly Step[]): RubricContext {
+  return { allSteps, index };
+}
+
+function makeStep(overrides: Partial<Step> = {}): Step {
+  return {
+    id: 's',
+    title: 'Step',
+    ...overrides,
+  };
+}
+
+describe('RUBRIC integrity', () => {
+  it('is a frozen array (Object.isFrozen)', () => {
+    expect(Object.isFrozen(RUBRIC)).toBe(true);
+  });
+
+  it('refuses runtime push() mutation', () => {
+    // TS prevents this at compile time via ReadonlyArray; the runtime freeze
+    // is the belt-and-braces guarantee that downstream consumers can't reach
+    // around the type system and mutate the shared rubric.
+    const mutate = (): void => {
+      (RUBRIC as Rule[]).push(getRule('one-idea'));
+    };
+    expect(mutate).toThrow(TypeError);
+  });
+
+  it('refuses runtime index-write mutation', () => {
+    const mutate = (): void => {
+      (RUBRIC as Rule[])[0] = getRule('one-idea');
+    };
+    expect(mutate).toThrow(TypeError);
+  });
+
+  it('every rule object is itself frozen', () => {
+    for (const rule of RUBRIC) {
+      expect(Object.isFrozen(rule)).toBe(true);
+    }
+  });
+
+  it('every rule id is unique', () => {
+    const ids = RUBRIC.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every rule.severity is one of the documented set: block | warn | note', () => {
+    for (const rule of RUBRIC) {
+      expect(ALLOWED_SEVERITIES).toContain(rule.severity);
+    }
+  });
+
+  it('every rule has a non-empty id, category, summary, and rationale', () => {
+    for (const rule of RUBRIC) {
+      expect(rule.id.length).toBeGreaterThan(0);
+      expect(rule.category.length).toBeGreaterThan(0);
+      expect(rule.summary.length).toBeGreaterThan(0);
+      expect(rule.rationale.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every rule exposes a (step, context) evaluator of arity 2 (uniform signature)', () => {
+    for (const rule of RUBRIC) {
+      expect(typeof rule.evaluator).toBe('function');
+      expect(rule.evaluator.length).toBe(2);
+    }
+  });
+
+  it('exposes the six rule ids called out in the Phase 2 brief plus the per-transition motion rule', () => {
+    const expected = [
+      'one-idea',
+      'cognitive-load',
+      'missing-alt-text-intent',
+      'motion-per-transition',
+      'narrative-continuity',
+      'redundant-content',
+      'motion-aggregate',
+    ];
+    const actual = RUBRIC.map((r) => r.id).sort();
+    expect(actual).toEqual([...expected].sort());
+  });
+});
+
+describe('one-idea rule (per-step)', () => {
+  const rule = getRule('one-idea');
+
+  it('passes when oneIdea is true', () => {
+    const step = makeStep({ oneIdea: true });
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('passes when oneIdea is undefined (no assertion either way)', () => {
+    const step = makeStep();
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('fires when oneIdea is explicitly false', () => {
+    const step = makeStep({ oneIdea: false, title: 'Crowded slide' });
+    const finding = rule.evaluator(step, ctxAt(0, [step]));
+    expect(finding).not.toBeNull();
+    const f = finding as Finding;
+    expect(f.rule).toBe('one-idea');
+    expect(f.severity).toBe('warn');
+    expect(f.message).toMatch(/one idea/i);
+  });
+
+  it('includes an actionable suggestion when firing', () => {
+    const step = makeStep({ oneIdea: false });
+    const finding = rule.evaluator(step, ctxAt(0, [step])) as Finding;
+    expect(finding.suggestion).toBeDefined();
+    expect(finding.suggestion?.length).toBeGreaterThan(0);
+  });
+});
+
+describe('cognitive-load rule (per-step)', () => {
+  const rule = getRule('cognitive-load');
+
+  it('passes when content is within the word budget', () => {
+    const step = makeStep({ content: 'Five short words sit here.' });
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('passes when content is undefined', () => {
+    const step = makeStep();
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('fires when content exceeds the per-step word budget', () => {
+    const overload = Array.from({ length: 200 }, (_, i) => `word${i}`).join(' ');
+    const step = makeStep({ content: overload });
+    const finding = rule.evaluator(step, ctxAt(0, [step]));
+    expect(finding).not.toBeNull();
+    const f = finding as Finding;
+    expect(f.rule).toBe('cognitive-load');
+    expect(f.severity).toBe('warn');
+    // The message must name the offending count so authors know how far over.
+    expect(f.message).toMatch(/\b200\b/);
+  });
+
+  it('counts words by whitespace and ignores extra spacing', () => {
+    const overload = Array.from({ length: 120 }, (_, i) => `word${i}`).join('   ');
+    const step = makeStep({ content: `  ${overload}  ` });
+    expect(rule.evaluator(step, ctxAt(0, [step]))).not.toBeNull();
+  });
+});
+
+describe('missing-alt-text-intent rule (per-step)', () => {
+  const rule = getRule('missing-alt-text-intent');
+
+  it('passes when there are no images', () => {
+    const step = makeStep();
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('passes when every image has non-empty alt text', () => {
+    const step = makeStep({
+      images: [
+        { src: 'arch.png', alt: 'System architecture diagram with three tiers' },
+        { src: 'team.png', alt: 'Photo of the engineering team' },
+      ],
+    });
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('passes when an image is explicitly marked decorative', () => {
+    const step = makeStep({
+      images: [{ src: 'flourish.png', decorative: true }],
+    });
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('fires when an image has neither alt nor decorative marker', () => {
+    const step = makeStep({
+      images: [{ src: 'mystery.png' }],
+    });
+    const finding = rule.evaluator(step, ctxAt(0, [step]));
+    expect(finding).not.toBeNull();
+    const f = finding as Finding;
+    expect(f.rule).toBe('missing-alt-text-intent');
+    expect(f.severity).toBe('block');
+    expect(f.message).toContain('mystery.png');
+  });
+
+  it('fires when alt is empty / whitespace-only and image is not decorative', () => {
+    const step = makeStep({
+      images: [{ src: 'empty.png', alt: '   ' }],
+    });
+    expect(rule.evaluator(step, ctxAt(0, [step]))).not.toBeNull();
+  });
+
+  it('cites WCAG 1.1.1 in its suggestion', () => {
+    const step = makeStep({ images: [{ src: 'a.png' }] });
+    const finding = rule.evaluator(step, ctxAt(0, [step])) as Finding;
+    expect(finding.suggestion).toBeDefined();
+    expect(finding.suggestion).toMatch(/decorative|alt/i);
+  });
+});
+
+describe('motion-per-transition rule (per-step)', () => {
+  const rule = getRule('motion-per-transition');
+
+  it('passes when there are no transitions', () => {
+    const step = makeStep();
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('passes at exactly MAX_TRANSITION_DURATION_MS — pinned to 800ms (boundary)', () => {
+    expect(MAX_TRANSITION_DURATION_MS).toBe(800);
+    const step = makeStep({
+      transitions: [{ name: 'fade', durationMs: MAX_TRANSITION_DURATION_MS }],
+    });
+    expect(rule.evaluator(step, ctxAt(0, [step]))).toBeNull();
+  });
+
+  it('fires at MAX_TRANSITION_DURATION_MS + 1ms — 801ms (boundary, pinning)', () => {
+    const overBy = MAX_TRANSITION_DURATION_MS + 1;
+    const step = makeStep({
+      transitions: [{ name: 'fade', durationMs: overBy }],
+    });
+    const finding = rule.evaluator(step, ctxAt(0, [step]));
+    expect(finding).not.toBeNull();
+    const f = finding as Finding;
+    expect(f.rule).toBe('motion-per-transition');
+    expect(f.severity).toBe('block');
+    expect(f.message).toContain(String(overBy));
+    expect(f.message).toContain(String(MAX_TRANSITION_DURATION_MS));
+  });
+
+  it('fires if ANY transition (not just the first) exceeds the cap', () => {
+    const step = makeStep({
+      transitions: [
+        { name: 'fade', durationMs: 300 },
+        { name: 'slide', durationMs: MAX_TRANSITION_DURATION_MS + 100 },
+      ],
+    });
+    const finding = rule.evaluator(step, ctxAt(0, [step]));
+    expect(finding).not.toBeNull();
+    expect((finding as Finding).message).toContain('slide');
+  });
+});
+
+describe('narrative-continuity rule (cross-step — uses context.allSteps + context.index)', () => {
+  const rule = getRule('narrative-continuity');
+
+  it('passes for the first step regardless of narrativeBridge', () => {
+    const steps = [
+      makeStep({ id: '1', title: 'Intro' }),
+      makeStep({ id: '2', title: 'Next', narrativeBridge: 'After the intro...' }),
+    ];
+    expect(rule.evaluator(steps[0], ctxAt(0, steps))).toBeNull();
+  });
+
+  it('passes for a non-first step that has a non-empty narrativeBridge', () => {
+    const steps = [
+      makeStep({ id: '1', title: 'Intro' }),
+      makeStep({ id: '2', title: 'Next', narrativeBridge: 'Building on the intro...' }),
+    ];
+    expect(rule.evaluator(steps[1], ctxAt(1, steps))).toBeNull();
+  });
+
+  it('fires for a non-first step missing a narrativeBridge', () => {
+    const steps = [
+      makeStep({ id: '1', title: 'Intro' }),
+      makeStep({ id: '2', title: 'Next' }),
+    ];
+    const finding = rule.evaluator(steps[1], ctxAt(1, steps));
+    expect(finding).not.toBeNull();
+    const f = finding as Finding;
+    expect(f.rule).toBe('narrative-continuity');
+    expect(f.severity).toBe('note');
+  });
+
+  it('uses context.index — a finding at index 2 names the previous step (index 1)', () => {
+    const steps = [
+      makeStep({ id: '1', title: 'Alpha' }),
+      makeStep({ id: '2', title: 'Bravo', narrativeBridge: 'continuing' }),
+      makeStep({ id: '3', title: 'Charlie' }),
+    ];
+    const finding = rule.evaluator(steps[2], ctxAt(2, steps)) as Finding;
+    expect(finding).not.toBeNull();
+    expect(finding.message).toContain('Bravo');
+    expect(finding.message).toContain('Charlie');
+  });
+
+  it('fires when narrativeBridge is whitespace-only', () => {
+    const steps = [
+      makeStep({ id: '1' }),
+      makeStep({ id: '2', narrativeBridge: '   ' }),
+    ];
+    expect(rule.evaluator(steps[1], ctxAt(1, steps))).not.toBeNull();
+  });
+});
+
+describe('redundant-content rule (cross-step — uses context.allSteps + context.index)', () => {
+  const rule = getRule('redundant-content');
+
+  it('passes when all steps have distinct content', () => {
+    const steps = [
+      makeStep({ id: '1', content: 'alpha bravo charlie delta echo' }),
+      makeStep({ id: '2', content: 'foxtrot golf hotel india juliet' }),
+    ];
+    expect(rule.evaluator(steps[1], ctxAt(1, steps))).toBeNull();
+  });
+
+  it('does not fire on the first occurrence of duplicated content (only on the duplicate)', () => {
+    const dup = 'alpha bravo charlie delta echo foxtrot golf hotel';
+    const steps = [
+      makeStep({ id: '1', title: 'First', content: dup }),
+      makeStep({ id: '2', title: 'Second', content: dup }),
+    ];
+    expect(rule.evaluator(steps[0], ctxAt(0, steps))).toBeNull();
+  });
+
+  it('fires on a later step whose content overlaps significantly with an earlier step', () => {
+    const dup = 'alpha bravo charlie delta echo foxtrot golf hotel';
+    const steps = [
+      makeStep({ id: '1', title: 'First', content: dup }),
+      makeStep({ id: '2', title: 'Second', content: dup }),
+    ];
+    const finding = rule.evaluator(steps[1], ctxAt(1, steps));
+    expect(finding).not.toBeNull();
+    const f = finding as Finding;
+    expect(f.rule).toBe('redundant-content');
+    expect(f.severity).toBe('note');
+    expect(f.message).toContain('First');
+  });
+
+  it('does not fire when current step has no content', () => {
+    const steps = [
+      makeStep({ id: '1', content: 'alpha bravo charlie delta echo foxtrot' }),
+      makeStep({ id: '2' }),
+    ];
+    expect(rule.evaluator(steps[1], ctxAt(1, steps))).toBeNull();
+  });
+
+  it('does not fire on partial overlap below the similarity threshold', () => {
+    const steps = [
+      makeStep({ id: '1', content: 'alpha bravo charlie delta echo foxtrot golf hotel' }),
+      makeStep({
+        id: '2',
+        content: 'alpha bravo india juliet kilo lima mike november',
+      }),
+    ];
+    expect(rule.evaluator(steps[1], ctxAt(1, steps))).toBeNull();
+  });
+});
+
+describe('motion-aggregate rule (cross-step — uses context.allSteps + context.index)', () => {
+  const rule = getRule('motion-aggregate');
+
+  it('passes at exactly MAX_AGGREGATE_TRANSITION_DURATION_MS — pinned to 4000ms (boundary)', () => {
+    expect(MAX_AGGREGATE_TRANSITION_DURATION_MS).toBe(4000);
+    const steps = [
+      makeStep({ id: '1', transitions: [{ name: 'fade', durationMs: 2000 }] }),
+      makeStep({ id: '2', transitions: [{ name: 'fade', durationMs: 2000 }] }),
+    ];
+    const last = steps.length - 1;
+    expect(rule.evaluator(steps[last], ctxAt(last, steps))).toBeNull();
+  });
+
+  it('fires at MAX_AGGREGATE_TRANSITION_DURATION_MS + 1ms — 4001ms (boundary, pinning)', () => {
+    const steps = [
+      makeStep({ id: '1', transitions: [{ name: 'fade', durationMs: 2000 }] }),
+      makeStep({ id: '2', transitions: [{ name: 'fade', durationMs: 2001 }] }),
+    ];
+    const last = steps.length - 1;
+    const finding = rule.evaluator(steps[last], ctxAt(last, steps));
+    expect(finding).not.toBeNull();
+    const f = finding as Finding;
+    expect(f.rule).toBe('motion-aggregate');
+    expect(f.severity).toBe('block');
+    expect(f.message).toContain(String(MAX_AGGREGATE_TRANSITION_DURATION_MS + 1));
+    expect(f.message).toContain(String(MAX_AGGREGATE_TRANSITION_DURATION_MS));
+  });
+
+  it('only fires on the last step — the finding lands on index = allSteps.length - 1', () => {
+    const steps = [
+      makeStep({ id: '1', transitions: [{ name: 'fade', durationMs: 2500 }] }),
+      makeStep({ id: '2', transitions: [{ name: 'fade', durationMs: 2500 }] }),
+    ];
+    // index 0 — intermediate, no finding (avoids duplicates across steps)
+    expect(rule.evaluator(steps[0], ctxAt(0, steps))).toBeNull();
+    // index 1 — last step, finding fires
+    expect(rule.evaluator(steps[1], ctxAt(1, steps))).not.toBeNull();
+  });
+
+  it('sums transition durations across many steps', () => {
+    const steps = [
+      makeStep({ id: '1', transitions: [{ name: 'fade', durationMs: 500 }] }),
+      makeStep({
+        id: '2',
+        transitions: [
+          { name: 'fade', durationMs: 500 },
+          { name: 'slide', durationMs: 500 },
+        ],
+      }),
+      makeStep({ id: '3', transitions: [{ name: 'fade', durationMs: 500 }] }),
+      makeStep({ id: '4', transitions: [{ name: 'fade', durationMs: 500 }] }),
+    ];
+    // aggregate = 2500ms, well under 4000ms — pass on the last step
+    const last = steps.length - 1;
+    expect(rule.evaluator(steps[last], ctxAt(last, steps))).toBeNull();
+  });
+
+  it('passes when no steps declare transitions', () => {
+    const steps = [makeStep({ id: '1' }), makeStep({ id: '2' })];
+    expect(rule.evaluator(steps[1], ctxAt(1, steps))).toBeNull();
+  });
+});
+
+describe('evaluator purity', () => {
+  function presentationFixture(): Step[] {
+    return [
+      makeStep({
+        id: 's1',
+        title: 'First',
+        oneIdea: false,
+        content: 'alpha bravo charlie delta echo foxtrot',
+        transitions: [{ name: 'fade', durationMs: 400 }],
+        images: [{ src: 'a.png' }],
+      }),
+      makeStep({
+        id: 's2',
+        title: 'Second',
+        oneIdea: true,
+        content: 'alpha bravo charlie delta echo foxtrot',
+        transitions: [{ name: 'spin', durationMs: 900 }],
+        narrativeBridge: 'continuing',
+        images: [{ src: 'b.png', alt: 'a real image' }],
+      }),
+    ];
+  }
+
+  it('every rule returns deterministic findings — same input, same output across calls', () => {
+    for (const rule of RUBRIC) {
+      const steps = presentationFixture();
+      const ctx = ctxAt(steps.length - 1, steps);
+      const a = rule.evaluator(steps[steps.length - 1], ctx);
+      const b = rule.evaluator(steps[steps.length - 1], ctx);
+      expect(a).toEqual(b);
+    }
+  });
+
+  it('no rule mutates the step it receives', () => {
+    for (const rule of RUBRIC) {
+      const steps = presentationFixture();
+      const target = steps[steps.length - 1];
+      const snapshot = JSON.stringify(target);
+      rule.evaluator(target, ctxAt(steps.length - 1, steps));
+      expect(JSON.stringify(target)).toBe(snapshot);
+    }
+  });
+
+  it('no rule mutates the context.allSteps array it receives', () => {
+    for (const rule of RUBRIC) {
+      const steps = presentationFixture();
+      const snapshot = JSON.stringify(steps);
+      rule.evaluator(steps[steps.length - 1], ctxAt(steps.length - 1, steps));
+      expect(JSON.stringify(steps)).toBe(snapshot);
+    }
+  });
+});

--- a/packages/services/src/sullivan/rubric.ts
+++ b/packages/services/src/sullivan/rubric.ts
@@ -1,0 +1,416 @@
+/**
+ * Sullivan's presentation rubric — per-step and cross-step evaluators.
+ *
+ * Each rule is a pure function over a `Step` and a `RubricContext`
+ * (`{ allSteps, index }`) that returns a `Finding` if the step violates
+ * the rule, or `null` if it passes. The signature is uniform — even
+ * rules that only look at the current step still accept and ignore the
+ * context, so the rubric runner can iterate without per-rule branching.
+ *
+ * The motion-sensitive rules consume the pinned constants from
+ * `./motionLimits` rather than inlining literals; this lets the
+ * value-pin tests in `motionLimits.test.ts` catch silent drift across
+ * both the constants and any rubric that depends on them.
+ */
+
+import {
+  MAX_AGGREGATE_TRANSITION_DURATION_MS,
+  MAX_TRANSITION_DURATION_MS,
+} from './motionLimits';
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+/**
+ * Finding severity:
+ *   - `block` — must be fixed before publishing (typically a WCAG-level
+ *     accessibility issue).
+ *   - `warn`  — a pedagogical or cognitive-load concern; the deck still
+ *     ships but the author should address it.
+ *   - `note`  — a stylistic suggestion; safe to ignore on a case-by-case
+ *     basis.
+ */
+export type Severity = 'block' | 'warn' | 'note';
+
+export type RuleCategory = 'pedagogy' | 'accessibility';
+
+export interface ImageRef {
+  readonly src: string;
+  readonly alt?: string;
+  readonly decorative?: boolean;
+}
+
+export interface TransitionRef {
+  readonly name: string;
+  readonly durationMs: number;
+}
+
+/**
+ * Minimum step shape the Phase 2 evaluators need. Phase 7's `types-barrel`
+ * todo will hoist this into a shared types module; until then it lives
+ * here next to the rules that consume it.
+ *
+ * TODO(types-barrel): move `Step`/`ImageRef`/`TransitionRef` to a shared
+ * package once the Phase 3 tool layer settles on the final fields.
+ */
+export interface Step {
+  readonly id: string;
+  readonly title: string;
+  readonly oneIdea?: boolean;
+  readonly content?: string;
+  readonly images?: readonly ImageRef[];
+  readonly transitions?: readonly TransitionRef[];
+  readonly narrativeBridge?: string;
+}
+
+export interface Finding {
+  readonly rule: string;
+  readonly severity: Severity;
+  readonly message: string;
+  readonly suggestion?: string;
+}
+
+export interface RubricContext {
+  readonly allSteps: readonly Step[];
+  readonly index: number;
+}
+
+export type RuleEvaluator = (step: Step, context: RubricContext) => Finding | null;
+
+export interface Rule {
+  readonly id: string;
+  readonly category: RuleCategory;
+  readonly severity: Severity;
+  readonly summary: string;
+  readonly rationale: string;
+  readonly evaluator: RuleEvaluator;
+}
+
+// -----------------------------------------------------------------------------
+// Sullivan editorial thresholds (non-motion).
+// Motion thresholds live in `./motionLimits.ts`.
+// -----------------------------------------------------------------------------
+
+/**
+ * Maximum word count per step.
+ *
+ * Sullivan editorial choice grounded in Sweller's Cognitive Load Theory
+ * (Sweller, 1988) and Mayer's Segmenting Principle (Mayer, Multimedia
+ * Learning, 2009). 75 words is roughly 30s of slow reading — long enough
+ * to develop one idea, short enough to keep working memory unloaded.
+ */
+export const MAX_STEP_WORD_COUNT = 75;
+
+/**
+ * Token-set Jaccard similarity at which two steps are considered
+ * redundant. 0.7 means 70% of distinct content tokens overlap.
+ *
+ * Sullivan editorial choice grounded in Mayer's Redundancy Principle
+ * (Mayer, Multimedia Learning, 2009). Below this threshold, partial
+ * overlap is treated as legitimate reinforcement rather than duplication.
+ */
+export const REDUNDANCY_JACCARD_THRESHOLD = 0.7;
+
+// -----------------------------------------------------------------------------
+// Pure helpers
+// -----------------------------------------------------------------------------
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+function tokenSet(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 3),
+  );
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection += 1;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function sumTransitionDurations(steps: readonly Step[]): number {
+  let total = 0;
+  for (const step of steps) {
+    if (!step.transitions) continue;
+    for (const t of step.transitions) {
+      total += t.durationMs;
+    }
+  }
+  return total;
+}
+
+function freezeRule(rule: Rule): Rule {
+  return Object.freeze(rule);
+}
+
+// -----------------------------------------------------------------------------
+// Rules
+// -----------------------------------------------------------------------------
+
+const oneIdeaRule: Rule = freezeRule({
+  id: 'one-idea',
+  category: 'pedagogy',
+  severity: 'warn',
+  summary: 'Each step should communicate a single idea.',
+  rationale:
+    'Reynolds (Presentation Zen, 2008) — "one slide, one idea" — and ' +
+    "Mayer's Coherence Principle (Mayer, Multimedia Learning, 2009, ch. 5) " +
+    'both argue that extraneous material on a slide hurts comprehension. ' +
+    'Sullivan flags steps that have explicitly declared more than one idea ' +
+    'so the author can split them before publishing.',
+  evaluator: (step: Step, context: RubricContext): Finding | null => {
+    // Per-step rule: context is accepted to preserve the uniform Rule
+    // signature but is not consulted by this evaluator.
+    void context;
+    if (step.oneIdea !== false) return null;
+    return {
+      rule: 'one-idea',
+      severity: 'warn',
+      message: `Step "${step.title}" declares more than one idea (oneIdea: false).`,
+      suggestion:
+        'Split this step into separate steps, each carrying a single idea ' +
+        '(Mayer, Coherence Principle).',
+    };
+  },
+});
+
+const cognitiveLoadRule: Rule = freezeRule({
+  id: 'cognitive-load',
+  category: 'pedagogy',
+  severity: 'warn',
+  summary: `Step content should stay within a ${MAX_STEP_WORD_COUNT}-word per-step budget.`,
+  rationale:
+    "Sweller's Cognitive Load Theory (Sweller, \"Cognitive Load During " +
+    'Problem Solving", Cognitive Science, 1988) and Mayer\'s Segmenting ' +
+    'Principle (Mayer, Multimedia Learning, 2009) both argue for chunking ' +
+    'material into small, learner-paced units. Sullivan caps each step at ' +
+    `${MAX_STEP_WORD_COUNT} words as an editorial reduction grounded in ` +
+    'those sources, not as a WCAG mandate.',
+  evaluator: (step: Step, context: RubricContext): Finding | null => {
+    // Per-step rule: context is accepted to preserve the uniform Rule
+    // signature but is not consulted by this evaluator.
+    void context;
+    if (step.content === undefined) return null;
+    const words = countWords(step.content);
+    if (words <= MAX_STEP_WORD_COUNT) return null;
+    return {
+      rule: 'cognitive-load',
+      severity: 'warn',
+      message:
+        `Step "${step.title}" has ${words} words, exceeding the ` +
+        `${MAX_STEP_WORD_COUNT}-word per-step budget.`,
+      suggestion:
+        `Trim to ≤ ${MAX_STEP_WORD_COUNT} words or split into multiple steps ` +
+        '(Mayer, Segmenting Principle).',
+    };
+  },
+});
+
+const missingAltTextIntentRule: Rule = freezeRule({
+  id: 'missing-alt-text-intent',
+  category: 'accessibility',
+  severity: 'block',
+  summary: 'Every image must declare alt text or be explicitly marked decorative.',
+  rationale:
+    'WCAG 2.1 SC 1.1.1 (Non-text Content, Level A) requires a text ' +
+    'alternative for non-text content, with an explicit exception for pure ' +
+    'decoration when assistive technology can ignore it. Sullivan enforces ' +
+    'an "intent" check: every image must either carry non-empty alt text or ' +
+    'be explicitly flagged decorative — silence is not a valid intent. ' +
+    'https://www.w3.org/TR/WCAG21/#non-text-content',
+  evaluator: (step: Step, context: RubricContext): Finding | null => {
+    // Per-step rule: context is accepted to preserve the uniform Rule
+    // signature but is not consulted by this evaluator.
+    void context;
+    if (!step.images || step.images.length === 0) return null;
+    for (const img of step.images) {
+      const altIsBlank = !img.alt || img.alt.trim().length === 0;
+      if (altIsBlank && img.decorative !== true) {
+        return {
+          rule: 'missing-alt-text-intent',
+          severity: 'block',
+          message:
+            `Image "${img.src}" on step "${step.title}" has neither alt text ` +
+            'nor an explicit decorative marker.',
+          suggestion:
+            "Add alt text describing the image's purpose, or mark " +
+            'decorative: true if the image is purely ornamental (WCAG 1.1.1).',
+        };
+      }
+    }
+    return null;
+  },
+});
+
+const motionPerTransitionRule: Rule = freezeRule({
+  id: 'motion-per-transition',
+  category: 'accessibility',
+  severity: 'block',
+  summary: `Each transition duration must be ≤ ${MAX_TRANSITION_DURATION_MS}ms.`,
+  rationale:
+    'WCAG 2.1 SC 2.2.2 (Pause, Stop, Hide, Level A) requires pause-controls ' +
+    'for motion lasting more than 5 seconds. Sullivan tightens this to ' +
+    `${MAX_TRANSITION_DURATION_MS}ms per transition so individual step ` +
+    'changes never approach the pause-control trigger and per-step ' +
+    'cognitive load stays low. ' +
+    'https://www.w3.org/TR/WCAG21/#pause-stop-hide',
+  evaluator: (step: Step, context: RubricContext): Finding | null => {
+    // Per-step rule: context is accepted to preserve the uniform Rule
+    // signature but is not consulted by this evaluator.
+    void context;
+    if (!step.transitions) return null;
+    for (const t of step.transitions) {
+      if (t.durationMs > MAX_TRANSITION_DURATION_MS) {
+        return {
+          rule: 'motion-per-transition',
+          severity: 'block',
+          message:
+            `Transition "${t.name}" on step "${step.title}" is ` +
+            `${t.durationMs}ms, exceeding the ${MAX_TRANSITION_DURATION_MS}ms ` +
+            'per-transition cap.',
+          suggestion:
+            `Reduce duration to ≤ ${MAX_TRANSITION_DURATION_MS}ms (WCAG 2.2.2).`,
+        };
+      }
+    }
+    return null;
+  },
+});
+
+const narrativeContinuityRule: Rule = freezeRule({
+  id: 'narrative-continuity',
+  category: 'pedagogy',
+  severity: 'note',
+  summary:
+    'Every non-first step should carry an explicit narrative bridge from ' +
+    'the previous step.',
+  rationale:
+    "Mayer's Signaling Principle (Mayer, Multimedia Learning, 2009, ch. 7) " +
+    'argues that making the structure of the material explicit improves ' +
+    'learning. Sullivan asks every non-first step for a one-line bridge so ' +
+    'the deck reads as continuous narrative rather than as a flat sequence ' +
+    'of independent slides.',
+  evaluator: (step: Step, context: RubricContext): Finding | null => {
+    if (context.index === 0) return null;
+    const bridge = step.narrativeBridge;
+    if (bridge !== undefined && bridge.trim().length > 0) return null;
+    const previous = context.allSteps[context.index - 1];
+    return {
+      rule: 'narrative-continuity',
+      severity: 'note',
+      message:
+        `Step "${step.title}" has no narrative bridge from the previous ` +
+        `step "${previous.title}".`,
+      suggestion:
+        `Add a one-sentence narrativeBridge linking "${previous.title}" to ` +
+        `"${step.title}" (Mayer, Signaling Principle).`,
+    };
+  },
+});
+
+const redundantContentRule: Rule = freezeRule({
+  id: 'redundant-content',
+  category: 'pedagogy',
+  severity: 'note',
+  summary: 'A step should not duplicate the content of an earlier step.',
+  rationale:
+    "Mayer's Redundancy Principle (Mayer, Multimedia Learning, 2009, ch. 6) " +
+    'argues that presenting the same information twice in the same channel ' +
+    'hurts learning. Sullivan flags any step whose token-set Jaccard ' +
+    `similarity with an earlier step is ≥ ${REDUNDANCY_JACCARD_THRESHOLD}. ` +
+    'The rule fires only on the duplicate, never the original, so each ' +
+    'overlap is reported exactly once.',
+  evaluator: (step: Step, context: RubricContext): Finding | null => {
+    if (step.content === undefined) return null;
+    const here = tokenSet(step.content);
+    if (here.size === 0) return null;
+    for (let i = 0; i < context.index; i += 1) {
+      const other = context.allSteps[i];
+      if (other.content === undefined) continue;
+      const there = tokenSet(other.content);
+      if (there.size === 0) continue;
+      const similarity = jaccardSimilarity(here, there);
+      if (similarity >= REDUNDANCY_JACCARD_THRESHOLD) {
+        const pct = Math.round(similarity * 100);
+        return {
+          rule: 'redundant-content',
+          severity: 'note',
+          message:
+            `Step "${step.title}" overlaps ${pct}% with earlier step ` +
+            `"${other.title}".`,
+          suggestion:
+            `Merge "${step.title}" into "${other.title}" or trim the ` +
+            'duplicate content (Mayer, Redundancy Principle).',
+        };
+      }
+    }
+    return null;
+  },
+});
+
+const motionAggregateRule: Rule = freezeRule({
+  id: 'motion-aggregate',
+  category: 'accessibility',
+  severity: 'block',
+  summary:
+    'Aggregate transition duration across a deck must be ≤ ' +
+    `${MAX_AGGREGATE_TRANSITION_DURATION_MS}ms.`,
+  rationale:
+    'WCAG 2.1 SC 2.2.2 (Pause, Stop, Hide, Level A) and SC 2.3.3 (Animation ' +
+    'from Interactions, Level AAA) together motivate minimising ' +
+    'non-essential motion across an experience. Sullivan caps the aggregate ' +
+    `of all transition durations at ${MAX_AGGREGATE_TRANSITION_DURATION_MS}` +
+    'ms — an editorial reduction layered on the WCAG floor, not a WCAG ' +
+    'mandate. The finding lands on the last step only, so the aggregate is ' +
+    'reported once per deck rather than once per step. ' +
+    'https://www.w3.org/TR/WCAG21/#pause-stop-hide ' +
+    'https://www.w3.org/TR/WCAG21/#animation-from-interactions',
+  evaluator: (step: Step, context: RubricContext): Finding | null => {
+    if (context.index !== context.allSteps.length - 1) return null;
+    const total = sumTransitionDurations(context.allSteps);
+    if (total <= MAX_AGGREGATE_TRANSITION_DURATION_MS) return null;
+    return {
+      rule: 'motion-aggregate',
+      severity: 'block',
+      message:
+        `Aggregate transition duration is ${total}ms, exceeding the ` +
+        `${MAX_AGGREGATE_TRANSITION_DURATION_MS}ms total motion budget for ` +
+        `step "${step.title}" (last in deck).`,
+      suggestion:
+        'Trim or shorten transitions so the aggregate is ≤ ' +
+        `${MAX_AGGREGATE_TRANSITION_DURATION_MS}ms (WCAG 2.2.2 / 2.3.3).`,
+    };
+  },
+});
+
+// -----------------------------------------------------------------------------
+// Public rubric
+// -----------------------------------------------------------------------------
+
+/**
+ * The full Sullivan rubric. Frozen at module load so downstream consumers
+ * cannot mutate the shared rule set; each rule object is also frozen so
+ * its evaluator/severity/citation cannot be swapped at runtime.
+ */
+export const RUBRIC: ReadonlyArray<Rule> = Object.freeze([
+  oneIdeaRule,
+  cognitiveLoadRule,
+  missingAltTextIntentRule,
+  motionPerTransitionRule,
+  narrativeContinuityRule,
+  redundantContentRule,
+  motionAggregateRule,
+]);

--- a/packages/services/src/sullivan/tools.test.ts
+++ b/packages/services/src/sullivan/tools.test.ts
@@ -1,0 +1,727 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionTool } from '../a2a/tools';
+import {
+  MAX_AGGREGATE_TRANSITION_DURATION_MS,
+  MAX_TRANSITION_DURATION_MS,
+  REDUCED_MOTION_EQUIVALENT,
+  VESTIBULAR_RISKY_TRANSITIONS,
+} from './motionLimits';
+import { MAX_STEP_WORD_COUNT, type Step } from './rubric';
+import {
+  buildSullivanTools,
+  type ContrastCheckResult,
+  type CritiqueResult,
+  type MotionBudgetResult,
+  type OutlineValidateResult,
+  type PresentationTemplateResult,
+  type SullivanService,
+} from './tools';
+
+// -----------------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------------
+
+const MIND_ID = 'mind-test';
+const MIND_PATH = '/tmp/mind-test';
+const SERVICE: SullivanService = {} as SullivanService;
+
+const TOOL_NAMES = [
+  'presentation_template',
+  'presentation_outline_validate',
+  'presentation_critique',
+  'presentation_contrast_check',
+  'presentation_motion_budget',
+] as const;
+
+function buildTools(): SessionTool[] {
+  return buildSullivanTools(MIND_ID, MIND_PATH, SERVICE);
+}
+
+function getTool(name: string): SessionTool {
+  const tool = buildTools().find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool "${name}" not found`);
+  return tool;
+}
+
+function makeStep(overrides: Partial<Step> & { id: string; title: string }): Step {
+  return overrides;
+}
+
+// -----------------------------------------------------------------------------
+// buildSullivanTools — shape
+// -----------------------------------------------------------------------------
+
+describe('buildSullivanTools — shape', () => {
+  it('returns exactly five SessionTool entries', () => {
+    const tools = buildTools();
+    expect(tools).toHaveLength(5);
+  });
+
+  it('returns the five documented tool names in a stable order', () => {
+    const tools = buildTools();
+    expect(tools.map((t) => t.name)).toEqual([...TOOL_NAMES]);
+  });
+
+  it('every tool has name, description, parameters (object), and async handler', () => {
+    const tools = buildTools();
+    for (const tool of tools) {
+      expect(typeof tool.name).toBe('string');
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.description).toBe('string');
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(typeof tool.parameters).toBe('object');
+      expect(tool.parameters).not.toBeNull();
+      expect(typeof tool.handler).toBe('function');
+      // SessionTool.handler signature: (args) => Promise<unknown>.
+      expect(tool.handler.constructor.name).toBe('AsyncFunction');
+    }
+  });
+
+  it('every tool exposes a JSON-schema-shaped parameters object', () => {
+    const tools = buildTools();
+    for (const tool of tools) {
+      const params = tool.parameters as Record<string, unknown>;
+      expect(params.type).toBe('object');
+      expect(typeof params.properties).toBe('object');
+      expect(params.properties).not.toBeNull();
+    }
+  });
+
+  it('builds without touching fs / electron / network — pure construction', () => {
+    // No keytar / fs / electron stubs needed; if any were required, the
+    // import chain would fail before we reach this point. The assertion
+    // here is informational: a smoke that buildSullivanTools is callable
+    // with placeholder context. The full purity contract is enforced by
+    // each handler's own no-side-effects test below.
+    expect(() => buildSullivanTools(MIND_ID, MIND_PATH, SERVICE)).not.toThrow();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// presentation_template
+// -----------------------------------------------------------------------------
+
+describe('presentation_template', () => {
+  const tool = (): SessionTool => getTool('presentation_template');
+
+  it('returns an empty outline scaffold + structural guidance on the happy path', async () => {
+    const result = (await tool().handler({
+      topic: 'Cognitive Load Theory',
+      audience: 'Junior engineers',
+      learningObjective: 'Recognise extraneous cognitive load and apply Mayer / Sweller mitigations.',
+      timeBudgetMinutes: 30,
+    })) as PresentationTemplateResult;
+
+    expect(typeof result).not.toBe('string');
+    expect(result).toEqual(
+      expect.objectContaining({
+        thesis: '',
+        narrativeArc: [],
+        steps: [],
+        guidance: expect.objectContaining({
+          oneIdeaPerStep: true,
+          maxWordsPerSlide: MAX_STEP_WORD_COUNT,
+          timeBudgetTargetMinutes: 30,
+        }),
+      }),
+    );
+  });
+
+  it('returns null timeBudgetTargetMinutes when the caller omits the optional field', async () => {
+    const result = (await tool().handler({
+      topic: 'Topic',
+      audience: 'Audience',
+      learningObjective: 'Objective',
+    })) as PresentationTemplateResult;
+
+    expect(result.guidance.timeBudgetTargetMinutes).toBeNull();
+  });
+
+  it('pins maxWordsPerSlide to the imported MAX_STEP_WORD_COUNT (no inline literal)', async () => {
+    // If the rubric's word-count budget changes, this tool's guidance must
+    // change with it — that's the contract. Pinning the assertion to the
+    // imported constant catches silent drift in either direction.
+    const result = (await tool().handler({
+      topic: 'X',
+      audience: 'Y',
+      learningObjective: 'Z',
+    })) as PresentationTemplateResult;
+    expect(result.guidance.maxWordsPerSlide).toBe(MAX_STEP_WORD_COUNT);
+  });
+
+  it('throws when topic is missing or blank', async () => {
+    await expect(tool().handler({ audience: 'a', learningObjective: 'o' })).rejects.toThrow(/topic/i);
+    await expect(tool().handler({ topic: '', audience: 'a', learningObjective: 'o' })).rejects.toThrow(/topic/i);
+    await expect(tool().handler({ topic: '   ', audience: 'a', learningObjective: 'o' })).rejects.toThrow(/topic/i);
+  });
+
+  it('throws when audience is missing or blank', async () => {
+    await expect(tool().handler({ topic: 't', learningObjective: 'o' })).rejects.toThrow(/audience/i);
+    await expect(tool().handler({ topic: 't', audience: '', learningObjective: 'o' })).rejects.toThrow(/audience/i);
+  });
+
+  it('throws when learningObjective is missing or blank', async () => {
+    await expect(tool().handler({ topic: 't', audience: 'a' })).rejects.toThrow(/learningObjective/i);
+    await expect(tool().handler({ topic: 't', audience: 'a', learningObjective: '   ' })).rejects.toThrow(
+      /learningObjective/i,
+    );
+  });
+
+  it('throws when timeBudgetMinutes is provided but non-positive or non-finite', async () => {
+    const base = { topic: 't', audience: 'a', learningObjective: 'o' };
+    await expect(tool().handler({ ...base, timeBudgetMinutes: 0 })).rejects.toThrow(/timeBudget/i);
+    await expect(tool().handler({ ...base, timeBudgetMinutes: -5 })).rejects.toThrow(/timeBudget/i);
+    await expect(tool().handler({ ...base, timeBudgetMinutes: Number.NaN })).rejects.toThrow(/timeBudget/i);
+    await expect(tool().handler({ ...base, timeBudgetMinutes: Number.POSITIVE_INFINITY })).rejects.toThrow(
+      /timeBudget/i,
+    );
+    await expect(tool().handler({ ...base, timeBudgetMinutes: 'thirty' as unknown as number })).rejects.toThrow(
+      /timeBudget/i,
+    );
+  });
+
+  it('is deterministic — same input yields deep-equal output across calls', async () => {
+    const args = {
+      topic: 'Topic',
+      audience: 'Audience',
+      learningObjective: 'Objective',
+      timeBudgetMinutes: 20,
+    };
+    const a = await tool().handler({ ...args });
+    const b = await tool().handler({ ...args });
+    expect(a).toEqual(b);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// presentation_outline_validate
+// -----------------------------------------------------------------------------
+
+describe('presentation_outline_validate', () => {
+  const tool = (): SessionTool => getTool('presentation_outline_validate');
+
+  it('returns no findings and zero summary counts on an empty (but well-formed) outline', async () => {
+    const result = (await tool().handler({
+      thesis: 'A clear thesis.',
+      narrativeArc: ['intro', 'body', 'close'],
+      steps: [],
+    })) as OutlineValidateResult;
+
+    expect(typeof result).not.toBe('string');
+    expect(result).toEqual(
+      expect.objectContaining({
+        findings: [],
+        summary: { blockCount: 0, warnCount: 0, noteCount: 0 },
+      }),
+    );
+  });
+
+  it('returns rubric findings (not throws) when steps trigger pedagogy rules', async () => {
+    const steps: Step[] = [
+      makeStep({ id: 's1', title: 'First', oneIdea: false, narrativeBridge: 'opening' }),
+    ];
+    const result = (await tool().handler({
+      thesis: '',
+      narrativeArc: [],
+      steps,
+    })) as OutlineValidateResult;
+
+    const ruleIds = result.findings.map((f) => f.rule);
+    expect(ruleIds).toContain('one-idea');
+    expect(result.summary.warnCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns block-severity findings as a successful result (not a throw)', async () => {
+    const steps: Step[] = [
+      makeStep({
+        id: 's1',
+        title: 'Image step',
+        images: [{ src: 'logo.png' }],
+      }),
+    ];
+    const result = (await tool().handler({ thesis: '', narrativeArc: [], steps })) as OutlineValidateResult;
+    expect(result.findings.some((f) => f.rule === 'missing-alt-text-intent' && f.severity === 'block')).toBe(true);
+    expect(result.summary.blockCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('summary counts match the severities of the returned findings', async () => {
+    const steps: Step[] = [
+      makeStep({
+        id: 's1',
+        title: 'A',
+        oneIdea: false,
+        images: [{ src: 'x.png' }],
+        transitions: [{ name: 't', durationMs: MAX_TRANSITION_DURATION_MS + 1 }],
+      }),
+    ];
+    const result = (await tool().handler({ thesis: '', narrativeArc: [], steps })) as OutlineValidateResult;
+    const block = result.findings.filter((f) => f.severity === 'block').length;
+    const warn = result.findings.filter((f) => f.severity === 'warn').length;
+    const note = result.findings.filter((f) => f.severity === 'note').length;
+    expect(result.summary).toEqual({ blockCount: block, warnCount: warn, noteCount: note });
+  });
+
+  it('throws when steps is missing or not an array', async () => {
+    await expect(tool().handler({ thesis: '', narrativeArc: [] })).rejects.toThrow(/steps/i);
+    await expect(
+      tool().handler({ thesis: '', narrativeArc: [], steps: 'not-an-array' as unknown as Step[] }),
+    ).rejects.toThrow(/steps/i);
+  });
+
+  it('throws when a step is missing required id or title', async () => {
+    await expect(
+      tool().handler({
+        thesis: '',
+        narrativeArc: [],
+        steps: [{ title: 'no id' } as unknown as Step],
+      }),
+    ).rejects.toThrow(/id/i);
+    await expect(
+      tool().handler({
+        thesis: '',
+        narrativeArc: [],
+        steps: [{ id: 'has-id' } as unknown as Step],
+      }),
+    ).rejects.toThrow(/title/i);
+  });
+
+  it('throws on duplicate step ids', async () => {
+    await expect(
+      tool().handler({
+        thesis: '',
+        narrativeArc: [],
+        steps: [makeStep({ id: 's1', title: 'A' }), makeStep({ id: 's1', title: 'B' })],
+      }),
+    ).rejects.toThrow(/duplicate/i);
+  });
+
+  it('throws when oneIdea is present but not a boolean', async () => {
+    await expect(
+      tool().handler({
+        thesis: '',
+        narrativeArc: [],
+        steps: [{ id: 's1', title: 'A', oneIdea: 'yes' } as unknown as Step],
+      }),
+    ).rejects.toThrow(/oneIdea/i);
+  });
+
+  it('throws when a transition has a non-finite or negative durationMs', async () => {
+    await expect(
+      tool().handler({
+        thesis: '',
+        narrativeArc: [],
+        steps: [
+          {
+            id: 's1',
+            title: 'A',
+            transitions: [{ name: 'bad', durationMs: Number.NaN }],
+          } as unknown as Step,
+        ],
+      }),
+    ).rejects.toThrow(/duration/i);
+    await expect(
+      tool().handler({
+        thesis: '',
+        narrativeArc: [],
+        steps: [
+          {
+            id: 's1',
+            title: 'A',
+            transitions: [{ name: 'bad', durationMs: -1 }],
+          } as unknown as Step,
+        ],
+      }),
+    ).rejects.toThrow(/duration/i);
+  });
+
+  it('throws when an image is missing src', async () => {
+    await expect(
+      tool().handler({
+        thesis: '',
+        narrativeArc: [],
+        steps: [
+          { id: 's1', title: 'A', images: [{ alt: 'no src' }] } as unknown as Step,
+        ],
+      }),
+    ).rejects.toThrow(/src/i);
+  });
+
+  it('is deterministic — same input yields deep-equal output across calls', async () => {
+    const args = {
+      thesis: '',
+      narrativeArc: [],
+      steps: [makeStep({ id: 's1', title: 'A', oneIdea: false })],
+    };
+    const a = await tool().handler(JSON.parse(JSON.stringify(args)));
+    const b = await tool().handler(JSON.parse(JSON.stringify(args)));
+    expect(a).toEqual(b);
+  });
+
+  it('returns a structured object, not a JSON-stringified payload', async () => {
+    const result = await tool().handler({ thesis: '', narrativeArc: [], steps: [] });
+    expect(typeof result).not.toBe('string');
+    expect(result).toEqual(expect.objectContaining({ findings: expect.any(Array) }));
+  });
+});
+
+// -----------------------------------------------------------------------------
+// presentation_critique
+// -----------------------------------------------------------------------------
+
+describe('presentation_critique', () => {
+  const tool = (): SessionTool => getTool('presentation_critique');
+
+  function badOutline(): Step[] {
+    // Crafted to trigger several rule kinds at once.
+    return [
+      makeStep({
+        id: 's1',
+        title: 'Opening',
+        oneIdea: false,
+        images: [{ src: 'logo.png' }],
+        transitions: [{ name: 'zoom', durationMs: MAX_TRANSITION_DURATION_MS + 1 }],
+        narrativeBridge: 'opening',
+      }),
+      makeStep({
+        id: 's2',
+        title: 'Closing',
+        transitions: [{ name: 'spin', durationMs: MAX_AGGREGATE_TRANSITION_DURATION_MS }],
+      }),
+    ];
+  }
+
+  it('returns no findings on a clean outline and an empty perStep bucket per step', async () => {
+    const steps: Step[] = [
+      makeStep({ id: 's1', title: 'A', oneIdea: true }),
+      makeStep({
+        id: 's2',
+        title: 'B',
+        oneIdea: true,
+        narrativeBridge: 'building on A',
+      }),
+    ];
+    const result = (await tool().handler({ steps })) as CritiqueResult;
+    expect(typeof result).not.toBe('string');
+    expect(result.findings).toEqual([]);
+    expect(result.perStep).toEqual([
+      { stepId: 's1', findings: [] },
+      { stepId: 's2', findings: [] },
+    ]);
+    expect(result.summary).toEqual({ blockCount: 0, warnCount: 0, noteCount: 0 });
+  });
+
+  it('returns the expected rule ids when an outline triggers several rules at once', async () => {
+    const steps = badOutline();
+    const result = (await tool().handler({ steps })) as CritiqueResult;
+    const ruleIds = new Set(result.findings.map((f) => f.rule));
+    // missing-alt-text-intent fires on s1's untagged image, motion-per-transition
+    // fires on s1's > cap transition, and motion-aggregate fires on s2 (last step)
+    // because the deck-total exceeds the aggregate cap.
+    expect(ruleIds.has('missing-alt-text-intent')).toBe(true);
+    expect(ruleIds.has('motion-per-transition')).toBe(true);
+    expect(ruleIds.has('motion-aggregate')).toBe(true);
+  });
+
+  it('attributes every finding to a perStep bucket whose stepId matches a real step', async () => {
+    const steps = badOutline();
+    const result = (await tool().handler({ steps })) as CritiqueResult;
+    const stepIds = new Set(steps.map((s) => s.id));
+    expect(result.perStep.map((b) => b.stepId)).toEqual([...steps.map((s) => s.id)]);
+    for (const bucket of result.perStep) {
+      expect(stepIds.has(bucket.stepId)).toBe(true);
+    }
+    // Every global finding appears in exactly one per-step bucket.
+    const flattened = result.perStep.flatMap((b) => b.findings);
+    expect(flattened).toHaveLength(result.findings.length);
+  });
+
+  it('every finding severity is one of block | warn | note', async () => {
+    const steps = badOutline();
+    const result = (await tool().handler({ steps })) as CritiqueResult;
+    for (const f of result.findings) {
+      expect(['block', 'warn', 'note']).toContain(f.severity);
+    }
+  });
+
+  it('throws on malformed steps using the same validator as outline_validate', async () => {
+    await expect(tool().handler({})).rejects.toThrow(/steps/i);
+    await expect(tool().handler({ steps: 'not-an-array' as unknown as Step[] })).rejects.toThrow(/steps/i);
+    await expect(
+      tool().handler({ steps: [{ id: 's1' } as unknown as Step] }),
+    ).rejects.toThrow(/title/i);
+    await expect(
+      tool().handler({
+        steps: [makeStep({ id: 'a', title: 'A' }), makeStep({ id: 'a', title: 'B' })],
+      }),
+    ).rejects.toThrow(/duplicate/i);
+  });
+
+  it('is deterministic — same input yields deep-equal output across calls', async () => {
+    const args = { steps: badOutline() };
+    const a = await tool().handler(JSON.parse(JSON.stringify(args)));
+    const b = await tool().handler(JSON.parse(JSON.stringify(args)));
+    expect(a).toEqual(b);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// presentation_contrast_check
+// -----------------------------------------------------------------------------
+
+describe('presentation_contrast_check', () => {
+  const tool = (): SessionTool => getTool('presentation_contrast_check');
+
+  it('returns an array of structured results, one per input pair', async () => {
+    const result = (await tool().handler({
+      pairs: [
+        { foreground: '#000000', background: '#ffffff', label: 'body text' },
+        { foreground: '#777777', background: '#ffffff' },
+      ],
+    })) as readonly ContrastCheckResult[];
+
+    expect(typeof result).not.toBe('string');
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(2);
+    for (const entry of result) {
+      expect(entry).toEqual(
+        expect.objectContaining({
+          foreground: expect.any(String),
+          background: expect.any(String),
+          ratio: expect.any(Number),
+          AA: expect.objectContaining({ largeText: expect.any(Boolean), normalText: expect.any(Boolean) }),
+          AAA: expect.objectContaining({ largeText: expect.any(Boolean), normalText: expect.any(Boolean) }),
+          recommendation: expect.any(String),
+        }),
+      );
+    }
+  });
+
+  it('preserves the optional label when supplied', async () => {
+    const result = (await tool().handler({
+      pairs: [{ foreground: '#000000', background: '#ffffff', label: 'headline' }],
+    })) as readonly ContrastCheckResult[];
+    expect(result[0].label).toBe('headline');
+  });
+
+  it('black on white passes WCAG AA and AAA at both sizes (max contrast)', async () => {
+    const result = (await tool().handler({
+      pairs: [{ foreground: '#000000', background: '#ffffff' }],
+    })) as readonly ContrastCheckResult[];
+    expect(result[0].AA).toEqual({ largeText: true, normalText: true });
+    expect(result[0].AAA).toEqual({ largeText: true, normalText: true });
+    expect(result[0].ratio).toBeGreaterThan(20);
+  });
+
+  it('low contrast fails every level and returns a remediation recommendation', async () => {
+    const result = (await tool().handler({
+      pairs: [{ foreground: '#cccccc', background: '#ffffff' }],
+    })) as readonly ContrastCheckResult[];
+    expect(result[0].AA.normalText).toBe(false);
+    expect(result[0].AA.largeText).toBe(false);
+    expect(result[0].AAA.normalText).toBe(false);
+    expect(result[0].AAA.largeText).toBe(false);
+    expect(result[0].recommendation.length).toBeGreaterThan(0);
+  });
+
+  it('mid-range contrast passes AA but not AAA for normal text', async () => {
+    // #767676 on white is the canonical "AA but not AAA for normal text"
+    // boundary case cited by WCAG guidance.
+    const result = (await tool().handler({
+      pairs: [{ foreground: '#767676', background: '#ffffff' }],
+    })) as readonly ContrastCheckResult[];
+    expect(result[0].AA.normalText).toBe(true);
+    expect(result[0].AAA.normalText).toBe(false);
+  });
+
+  it('throws on malformed hex via the imported parseHexColor helper', async () => {
+    await expect(
+      tool().handler({ pairs: [{ foreground: 'not-a-color', background: '#ffffff' }] }),
+    ).rejects.toThrow(/hex/i);
+    await expect(
+      tool().handler({ pairs: [{ foreground: '#fff', background: '#1234' }] }),
+    ).rejects.toThrow(/hex/i);
+  });
+
+  it('throws when pairs is missing, not an array, or a pair is missing colour fields', async () => {
+    await expect(tool().handler({})).rejects.toThrow(/pairs/i);
+    await expect(tool().handler({ pairs: 'not-an-array' as unknown as object[] })).rejects.toThrow(/pairs/i);
+    await expect(
+      tool().handler({ pairs: [{ background: '#fff' } as unknown as { foreground: string; background: string }] }),
+    ).rejects.toThrow(/foreground/i);
+    await expect(
+      tool().handler({ pairs: [{ foreground: '#000' } as unknown as { foreground: string; background: string }] }),
+    ).rejects.toThrow(/background/i);
+  });
+
+  it('is deterministic — same input yields deep-equal output across calls', async () => {
+    const args = { pairs: [{ foreground: '#000000', background: '#ffffff' }] };
+    const a = await tool().handler(JSON.parse(JSON.stringify(args)));
+    const b = await tool().handler(JSON.parse(JSON.stringify(args)));
+    expect(a).toEqual(b);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// presentation_motion_budget
+// -----------------------------------------------------------------------------
+
+describe('presentation_motion_budget', () => {
+  const tool = (): SessionTool => getTool('presentation_motion_budget');
+
+  it('returns empty perTransition and zero aggregate on an empty input', async () => {
+    const result = (await tool().handler({ transitions: [] })) as MotionBudgetResult;
+    expect(typeof result).not.toBe('string');
+    expect(result.perTransition).toEqual([]);
+    expect(result.aggregate.totalDurationMs).toBe(0);
+    expect(result.aggregate.withinAggregateBudget).toBe(true);
+    expect(typeof result.aggregate.recommendation).toBe('string');
+  });
+
+  it('marks a transition at the per-transition cap as within budget (pinned to MAX_TRANSITION_DURATION_MS)', async () => {
+    const result = (await tool().handler({
+      transitions: [{ id: 't1', durationMs: MAX_TRANSITION_DURATION_MS, type: 'fade' }],
+    })) as MotionBudgetResult;
+    expect(result.perTransition[0].withinPerTransitionBudget).toBe(true);
+  });
+
+  it('marks a transition one millisecond over the cap as out of budget', async () => {
+    const result = (await tool().handler({
+      transitions: [{ id: 't1', durationMs: MAX_TRANSITION_DURATION_MS + 1, type: 'fade' }],
+    })) as MotionBudgetResult;
+    expect(result.perTransition[0].withinPerTransitionBudget).toBe(false);
+    expect(result.perTransition[0].recommendation).toMatch(/(exceeds|reduce|cap)/i);
+  });
+
+  it('marks aggregate at exactly the cap as within budget', async () => {
+    const result = (await tool().handler({
+      transitions: [
+        { id: 't1', durationMs: MAX_TRANSITION_DURATION_MS, type: 'fade' },
+        { id: 't2', durationMs: MAX_AGGREGATE_TRANSITION_DURATION_MS - MAX_TRANSITION_DURATION_MS, type: 'fade' },
+      ],
+    })) as MotionBudgetResult;
+    expect(result.aggregate.totalDurationMs).toBe(MAX_AGGREGATE_TRANSITION_DURATION_MS);
+    expect(result.aggregate.withinAggregateBudget).toBe(true);
+  });
+
+  it('marks aggregate one millisecond over the cap as out of budget', async () => {
+    const result = (await tool().handler({
+      transitions: [
+        { durationMs: MAX_AGGREGATE_TRANSITION_DURATION_MS + 1, type: 'fade' },
+      ],
+      // ^ uses a single transition above the per-transition cap to drive
+      // the aggregate above its cap; the aggregate budget assertion is the
+      // one we care about here.
+    })) as MotionBudgetResult;
+    expect(result.aggregate.withinAggregateBudget).toBe(false);
+    expect(result.aggregate.recommendation).toMatch(/(exceeds|trim|aggregate)/i);
+  });
+
+  it('maps a vestibular-risky type to its REDUCED_MOTION_EQUIVALENT', async () => {
+    const result = (await tool().handler({
+      transitions: [{ id: 't1', durationMs: 400, type: 'zoom' }],
+    })) as MotionBudgetResult;
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has('zoom')).toBe(true);
+    expect(result.perTransition[0].reducedMotionEquivalent).toBe(REDUCED_MOTION_EQUIVALENT['zoom']);
+    // Pin to the imported map, not the literal 'fade', to catch silent drift.
+  });
+
+  it('emits a vestibular-risk recommendation when the type is in the risky set', async () => {
+    const result = (await tool().handler({
+      transitions: [{ id: 't1', durationMs: 400, type: 'parallax' }],
+    })) as MotionBudgetResult;
+    expect(result.perTransition[0].recommendation).toMatch(/(vestibular|reduced[- ]motion|prefers-reduced-motion)/i);
+  });
+
+  it('leaves a safe type unchanged in reducedMotionEquivalent', async () => {
+    const result = (await tool().handler({
+      transitions: [{ id: 't1', durationMs: 400, type: 'fade' }],
+    })) as MotionBudgetResult;
+    expect(result.perTransition[0].reducedMotionEquivalent).not.toMatch(/^$/);
+    expect(VESTIBULAR_RISKY_TRANSITIONS.has(result.perTransition[0].reducedMotionEquivalent)).toBe(false);
+  });
+
+  it('throws when transitions is missing or not an array', async () => {
+    await expect(tool().handler({})).rejects.toThrow(/transitions/i);
+    await expect(
+      tool().handler({ transitions: 'nope' as unknown as { durationMs: number }[] }),
+    ).rejects.toThrow(/transitions/i);
+  });
+
+  it('throws on non-finite or non-positive durationMs', async () => {
+    await expect(
+      tool().handler({ transitions: [{ durationMs: 0 }] }),
+    ).rejects.toThrow(/duration/i);
+    await expect(
+      tool().handler({ transitions: [{ durationMs: -100 }] }),
+    ).rejects.toThrow(/duration/i);
+    await expect(
+      tool().handler({ transitions: [{ durationMs: Number.NaN }] }),
+    ).rejects.toThrow(/duration/i);
+    await expect(
+      tool().handler({ transitions: [{ durationMs: Number.POSITIVE_INFINITY }] }),
+    ).rejects.toThrow(/duration/i);
+    await expect(
+      tool().handler({ transitions: [{ durationMs: 'fast' as unknown as number }] }),
+    ).rejects.toThrow(/duration/i);
+  });
+
+  it('throws when a transition object is missing durationMs entirely', async () => {
+    await expect(
+      tool().handler({ transitions: [{ id: 't1' } as unknown as { durationMs: number }] }),
+    ).rejects.toThrow(/duration/i);
+  });
+
+  it('is deterministic — same input yields deep-equal output across calls', async () => {
+    const args = {
+      transitions: [
+        { id: 't1', durationMs: 400, type: 'fade' },
+        { id: 't2', durationMs: 600, type: 'zoom' },
+      ],
+    };
+    const a = await tool().handler(JSON.parse(JSON.stringify(args)));
+    const b = await tool().handler(JSON.parse(JSON.stringify(args)));
+    expect(a).toEqual(b);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Cross-cutting — purity / no side effects across all handlers
+// -----------------------------------------------------------------------------
+
+describe('sullivan tools — purity', () => {
+  it('does not mutate its input arguments', async () => {
+    const cases: Array<{ name: string; args: Record<string, unknown> }> = [
+      {
+        name: 'presentation_template',
+        args: { topic: 't', audience: 'a', learningObjective: 'o', timeBudgetMinutes: 10 },
+      },
+      {
+        name: 'presentation_outline_validate',
+        args: {
+          thesis: '',
+          narrativeArc: ['intro'],
+          steps: [makeStep({ id: 's1', title: 'A', oneIdea: true })],
+        },
+      },
+      {
+        name: 'presentation_critique',
+        args: { steps: [makeStep({ id: 's1', title: 'A', oneIdea: true })] },
+      },
+      {
+        name: 'presentation_contrast_check',
+        args: { pairs: [{ foreground: '#000000', background: '#ffffff' }] },
+      },
+      {
+        name: 'presentation_motion_budget',
+        args: { transitions: [{ id: 't1', durationMs: 400, type: 'fade' }] },
+      },
+    ];
+
+    for (const c of cases) {
+      const before = JSON.stringify(c.args);
+      await getTool(c.name).handler(c.args);
+      const after = JSON.stringify(c.args);
+      expect(after).toBe(before);
+    }
+  });
+});

--- a/packages/services/src/sullivan/tools.ts
+++ b/packages/services/src/sullivan/tools.ts
@@ -1,0 +1,758 @@
+/**
+ * Sullivan's five pure presentation tools.
+ *
+ * Each tool is a deterministic, side-effect-free function over its
+ * declared inputs. The five tools compose the Phase 1 / Phase 2
+ * primitives (`./contrast`, `./motionLimits`, `./rubric`) — no fresh
+ * math, no fs, no electron, no network, no global state.
+ *
+ * Validation failures (input that doesn't match the documented shape)
+ * **throw**, so the SDK surfaces them as tool errors. Rubric findings,
+ * contrast failures, and motion-budget violations are **successful
+ * returns** — the finding *is* the result.
+ *
+ * Phase 3 layering note:
+ *   `buildSullivanTools` accepts a `SullivanService` parameter to
+ *   mirror `buildCanvasTools` and reserve the wiring slot for the
+ *   Phase 4 service implementation. Phase 3 handlers compose the
+ *   Phase 1/2 modules directly and do not consume the service.
+ */
+
+import type { SessionTool } from '../a2a/tools';
+import { contrastRatio, passesAA, passesAAA } from './contrast';
+import {
+  MAX_AGGREGATE_TRANSITION_DURATION_MS,
+  MAX_TRANSITION_DURATION_MS,
+  REDUCED_MOTION_EQUIVALENT,
+  VESTIBULAR_RISKY_TRANSITIONS,
+} from './motionLimits';
+import {
+  MAX_STEP_WORD_COUNT,
+  RUBRIC,
+  type Finding,
+  type Severity,
+  type Step,
+} from './rubric';
+
+// -----------------------------------------------------------------------------
+// SullivanService — forward-declared interface (Phase 4 will implement).
+// -----------------------------------------------------------------------------
+
+/**
+ * Forward declaration for the concrete service that Phase 4 will
+ * implement. Phase 3 handlers compose the Phase 1/2 modules directly
+ * and do not call any service methods. The interface remains in
+ * `tools.ts` so the `buildSullivanTools(mindId, mindPath, service)`
+ * signature stays stable across phases — the wiring in Phase 4 / 5
+ * can pass a real service without touching the tool builder shape.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface SullivanService {}
+
+// -----------------------------------------------------------------------------
+// Public result types — exported so downstream consumers can import them.
+// -----------------------------------------------------------------------------
+
+export interface PresentationTemplateInput {
+  readonly topic: string;
+  readonly audience: string;
+  readonly learningObjective: string;
+  readonly timeBudgetMinutes?: number;
+}
+
+export interface PresentationTemplateGuidance {
+  readonly oneIdeaPerStep: true;
+  readonly maxWordsPerSlide: number;
+  readonly timeBudgetTargetMinutes: number | null;
+}
+
+export interface PresentationTemplateResult {
+  readonly thesis: '';
+  readonly narrativeArc: readonly string[];
+  readonly steps: readonly Step[];
+  readonly guidance: PresentationTemplateGuidance;
+}
+
+export interface OutlineValidateInput {
+  readonly thesis?: string;
+  readonly narrativeArc?: readonly string[];
+  readonly steps: readonly Step[];
+}
+
+export interface FindingSummary {
+  readonly blockCount: number;
+  readonly warnCount: number;
+  readonly noteCount: number;
+}
+
+export interface OutlineValidateResult {
+  readonly findings: readonly Finding[];
+  readonly summary: FindingSummary;
+}
+
+export interface CritiqueInput {
+  readonly steps: readonly Step[];
+}
+
+export interface PerStepFindings {
+  readonly stepId: string;
+  readonly findings: readonly Finding[];
+}
+
+export interface CritiqueResult {
+  readonly findings: readonly Finding[];
+  readonly perStep: readonly PerStepFindings[];
+  readonly summary: FindingSummary;
+}
+
+export interface ContrastPairInput {
+  readonly foreground: string;
+  readonly background: string;
+  readonly label?: string;
+}
+
+export interface ContrastCheckInput {
+  readonly pairs: readonly ContrastPairInput[];
+}
+
+export interface WcagLevelResult {
+  readonly largeText: boolean;
+  readonly normalText: boolean;
+}
+
+export interface ContrastCheckResult {
+  readonly label?: string;
+  readonly foreground: string;
+  readonly background: string;
+  readonly ratio: number;
+  readonly AA: WcagLevelResult;
+  readonly AAA: WcagLevelResult;
+  readonly recommendation: string;
+}
+
+export interface TransitionInput {
+  readonly id?: string;
+  readonly durationMs: number;
+  readonly type?: string;
+}
+
+export interface MotionBudgetInput {
+  readonly transitions: readonly TransitionInput[];
+}
+
+export interface PerTransitionResult {
+  readonly id?: string;
+  readonly durationMs: number;
+  readonly type?: string;
+  readonly withinPerTransitionBudget: boolean;
+  readonly reducedMotionEquivalent: string;
+  readonly recommendation: string;
+}
+
+export interface AggregateMotionResult {
+  readonly totalDurationMs: number;
+  readonly withinAggregateBudget: boolean;
+  readonly recommendation: string;
+}
+
+export interface MotionBudgetResult {
+  readonly perTransition: readonly PerTransitionResult[];
+  readonly aggregate: AggregateMotionResult;
+}
+
+// -----------------------------------------------------------------------------
+// Default safe reduced-motion fallback for transitions with no declared type.
+// Sourced from REDUCED_MOTION_EQUIVALENT (zoom/parallax/spin/flip → fade) so
+// the fallback stays coherent with the same map.
+// -----------------------------------------------------------------------------
+
+const DEFAULT_REDUCED_MOTION_EQUIVALENT = 'fade';
+
+// -----------------------------------------------------------------------------
+// Input validation — throws Error on malformed input so the SDK surfaces it.
+// -----------------------------------------------------------------------------
+
+function asObject(args: unknown, label: string): Record<string, unknown> {
+  if (typeof args !== 'object' || args === null || Array.isArray(args)) {
+    throw new Error(`${label} input must be an object.`);
+  }
+  return args as Record<string, unknown>;
+}
+
+function requireNonBlankString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`"${label}" is required and must be a non-empty string.`);
+  }
+  return value;
+}
+
+function validatePositiveFiniteNumber(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`"${label}" must be a positive finite number.`);
+  }
+  return value;
+}
+
+function validateTemplateInput(args: unknown): {
+  topic: string;
+  audience: string;
+  learningObjective: string;
+  timeBudgetMinutes: number | null;
+} {
+  const obj = asObject(args, 'presentation_template');
+  const topic = requireNonBlankString(obj.topic, 'topic');
+  const audience = requireNonBlankString(obj.audience, 'audience');
+  const learningObjective = requireNonBlankString(obj.learningObjective, 'learningObjective');
+  let timeBudgetMinutes: number | null = null;
+  if (obj.timeBudgetMinutes !== undefined && obj.timeBudgetMinutes !== null) {
+    timeBudgetMinutes = validatePositiveFiniteNumber(obj.timeBudgetMinutes, 'timeBudgetMinutes');
+  }
+  return { topic, audience, learningObjective, timeBudgetMinutes };
+}
+
+function validateSteps(steps: readonly unknown[]): readonly Step[] {
+  const seenIds = new Set<string>();
+  for (let i = 0; i < steps.length; i += 1) {
+    const raw = steps[i];
+    if (typeof raw !== 'object' || raw === null) {
+      throw new Error(`Step at index ${i} must be an object.`);
+    }
+    const step = raw as Record<string, unknown>;
+
+    if (typeof step.id !== 'string' || step.id.length === 0) {
+      throw new Error(`Step at index ${i} is missing required field "id".`);
+    }
+    if (typeof step.title !== 'string' || step.title.length === 0) {
+      throw new Error(`Step "${step.id}" is missing required field "title".`);
+    }
+    if (seenIds.has(step.id)) {
+      throw new Error(`Duplicate step id "${step.id}" at index ${i}.`);
+    }
+    seenIds.add(step.id);
+
+    if (step.oneIdea !== undefined && typeof step.oneIdea !== 'boolean') {
+      throw new Error(`Step "${step.id}" field "oneIdea" must be a boolean when provided.`);
+    }
+    if (step.content !== undefined && typeof step.content !== 'string') {
+      throw new Error(`Step "${step.id}" field "content" must be a string when provided.`);
+    }
+    if (step.narrativeBridge !== undefined && typeof step.narrativeBridge !== 'string') {
+      throw new Error(`Step "${step.id}" field "narrativeBridge" must be a string when provided.`);
+    }
+    validateStepTransitions(step.id, step.transitions);
+    validateStepImages(step.id, step.images);
+  }
+  return steps as readonly Step[];
+}
+
+function validateStepTransitions(stepId: string, transitions: unknown): void {
+  if (transitions === undefined) return;
+  if (!Array.isArray(transitions)) {
+    throw new Error(`Step "${stepId}" field "transitions" must be an array when provided.`);
+  }
+  for (let j = 0; j < transitions.length; j += 1) {
+    const t = transitions[j];
+    if (typeof t !== 'object' || t === null) {
+      throw new Error(`Step "${stepId}" transition at index ${j} must be an object.`);
+    }
+    const tr = t as Record<string, unknown>;
+    if (typeof tr.name !== 'string' || tr.name.length === 0) {
+      throw new Error(`Step "${stepId}" transition at index ${j} is missing required field "name".`);
+    }
+    if (typeof tr.durationMs !== 'number' || !Number.isFinite(tr.durationMs) || tr.durationMs < 0) {
+      throw new Error(
+        `Step "${stepId}" transition "${tr.name}" has invalid durationMs (must be a non-negative finite number).`,
+      );
+    }
+  }
+}
+
+function validateStepImages(stepId: string, images: unknown): void {
+  if (images === undefined) return;
+  if (!Array.isArray(images)) {
+    throw new Error(`Step "${stepId}" field "images" must be an array when provided.`);
+  }
+  for (let j = 0; j < images.length; j += 1) {
+    const img = images[j];
+    if (typeof img !== 'object' || img === null) {
+      throw new Error(`Step "${stepId}" image at index ${j} must be an object.`);
+    }
+    const im = img as Record<string, unknown>;
+    if (typeof im.src !== 'string' || im.src.length === 0) {
+      throw new Error(`Step "${stepId}" image at index ${j} is missing required field "src".`);
+    }
+  }
+}
+
+function validateOutlineInput(args: unknown): {
+  thesis: string;
+  narrativeArc: readonly string[];
+  steps: readonly Step[];
+} {
+  const obj = asObject(args, 'presentation_outline_validate');
+  if (obj.thesis !== undefined && typeof obj.thesis !== 'string') {
+    throw new Error('"thesis" must be a string when provided.');
+  }
+  if (obj.narrativeArc !== undefined) {
+    if (!Array.isArray(obj.narrativeArc)) {
+      throw new Error('"narrativeArc" must be an array of strings when provided.');
+    }
+    for (const item of obj.narrativeArc) {
+      if (typeof item !== 'string') {
+        throw new Error('"narrativeArc" items must be strings.');
+      }
+    }
+  }
+  if (obj.steps === undefined) {
+    throw new Error('"steps" is required.');
+  }
+  if (!Array.isArray(obj.steps)) {
+    throw new Error('"steps" must be an array.');
+  }
+  const steps = validateSteps(obj.steps);
+  return {
+    thesis: (obj.thesis as string | undefined) ?? '',
+    narrativeArc: (obj.narrativeArc as readonly string[] | undefined) ?? [],
+    steps,
+  };
+}
+
+function validateCritiqueInput(args: unknown): readonly Step[] {
+  const obj = asObject(args, 'presentation_critique');
+  if (obj.steps === undefined) {
+    throw new Error('"steps" is required.');
+  }
+  if (!Array.isArray(obj.steps)) {
+    throw new Error('"steps" must be an array.');
+  }
+  return validateSteps(obj.steps);
+}
+
+function validateContrastInput(args: unknown): readonly ContrastPairInput[] {
+  const obj = asObject(args, 'presentation_contrast_check');
+  if (obj.pairs === undefined) {
+    throw new Error('"pairs" is required.');
+  }
+  if (!Array.isArray(obj.pairs)) {
+    throw new Error('"pairs" must be an array.');
+  }
+  const pairs: ContrastPairInput[] = [];
+  for (let i = 0; i < obj.pairs.length; i += 1) {
+    const raw = obj.pairs[i];
+    if (typeof raw !== 'object' || raw === null) {
+      throw new Error(`Pair at index ${i} must be an object.`);
+    }
+    const pair = raw as Record<string, unknown>;
+    if (typeof pair.foreground !== 'string' || pair.foreground.length === 0) {
+      throw new Error(`Pair at index ${i} requires "foreground" as a non-empty string.`);
+    }
+    if (typeof pair.background !== 'string' || pair.background.length === 0) {
+      throw new Error(`Pair at index ${i} requires "background" as a non-empty string.`);
+    }
+    if (pair.label !== undefined && typeof pair.label !== 'string') {
+      throw new Error(`Pair at index ${i} field "label" must be a string when provided.`);
+    }
+    pairs.push({
+      foreground: pair.foreground,
+      background: pair.background,
+      ...(pair.label !== undefined ? { label: pair.label as string } : {}),
+    });
+  }
+  return pairs;
+}
+
+function validateMotionInput(args: unknown): readonly TransitionInput[] {
+  const obj = asObject(args, 'presentation_motion_budget');
+  if (obj.transitions === undefined) {
+    throw new Error('"transitions" is required.');
+  }
+  if (!Array.isArray(obj.transitions)) {
+    throw new Error('"transitions" must be an array.');
+  }
+  const transitions: TransitionInput[] = [];
+  for (let i = 0; i < obj.transitions.length; i += 1) {
+    const raw = obj.transitions[i];
+    if (typeof raw !== 'object' || raw === null) {
+      throw new Error(`Transition at index ${i} must be an object.`);
+    }
+    const tx = raw as Record<string, unknown>;
+    if (
+      typeof tx.durationMs !== 'number' ||
+      !Number.isFinite(tx.durationMs) ||
+      tx.durationMs <= 0
+    ) {
+      throw new Error(
+        `Transition at index ${i} has invalid durationMs (must be a positive finite number).`,
+      );
+    }
+    if (tx.id !== undefined && typeof tx.id !== 'string') {
+      throw new Error(`Transition at index ${i} field "id" must be a string when provided.`);
+    }
+    if (tx.type !== undefined && typeof tx.type !== 'string') {
+      throw new Error(`Transition at index ${i} field "type" must be a string when provided.`);
+    }
+    transitions.push({
+      durationMs: tx.durationMs,
+      ...(tx.id !== undefined ? { id: tx.id as string } : {}),
+      ...(tx.type !== undefined ? { type: tx.type as string } : {}),
+    });
+  }
+  return transitions;
+}
+
+// -----------------------------------------------------------------------------
+// Composition helpers — wrap the Phase 1 / Phase 2 modules.
+// -----------------------------------------------------------------------------
+
+function runRubricPerStep(steps: readonly Step[]): {
+  global: Finding[];
+  perStep: PerStepFindings[];
+} {
+  const perStepFindings: Finding[][] = steps.map(() => []);
+  const global: Finding[] = [];
+  // Rule-major, step-minor iteration so the global order matches the
+  // RUBRIC declaration order and is stable across calls.
+  for (const rule of RUBRIC) {
+    for (let index = 0; index < steps.length; index += 1) {
+      const finding = rule.evaluator(steps[index], { allSteps: steps, index });
+      if (finding !== null) {
+        global.push(finding);
+        perStepFindings[index].push(finding);
+      }
+    }
+  }
+  const perStep: PerStepFindings[] = steps.map((step, i) => ({
+    stepId: step.id,
+    findings: perStepFindings[i],
+  }));
+  return { global, perStep };
+}
+
+function summarize(findings: readonly Finding[]): FindingSummary {
+  let blockCount = 0;
+  let warnCount = 0;
+  let noteCount = 0;
+  for (const f of findings) {
+    const severity: Severity = f.severity;
+    if (severity === 'block') blockCount += 1;
+    else if (severity === 'warn') warnCount += 1;
+    else noteCount += 1;
+  }
+  return { blockCount, warnCount, noteCount };
+}
+
+function recommendContrast(ratio: number): string {
+  if (passesAAA(ratio, false)) {
+    return `Passes WCAG AAA for both normal and large text (ratio ${ratio.toFixed(2)}).`;
+  }
+  if (passesAA(ratio, false)) {
+    return (
+      `Passes WCAG AA for normal text and AAA for large text only ` +
+      `(ratio ${ratio.toFixed(2)}); increase contrast to meet AAA for normal text.`
+    );
+  }
+  if (passesAA(ratio, true)) {
+    return (
+      `Passes WCAG AA for large text only (ratio ${ratio.toFixed(2)}); ` +
+      `fails AA for normal text — increase contrast (WCAG 1.4.3).`
+    );
+  }
+  return (
+    `Fails WCAG AA at every text size (ratio ${ratio.toFixed(2)}); ` +
+    `increase contrast significantly (WCAG 1.4.3 / 1.4.6).`
+  );
+}
+
+function computeReducedMotionEquivalent(type: string | undefined): string {
+  if (type === undefined) return DEFAULT_REDUCED_MOTION_EQUIVALENT;
+  if (VESTIBULAR_RISKY_TRANSITIONS.has(type)) {
+    return REDUCED_MOTION_EQUIVALENT[type];
+  }
+  return type;
+}
+
+function recommendTransition(
+  transition: TransitionInput,
+  withinBudget: boolean,
+  reducedEquivalent: string,
+): string {
+  const reasons: string[] = [];
+  if (!withinBudget) {
+    reasons.push(
+      `Exceeds per-transition cap of ${MAX_TRANSITION_DURATION_MS}ms (WCAG 2.2.2) — ` +
+        `reduce duration to ≤ ${MAX_TRANSITION_DURATION_MS}ms.`,
+    );
+  }
+  if (transition.type !== undefined && VESTIBULAR_RISKY_TRANSITIONS.has(transition.type)) {
+    reasons.push(
+      `Vestibular risk (WCAG 2.3.3) — provide "${reducedEquivalent}" as the ` +
+        `prefers-reduced-motion fallback.`,
+    );
+  }
+  if (reasons.length === 0) {
+    return (
+      `Within per-transition budget ` +
+      `(${transition.durationMs}/${MAX_TRANSITION_DURATION_MS}ms).`
+    );
+  }
+  return reasons.join(' ');
+}
+
+function recommendAggregate(totalDurationMs: number, withinBudget: boolean): string {
+  if (withinBudget) {
+    return (
+      `Within aggregate motion budget ` +
+      `(${totalDurationMs}/${MAX_AGGREGATE_TRANSITION_DURATION_MS}ms).`
+    );
+  }
+  const overBy = totalDurationMs - MAX_AGGREGATE_TRANSITION_DURATION_MS;
+  return (
+    `Exceeds aggregate motion budget by ${overBy}ms — trim transitions ` +
+    `to bring the total ≤ ${MAX_AGGREGATE_TRANSITION_DURATION_MS}ms (WCAG 2.2.2 / 2.3.3).`
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Handlers
+// -----------------------------------------------------------------------------
+
+async function handlePresentationTemplate(
+  args: Record<string, unknown>,
+): Promise<PresentationTemplateResult> {
+  const input = validateTemplateInput(args);
+  // The template is canonical (empty scaffold). Inputs are validated to
+  // surface bad calls but do not feed into the returned shape — that's
+  // the contract: an empty outline + structural guidance, deterministic
+  // across every well-formed call.
+  void input.topic;
+  void input.audience;
+  void input.learningObjective;
+  return {
+    thesis: '',
+    narrativeArc: [],
+    steps: [],
+    guidance: {
+      oneIdeaPerStep: true,
+      maxWordsPerSlide: MAX_STEP_WORD_COUNT,
+      timeBudgetTargetMinutes: input.timeBudgetMinutes,
+    },
+  };
+}
+
+async function handlePresentationOutlineValidate(
+  args: Record<string, unknown>,
+): Promise<OutlineValidateResult> {
+  const { steps } = validateOutlineInput(args);
+  const { global } = runRubricPerStep(steps);
+  return { findings: global, summary: summarize(global) };
+}
+
+async function handlePresentationCritique(
+  args: Record<string, unknown>,
+): Promise<CritiqueResult> {
+  const steps = validateCritiqueInput(args);
+  const { global, perStep } = runRubricPerStep(steps);
+  return { findings: global, perStep, summary: summarize(global) };
+}
+
+async function handlePresentationContrastCheck(
+  args: Record<string, unknown>,
+): Promise<readonly ContrastCheckResult[]> {
+  const pairs = validateContrastInput(args);
+  // contrastRatio throws on malformed hex via parseHexColor — that
+  // throw propagates out and the SDK surfaces it as a tool error.
+  return pairs.map((p) => {
+    const ratio = contrastRatio(p.foreground, p.background);
+    const aa: WcagLevelResult = {
+      largeText: passesAA(ratio, true),
+      normalText: passesAA(ratio, false),
+    };
+    const aaa: WcagLevelResult = {
+      largeText: passesAAA(ratio, true),
+      normalText: passesAAA(ratio, false),
+    };
+    return {
+      ...(p.label !== undefined ? { label: p.label } : {}),
+      foreground: p.foreground,
+      background: p.background,
+      ratio,
+      AA: aa,
+      AAA: aaa,
+      recommendation: recommendContrast(ratio),
+    };
+  });
+}
+
+async function handlePresentationMotionBudget(
+  args: Record<string, unknown>,
+): Promise<MotionBudgetResult> {
+  const transitions = validateMotionInput(args);
+  let totalDurationMs = 0;
+  const perTransition: PerTransitionResult[] = transitions.map((t) => {
+    totalDurationMs += t.durationMs;
+    const withinPer = t.durationMs <= MAX_TRANSITION_DURATION_MS;
+    const reducedMotionEquivalent = computeReducedMotionEquivalent(t.type);
+    return {
+      ...(t.id !== undefined ? { id: t.id } : {}),
+      durationMs: t.durationMs,
+      ...(t.type !== undefined ? { type: t.type } : {}),
+      withinPerTransitionBudget: withinPer,
+      reducedMotionEquivalent,
+      recommendation: recommendTransition(t, withinPer, reducedMotionEquivalent),
+    };
+  });
+  const withinAggregateBudget = totalDurationMs <= MAX_AGGREGATE_TRANSITION_DURATION_MS;
+  return {
+    perTransition,
+    aggregate: {
+      totalDurationMs,
+      withinAggregateBudget,
+      recommendation: recommendAggregate(totalDurationMs, withinAggregateBudget),
+    },
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Builder
+// -----------------------------------------------------------------------------
+
+/**
+ * Build the five Sullivan presentation tools for a session. Mirrors
+ * `buildCanvasTools(mindId, mindPath, service)` so the composition root
+ * can wire Sullivan the same way it wires Canvas.
+ *
+ * Phase 3: handlers compose Phase 1 / Phase 2 modules directly and
+ * the `service` parameter is reserved for Phase 4's concrete service.
+ */
+export function buildSullivanTools(
+  mindId: string,
+  mindPath: string,
+  service: SullivanService,
+): SessionTool[] {
+  // Reserved for Phase 4 wiring. The signature stays stable so the
+  // composition root won't need to change when the real service lands.
+  void mindId;
+  void mindPath;
+  void service;
+
+  return [
+    {
+      name: 'presentation_template',
+      description:
+        'Return a canonical empty outline scaffold (thesis, narrativeArc, steps) plus the structural guidance constants (one idea per step, max words per slide, time-budget target) the author should use when filling it in.',
+      parameters: {
+        type: 'object',
+        properties: {
+          topic: { type: 'string', description: 'The subject of the presentation.' },
+          audience: { type: 'string', description: 'Who the presentation is for.' },
+          learningObjective: {
+            type: 'string',
+            description: 'What the audience should be able to do or know after the presentation.',
+          },
+          timeBudgetMinutes: {
+            type: 'number',
+            description: 'Optional target total presentation length in minutes (must be a positive finite number).',
+          },
+        },
+        required: ['topic', 'audience', 'learningObjective'],
+      },
+      handler: handlePresentationTemplate,
+    },
+    {
+      name: 'presentation_outline_validate',
+      description:
+        'Run the Sullivan pedagogy + accessibility rubric across an outline and return the findings plus a severity-bucketed summary. Findings (including block-severity) are a successful return — only malformed input throws.',
+      parameters: {
+        type: 'object',
+        properties: {
+          thesis: { type: 'string', description: 'Optional outline thesis statement.' },
+          narrativeArc: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional ordered list of narrative beats for the outline.',
+          },
+          steps: {
+            type: 'array',
+            description: 'Steps in the outline. Each step requires id and title.',
+            items: { type: 'object' },
+          },
+        },
+        required: ['steps'],
+      },
+      handler: handlePresentationOutlineValidate,
+    },
+    {
+      name: 'presentation_critique',
+      description:
+        'Run the full Sullivan rubric across drafted steps and return findings, a per-step breakdown, and a severity summary. Block-severity findings are a successful return; malformed step input throws.',
+      parameters: {
+        type: 'object',
+        properties: {
+          steps: {
+            type: 'array',
+            description: 'Steps in the drafted outline. Each step requires id and title.',
+            items: { type: 'object' },
+          },
+        },
+        required: ['steps'],
+      },
+      handler: handlePresentationCritique,
+    },
+    {
+      name: 'presentation_contrast_check',
+      description:
+        'Compute WCAG 2.1 contrast ratios for an array of foreground / background colour pairs and return AA + AAA pass/fail (normal and large text) plus a recommendation. Malformed hex throws.',
+      parameters: {
+        type: 'object',
+        properties: {
+          pairs: {
+            type: 'array',
+            description: 'Foreground / background colour pairs to evaluate.',
+            items: {
+              type: 'object',
+              properties: {
+                foreground: { type: 'string', description: 'Foreground colour (hex, e.g. "#1a1a1a").' },
+                background: { type: 'string', description: 'Background colour (hex, e.g. "#ffffff").' },
+                label: { type: 'string', description: 'Optional label for the pair (e.g. "body text").' },
+              },
+              required: ['foreground', 'background'],
+            },
+          },
+        },
+        required: ['pairs'],
+      },
+      handler: handlePresentationContrastCheck,
+    },
+    {
+      name: 'presentation_motion_budget',
+      description:
+        'Check transitions against the Sullivan per-transition (800ms, WCAG 2.2.2) and aggregate (4000ms, WCAG 2.2.2 / 2.3.3) motion budgets. Returns per-transition status with a vestibular-safe reduced-motion equivalent plus an aggregate budget verdict. Non-finite / non-positive durations throw.',
+      parameters: {
+        type: 'object',
+        properties: {
+          transitions: {
+            type: 'array',
+            description: 'Transitions to evaluate against the motion budget.',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', description: 'Optional transition identifier.' },
+                durationMs: {
+                  type: 'number',
+                  description: 'Transition duration in milliseconds (positive, finite).',
+                },
+                type: {
+                  type: 'string',
+                  description: 'Optional transition kind (e.g. "fade", "zoom", "parallax").',
+                },
+              },
+              required: ['durationMs'],
+            },
+          },
+        },
+        required: ['transitions'],
+      },
+      handler: handlePresentationMotionBudget,
+    },
+  ];
+}

--- a/packages/services/src/sullivan/types.ts
+++ b/packages/services/src/sullivan/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Public type surface for the Sullivan presentation capability.
+ *
+ * This barrel re-exports the shared pedagogy / accessibility types from
+ * `./rubric` and the tool input/output result types from `./tools` so
+ * downstream consumers can import everything from one place:
+ *
+ *   import type { Step, Finding, CritiqueResult } from '@chamber/services/sullivan';
+ *
+ * `SullivanService` is declared in `./tools` (to keep this phase's diff
+ * additive) and re-exported here. The public symbol name is stable —
+ * Phase 5's composition root references it through this barrel.
+ *
+ * Internal helpers (`validateSteps`, `runRubricPerStep`,
+ * `recommendContrast`, `recommendTransition`, `summarize`) are not
+ * re-exported and remain module-private to `./tools`. Motion-limit and
+ * rubric constants (`MAX_TRANSITION_DURATION_MS`, `RUBRIC`,
+ * `MAX_STEP_WORD_COUNT`, ...) are reachable through their owning module
+ * paths and are intentionally not part of the public type surface.
+ */
+
+// -----------------------------------------------------------------------------
+// Shared pedagogy / accessibility types — sourced from the rubric.
+// -----------------------------------------------------------------------------
+
+export type {
+  Step,
+  Finding,
+  Rule,
+  Severity,
+  RuleCategory,
+  ImageRef,
+  TransitionRef,
+  RubricContext,
+  RuleEvaluator,
+} from './rubric';
+
+// -----------------------------------------------------------------------------
+// Tool input / output public types — sourced from the tool builder.
+// -----------------------------------------------------------------------------
+
+export type {
+  SullivanService,
+  PresentationTemplateInput,
+  PresentationTemplateGuidance,
+  PresentationTemplateResult,
+  OutlineValidateInput,
+  OutlineValidateResult,
+  CritiqueInput,
+  CritiqueResult,
+  PerStepFindings,
+  ContrastPairInput,
+  ContrastCheckInput,
+  ContrastCheckResult,
+  WcagLevelResult,
+  TransitionInput,
+  MotionBudgetInput,
+  MotionBudgetResult,
+  PerTransitionResult,
+  AggregateMotionResult,
+  FindingSummary,
+} from './tools';


### PR DESCRIPTION
## Summary

Adds the Sullivan presentation-pedagogy tool provider: an in-process `ChamberToolProvider` (`SullivanToolsService` in `@chamber/services`) that exposes five pure presentation tools to any mind — `presentation_template`, `presentation_outline_validate`, `presentation_critique`, `presentation_contrast_check`, and `presentation_motion_budget`. Built on two deterministic primitives (WCAG contrast ratio + per-transition / aggregate motion budgets) and a cross-step rubric, with full unit coverage and a barrel → service → handler → primitive integration smoke. Wired into both composition roots (`apps/desktop/src/main.ts` and `apps/server/src/bin.ts`) via the `@chamber/services` package barrel. Stateless v1: `activateMind` / `releaseMind` are intentional no-ops.

## Test plan

- `npm run typecheck` → exit 0
- `npm run lint` (= `tsc --noEmit && eslint . && npm run deps:check`) → exit 0; depcruise: 0 violations across 433 modules / 864 dependencies
- `npm test` → exit 0; 1741 / 1741 tests passing across 160 test files

## Release notes

- `CHANGELOG.md`: new `## v0.62.0 (2026-05-14)` entry under `### Sullivan`.
- `package.json`: 0.61.0 → 0.62.0 (minor — new feature).
- `package-lock.json`: regenerated via full `npm install`. Every `@emnapi/core` (6) and `@emnapi/runtime` (7) optional cross-platform entry preserved (npm's `--package-lock-only` is known to strip these on the npm version this dev environment ships — full `npm install` was used per the stored lockfile-maintenance memory).

Fixes #6
