### PR TITLE
Fix macOS notarization config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           CSC_LINK: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Stage artifacts

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -9,7 +9,7 @@ const macNotarizeEnabled =
   macSigningEnabled
   && Boolean(process.env.APPLE_TEAM_ID)
   && Boolean(process.env.APPLE_ID)
-  && Boolean(process.env.APPLE_ID_PASSWORD);
+  && Boolean(process.env.APPLE_APP_SPECIFIC_PASSWORD);
 
 function requireEnv(name) {
   const value = process.env[name]?.trim();
@@ -90,9 +90,7 @@ const config = {
     ...(macSigningEnabled
       ? {
           identity: process.env.CHAMBER_MACOS_IDENTITY?.trim() || undefined,
-          ...(macNotarizeEnabled
-            ? { notarize: { teamId: process.env.APPLE_TEAM_ID } }
-            : {}),
+          notarize: macNotarizeEnabled,
         }
       : { identity: null }),
   },


### PR DESCRIPTION
## Summary\n- use electron-builder 26's boolean mac.notarize option\n- expose the app-specific password as APPLE_APP_SPECIFIC_PASSWORD for notarization\n\n## Validation\n- parsed .github/workflows/release.yml as YAML\n- loaded electron-builder config with macOS signing/notarization env enabled\n- git diff --check