### PR TITLE
Test signed macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,54 @@ jobs:
           path: staged/*
           if-no-files-found: error
 
+  build-macos:
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build signed macOS package
+        run: npm run make:builder:mac
+        env:
+          CHAMBER_MACOS_SIGNING: 'true'
+          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Stage artifacts
+        run: |
+          version="${{ needs.check-version.outputs.version }}"
+          mkdir -p staged
+          cp out/builder/Chamber-"$version"-*.dmg staged/
+          cp out/builder/Chamber-"$version"-*.dmg.blockmap staged/
+          cp out/builder/Chamber-"$version"-*.zip staged/
+          cp out/builder/Chamber-"$version"-*.zip.blockmap staged/
+          cp out/builder/latest-mac.yml staged/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos
+          path: staged/*
+          if-no-files-found: error
+
   release:
-    needs: [check-version, build]
+    needs: [check-version, build, build-macos]
     if: needs.check-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -135,8 +181,9 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release-windows
+          pattern: release-*
           path: artifacts
+          merge-multiple: true
 
       - name: Display downloaded files
         run: find artifacts -type f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.62.1 (2026-05-15)
+
+### Release
+
+- **Test signed macOS release artifacts** — Adds a macOS release workflow leg that builds signed DMG and ZIP artifacts from the Developer ID Application certificate stored in GitHub Actions secrets, then includes those artifacts in the GitHub Release alongside Windows.
+
 ## v0.62.0 (2026-05-14)
 
 ### A2A

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.62.0",
+      "version": "0.62.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary\n- bump to v0.62.1 for a release workflow test\n- add a macOS release job that signs/notarizes using GitHub Actions secrets\n- upload macOS DMG/ZIP artifacts alongside Windows artifacts\n\n## Validation\n- parsed .github/workflows/release.yml as YAML\n- git diff --check