### PR TITLE
Add notarization polling logs

### DIFF
--- a/scripts/notarize-macos-prepackaged.js
+++ b/scripts/notarize-macos-prepackaged.js
@@ -5,6 +5,10 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
+const NOTARIZATION_TIMEOUT_MS = Number(process.env.CHAMBER_NOTARIZATION_TIMEOUT_MS ?? 30 * 60 * 1000);
+const NOTARIZATION_POLL_INTERVAL_MS = Number(
+  process.env.CHAMBER_NOTARIZATION_POLL_INTERVAL_MS ?? 30 * 1000
+);
 
 function parseArgs(argv) {
   const args = new Map();
@@ -26,8 +30,80 @@ function notarizationEnabled() {
 function runCommand(command, args, options = {}) {
   const result = spawnSync(command, args, { stdio: 'inherit', ...options });
   if (result.status !== 0) {
-    throw new Error(`Command failed: ${command} ${args.join(' ')}`);
+    throw new Error(`Command failed: ${command}`);
   }
+}
+
+function runJsonCommand(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${command}`);
+  }
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`Expected JSON output from ${command}: ${error.message}`);
+  }
+}
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function notarytoolArgs(command, extraArgs) {
+  return [
+    'notarytool',
+    command,
+    ...extraArgs,
+    '--apple-id',
+    env('APPLE_ID'),
+    '--password',
+    env('APPLE_APP_SPECIFIC_PASSWORD'),
+    '--team-id',
+    env('APPLE_TEAM_ID'),
+    '--output-format',
+    'json',
+  ];
+}
+
+function submitForNotarization(zipPath) {
+  console.log(`Submitting ${path.basename(zipPath)} for Apple notarization...`);
+  const result = runJsonCommand('xcrun', notarytoolArgs('submit', [zipPath]));
+  if (!result.id) {
+    throw new Error('Apple notarytool did not return a submission id.');
+  }
+  console.log(`Apple notarization submission id: ${result.id}`);
+  return result.id;
+}
+
+function waitForNotarization(submissionId) {
+  const deadline = Date.now() + NOTARIZATION_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const result = runJsonCommand('xcrun', notarytoolArgs('info', [submissionId]));
+    console.log(`Apple notarization status: ${result.status}`);
+
+    if (result.status === 'Accepted') {
+      return;
+    }
+
+    if (result.status && result.status !== 'In Progress') {
+      throw new Error(`Apple notarization failed with status: ${result.status}`);
+    }
+
+    sleep(NOTARIZATION_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `Apple notarization did not finish within ${Math.round(NOTARIZATION_TIMEOUT_MS / 60_000)} minutes.`
+  );
 }
 
 const cliArgs = parseArgs(process.argv.slice(2));
@@ -52,18 +128,8 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-notarize-'));
 try {
   const zipPath = path.join(tempDir, 'Chamber.app.zip');
   runCommand('ditto', ['-c', '-k', '--keepParent', appPath, zipPath]);
-  runCommand('xcrun', [
-    'notarytool',
-    'submit',
-    zipPath,
-    '--apple-id',
-    env('APPLE_ID'),
-    '--password',
-    env('APPLE_APP_SPECIFIC_PASSWORD'),
-    '--team-id',
-    env('APPLE_TEAM_ID'),
-    '--wait',
-  ]);
+  const submissionId = submitForNotarization(zipPath);
+  waitForNotarization(submissionId);
   runCommand('xcrun', ['stapler', 'staple', appPath]);
   runCommand('xcrun', ['stapler', 'validate', appPath]);
   console.log(`Notarized and stapled ${path.relative(repoRoot, appPath)}`);

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -66,6 +66,9 @@ describe('packaging scripts', () => {
     expect(signMacPrepackaged).toContain('electron-osx-sign');
     expect(signMacPrepackaged).toContain('CHAMBER_MACOS_SIGNING');
     expect(notarizeMacPrepackaged).toContain('notarytool');
+    expect(notarizeMacPrepackaged).toContain('Apple notarization submission id:');
+    expect(notarizeMacPrepackaged).toContain('Apple notarization status:');
+    expect(notarizeMacPrepackaged).toContain('CHAMBER_NOTARIZATION_TIMEOUT_MS');
     expect(notarizeMacPrepackaged).toContain('stapler');
     expect(notarizeMacPrepackaged).toContain('APPLE_APP_SPECIFIC_PASSWORD');
     expect(validateBuilder).toContain('assertAppUpdatePublisherName');


### PR DESCRIPTION
## Summary\n- replace notarytool --wait with explicit submit + polling\n- log the Apple notarization submission id and status\n- bound notarization waits with CHAMBER_NOTARIZATION_TIMEOUT_MS\n\n## Validation\n- npm test -- tests/regression/packaging-scripts.test.ts\n- git diff --check