### PR TITLE
perf(startup): pre-load Copilot SDK module at app launch (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 - **Gate loopback MVP server resource on `CHAMBER_MVP_SERVER=1` at package time** — `forge.config.ts` now only includes `./apps/server/dist` in `extraResource` when `process.env.CHAMBER_MVP_SERVER === '1'` is set at module-load, mirroring the existing runtime spawn gate in `apps/desktop/src/main.ts`. Default installs no longer ship installer bytes for a code path they never reach; opt-in users who set the same env get the same behavior they had before. Unconditional resources (`./resources/node`, `./resources/copilot-runtime`, `./node_modules/keytar`) are unaffected. New regression tests cover off/on toggles and the unconditional resources. Closes #145.
 
+### Performance
+
+- **Pre-load the Copilot SDK module at app launch** — `CopilotClientFactory.preloadSdk()` kicks off the SDK JavaScript module load once at `app.on('ready', ...)` so the first user-initiated `createClient` call no longer pays the import cost on the critical path. Safe to call repeatedly and concurrently (first call kicks off the load; subsequent calls await the same Promise). No subprocess is spawned — only the JS module is warmed. Closes #59.
+
 ### A2A client extension
 
 - **Default agent name now `copilot-chamber`** — `.github/extensions/a2a-client` registers as `copilot-chamber` instead of `Copilot CLI`, matching a `copilot-<repo>` convention so multiple Copilot CLI sessions across repos don't collide on the relay. Still overridable via `CHAMBER_A2A_AGENT_NAME` or the `agent_name` connect arg.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -173,6 +173,16 @@ const notifier: Notifier = {
 
 const chamberToolsBinDir = getChamberToolsBinDir();
 const clientFactory = new CopilotClientFactory({ toolsBinDir: chamberToolsBinDir });
+
+// Issue #59 — pre-load the Copilot SDK JS module while the renderer is still
+// drawing the landing/loading screen so the first user-initiated `createClient`
+// (genesis create, mind:add, mind restore) does not pay the import cost on
+// the critical path. Fire-and-forget; the promise is internally deduped by
+// `CopilotClientFactory`, so any concurrent `createClient` awaits the same
+// load instead of triggering a second import.
+void clientFactory.preloadSdk().catch((err: unknown) => {
+  log.warn('SDK preload failed (non-fatal — first createClient will retry):', err);
+});
 const configService = new ConfigService();
 const identityLoader = new IdentityLoader(() => configService.load().installedTools ?? []);
 const getGenesisMarketplaceSources = (): GenesisMindTemplateMarketplaceSource[] =>

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -241,4 +241,36 @@ describe('CopilotClientFactory', () => {
       expect(mockForceStop).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('preloadSdk (#59)', () => {
+    it('loads the SDK module exactly once when called repeatedly (idempotent)', async () => {
+      const { loadSdkModule } = await import('./sdkImport');
+      await factory.preloadSdk();
+      await factory.preloadSdk();
+      await factory.preloadSdk();
+      expect(loadSdkModule).toHaveBeenCalledTimes(1);
+    });
+
+    it('warms the cache so a subsequent createClient does not re-load the SDK module', async () => {
+      const { loadSdkModule } = await import('./sdkImport');
+      await factory.preloadSdk();
+      await factory.createClient('C:\\agents\\q');
+      // Pre-warm + first createClient share the same cached SDK module — no
+      // second import. Without preloadSdk this would still pass because
+      // getSdk caches; the value-add is that the import happens during the
+      // landing-screen wait instead of blocking the user-initiated load.
+      expect(loadSdkModule).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not start a CopilotClient subprocess (only loads the JS module)', async () => {
+      await factory.preloadSdk();
+      expect(mockStart).not.toHaveBeenCalled();
+    });
+
+    it('returns the same Promise to concurrent preload calls so the SDK loads once', async () => {
+      const { loadSdkModule } = await import('./sdkImport');
+      await Promise.all([factory.preloadSdk(), factory.preloadSdk(), factory.preloadSdk()]);
+      expect(loadSdkModule).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/services/src/sdk/CopilotClientFactory.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.ts
@@ -46,8 +46,22 @@ export interface CreateClientOptions {
 
 export class CopilotClientFactory {
   private sdkModule: typeof import('@github/copilot-sdk') | null = null;
+  private sdkLoadPromise: Promise<typeof import('@github/copilot-sdk')> | null = null;
 
   constructor(private readonly options: CopilotClientFactoryOptions = {}) {}
+
+  /**
+   * Pre-load the SDK JavaScript module without spawning any CopilotClient
+   * subprocess. Issue #59 — call this once at app launch (e.g. while the
+   * user is still on the landing screen) so the first user-initiated
+   * `createClient` does not pay the module-import cost on the critical path.
+   *
+   * Safe to call repeatedly and concurrently: the first call kicks off the
+   * load; subsequent calls await the same Promise.
+   */
+  async preloadSdk(): Promise<void> {
+    await this.getSdk();
+  }
 
   async createClient(mindPath: string, createOptions: CreateClientOptions = {}): Promise<CopilotClient> {
     const sdk = await this.getSdk();
@@ -135,10 +149,20 @@ export class CopilotClientFactory {
   }
 
   private async getSdk(): Promise<typeof import('@github/copilot-sdk')> {
-    if (!this.sdkModule) {
-      this.sdkModule = await loadSdkModule();
+    if (this.sdkModule) return this.sdkModule;
+    // Reuse an in-flight load so concurrent callers (e.g. preloadSdk + an
+    // eager createClient) only trigger one module import.
+    if (!this.sdkLoadPromise) {
+      this.sdkLoadPromise = loadSdkModule()
+        .then((mod) => {
+          this.sdkModule = mod;
+          return mod;
+        })
+        .finally(() => {
+          this.sdkLoadPromise = null;
+        });
     }
-    return this.sdkModule;
+    return this.sdkLoadPromise;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #59. Pre-loads the @github/copilot-sdk JavaScript module at app launch so the first user-initiated session creation (genesis flow, mind:add, or restored mind) does not pay the import cost on the critical path. The import happens while the renderer is still drawing the landing/loading screen.

## Why

The issue: `perf — pre-warm getSharedClient() at app launch (CLI spawn + auth in background while user is on landing screen). Also: session reuse via resumeSession API.`

The Chamber architecture creates one `CopilotClient` per mind (not a shared client), so the "shared client" framing doesn't map directly. The portable win that still applies — and that the issue intent captures — is **pre-loading the SDK JS module** so the cost shifts out of the user's wait. The first `createClient` after preload skips the import; subsequent ones already shared the cache.

## Changes

- `packages/services/src/sdk/CopilotClientFactory.ts`:
  - New `preloadSdk()` public method — loads the SDK module without starting any CopilotClient subprocess.
  - New private `sdkLoadPromise` field — de-duplicates concurrent loads (e.g. `preloadSdk()` racing an eager `createClient` no longer triggers two imports).
- `apps/desktop/src/main.ts` — fires `void clientFactory.preloadSdk()` at the point the factory is constructed (very early in main). Failure is logged at `warn` level and the first `createClient` retries; no startup-blocking side effects.

## Out of scope (follow-up)

The issue also mentions `resumeSession` API integration. That requires refactoring `MindManager`'s per-mind client mapping (currently each mind owns a private `CopilotClient` subprocess) so sessions can be reused across reloads. Deeper refactor than one slate PR justifies; leaving as a follow-up issue.

## Test evidence

- `packages/services/src/sdk/CopilotClientFactory.test.ts` — 17 tests pass, including 4 new under `preloadSdk (#59)`:
  - Idempotent across repeated calls (one `loadSdkModule` invocation).
  - Cache shared with a subsequent `createClient` (still one load total).
  - No `CopilotClient` subprocess is started by preload.
  - Concurrent `preloadSdk()` calls share the same Promise (one load even under parallel race).
- `npm run smoke:sdk` — pass.
- `npm run lint` — clean.
- `npm test` — 1598 passed / 1 failed. The single failure is `MindProfileService.test.ts > rejects symlinked profile files` (`EPERM` on `fs.symlinkSync` — Windows symlink permission). Pre-existing on `origin/master`, not introduced by this PR.

Release metadata deferred until #299 (PR #313) merges.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
