### PR TITLE
Notarize macOS app before packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.62.3 (2026-05-15)
+
+### Release
+
+- **Staple notarization tickets into macOS apps** — Notarizes and staples the signed prepackaged `Chamber.app` before DMG/ZIP creation so downloaded Developer ID builds pass Gatekeeper instead of showing the unverified malware warning.
+
 ## v0.62.2 (2026-05-15)
 
 ### Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.62.2",
+  "version": "0.62.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.62.2",
+      "version": "0.62.3",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.62.2",
+  "version": "0.62.3",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,
@@ -15,7 +15,7 @@
     "make": "npm run make:builder",
     "make:forge": "npm --workspace @chamber/server run build && node scripts/prepare-node-runtime.js && electron-forge make",
     "make:builder": "npm run package && node scripts/prepare-builder-prepackaged.js && electron-builder --win nsis --x64 --prepackaged out/Chamber-win32-x64 --config config/electron-builder.config.cjs --publish never",
-    "make:builder:mac": "npm run package && node scripts/prepare-builder-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && node scripts/sign-macos-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && electron-builder --mac --$(node -p \"process.arch\") --prepackaged out/Chamber-darwin-$(node -p \"process.arch\")/Chamber.app --config config/electron-builder.config.cjs --publish never",
+    "make:builder:mac": "npm run package && node scripts/prepare-builder-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && node scripts/sign-macos-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && node scripts/notarize-macos-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && electron-builder --mac --$(node -p \"process.arch\") --prepackaged out/Chamber-darwin-$(node -p \"process.arch\")/Chamber.app --config config/electron-builder.config.cjs --publish never",
     "make:mac": "npm run make:builder:mac",
     "make:sandbox": "npm run make && node scripts/sandbox-test.js",
     "sandbox": "node scripts/sandbox-test.js",

--- a/scripts/notarize-macos-prepackaged.js
+++ b/scripts/notarize-macos-prepackaged.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (const arg of argv) {
+    const match = arg.match(/^--([^=]+)=(.*)$/);
+    if (match?.[1]) args.set(match[1], match[2] ?? '');
+  }
+  return args;
+}
+
+function env(name) {
+  return process.env[name]?.trim();
+}
+
+function notarizationEnabled() {
+  return Boolean(env('APPLE_TEAM_ID') && env('APPLE_ID') && env('APPLE_APP_SPECIFIC_PASSWORD'));
+}
+
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(' ')}`);
+  }
+}
+
+const cliArgs = parseArgs(process.argv.slice(2));
+const targetPlatform = cliArgs.get('platform') ?? process.platform;
+const targetArch = cliArgs.get('arch') ?? process.arch;
+
+if (targetPlatform !== 'darwin' || process.env.CHAMBER_MACOS_SIGNING !== 'true') {
+  process.exit(0);
+}
+
+if (!notarizationEnabled()) {
+  console.log('Skipping macOS notarization; Apple notarization credentials are not configured.');
+  process.exit(0);
+}
+
+const appPath = path.join(repoRoot, 'out', `Chamber-${targetPlatform}-${targetArch}`, 'Chamber.app');
+if (!fs.existsSync(appPath)) {
+  throw new Error(`Expected macOS app bundle to exist: ${appPath}`);
+}
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-notarize-'));
+try {
+  const zipPath = path.join(tempDir, 'Chamber.app.zip');
+  runCommand('ditto', ['-c', '-k', '--keepParent', appPath, zipPath]);
+  runCommand('xcrun', [
+    'notarytool',
+    'submit',
+    zipPath,
+    '--apple-id',
+    env('APPLE_ID'),
+    '--password',
+    env('APPLE_APP_SPECIFIC_PASSWORD'),
+    '--team-id',
+    env('APPLE_TEAM_ID'),
+    '--wait',
+  ]);
+  runCommand('xcrun', ['stapler', 'staple', appPath]);
+  runCommand('xcrun', ['stapler', 'validate', appPath]);
+  console.log(`Notarized and stapled ${path.relative(repoRoot, appPath)}`);
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -28,6 +28,7 @@ describe('packaging scripts', () => {
       '--prepackaged out/Chamber-darwin-$(node -p "process.arch")/Chamber.app'
     );
     expect(packageJson.scripts['make:builder:mac']).toContain('scripts/sign-macos-prepackaged.js');
+    expect(packageJson.scripts['make:builder:mac']).toContain('scripts/notarize-macos-prepackaged.js');
   });
 
   it('runs PR packaging only for major or minor version bumps', () => {
@@ -45,6 +46,7 @@ describe('packaging scripts', () => {
     const prepareBuilder = readFileSync('scripts/prepare-builder-prepackaged.js', 'utf-8');
     const prepareNodeRuntime = readFileSync('scripts/prepare-node-runtime.js', 'utf-8');
     const signMacPrepackaged = readFileSync('scripts/sign-macos-prepackaged.js', 'utf-8');
+    const notarizeMacPrepackaged = readFileSync('scripts/notarize-macos-prepackaged.js', 'utf-8');
     const validateBuilder = readFileSync('scripts/validate-builder-release.js', 'utf-8');
     const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf-8');
     const windowsPublisher = readFileSync('config/windows-publisher.cjs', 'utf-8');
@@ -63,6 +65,9 @@ describe('packaging scripts', () => {
     expect(prepareNodeRuntime).toContain('materializeRuntimeCommandSymlinks');
     expect(signMacPrepackaged).toContain('electron-osx-sign');
     expect(signMacPrepackaged).toContain('CHAMBER_MACOS_SIGNING');
+    expect(notarizeMacPrepackaged).toContain('notarytool');
+    expect(notarizeMacPrepackaged).toContain('stapler');
+    expect(notarizeMacPrepackaged).toContain('APPLE_APP_SPECIFIC_PASSWORD');
     expect(validateBuilder).toContain('assertAppUpdatePublisherName');
     expect(validateBuilder).toContain('matchesPublisherName');
     expect(validateBuilder).toContain('SignerCertificate.Subject');


### PR DESCRIPTION
## Summary\n- bump to v0.62.3 for a notarized macOS release\n- add a prepackaged macOS notarization/stapling step before DMG/ZIP creation\n- keep local builds working by skipping notarization unless Apple credentials are configured\n\n## Validation\n- npm test -- tests/regression/packaging-scripts.test.ts\n- parsed .github/workflows/release.yml as YAML\n- local signed macOS build succeeds with notarization skipped and verifies app/DMG signatures