### PR TITLE
Fix macOS CI app signing runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,11 +153,14 @@ jobs:
         run: |
           keychain="$RUNNER_TEMP/chamber-signing.keychain-db"
           certificate="$RUNNER_TEMP/chamber-signing.p12"
+          intermediate="$RUNNER_TEMP/DeveloperIDG2CA.cer"
           echo "$MACOS_CERTIFICATE_BASE64" | base64 --decode > "$certificate"
+          curl -fsSL https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer -o "$intermediate"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
           security import "$certificate" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security add-certificates -k "$keychain" "$intermediate"
           security list-keychains -d user -s "$keychain" login.keychain-db
           security default-keychain -d user -s "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"

--- a/scripts/prepare-node-runtime.js
+++ b/scripts/prepare-node-runtime.js
@@ -57,6 +57,24 @@ function validateRuntimeDir(rootDir) {
   return { nodeBinary, npmCli };
 }
 
+function materializeRuntimeCommandSymlinks(rootDir) {
+  if (process.platform === 'win32') return;
+
+  const binDir = path.join(rootDir, 'bin');
+  for (const command of ['corepack', 'npm', 'npx']) {
+    const binPath = path.join(binDir, command);
+    if (!fs.existsSync(binPath) || !fs.lstatSync(binPath).isSymbolicLink()) {
+      continue;
+    }
+
+    const linkTarget = fs.readlinkSync(binPath);
+    const targetPath = path.resolve(binDir, linkTarget);
+    fs.rmSync(binPath);
+    fs.cpSync(targetPath, binPath);
+    fs.chmodSync(binPath, 0o755);
+  }
+}
+
 function quotePowerShell(value) {
   return `'${value.replace(/'/g, "''")}'`;
 }
@@ -131,6 +149,7 @@ function promoteRuntime(extractedDir, version) {
   fs.rmSync(backupDir, { recursive: true, force: true });
 
   fs.cpSync(extractedDir, stagingDir, { recursive: true, dereference: true });
+  materializeRuntimeCommandSymlinks(stagingDir);
   fs.writeFileSync(path.join(stagingDir, 'version.txt'), version, 'utf-8');
   validateRuntimeDir(stagingDir);
 

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -60,6 +60,7 @@ describe('packaging scripts', () => {
     expect(prepareBuilder).toContain('CHAMBER_WINDOWS_SIGNING');
     expect(prepareBuilder).toContain("path.join(outputDir, 'Chamber.app')");
     expect(prepareNodeRuntime).toContain('dereference: true');
+    expect(prepareNodeRuntime).toContain('materializeRuntimeCommandSymlinks');
     expect(signMacPrepackaged).toContain('electron-osx-sign');
     expect(signMacPrepackaged).toContain('CHAMBER_MACOS_SIGNING');
     expect(validateBuilder).toContain('assertAppUpdatePublisherName');
@@ -68,6 +69,7 @@ describe('packaging scripts', () => {
     expect(releaseWorkflow).toContain('azure/login@v2');
     expect(releaseWorkflow).toContain('CHAMBER_REQUIRE_WINDOWS_SIGNATURE');
     expect(releaseWorkflow).toContain('Import macOS signing certificate');
+    expect(releaseWorkflow).toContain('DeveloperIDG2CA.cer');
     expect(releaseWorkflow).toContain('security import "$certificate"');
     expect(releaseWorkflow).toContain('security set-key-partition-list');
     expect(releaseWorkflow).toContain('release-macos-${{ matrix.arch }}');


### PR DESCRIPTION
## Summary\n- materialize Node runtime command shims so macOS app signing does not see broken symlinks\n- install the Developer ID G2 intermediate certificate in the CI signing keychain\n\n## Validation\n- npm test -- tests/regression/packaging-scripts.test.ts\n- parsed .github/workflows/release.yml as YAML\n- local fresh signed macOS build verifies app and DMG signatures