### PR TITLE
Unblock macOS release on arm64 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,15 +125,7 @@ jobs:
   build-macos:
     needs: check-version
     if: needs.check-version.outputs.should_release == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: arm64
-            runner: macos-latest
-          - arch: x64
-            runner: macos-13
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     permissions:
       contents: read
     steps:
@@ -168,7 +160,7 @@ jobs:
         env:
           MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ github.run_id }}-${{ matrix.arch }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}-macos
 
       - name: Build signed macOS package
         run: npm run make:builder:mac
@@ -193,7 +185,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-macos-${{ matrix.arch }}
+          name: release-macos
           path: staged/*
           if-no-files-found: error
 

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -73,9 +73,10 @@ describe('packaging scripts', () => {
     expect(releaseWorkflow).toContain('security add-certificates -k "$keychain" "$intermediate" || true');
     expect(releaseWorkflow).toContain('security import "$certificate"');
     expect(releaseWorkflow).toContain('security set-key-partition-list');
-    expect(releaseWorkflow).toContain('release-macos-${{ matrix.arch }}');
-    expect(releaseWorkflow).toContain('runner: macos-13');
+    expect(releaseWorkflow).toContain('name: release-macos');
+    expect(releaseWorkflow).toContain('runs-on: macos-latest');
     expect(releaseWorkflow).not.toContain('AZURE_CLIENT_SECRET');
+    expect(releaseWorkflow).not.toContain('macos-13');
   });
 
   it('shares the packaged renderer path across Forge, Vite, and sandbox preflight', () => {


### PR DESCRIPTION
## Summary\n- publish signed arm64 macOS artifacts from macos-latest for this release path\n- avoid blocking releases on unavailable macos-13 Intel runner capacity\n\n## Validation\n- npm test -- tests/regression/packaging-scripts.test.ts\n- parsed .github/workflows/release.yml as YAML