### PR TITLE
Make macOS CI certificate import idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
           security import "$certificate" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
-          security add-certificates -k "$keychain" "$intermediate"
+          security add-certificates -k "$keychain" "$intermediate" || true
           security list-keychains -d user -s "$keychain" login.keychain-db
           security default-keychain -d user -s "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -70,6 +70,7 @@ describe('packaging scripts', () => {
     expect(releaseWorkflow).toContain('CHAMBER_REQUIRE_WINDOWS_SIGNATURE');
     expect(releaseWorkflow).toContain('Import macOS signing certificate');
     expect(releaseWorkflow).toContain('DeveloperIDG2CA.cer');
+    expect(releaseWorkflow).toContain('security add-certificates -k "$keychain" "$intermediate" || true');
     expect(releaseWorkflow).toContain('security import "$certificate"');
     expect(releaseWorkflow).toContain('security set-key-partition-list');
     expect(releaseWorkflow).toContain('release-macos-${{ matrix.arch }}');


### PR DESCRIPTION
## Summary\n- allow the Developer ID G2 intermediate install to be a no-op when the p12 already includes it\n\n## Validation\n- npm test -- tests/regression/packaging-scripts.test.ts\n- parsed .github/workflows/release.yml as YAML