### PR TITLE
Use notarytool keychain profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,17 @@ jobs:
           security default-keychain -d user -s "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"
           security find-identity -v -p codesigning "$keychain"
+          xcrun notarytool store-credentials chamber-notary \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --keychain "$keychain"
         env:
           MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           KEYCHAIN_PASSWORD: ${{ github.run_id }}-macos
 
       - name: Build signed macOS package
@@ -176,6 +184,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CHAMBER_NOTARY_KEYCHAIN_PROFILE: chamber-notary
+          CHAMBER_NOTARY_KEYCHAIN: ${{ runner.temp }}/chamber-signing.keychain-db
 
       - name: Stage artifacts
         run: |
@@ -229,9 +239,17 @@ jobs:
           security default-keychain -d user -s "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"
           security find-identity -v -p codesigning "$keychain"
+          xcrun notarytool store-credentials chamber-notary \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --keychain "$keychain"
         env:
           MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           KEYCHAIN_PASSWORD: ${{ github.run_id }}-macos-x64
 
       - name: Build signed Intel macOS package
@@ -243,6 +261,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CHAMBER_NOTARY_KEYCHAIN_PROFILE: chamber-notary
+          CHAMBER_NOTARY_KEYCHAIN: ${{ runner.temp }}/chamber-signing.keychain-db
 
       - name: Stage artifacts
         run: |

--- a/scripts/notarize-macos-prepackaged.js
+++ b/scripts/notarize-macos-prepackaged.js
@@ -5,10 +5,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
-const NOTARIZATION_TIMEOUT_MS = Number(process.env.CHAMBER_NOTARIZATION_TIMEOUT_MS ?? 30 * 60 * 1000);
-const NOTARIZATION_POLL_INTERVAL_MS = Number(
-  process.env.CHAMBER_NOTARIZATION_POLL_INTERVAL_MS ?? 30 * 1000
-);
+const NOTARIZATION_TIMEOUT = process.env.CHAMBER_NOTARIZATION_TIMEOUT ?? '30m';
 
 function parseArgs(argv) {
   const args = new Map();
@@ -24,7 +21,10 @@ function env(name) {
 }
 
 function notarizationEnabled() {
-  return Boolean(env('APPLE_TEAM_ID') && env('APPLE_ID') && env('APPLE_APP_SPECIFIC_PASSWORD'));
+  return Boolean(
+    (env('CHAMBER_NOTARY_KEYCHAIN_PROFILE') && env('CHAMBER_NOTARY_KEYCHAIN'))
+      || (env('APPLE_TEAM_ID') && env('APPLE_ID') && env('APPLE_APP_SPECIFIC_PASSWORD'))
+  );
 }
 
 function runCommand(command, args, options = {}) {
@@ -34,76 +34,34 @@ function runCommand(command, args, options = {}) {
   }
 }
 
-function runJsonCommand(command, args) {
-  const result = spawnSync(command, args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-
-  if (result.stdout) process.stdout.write(result.stdout);
-  if (result.stderr) process.stderr.write(result.stderr);
-
-  if (result.status !== 0) {
-    throw new Error(`Command failed: ${command}`);
+function notarytoolAuthArgs() {
+  const profile = env('CHAMBER_NOTARY_KEYCHAIN_PROFILE');
+  const keychain = env('CHAMBER_NOTARY_KEYCHAIN');
+  if (profile && keychain) {
+    return ['--keychain-profile', profile, '--keychain', keychain];
   }
 
-  try {
-    return JSON.parse(result.stdout);
-  } catch (error) {
-    throw new Error(`Expected JSON output from ${command}: ${error.message}`);
-  }
-}
-
-function sleep(milliseconds) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
-}
-
-function notarytoolArgs(command, extraArgs) {
   return [
-    'notarytool',
-    command,
-    ...extraArgs,
     '--apple-id',
     env('APPLE_ID'),
     '--password',
     env('APPLE_APP_SPECIFIC_PASSWORD'),
     '--team-id',
     env('APPLE_TEAM_ID'),
-    '--output-format',
-    'json',
   ];
 }
 
-function submitForNotarization(zipPath) {
+function notarize(zipPath) {
   console.log(`Submitting ${path.basename(zipPath)} for Apple notarization...`);
-  const result = runJsonCommand('xcrun', notarytoolArgs('submit', [zipPath]));
-  if (!result.id) {
-    throw new Error('Apple notarytool did not return a submission id.');
-  }
-  console.log(`Apple notarization submission id: ${result.id}`);
-  return result.id;
-}
-
-function waitForNotarization(submissionId) {
-  const deadline = Date.now() + NOTARIZATION_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const result = runJsonCommand('xcrun', notarytoolArgs('info', [submissionId]));
-    console.log(`Apple notarization status: ${result.status}`);
-
-    if (result.status === 'Accepted') {
-      return;
-    }
-
-    if (result.status && result.status !== 'In Progress') {
-      throw new Error(`Apple notarization failed with status: ${result.status}`);
-    }
-
-    sleep(NOTARIZATION_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(
-    `Apple notarization did not finish within ${Math.round(NOTARIZATION_TIMEOUT_MS / 60_000)} minutes.`
-  );
+  runCommand('xcrun', [
+    'notarytool',
+    'submit',
+    zipPath,
+    ...notarytoolAuthArgs(),
+    '--wait',
+    '--timeout',
+    NOTARIZATION_TIMEOUT,
+  ]);
 }
 
 const cliArgs = parseArgs(process.argv.slice(2));
@@ -128,8 +86,7 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-notarize-'));
 try {
   const zipPath = path.join(tempDir, 'Chamber.app.zip');
   runCommand('ditto', ['-c', '-k', '--keepParent', appPath, zipPath]);
-  const submissionId = submitForNotarization(zipPath);
-  waitForNotarization(submissionId);
+  notarize(zipPath);
   runCommand('xcrun', ['stapler', 'staple', appPath]);
   runCommand('xcrun', ['stapler', 'validate', appPath]);
   console.log(`Notarized and stapled ${path.relative(repoRoot, appPath)}`);

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -66,9 +66,10 @@ describe('packaging scripts', () => {
     expect(signMacPrepackaged).toContain('electron-osx-sign');
     expect(signMacPrepackaged).toContain('CHAMBER_MACOS_SIGNING');
     expect(notarizeMacPrepackaged).toContain('notarytool');
-    expect(notarizeMacPrepackaged).toContain('Apple notarization submission id:');
-    expect(notarizeMacPrepackaged).toContain('Apple notarization status:');
-    expect(notarizeMacPrepackaged).toContain('CHAMBER_NOTARIZATION_TIMEOUT_MS');
+    expect(notarizeMacPrepackaged).toContain('CHAMBER_NOTARY_KEYCHAIN_PROFILE');
+    expect(notarizeMacPrepackaged).toContain('CHAMBER_NOTARIZATION_TIMEOUT');
+    expect(notarizeMacPrepackaged).toContain('--keychain-profile');
+    expect(notarizeMacPrepackaged).toContain('--timeout');
     expect(notarizeMacPrepackaged).toContain('stapler');
     expect(notarizeMacPrepackaged).toContain('APPLE_APP_SPECIFIC_PASSWORD');
     expect(validateBuilder).toContain('assertAppUpdatePublisherName');
@@ -81,6 +82,8 @@ describe('packaging scripts', () => {
     expect(releaseWorkflow).toContain('security add-certificates -k "$keychain" "$intermediate" || true');
     expect(releaseWorkflow).toContain('security import "$certificate"');
     expect(releaseWorkflow).toContain('security set-key-partition-list');
+    expect(releaseWorkflow).toContain('notarytool store-credentials chamber-notary');
+    expect(releaseWorkflow).toContain('CHAMBER_NOTARY_KEYCHAIN_PROFILE: chamber-notary');
     expect(releaseWorkflow).toContain('name: release-macos');
     expect(releaseWorkflow).toContain('runs-on: macos-latest');
     expect(releaseWorkflow).toContain('build_macos_x64');


### PR DESCRIPTION
## Summary\n- store Apple notarization credentials in the CI keychain with notarytool store-credentials\n- submit notarization with --keychain-profile and a bounded --timeout\n- avoid custom polling and align the script with Apple’s documented workflow\n\n## Validation\n- npm test -- tests/regression/packaging-scripts.test.ts\n- parsed .github/workflows/release.yml as YAML\n- git diff --check