### PR TITLE
feat(release): move to Model B release-time versioning

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -38,35 +38,41 @@ Both are `workflow_dispatch` only — neither fires on push.
 
 The core shape to keep in mind:
 
-- **Insiders cut** = bump counter (`-insiders.N`) → build → upload to
-  blob → push the tag only. Master is never modified.
-- **Stable cut** = either release current master (`source_ref` empty)
-  or promote an insider tag (`source_ref: vX.Y.Z-insiders.N`).
-  Promotion rebuilds from the insider commit; it does not reuse the
-  insider binary. macOS requires notarization warmup to be complete.
+- **Insiders cut** = compute target stable from `## Unreleased` in
+  `CHANGELOG.md` → bump counter (`vX.Y.Z-insiders.N`) → build → upload
+  to blob → push the tag only. Master is never modified.
+- **Stable cut** is almost always **promote an insider tag**
+  (`source_ref: vX.Y.Z-insiders.N`). Direct-from-master dispatch is an
+  emergency fallback that derives the version from `## Unreleased` the
+  same way insiders does.
+- **Post-stable** (this skill's responsibility, run locally): open a PR
+  that bumps `package.json` to the freshly shipped stable version and
+  promotes `## Unreleased` into `## vX.Y.Z (date)` in `CHANGELOG.md`.
+  This keeps master's invariant (version = last shipped stable).
 
 ## Worked examples
 
 **"Cut an insider build for testers"** →
-Confirm channel is `insiders`. Predict next tag from
-`git tag -l 'v*-insiders.*' --sort=-v:refname | head -1` and
-`package.json` version. Dispatch
+Confirm channel is `insiders`. Predict the next tag with
+`node scripts/bump-insiders-version.js --dry-run` — this reads
+`## Unreleased` in `CHANGELOG.md`, classifies the highest-precedence
+heading, and prints the target stable + insider counter. Dispatch
 `gh workflow run release-insiders.yml --ref master`. After success,
 hand back the install URL and the new tag.
 
-**"Promote v0.62.4-insiders.3 to stable"** →
-Confirm channel is `stable`, flow B. Verify `v0.62.4` doesn't already
-exist (`git tag -l v0.62.4`). Verify macOS notary warmup is done.
-Dispatch
-`gh workflow run release.yml --ref master -f source_ref=v0.62.4-insiders.3`.
-After success, surface the GitHub Release URL and call out that both
-tags now point at the same commit.
+**"Promote v0.63.0-insiders.3 to stable"** →
+Confirm channel is `stable`. Verify `v0.63.0` doesn't already exist
+(`git tag -l v0.63.0`). Verify macOS notary warmup is done. Dispatch
+`gh workflow run release.yml --ref master -f source_ref=v0.63.0-insiders.3`.
+After success, open the post-release bump PR (Phase 3b.6) and surface
+the GitHub Release URL.
 
-**"Release master to stable"** →
-Confirm channel is `stable`, flow A. Verify the version on
-`origin/master` is what should ship and no tag conflict.
-Dispatch `gh workflow run release.yml --ref master`. After success,
-surface the GitHub Release URL.
+**"Release straight from master (emergency)"** →
+Confirm channel is `stable`, flow A. The workflow will compute the
+target stable from `## Unreleased`. Confirm the computed version
+doesn't already exist as a tag. Dispatch
+`gh workflow run release.yml --ref master`. After success, open the
+post-release bump PR.
 
 ## Workflow
 
@@ -108,39 +114,41 @@ Reflect the choice back before continuing.
 #### 3a.1 AGENT - Compute the next version
 
 ```bash
-git tag -l 'v*-insiders.*' --sort=-v:refname | head -5
-node -p "require('./package.json').version"
+node scripts/bump-insiders-version.js --dry-run
 ```
 
-Predict the next version:
+The script reads `package.json` (last shipped stable), parses
+`## Unreleased` in `CHANGELOG.md` for the highest-precedence conventional
+heading, derives the target stable via SemVer, queries `git tag -l` for
+existing `v<target>-insiders.*` tags, and prints the next insider version
+plus the bump source heading.
 
-- Latest insider tag base ≥ `package.json` version → increment the
-  insider counter (`v0.62.4-insiders.3` → `v0.62.4-insiders.4`).
-- Otherwise → reset counter on the new base (master is at `0.63.0`,
-  latest insider is `v0.62.4-insiders.7` → next is `v0.63.0-insiders.0`).
+Surface the predicted target stable, counter, and bump source to the
+user so they can confirm intent (e.g. "next insider is
+`v0.63.0-insiders.0`, derived from a `### Features` bullet in
+Unreleased"). If `## Unreleased` is empty the script fails — direct the
+user to ship a change first, or to use the override below for a
+genuinely test-only build.
 
-Surface the prediction so the user confirms. The runner-side script
-(`scripts/bump-insiders-version.js`) is the source of truth for the
-actual computation; this prediction is for human confidence.
+#### 3a.2 ASK - Optional bump override
 
-#### 3a.2 ASK - Optional base bump
-
-By default the workflow increments the insider counter within the
-current base. If the user wants to bake a base-version bump into this
-insider build, ask:
+By default the workflow honors the bump derived from `## Unreleased`.
+Override is only for emergency cases (e.g., re-cut for infrastructure
+reasons without any user-facing changelog entries). Ask only if the user
+mentioned it:
 
 ```
-Bump base version? patch | minor | major | none (default)
+Override bump? patch | minor | major | none (default)
 ```
 
-Pass `-f bump=<value>` to the dispatch if non-default.
+Pass `-f override_bump=<value>` to the dispatch if non-default.
 
 #### 3a.3 AGENT - Dispatch
 
 ```bash
 gh workflow run release-insiders.yml --ref master
-# or with bump:
-gh workflow run release-insiders.yml --ref master -f bump=minor
+# or with override:
+gh workflow run release-insiders.yml --ref master -f override_bump=minor
 ```
 
 Confirm the dispatch landed:
@@ -176,28 +184,17 @@ out-of-band.
 
 ```
 Which stable flow?
-  A – release current master            (source_ref empty)
-  B – promote an existing insider tag   (source_ref = vX.Y.Z-insiders.N)
+  B – promote an existing insider tag   (source_ref = vX.Y.Z-insiders.N)   [default]
+  A – emergency release from master     (source_ref empty; computes from ## Unreleased)
 ```
+
+Default is **B**. Flow A skips insider piloting and should be an
+explicit choice (hotfix where insider piloting isn't possible, or first
+release after the migration).
 
 #### 3b.2 AGENT - Pre-flight for the chosen flow
 
-**Flow A (release master):**
-
-```bash
-git fetch origin master --quiet
-git --no-pager log origin/master --oneline -n 5
-node -p "require('./package.json').version"
-gh api repos/ianphil/chamber/contents/package.json --jq '.content' \
-  | base64 -d | jq -r .version
-git tag -l 'v*' --sort=-v:refname | grep -v -- '-insiders\.' | head -5
-```
-
-Confirm the version on `origin/master`'s `package.json` is what should
-ship and no `v<that-version>` tag already exists. If it does, the user
-must bump master via `ship` first and come back.
-
-**Flow B (promote insider):**
+**Flow B (promote insider) — default:**
 
 ```bash
 git fetch origin --tags --quiet
@@ -208,13 +205,35 @@ Ask which tag to promote, then confirm the derived stable version
 doesn't already exist:
 
 ```bash
-insider='v0.62.4-insiders.3'
+insider='v0.63.0-insiders.3'
 stable=$(echo "$insider" | sed -E 's/-insiders\.[0-9]+$//')
 git tag -l "$stable"
 ```
 
-If the stable tag exists, stop. The user must bump master via `ship`,
-cut a new insider off that bump, then promote that. Explain why.
+If the stable tag exists, stop. The user must ship more changes to bump
+the target, cut a new insider, then promote that. Explain why.
+
+**Flow A (emergency release from master):**
+
+```bash
+git fetch origin master --quiet
+git --no-pager log origin/master --oneline -n 5
+node -e "
+  const ch = require('./scripts/changelog');
+  const pkg = require('./package.json');
+  const semver = require('semver');
+  const { bump, section } = ch.recommendBumpFromChangelog('./CHANGELOG.md');
+  if (!bump) { console.error('Empty ## Unreleased — nothing to release.'); process.exit(1); }
+  console.log('Master version (last shipped stable):', pkg.version);
+  console.log('Bump source headings:', section.headings.join(', '));
+  console.log('Target stable:', semver.inc(pkg.version, bump));
+"
+git tag -l 'v*' --sort=-v:refname | grep -v -- '-insiders\.' | head -5
+```
+
+Confirm `## Unreleased` has actionable entries and no `v<target>` tag
+already exists. If the tag exists, stop and direct the user to cut an
+insider first (so master gets updated via Flow B's post-release PR).
 
 #### 3b.3 ASK - macOS notary warmup
 
@@ -241,18 +260,18 @@ Recent submissions completing in <5 minutes means warmup is done.
 
 #### 3b.4 AGENT - Dispatch
 
-**Flow A:**
+**Flow B (default):**
+
+```bash
+gh workflow run release.yml --ref master -f source_ref=v0.63.0-insiders.3
+```
+
+**Flow A (emergency):**
 
 ```bash
 gh workflow run release.yml --ref master
 # patch-only bumps that need to release anyway:
 gh workflow run release.yml --ref master -f force_release=true
-```
-
-**Flow B:**
-
-```bash
-gh workflow run release.yml --ref master -f source_ref=v0.62.4-insiders.3
 ```
 
 Confirm the run started:
@@ -276,9 +295,48 @@ Surface:
 - The GitHub Releases URL.
 - The two tags (insider + stable) if Flow B — both point at the same
   commit, by design.
-- A reminder that `git checkout v<version>` will show the
-  pre-promotion `package.json` content if Flow B (the version-strip
-  mutation was not committed; the installer is the truthful artifact).
+- A reminder that `git checkout v<version>` will show master's stale
+  `package.json` (one stable behind). Under Model B, the released
+  version was computed at dispatch time and only embedded in the built
+  artifact, not committed. The post-release bump PR (next phase) fixes
+  this.
+
+#### 3b.6 AGENT - Post-release bump PR
+
+Master's `package.json` and `CHANGELOG.md` must now be advanced. This is
+the **only** automation that mutates `package.json` on master under
+Model B. Run locally:
+
+```bash
+git checkout master
+git pull --ff-only origin master
+git checkout -b release/bump-vX.Y.Z
+
+# Bump master to the freshly shipped stable version
+npm version <X.Y.Z> --no-git-tag-version --allow-same-version
+
+# Promote ## Unreleased into ## vX.Y.Z (YYYY-MM-DD)
+node -e "
+  const ch = require('./scripts/changelog');
+  const today = new Date().toISOString().slice(0, 10);
+  ch.promoteUnreleasedToVersion('./CHANGELOG.md', '<X.Y.Z>', today);
+"
+
+git add package.json package-lock.json CHANGELOG.md
+git commit -m "chore(release): bump master to vX.Y.Z post-release
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin HEAD
+
+gh pr create --base master --head release/bump-vX.Y.Z \
+  --title "chore(release): bump master to vX.Y.Z post-release" \
+  --body "Post-release bump. Master now reflects the freshly shipped stable version. \`## Unreleased\` has been promoted to \`## vX.Y.Z\` in CHANGELOG.md.
+
+This PR is mechanical and CI-validated; merge after green checks."
+```
+
+The user reviews and merges the PR. Do not auto-merge — the user owns
+the master-mutation moment.
 
 ### 4. AGENT - Summarize what was decided
 
@@ -307,9 +365,16 @@ dispatched — benefits from a written trail.
   should land via `ship` first.
 - **`gh auth status` fails** — stop, surface the message, ask to
   re-auth.
+- **Empty `## Unreleased`** (insiders compute or Flow A) — stop. Direct
+  the user to ship at least one change so the bump source exists.
 - **Insider tag doesn't exist** (Flow B) — stop, list recent tags.
 - **Stable version tag already exists** (Flow A or B) — stop. Direct
-  the user to bump master via `ship`, cut a new insider, then promote.
+  the user to ship more changes (so the next target stable advances)
+  and re-cut the insider, then promote.
+- **Post-release bump PR conflicts with concurrent ship** — rebase the
+  bump branch on master; resolve `CHANGELOG.md` by keeping
+  `promoteUnreleasedToVersion`'s output and re-inserting any newer
+  `## Unreleased` bullets at the top.
 - **Workflow dispatch returns non-zero** — capture and surface the
   error. Don't retry blindly.
 - **macOS warmup uncertain** — default to *not* dispatching stable.
@@ -324,9 +389,12 @@ These are easy to do by accident and hard to undo:
 - **Don't delete insider tags casually.** The commit they point at is
   off-branch; deleting the tag makes it unreachable and Git GC will
   prune it (~30 days). Reproducibility and promotion are lost.
-- **Don't push the version-bump commit to master.** That's why the
-  insiders workflow pushes the tag only. Never run `git push origin
-  HEAD` from a release workflow that just bumped the version.
+- **Don't push the version-bump commit to master from the workflow.**
+  The insiders workflow tags master's SHA directly under Model B — no
+  bump commit is generated. The release workflow mutates `package.json`
+  only on the runner. The only legitimate path that mutates master's
+  version field is the post-release bump PR opened by this skill
+  (Phase 3b.6).
 - **Don't reuse the insider binary as the stable artifact.** Promotion
   must rebuild — different channel string, different feed URL,
   different embedded `app-update.yml`, fresh signatures.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -301,18 +301,42 @@ Surface:
   artifact, not committed. The post-release bump PR (next phase) fixes
   this.
 
-#### 3b.6 AGENT - Post-release bump PR
+#### 3b.6 AGENT - Post-release bump PR (anchored to build SHA)
 
 Master's `package.json` and `CHANGELOG.md` must now be advanced. This is
 the **only** automation that mutates `package.json` on master under
-Model B. Run locally:
+Model B.
+
+**Critical:** branch the bump PR from the **build SHA** (the insider tag
+for Flow B, or `origin/master`'s SHA at dispatch time for Flow A) —
+**not** from current `origin/master`. If anyone merged a `## Unreleased`
+bullet during the build window (often 30–60 min for macOS
+notarization), branching from current master would falsely attribute
+those bullets to the just-released version and silently corrupt the
+CHANGELOG. Anchoring to the build SHA captures `## Unreleased` exactly
+as it was at build time; interim bullets land as a visible 3-way merge
+conflict instead of silent corruption.
+
+First, surface whether the conflict is coming. For Flow B
+(`source_ref=vX.Y.Z-insiders.N`):
 
 ```bash
-git checkout master
-git pull --ff-only origin master
-git checkout -b release/bump-vX.Y.Z
+BUILD_SHA=$(git rev-list -n1 vX.Y.Z-insiders.N)
+git fetch origin master --quiet
+git --no-pager log --oneline "$BUILD_SHA..origin/master"
+```
 
-# Bump master to the freshly shipped stable version
+If the log is empty: clean fast-forward expected. If non-empty: a
+CHANGELOG conflict is likely; surface the commit list to the user so
+they know what to expect when reviewing.
+
+Then open the bump PR:
+
+```bash
+git fetch origin --tags --quiet
+git checkout -b release/bump-vX.Y.Z "$BUILD_SHA"
+
+# Bump to the freshly shipped stable version
 npm version <X.Y.Z> --no-git-tag-version --allow-same-version
 
 # Promote ## Unreleased into ## vX.Y.Z (YYYY-MM-DD)
@@ -330,10 +354,35 @@ git push -u origin HEAD
 
 gh pr create --base master --head release/bump-vX.Y.Z \
   --title "chore(release): bump master to vX.Y.Z post-release" \
-  --body "Post-release bump. Master now reflects the freshly shipped stable version. \`## Unreleased\` has been promoted to \`## vX.Y.Z\` in CHANGELOG.md.
+  --body "Post-release bump anchored to build SHA \`$BUILD_SHA\` (tag \`vX.Y.Z-insiders.N\`). Master now reflects the freshly shipped stable version. \`## Unreleased\` content at build time has been promoted to \`## vX.Y.Z\` in CHANGELOG.md.
+
+If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new \`## vX.Y.Z\` section AS-IS, and keep any \`## Unreleased\` bullets that landed during the build window under a fresh \`## Unreleased\` block above it.
 
 This PR is mechanical and CI-validated; merge after green checks."
 ```
+
+**Conflict resolution on merge.** Common ancestor is the build SHA.
+Master may have added bullets to `## Unreleased`; the bump branch
+removed all `## Unreleased` content and inserted a new `## vX.Y.Z`
+section. Git usually auto-merges (non-overlapping edits). When it
+doesn't, resolve by keeping **both** sections:
+
+```
+## Unreleased
+
+### Fixes
+
+- **Bullet that landed during the build window** - ...
+
+## vX.Y.Z (YYYY-MM-DD)
+
+### Features
+
+- **Bullet that was in Unreleased at build SHA** - ...
+```
+
+No bullet is ever lost. The interim bullets stay in `## Unreleased` for
+the next release to pick up.
 
 The user reviews and merges the PR. Do not auto-merge — the user owns
 the master-mutation moment.
@@ -371,10 +420,12 @@ dispatched — benefits from a written trail.
 - **Stable version tag already exists** (Flow A or B) — stop. Direct
   the user to ship more changes (so the next target stable advances)
   and re-cut the insider, then promote.
-- **Post-release bump PR conflicts with concurrent ship** — rebase the
-  bump branch on master; resolve `CHANGELOG.md` by keeping
-  `promoteUnreleasedToVersion`'s output and re-inserting any newer
-  `## Unreleased` bullets at the top.
+- **Post-release bump PR has CHANGELOG conflict at merge** — expected
+  when commits landed on master during the build window. Resolve by
+  keeping both sections: the new `## vX.Y.Z (date)` AS-IS, and any
+  interim `## Unreleased` bullets under a fresh `## Unreleased` block
+  above it. Never `--theirs` or `--ours` blindly — both sides carry
+  real content. See Phase 3b.6 for the resolution template.
 - **Workflow dispatch returns non-zero** — capture and surface the
   error. Don't retry blindly.
 - **macOS warmup uncertain** — default to *not* dispatching stable.

--- a/.github/skills/ship/SKILL.md
+++ b/.github/skills/ship/SKILL.md
@@ -27,14 +27,14 @@ In autopilot mode, do not stop for repeated confirmation prompts. Apply these de
 
 | Prompt area | Autopilot default |
 |---|---|
-| Version bump | Accept the LLM/agent recommendation. For stacks, use the next sequential version after the parent branch. |
-| Changelog | Draft and apply the matching entry using the existing format. |
+| Change classification | Pick the conventional kind (`breaking`/`feature`/`fix`/`perf`/`refactor`/`docs`/`tests`/`build`/`ci`/`chore`) from the diff; the release skill computes the actual version bump later from accumulated `## Unreleased` entries. |
+| Changelog | Append a bullet under the matching `### Heading` of `## Unreleased` using `scripts/append-changelog-entry.js`. |
 | Closing issue | Include all planned issue refs from the roadmap or branch commit messages. |
 | Uncle Bob | Run for non-trivial, runtime, architecture, SDK, security, or broad behavior changes; skip for small docs, tests, and focused UI fixes. |
 | Packaging sandbox | Do not run `npm run make:sandbox`; use `npm run package` only when packaging/startup paths need smoke coverage. |
 | PR base | Use the supplied stack parent branch; otherwise use `master`. |
 
-Autopilot still stops for dirty working trees, being on `master`, rebase conflicts, ambiguous release ordering, failing checks, destructive operations, serious review findings, missing issue refs, or anything that would merge code. Opening a PR is allowed; merging still requires explicit user approval.
+Autopilot still stops for dirty working trees, being on `master`, rebase conflicts, failing checks, destructive operations, serious review findings, missing issue refs, or anything that would merge code. Opening a PR is allowed; merging still requires explicit user approval.
 
 ## Prerequisites
 
@@ -69,12 +69,12 @@ git rebase origin/<parent-branch>
 
 If the rebase has conflicts, stop and surface them. Do not attempt automatic resolution unless the user explicitly approves.
 
-### 2. ASK/AUTOPILOT - Version bump recommendation
+### 2. ASK/AUTOPILOT - Classify the change and append a `## Unreleased` entry
 
-> Master pushes do **not** trigger a release. Stable and insiders are
-> both manual `workflow_dispatch`. Bumping the version here keeps
-> master's "development version" coherent and pairs the change with a
-> changelog entry — it does **not** publish anything. See
+> **Under Model B, ship does not bump `package.json`.** Versions are computed
+> at release time from accumulated bullets in `## Unreleased`. Ship's job is
+> to file an entry under the right conventional `### Heading` so the release
+> skill can compute the next version deterministically. See
 > [`ai-docs/release-channels.md`](../../../ai-docs/release-channels.md).
 
 Inspect the diff against the intended base:
@@ -84,41 +84,43 @@ git --no-pager diff <base-ref> --stat
 git --no-pager diff <base-ref> -- <changed-files>
 ```
 
-Recommend **patch** vs **minor** vs **none** based on:
+Classify the change using these conventional kinds (in precedence order — the
+release skill picks the highest one across all bullets to compute the bump):
 
-- **patch** - bug fixes, internal refactors, doc-only or test-only changes.
-- **minor** - new user-visible feature, new mind capability, new Lens view type, new cron job kind, new tool, schema additions.
-- **major** - breaking changes. Chamber is pre-1.0, so prefer minor with a clear changelog warning unless the break is intentional.
+- **breaking** - intentional incompatible change (API removed, contract broken). Drives a major bump.
+- **feature** - new user-visible capability (new mind capability, new Lens view type, new cron job kind, new tool, schema additions). Drives a minor bump.
+- **fix** - bug fix.
+- **perf** - performance improvement with no behavior change.
+- **refactor** - internal restructuring, no behavior change.
+- **docs** - documentation only.
+- **tests** - test-only changes.
+- **build** - build/packaging tooling.
+- **ci** - CI workflow / governance.
+- **chore** - everything else (release plumbing, dependency hygiene).
 
-Interactive mode: use `ask_user` to confirm the bump.
+All non-feature/non-breaking kinds drive a patch bump.
 
-Autopilot mode: apply the recommendation automatically. For issue-slate stacks, do not duplicate a parent branch version; choose the next sequential version already implied by the stack order. Then run:
+Interactive mode: use `ask_user` to confirm the kind with a suggested choice.
+
+Autopilot mode: pick the highest-precedence kind that fits the diff.
+
+Then append the bullet:
 
 ```powershell
-npm version <patch|minor|major> --no-git-tag-version
+node scripts/append-changelog-entry.js \
+  --kind=<kind> \
+  --summary="<bold one-liner without leading dash>" \
+  --detail="<detail, with issue refs like (#NNN)>" \
+  --issue=NNN
 ```
 
-`npm version` updates the `version` field in both `package.json` and `package-lock.json`. **Do not run `npm install --package-lock-only` afterwards** — on local npm 11.6.x it strips top-level optional cross-platform binary entries (e.g. `node_modules/@emnapi/core`, `node_modules/@emnapi/runtime`) that CI's npm 11.12.x rejects with `npm error Missing: <pkg> from lock file` during `npm ci`. If a real dependency change requires regenerating the lockfile, run a full `npm install` instead and verify the diff with `git --no-pager diff <base-ref> -- package-lock.json` before staging — the diff for a pure version bump should be limited to the two `"version":` fields at the top of the file.
+The script creates `## Unreleased` if missing, ensures the right `### Heading`
+exists under it, and appends the bullet in the existing format
+(`- **<summary>** - <detail> (#<issue>)`). It does **not** touch `package.json`.
 
-Stage `package.json` and `package-lock.json`.
+Stage `CHANGELOG.md`.
 
-### 3. ASK/AUTOPILOT - Changelog check
-
-Read `CHANGELOG.md`. Confirm the top section matches the new version and describes the change.
-
-Interactive mode: if missing or stale, draft an entry and ask before writing it.
-
-Autopilot mode: write the entry directly, following the existing format:
-
-```markdown
-## vX.Y.Z (YYYY-MM-DD)
-
-### Area
-
-- **Bold one-line summary** - concise detail with issue refs.
-```
-
-### 4. AGENT - Closing issue check
+### 3. AGENT - Closing issue check
 
 Inspect commit messages and the roadmap/branch context:
 
@@ -132,7 +134,7 @@ Interactive mode: if the closing relationship is plausible but not explicit, ask
 
 Autopilot mode: include roadmap-provided issue refs and explicit commit refs automatically. Stop only if no issue ref is known for issue-driven work.
 
-### 5. ASK/AUTOPILOT - Uncle Bob review
+### 4. ASK/AUTOPILOT - Uncle Bob review
 
 Run Uncle Bob for non-trivial, runtime, architecture, SDK, security, or broad behavior changes. Skip for small docs, tests, and focused UI fixes.
 
@@ -144,7 +146,7 @@ When running it, delegate via the `task` tool with `agent_type: "Uncle Bob"` and
 
 Surface the findings. In autopilot mode, fix critical findings directly when the fix is clearly in scope; otherwise stop and ask.
 
-### 6. AGENT - Smoke tests
+### 5. AGENT - Smoke tests
 
 Run, in order, surfacing any failure immediately:
 
@@ -171,7 +173,7 @@ If browser UI routing/chat paths changed and existing coverage applies, run:
 npm run smoke:web
 ```
 
-### 7. ASK/AUTOPILOT - Packaging smoke
+### 6. ASK/AUTOPILOT - Packaging smoke
 
 Do not run `npm run make:sandbox` in issue-slate autopilot.
 
@@ -185,7 +187,7 @@ Interactive mode: ask before packaging smoke unless the user already requested i
 
 Autopilot mode: run `npm run package` automatically when the changed surface requires it; otherwise skip and record why.
 
-### 8. AGENT - Push and open the PR
+### 7. AGENT - Push and open the PR
 
 Push the branch:
 
@@ -215,10 +217,10 @@ Print the resulting PR URL.
 - **Current branch is `master`** - abort.
 - **Unknown PR base** - ask.
 - **Rebase conflicts** - stop, surface conflicts, ask for direction.
-- **Version ordering ambiguity** - stop and ask.
+- **Empty / missing `## Unreleased` section after appending** - script failure; surface the error and stop.
 - **Lint, test, or smoke failure** - stop, show the failure, do not push.
 - **Critical Uncle Bob finding** - fix if clearly in scope; otherwise ask.
-- **No changelog entry for a non-trivial change** - block until one exists.
+- **No `## Unreleased` bullet for a non-trivial change** - block until one exists. Docs/test-only PRs may use a `### Docs` / `### Tests` bullet.
 - **Dirty working tree at the end** - never push with uncommitted changes.
 
 ## Notes

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -3,8 +3,8 @@ name: Release Insiders
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: 'Base version bump applied before -insiders.N counter (leave empty to keep current base and just increment the counter)'
+      override_bump:
+        description: 'Emergency override: force patch/minor/major instead of reading ## Unreleased from CHANGELOG.md. Leave empty for normal Model B behavior.'
         required: false
         default: ''
         type: choice
@@ -52,14 +52,14 @@ jobs:
         shell: bash
         run: |
           bump_arg=""
-          if [ -n "${{ inputs.bump }}" ]; then
-            bump_arg="--bump=${{ inputs.bump }}"
+          if [ -n "${{ inputs.override_bump }}" ]; then
+            bump_arg="--override-bump=${{ inputs.override_bump }}"
           fi
           node scripts/bump-insiders-version.js $bump_arg
           new_version=$(jq -r '.version' package.json)
           echo "version=$new_version" >> "$GITHUB_OUTPUT"
           echo "tag=v$new_version" >> "$GITHUB_OUTPUT"
-          echo "Bumped to $new_version"
+          echo "Computed insider version: $new_version (target stable: ${target_stable:-from script output})"
 
       - name: Azure login (Trusted Signing)
         uses: azure/login@v2
@@ -118,11 +118,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
-          git commit -m "Release ${{ steps.bump.outputs.tag }}
-
-          Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          # Model B: do NOT commit the package.json/package-lock.json mutation.
+          # Master holds the last shipped stable version on disk. The runner
+          # mutates package.json only to build with the right embedded version;
+          # the tag points at the original master commit so promotion-from-SHA
+          # and master's own history stay aligned.
           git tag -a "${{ steps.bump.outputs.tag }}" -m "Insiders release ${{ steps.bump.outputs.tag }}"
-          # Push the tag only. The version-bump commit is reachable via the tag
-          # but is NOT merged back to master, so master stays free of release ceremony commits.
           git push origin "${{ steps.bump.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,18 +51,32 @@ jobs:
       - name: Check for major/minor version change
         id: check
         run: |
-          SOURCE_VERSION=$(jq -r '.version' package.json)
-          echo "Source version: $SOURCE_VERSION"
+          source_ref="${{ steps.source.outputs.source_ref }}"
 
-          # If the source ref points at an insider prerelease, strip -insiders.N to
-          # determine the stable version that will actually be released.
-          STABLE_VERSION="${SOURCE_VERSION%-insiders.*}"
-          PROMOTED_FROM=""
-          if [ "$STABLE_VERSION" != "$SOURCE_VERSION" ]; then
-            PROMOTED_FROM="${{ steps.source.outputs.source_ref }}"
-            echo "Detected insiders source. Promoting $SOURCE_VERSION -> $STABLE_VERSION."
+          # Model B: derive the stable target from the insider tag name when
+          # promoting (master's package.json points at the last shipped stable,
+          # so stripping its suffix would yield the wrong value). For direct
+          # dispatches without an insider tag, compute from ## Unreleased.
+          INSIDER_TAG_REGEX='^v?([0-9]+\.[0-9]+\.[0-9]+)-insiders\.[0-9]+$'
+          if [[ "$source_ref" =~ $INSIDER_TAG_REGEX ]]; then
+            CURRENT_VERSION="${BASH_REMATCH[1]}"
+            PROMOTED_FROM="$source_ref"
+            echo "Promoting from insider tag $source_ref -> stable v$CURRENT_VERSION"
+          else
+            CURRENT_VERSION=$(node -e "
+              const ch = require('./scripts/changelog');
+              const pkg = require('./package.json');
+              const semver = require('semver');
+              const { bump } = ch.recommendBumpFromChangelog('./CHANGELOG.md');
+              if (!bump) {
+                console.error('No actionable ## Unreleased section. Either add entries via ship or promote an insider tag.');
+                process.exit(1);
+              }
+              process.stdout.write(semver.inc(pkg.version, bump));
+            ")
+            PROMOTED_FROM=""
+            echo "Computed stable version from ## Unreleased: v$CURRENT_VERSION"
           fi
-          CURRENT_VERSION="$STABLE_VERSION"
           echo "Stable version: $CURRENT_VERSION"
 
           CURRENT_MAJOR_MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f1,2)
@@ -71,7 +85,7 @@ jobs:
           LATEST_TAG=$(git describe --tags --abbrev=0 --exclude='*-insiders.*' 2>/dev/null || echo "")
           echo "Latest stable tag: $LATEST_TAG"
 
-          echo "source_ref=${{ steps.source.outputs.source_ref }}" >> $GITHUB_OUTPUT
+          echo "source_ref=$source_ref" >> $GITHUB_OUTPUT
           echo "promoted_from=$PROMOTED_FROM" >> $GITHUB_OUTPUT
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Move to Model B release versioning** — Master's `package.json#version` now stays at the last shipped stable version between releases. Ship appends bullets to `## Unreleased` under conventional `### Headings` (Breaking / Features / Fixes / …). The release skill reads those headings at insider-cut time to compute the next stable version, and the `-insiders.N` counter grows across iterations against the same future stable. Eliminates stable-version gaps. See [`ai-docs/release-channels.md`](ai-docs/release-channels.md).
 
+### Fixes
+
+- **Anchor post-release bump PR to build SHA** — The release skill now branches the post-release bump PR from the build SHA (insider tag or dispatch commit), not from current `origin/master`. Without this, ship PRs that merge during the 30–60 min build window get silently misattributed to the just-shipped version. Anchoring surfaces interim bullets as a visible 3-way merge conflict at PR-merge time, mechanical to resolve. Documented in the Decision Log with reference to release-please #2754 as the canonical postmortem of what goes wrong without it.
+
 ## v0.62.4 (2026-05-16)
 
 ### Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Move to Model B release versioning** — Master's `package.json#version` now stays at the last shipped stable version between releases. Ship appends bullets to `## Unreleased` under conventional `### Headings` (Breaking / Features / Fixes / …). The release skill reads those headings at insider-cut time to compute the next stable version, and the `-insiders.N` counter grows across iterations against the same future stable. Eliminates stable-version gaps. See [`ai-docs/release-channels.md`](ai-docs/release-channels.md).
+
 ## v0.62.4 (2026-05-16)
 
 ### Release

--- a/INSIDERS.md
+++ b/INSIDERS.md
@@ -10,7 +10,11 @@ Insiders installers come from a private Azure Blob container, are code-signed wi
 
 - Faster cadence (often multiple builds per week vs. weekly stable).
 - Less manual QA. Bugs are more likely.
-- Prerelease version numbers (`vX.Y.Z-insiders.N`).
+- Prerelease version numbers (`vX.Y.Z-insiders.N`). The base `X.Y.Z`
+  previews the **next stable** — so `v0.63.0-insiders.3` is the third
+  preview of the upcoming `v0.63.0`. When stable ships, the
+  corresponding insider tag and the stable tag point at the same source
+  commit.
 - Not advertised, not listed on GitHub Releases.
 
 If you would like to be removed from the invite list, tell whoever invited you. The download URL itself is unlisted.

--- a/ai-docs/release-channels.md
+++ b/ai-docs/release-channels.md
@@ -73,8 +73,15 @@ signatures) but they came from the same source tree.
 After the workflow succeeds, the `release` skill opens a **post-release
 bump PR** that:
 
-- runs `npm version 0.63.0 --no-git-tag-version --allow-same-version`
-  on master,
+- branches from the **build SHA** (the insider tag in Flow B, the
+  dispatch SHA in Flow A) — **not** from current `origin/master`. This
+  ensures the CHANGELOG content promoted into `## vX.Y.Z` reflects
+  exactly what was in `## Unreleased` at the moment we built. Any
+  bullets added to `## Unreleased` during the build window land as a
+  visible 3-way merge conflict at PR-merge time (mechanical to resolve:
+  keep both sections), rather than silently being misattributed to the
+  released version,
+- runs `npm version 0.63.0 --no-git-tag-version --allow-same-version`,
 - calls `promoteUnreleasedToVersion` on `CHANGELOG.md` to turn the
   `## Unreleased` block into `## v0.63.0 (YYYY-MM-DD)`,
 - opens the PR for review.
@@ -270,6 +277,19 @@ auto-skip guard — keep it `true` for manual dispatches.
 
 ## Decision log
 
+- **Why anchor the post-release bump PR to the build SHA?** Stable
+  builds take 30–60 minutes (macOS notarization). Ship PRs can merge
+  during that window and add bullets to `## Unreleased`. If the bump PR
+  were branched from current `origin/master` at Part B time, those
+  interim bullets would get silently promoted into the just-released
+  `## vX.Y.Z` section — falsely attributing changes that aren't in the
+  shipped binary. Branching the bump PR from the build SHA captures
+  `## Unreleased` exactly as it was at build time. Interim bullets
+  surface as a visible 3-way merge conflict when the bump PR is merged
+  to master — mechanical to resolve (keep both sections), loud instead
+  of silent. This is the "anchor bump branch to build SHA" pattern; the
+  release-please #2754 postmortem (April 2026) is the canonical example
+  of what goes wrong without it.
 - **Why Model B (release-time version bumps)?** Surveyed VS Code,
   Electron, Node.js, Chrome, Firefox, GitHub CLI, `semantic-release`,
   and `release-please`. The dominant pattern is: derive the version

--- a/ai-docs/release-channels.md
+++ b/ai-docs/release-channels.md
@@ -10,47 +10,58 @@ nothing is published on push to `master`.
 
 ## Mental model
 
-- `master` carries the development version. Releases come from off-master
-  tag snapshots, not from master itself.
+- `master`'s `package.json#version` always equals the **last shipped
+  stable version**. It is stale between releases. The only automation
+  that mutates it is the post-release bump PR opened by the `release`
+  skill after a stable cut succeeds.
+- The next stable version is **computed at release time** from the
+  conventional `### Headings` accumulated in `## Unreleased` in
+  `CHANGELOG.md`. `### Breaking` → major; `### Features` → minor;
+  everything else → patch. Highest precedence wins.
+- Insiders preview the **next stable**. `v0.63.0-insiders.0` is the
+  first preview of the upcoming `v0.63.0`. The counter (`N`) advances
+  with each preview against that target. If a new ship adds a
+  higher-precedence heading to `## Unreleased`, the target stable
+  advances (e.g. `0.62.5` → `0.63.0`) and the counter resets to `0`.
 - Stable releases create `vX.Y.Z` tags; insiders create
-  `vX.Y.Z-insiders.N` tags. The commit each tag points to is **not pushed
-  to master** — the tag is the only handle.
+  `vX.Y.Z-insiders.N` tags. **Under Model B the insider tag points at
+  master's SHA directly** — no off-branch version-bump commit exists.
 - The same source SHA can be cut as an insider build, hardened, and then
   promoted to stable. Promotion rebuilds — it does not re-publish the
   insider binary.
-- `package.json` on master does not need to track every release. The
-  source of truth for "what version exists" is the git tags.
 
 ## Git shape
 
 ### After an insider cut
-The CI runner mutates `package.json` to add `-insiders.N`, commits, tags,
-and pushes the **tag only**:
+The CI runner computes the next insider version from `## Unreleased`,
+mutates `package.json` in the runner's working tree (used only by the
+build), and tags master's commit. No commit is created; the tag points
+at master:
 
 ```
-master:   A──B──C──D
-                  │
-                  └─E    ← tag: v0.62.4-insiders.3
+master:   A──B──C──D    ← tag: v0.63.0-insiders.3
 ```
 
-Commit `E` is **off-branch**. It exists in the object database, reachable
-only because the tag points at it. No `insiders/*` branch exists or is
-needed.
+`git tag -l 'v*-insiders.*'` lists every insider build. They all point
+at master commits. No `insiders/*` branch exists or is needed.
 
-`git tag -l 'v*-insiders.*'` lists every insider build. `git branch -a |
-grep insider` returns nothing.
+> **Surprise to expect:** `git checkout v0.63.0-insiders.3` shows the
+> stale master `package.json` (e.g. `"version": "0.62.4"`). That's by
+> design. The insider version was computed at dispatch time and only
+> embedded in the **built installer**, never committed. The installer
+> is the truthful artifact for the released version string.
 
 ### After promoting an insider to stable
-`release.yml` with `source_ref: v0.62.4-insiders.3` checks out `E`,
-strips `-insiders.3` from `package.json` **in the runner workspace only
-— no commit is made**, builds + signs + notarizes, and softprops creates
-the stable tag at the same commit:
+`release.yml` with `source_ref: v0.63.0-insiders.3` checks out master
+at that SHA, derives the stable version from the **tag name**
+(`v0.63.0-insiders.3` → `0.63.0`), applies it via `npm version
+--allow-same-version` in the runner workspace **only — no commit is
+made**, builds + signs + notarizes, and creates the stable tag at the
+same commit:
 
 ```
-master:   A──B──C──D
-                  │
-                  └─E    ← tag: v0.62.4-insiders.3
-                          ← tag: v0.62.4   (added by promotion)
+master:   A──B──C──D    ← tag: v0.63.0-insiders.3
+                        ← tag: v0.63.0   (added by promotion)
 ```
 
 Two tags, same commit. The insider tag is the audit record ("this is
@@ -59,30 +70,40 @@ against. The two installers are different binaries (different embedded
 version string, different `app-update.yml` channel + feed URL, fresh
 signatures) but they came from the same source tree.
 
-> **Surprise to expect:** `git checkout v0.62.4` shows
-> `0.62.4-insiders.3` in `package.json`. That's by design. The tag is a
-> pointer at commit `E`; the shipped installer is the truthful artifact
-> for the released version string.
+After the workflow succeeds, the `release` skill opens a **post-release
+bump PR** that:
 
-### After releasing master directly (no insider step)
-`release.yml` with `source_ref` empty just creates `vX.Y.Z` at the
-master commit. No off-branch commit, no version mutation, no surprises.
+- runs `npm version 0.63.0 --no-git-tag-version --allow-same-version`
+  on master,
+- calls `promoteUnreleasedToVersion` on `CHANGELOG.md` to turn the
+  `## Unreleased` block into `## v0.63.0 (YYYY-MM-DD)`,
+- opens the PR for review.
+
+Once merged, master satisfies the invariant again: `package.json#version
+= 0.63.0 = last shipped stable`.
+
+### Emergency release from master (no insider step)
+`release.yml` with `source_ref` empty computes the next stable from
+`## Unreleased` the same way the insiders compute does, applies it on
+the runner, and tags master. The post-release bump PR is still required
+afterward.
 
 ### Tag hygiene
-- **Do not delete insider tags casually.** Deleting the tag makes commit
-  `E` unreachable; Git's GC will eventually prune the commit (~30 days
-  for unreachable objects). After that you cannot promote or reproduce
-  that build.
-- Tags are cheap (a ref + one commit). A few hundred is fine. Prune only
-  if/when the list actually becomes a nuisance, and only prune insider
-  tags whose stable counterpart has already shipped.
+- **Do not delete insider tags casually.** Under Model B insider tags
+  point at master commits, so deleting an insider tag does not orphan a
+  commit — but you do lose the audit record of "this is what testers
+  ran" and the reproducibility handle. Keep insider tags until at least
+  the stable they previewed has shipped.
+- Tags are cheap (a ref). A few hundred is fine. Prune only if/when the
+  list actually becomes a nuisance, and only prune insider tags whose
+  stable counterpart has already shipped.
 - No release branches exist or need to.
 
 ### Version conflicts
-If `vX.Y.Z` already exists when you try to promote, softprops will fail
-with "tag already exists." Correct behavior — you can't double-publish.
-Bump master to the next version via the ship skill, cut a new insider
-off that bump, then promote.
+If `vX.Y.Z` already exists when you try to promote, the workflow will
+fail. Correct behavior — you can't double-publish. Add more changelog
+entries via `ship` so the next target stable advances, cut a new
+insider, then promote.
 
 ## Insiders channel
 
@@ -117,16 +138,19 @@ off that bump, then promote.
   secrets.
 
 ### How to cut an insider build
-1. Go to **Actions → Release Insiders → Run workflow** on the default
+1. Make sure `## Unreleased` in `CHANGELOG.md` has the bullets you want
+   the next stable to contain. Each `ship` invocation appends one.
+2. Go to **Actions → Release Insiders → Run workflow** on the default
    branch.
-2. Optional `bump` input — `patch` (default behavior), `minor`, or
-   `major`. Otherwise the patch counter increments.
-3. The workflow will:
-   - Run `scripts/bump-insiders-version.js`, which reads the latest
-     `v*-insiders.*` tag and `package.json` (whichever is newer) and
-     computes the next version.
-   - Run `npm install` to refresh the lockfile (full install, not
-     `--package-lock-only`).
+3. Optional `override_bump` input — `patch`, `minor`, `major`, or `none`
+   (default = derive from `## Unreleased`). Only use for emergencies
+   where the changelog doesn't reflect the intended bump.
+4. The workflow will:
+   - Run `scripts/bump-insiders-version.js`, which reads master's
+     `package.json#version` and the highest-precedence `### Heading`
+     in `## Unreleased`, computes the target stable via SemVer, and
+     advances/resets the `-insiders.N` counter against existing tags.
+   - Run `npm install` to refresh the lockfile in the runner workspace.
    - Sign via the existing Trusted Signing identity.
    - Build with `CHAMBER_RELEASE_CHANNEL=insiders` and
      `CHAMBER_BUILDER_UPDATE_URL` pointing at the blob. The embedded
@@ -136,8 +160,9 @@ off that bump, then promote.
      `node scripts/validate-builder-release.js --channel=insiders`.
    - Upload artifacts to the blob via `az storage blob upload-batch
      --auth-mode login`.
-   - Tag the bump commit `vX.Y.Z-insiders.N` and push the **tag only**.
-     The commit is not pushed to master.
+   - Tag master's commit `vX.Y.Z-insiders.N` and push the **tag only**.
+     No commit is created — the `package.json` mutation lives only in
+     the runner's working tree and the built installer.
 
 ### What testers do
 - First install: download
@@ -162,27 +187,34 @@ this.
 - macOS builds are signed with the Developer ID identity and notarized.
 
 ### How to cut a stable release
-Two flows, same workflow.
+Two flows, same workflow. **Flow B (promote insider) is the default.**
 
-**Flow A — release current `master`:**
-1. Bump the version in `package.json` on master and merge it.
-2. Go to **Actions → Release → Run workflow** on `master`.
-3. Leave `source_ref` empty. The workflow runs against the triggering
-   commit.
-
-**Flow B — promote an insider build:**
+**Flow B — promote an insider build (recommended):**
 1. Go to **Actions → Release → Run workflow** on `master`.
-2. Set `source_ref` to the insider tag, e.g. `v0.62.4-insiders.7` (or a
-   raw commit SHA).
+2. Set `source_ref` to the insider tag, e.g. `v0.63.0-insiders.7`.
 3. The workflow will:
-   - Check out that ref.
-   - Detect the `-insiders.N` suffix on `package.json#version` and strip
-     it for the stable version (`0.62.4-insiders.7` → `0.62.4`).
+   - Check out master at that SHA.
+   - Detect the `vX.Y.Z-insiders.N` tag-name pattern in `source_ref`
+     and derive the stable version from the **tag name** (not from
+     `package.json`, which under Model B holds the last shipped stable).
    - Apply that version via `npm version --no-git-tag-version
      --allow-same-version`, then `npm install`.
    - Build Windows + macOS, sign, notarize macOS.
    - Publish to GitHub Releases tagged `vX.Y.Z`. Release notes include
      `Promoted from insiders build vX.Y.Z-insiders.N`.
+4. After the workflow succeeds, the `release` skill opens a
+   **post-release bump PR** that advances master's `package.json` to
+   `X.Y.Z` and promotes `## Unreleased` into `## vX.Y.Z (date)` in
+   `CHANGELOG.md`.
+
+**Flow A — emergency release from master:**
+1. Make sure `## Unreleased` in `CHANGELOG.md` is non-empty.
+2. Go to **Actions → Release → Run workflow** on `master`.
+3. Leave `source_ref` empty. The workflow computes the next stable
+   version from `## Unreleased` using the same precedence rules as
+   insiders (`### Breaking` → major; `### Features` → minor; else
+   patch), applies it on the runner, builds, and tags master.
+4. The post-release bump PR is still required afterward.
 
 The `force_release` input (defaults to `true`) skips the patch-only
 auto-skip guard — keep it `true` for manual dispatches.
@@ -215,16 +247,43 @@ auto-skip guard — keep it `true` for manual dispatches.
 - `--channel=<name>` (defaults to `latest`) selects which manifest file
   to validate against. The insiders workflow passes `--channel=insiders`.
 
+`scripts/changelog.js`:
+- Single source of truth for parsing/writing `CHANGELOG.md`.
+  `readUnreleasedSection` returns the headings + raw text under
+  `## Unreleased`. `recommendBumpFromChangelog` maps the highest-
+  precedence heading to `patch`/`minor`/`major`/null. `appendEntry`
+  writes a new bullet under the correct `### Heading` (used by ship).
+  `promoteUnreleasedToVersion` turns `## Unreleased` into a real
+  `## vX.Y.Z (date)` section (used by the post-release bump PR).
+
 `scripts/bump-insiders-version.js`:
-- `readLatestInsidersTag()` — reads latest `v*-insiders.*` tag via
-  `git describe`.
-- `resolveBaseVersion()` — uses `semver.gt` to pick the newer of the
-  latest insider tag's base and `package.json#version`. This lets
-  master sit on a stable version while insider counters increment via
-  tags.
+- `readMasterVersion()` reads `package.json` and refuses to run if it
+  contains a prerelease suffix (would mean master's Model B invariant
+  was already violated).
+- Computes target stable via `semver.inc(masterVersion,
+  recommendBumpFromChangelog())`.
+- `listInsiderCountersForBase(target)` queries
+  `git tag --list v<target>-insiders.*` and returns the next counter
+  (max + 1, or 0 if none exist).
+- `stableTagExists(target)` blocks dispatch if the target stable
+  already shipped — forces sequencing through the post-release bump PR.
 
 ## Decision log
 
+- **Why Model B (release-time version bumps)?** Surveyed VS Code,
+  Electron, Node.js, Chrome, Firefox, GitHub CLI, `semantic-release`,
+  and `release-please`. The dominant pattern is: derive the version
+  from accumulated commit/changelog signal at release time, not at PR
+  time. Benefits: consecutive stable history without gaps; `-insiders.N`
+  counter has real meaning (iterations against a single target); CHANGELOG
+  authorship happens close to the change while version computation
+  happens close to the cut. Trade-off: master's `package.json` is stale
+  between releases — accepted because the released artifacts (installer,
+  GitHub Release tag) carry the truthful version.
+- **Why conventional headings to drive the bump?** Mechanical and
+  auditable. The release skill never has to infer intent; it reads the
+  headings and applies the precedence table. Typos default to `patch`
+  so a misspelled heading never blocks a release.
 - **Why not GitHub Releases prereleases for insiders?** They're still
   indexed and discoverable. "Unlisted" needed an out-of-band URL — Azure
   blob with anonymous reads but no listing fits.
@@ -237,10 +296,11 @@ auto-skip guard — keep it `true` for manual dispatches.
   The cost of "every PR merge ships to testers" is update fatigue and
   the risk of a bad auto-update with no human in the loop. Manual
   dispatch keeps the human in the loop without slowing things down.
-- **Why tag-only pushes?** Master should not be polluted with release
-  ceremony commits (version bumps, lockfile churn). Tags are sufficient
-  to retrieve the source. Promotion off an insider tag uses the same
-  pattern.
+- **Why tag-only pushes (no synthetic bump commit)?** Under Model B the
+  insider's version is derived data; embedding it in a committed
+  `package.json` mutation would add noise to history with no benefit.
+  The tag points at master's commit; the version lives in the built
+  artifact.
 - **Why federated identity instead of a managed identity?** GH-hosted
   runners are outside Azure and cannot host an MI. OIDC federation is
   the equivalent — no long-lived secret to rotate.

--- a/scripts/append-changelog-entry.js
+++ b/scripts/append-changelog-entry.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * CLI: append a bullet to `## Unreleased` in CHANGELOG.md.
+ *
+ * Used by the ship skill. Creates `## Unreleased` and the relevant
+ * `### Heading` if missing.
+ *
+ * Usage:
+ *   node scripts/append-changelog-entry.js \
+ *     --kind=fixes \
+ *     --summary="Bold one-liner" \
+ *     --detail="Longer explanation of the change" \
+ *     --issue=123
+ *
+ *   --kind     one of: breaking, features, fixes, performance, refactor,
+ *              docs, tests, build, ci, chore, release (case-insensitive)
+ *   --summary  required, becomes **bolded** at the start of the bullet
+ *   --detail   optional, follows " — " after the summary
+ *   --issue    optional, appended as " (#N)" at the end
+ *   --changelog  optional path override (defaults to ./CHANGELOG.md)
+ */
+
+const path = require('node:path');
+const { appendEntry, HEADING_PRECEDENCE } = require('./changelog');
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (const arg of argv) {
+    if (arg.startsWith('--')) {
+      const [key, value] = arg.slice(2).split('=');
+      args.set(key, value ?? 'true');
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const kind = args.get('kind');
+  const summary = args.get('summary');
+  const detail = args.get('detail');
+  const issue = args.get('issue');
+  const changelog = args.get('changelog') ?? path.resolve(process.cwd(), 'CHANGELOG.md');
+
+  if (!kind || !summary) {
+    console.error('Usage: append-changelog-entry --kind=<heading> --summary="..." [--detail="..."] [--issue=N]');
+    console.error('Known kinds:', Object.keys(HEADING_PRECEDENCE).join(', '));
+    process.exit(2);
+  }
+
+  appendEntry(changelog, { kind, summary, detail, issue });
+  console.log(`Appended ${kind} entry to ${changelog}`);
+}
+
+main();

--- a/scripts/bump-insiders-version.js
+++ b/scripts/bump-insiders-version.js
@@ -1,13 +1,46 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
+/**
+ * Model B insiders version computer.
+ *
+ * Reads:
+ *   - package.json#version          (the last shipped stable version)
+ *   - CHANGELOG.md  ## Unreleased   (drives the patch / minor / major decision)
+ *   - git tag --list v*-insiders.*  (drives the .N counter)
+ *
+ * Writes:
+ *   - package.json  (mutated to <target-stable>-insiders.<N> for the runner build)
+ *   - package-lock.json (kept in sync via `npm install`)
+ *   - GITHUB_OUTPUT  (target_stable, insider_version, counter, bump_kind)
+ *
+ * The mutation is NOT committed by this script. The release-insiders.yml
+ * workflow consumes the mutated package.json for the build, then `git tag`s
+ * v<insider_version> against the original commit. Master's package.json on
+ * disk remains at the last stable version.
+ *
+ * Usage:
+ *   node scripts/bump-insiders-version.js
+ *   node scripts/bump-insiders-version.js --override-bump=patch
+ *   node scripts/bump-insiders-version.js --changelog=/path/to/CHANGELOG.md
+ *   node scripts/bump-insiders-version.js --dry-run
+ *
+ * --override-bump  Force a specific bump (patch/minor/major), ignoring
+ *                  Unreleased. Emergency escape hatch; ship/release skills
+ *                  never pass this in normal flow.
+ * --changelog      Path override (defaults to <repo>/CHANGELOG.md).
+ * --dry-run        Compute and print but do not mutate package.json.
+ */
+
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const semver = require('semver');
+const { recommendBumpFromChangelog } = require('./changelog');
 
 const INSIDERS_TAG = 'insiders';
 const repoRoot = path.resolve(__dirname, '..');
 const packageJsonPath = path.join(repoRoot, 'package.json');
+const defaultChangelogPath = path.join(repoRoot, 'CHANGELOG.md');
 
 function parseArgs(argv) {
   const args = new Map();
@@ -18,51 +51,6 @@ function parseArgs(argv) {
     }
   }
   return args;
-}
-
-function readLatestInsidersTag() {
-  const result = spawnSync('git', ['tag', '--list', `v*-${INSIDERS_TAG}.*`], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
-  if (result.status !== 0) return null;
-  const tags = result.stdout
-    .split('\n')
-    .map((t) => t.trim())
-    .filter(Boolean)
-    .map((t) => t.replace(/^v/, ''))
-    .filter((v) => semver.valid(v));
-  if (tags.length === 0) return null;
-  return tags.sort(semver.rcompare)[0];
-}
-
-function resolveBaseVersion() {
-  const pkgVersion = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version;
-  const tagVersion = readLatestInsidersTag();
-  if (!tagVersion) return pkgVersion;
-  // Use whichever is "newer" in semver terms so a manual stable bump can leapfrog older insider tags.
-  return semver.gt(tagVersion, pkgVersion) ? tagVersion : pkgVersion;
-}
-
-function computeNextVersion(current, bumpType) {
-  const parsed = semver.parse(current);
-  if (!parsed) throw new Error(`Invalid current version: ${current}`);
-
-  const isInsidersPrerelease = parsed.prerelease[0] === INSIDERS_TAG;
-
-  if (isInsidersPrerelease && !bumpType) {
-    const next = semver.inc(current, 'prerelease', INSIDERS_TAG);
-    if (!next) throw new Error(`semver.inc returned null for ${current}`);
-    return next;
-  }
-
-  const releaseType = bumpType
-    ? `pre${bumpType}`
-    : 'prerelease';
-
-  const next = semver.inc(current, releaseType, INSIDERS_TAG);
-  if (!next) throw new Error(`semver.inc returned null for ${current}/${releaseType}`);
-  return next;
 }
 
 function runOrThrow(command, args, options = {}) {
@@ -77,26 +65,128 @@ function runOrThrow(command, args, options = {}) {
   }
 }
 
-const cliArgs = parseArgs(process.argv.slice(2));
-const bumpType = cliArgs.get('bump');
-if (bumpType && !['major', 'minor', 'patch'].includes(bumpType)) {
-  throw new Error(`--bump must be one of major|minor|patch, got: ${bumpType}`);
+function readMasterVersion() {
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  if (!semver.valid(pkg.version)) {
+    throw new Error(`package.json#version is not valid semver: ${pkg.version}`);
+  }
+  if (semver.prerelease(pkg.version)) {
+    throw new Error(
+      `package.json#version (${pkg.version}) carries a prerelease suffix. ` +
+        'Master must hold the last shipped stable version under Model B. ' +
+        'See ai-docs/release-channels.md.',
+    );
+  }
+  return pkg.version;
 }
 
-const baseVersion = resolveBaseVersion();
-const nextVersion = computeNextVersion(baseVersion, bumpType);
-
-console.log(`Resolved base version: ${baseVersion}`);
-console.log(`Bumping ${baseVersion} -> ${nextVersion}`);
-
-runOrThrow('npm', ['version', nextVersion, '--no-git-tag-version']);
-
-// Full `npm install` keeps optional cross-platform deps like @emnapi/core and
-// @emnapi/runtime in the lockfile, which CI requires. Do NOT use the
-// lockfile-only flag (npm install strips those entries on some npm versions).
-runOrThrow('npm', ['install']);
-
-if (cliArgs.get('print-version') === 'true') {
-  console.log(nextVersion);
+function listInsiderCountersForBase(baseStable) {
+  const result = spawnSync('git', ['tag', '--list', `v${baseStable}-${INSIDERS_TAG}.*`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) return [];
+  return result.stdout
+    .split('\n')
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map((t) => t.replace(/^v/, ''))
+    .map((v) => {
+      const parsed = semver.parse(v);
+      if (!parsed) return -1;
+      if (parsed.prerelease[0] !== INSIDERS_TAG) return -1;
+      const counter = parsed.prerelease[1];
+      return typeof counter === 'number' ? counter : Number.parseInt(counter, 10);
+    })
+    .filter((n) => Number.isInteger(n) && n >= 0);
 }
 
+function stableTagExists(version) {
+  const result = spawnSync('git', ['tag', '--list', `v${version}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 && result.stdout.trim() !== '';
+}
+
+function computeNextInsiderVersion({ masterVersion, bumpKind }) {
+  const targetStable = semver.inc(masterVersion, bumpKind);
+  if (!targetStable) throw new Error(`semver.inc returned null for ${masterVersion}/${bumpKind}`);
+
+  if (stableTagExists(targetStable)) {
+    throw new Error(
+      `Target stable v${targetStable} already exists as a tag. ` +
+        `Master should have been bumped to ${targetStable} after that release. ` +
+        'Open the post-release bump PR before cutting another insider.',
+    );
+  }
+
+  const counters = listInsiderCountersForBase(targetStable);
+  const nextCounter = counters.length === 0 ? 0 : Math.max(...counters) + 1;
+  const insiderVersion = `${targetStable}-${INSIDERS_TAG}.${nextCounter}`;
+  return { targetStable, insiderVersion, counter: nextCounter };
+}
+
+function writeGithubOutput(values) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  const lines = Object.entries(values).map(([k, v]) => `${k}=${v}`).join('\n');
+  fs.appendFileSync(outputPath, `${lines}\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const overrideBump = args.get('override-bump');
+  const changelogPath = args.get('changelog') ?? defaultChangelogPath;
+  const dryRun = args.get('dry-run') === 'true';
+
+  if (overrideBump && !['major', 'minor', 'patch'].includes(overrideBump)) {
+    throw new Error(`--override-bump must be one of major|minor|patch, got: ${overrideBump}`);
+  }
+
+  const masterVersion = readMasterVersion();
+  let bumpKind = overrideBump ?? null;
+  let bumpSource = overrideBump ? 'override' : null;
+
+  if (!bumpKind) {
+    const { bump, section } = recommendBumpFromChangelog(changelogPath);
+    if (!bump) {
+      throw new Error(
+        section.present
+          ? '## Unreleased is empty. Add at least one bullet under a ### heading before cutting an insider.'
+          : 'CHANGELOG.md has no ## Unreleased section. Run ship to record changes, or pass --override-bump explicitly.',
+      );
+    }
+    bumpKind = bump;
+    bumpSource = 'changelog';
+  }
+
+  const { targetStable, insiderVersion, counter } = computeNextInsiderVersion({
+    masterVersion,
+    bumpKind,
+  });
+
+  console.log(`Master version:    ${masterVersion}`);
+  console.log(`Bump source:       ${bumpSource} (${bumpKind})`);
+  console.log(`Target stable:     ${targetStable}`);
+  console.log(`Insider counter:   ${counter}`);
+  console.log(`Insider version:   ${insiderVersion}`);
+
+  writeGithubOutput({
+    version: insiderVersion,
+    target_stable: targetStable,
+    counter: String(counter),
+    bump_kind: bumpKind,
+    bump_source: bumpSource,
+  });
+
+  if (dryRun) {
+    console.log('--dry-run: skipping package.json mutation');
+    return;
+  }
+
+  runOrThrow('npm', ['version', insiderVersion, '--no-git-tag-version', '--allow-same-version']);
+  runOrThrow('npm', ['install']);
+}
+
+main();

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -171,16 +171,34 @@ function ensureUnreleasedSection(changelogPath) {
   return true;
 }
 
+const CANONICAL_HEADINGS = {
+  breaking: 'Breaking',
+  feature: 'Features',
+  features: 'Features',
+  fix: 'Fixes',
+  fixes: 'Fixes',
+  perf: 'Performance',
+  performance: 'Performance',
+  refactor: 'Refactor',
+  docs: 'Docs',
+  tests: 'Tests',
+  build: 'Build',
+  ci: 'CI',
+  chore: 'Chore',
+  release: 'Release',
+};
+
+function canonicalHeading(kind) {
+  const key = String(kind || '').trim().toLowerCase();
+  return CANONICAL_HEADINGS[key] ?? (key ? key.charAt(0).toUpperCase() + key.slice(1) : 'Chore');
+}
+
 /**
- * Append a bullet under the right `### Heading` of `## Unreleased`,
+ * Append a bullet under the appropriate `### Heading` of `## Unreleased`,
  * creating the section and the heading if either is missing.
  *
  * @param {string} changelogPath
  * @param {{ kind: string, summary: string, detail?: string, issue?: string }} entry
- *   kind: one of the conventional heading words (features, fixes, breaking, ...)
- *   summary: bold one-liner without the surrounding `**`
- *   detail: optional explanatory text
- *   issue: optional issue number (no `#`)
  * @returns {void}
  */
 function appendEntry(changelogPath, { kind, summary, detail, issue }) {
@@ -191,7 +209,7 @@ function appendEntry(changelogPath, { kind, summary, detail, issue }) {
   const lines = text.split(/\r?\n/);
   const section = readUnreleasedSection(changelogPath);
 
-  const headingWord = kind.charAt(0).toUpperCase() + kind.slice(1).toLowerCase();
+  const headingWord = canonicalHeading(kind);
   const headingRegex = new RegExp(`^###\\s+${headingWord}\\s*$`, 'i');
 
   let headingLine = -1;
@@ -208,8 +226,13 @@ function appendEntry(changelogPath, { kind, summary, detail, issue }) {
   if (issue) bullet += ` (#${issue})`;
 
   if (headingLine === -1) {
-    const insertAt = section.endLine;
-    const block = ['', `### ${headingWord}`, '', bullet];
+    // Insert a new ### Heading block at the end of ## Unreleased, ensuring a
+    // blank line separates it from the next ## heading.
+    let insertAt = section.endLine;
+    while (insertAt > section.startLine + 1 && lines[insertAt - 1].trim() === '') {
+      insertAt -= 1;
+    }
+    const block = ['', `### ${headingWord}`, '', bullet, ''];
     const updated = [...lines.slice(0, insertAt), ...block, ...lines.slice(insertAt)];
     fs.writeFileSync(changelogPath, updated.join('\n'));
     return;

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,0 +1,234 @@
+/* eslint-disable no-console */
+/**
+ * CHANGELOG.md parser + writer for Chamber's Model B release flow.
+ *
+ * The single source of truth for:
+ *   - reading the `## Unreleased` section and the conventional `### Headings`
+ *     it contains,
+ *   - recommending the next stable version bump (patch / minor / major) from
+ *     those headings,
+ *   - promoting `## Unreleased` into `## vX.Y.Z (YYYY-MM-DD)` at stable
+ *     release time.
+ *
+ * This module is consumed by:
+ *   - scripts/bump-insiders-version.js  (computes the target stable + counter)
+ *   - scripts/append-changelog-entry.js (ship-time bullet append)
+ *   - .github/skills/release/           (post-stable promote)
+ *   - tests/regression/changelog-parser.test.ts
+ */
+
+const fs = require('node:fs');
+
+const UNRELEASED_HEADING = 'Unreleased';
+
+// Precedence: higher number wins. Headings are matched case-insensitively
+// against the leading word of the `### Heading`. Anything not listed defaults
+// to patch precedence so unknown sections never block a release.
+const HEADING_PRECEDENCE = {
+  breaking: { rank: 3, bump: 'major' },
+  features: { rank: 2, bump: 'minor' },
+  feature: { rank: 2, bump: 'minor' },
+  fixes: { rank: 1, bump: 'patch' },
+  fix: { rank: 1, bump: 'patch' },
+  performance: { rank: 1, bump: 'patch' },
+  perf: { rank: 1, bump: 'patch' },
+  refactor: { rank: 1, bump: 'patch' },
+  docs: { rank: 1, bump: 'patch' },
+  documentation: { rank: 1, bump: 'patch' },
+  tests: { rank: 1, bump: 'patch' },
+  test: { rank: 1, bump: 'patch' },
+  build: { rank: 1, bump: 'patch' },
+  ci: { rank: 1, bump: 'patch' },
+  chore: { rank: 1, bump: 'patch' },
+  release: { rank: 1, bump: 'patch' },
+};
+
+function normalizeHeading(raw) {
+  return raw.trim().toLowerCase().split(/\s+/)[0];
+}
+
+/**
+ * Read `## Unreleased` and return its contents.
+ *
+ * @param {string} changelogPath
+ * @returns {{
+ *   present: boolean,            // true if `## Unreleased` exists at all
+ *   raw: string,                 // the section body (without the `## Unreleased` heading)
+ *   headings: string[],          // normalized headings found inside, in order
+ *   bulletCount: number,         // total `- ` bullets across all subsections
+ *   startLine: number,           // 0-indexed line of the `## Unreleased` heading
+ *   endLine: number              // 0-indexed line just past the last line of the section
+ * }}
+ */
+function readUnreleasedSection(changelogPath) {
+  const text = fs.readFileSync(changelogPath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const startLine = lines.findIndex((line) => /^##\s+Unreleased\s*$/i.test(line));
+  if (startLine === -1) {
+    return { present: false, raw: '', headings: [], bulletCount: 0, startLine: -1, endLine: -1 };
+  }
+  let endLine = lines.length;
+  for (let i = startLine + 1; i < lines.length; i += 1) {
+    if (/^##\s+/.test(lines[i])) {
+      endLine = i;
+      break;
+    }
+  }
+  const body = lines.slice(startLine + 1, endLine);
+  const headings = [];
+  let bulletCount = 0;
+  for (const line of body) {
+    const headingMatch = line.match(/^###\s+(.+?)\s*$/);
+    if (headingMatch) {
+      headings.push(normalizeHeading(headingMatch[1]));
+      continue;
+    }
+    if (/^\s*-\s+/.test(line)) {
+      bulletCount += 1;
+    }
+  }
+  return {
+    present: true,
+    raw: body.join('\n'),
+    headings,
+    bulletCount,
+    startLine,
+    endLine,
+  };
+}
+
+/**
+ * Recommend a SemVer bump (patch / minor / major) from the headings inside
+ * `## Unreleased`. Returns null if there are no actionable entries — the
+ * release skill treats null as "block dispatch".
+ *
+ * @param {string[]} headings — normalized headings from readUnreleasedSection
+ * @returns {'patch' | 'minor' | 'major' | null}
+ */
+function recommendBump(headings) {
+  if (!headings || headings.length === 0) return null;
+  let best = null;
+  for (const heading of headings) {
+    const entry = HEADING_PRECEDENCE[heading] ?? HEADING_PRECEDENCE.chore;
+    if (!best || entry.rank > best.rank) best = entry;
+  }
+  return best ? best.bump : null;
+}
+
+/**
+ * Convenience: read + recommend in one call.
+ *
+ * @param {string} changelogPath
+ * @returns {{
+ *   bump: 'patch' | 'minor' | 'major' | null,
+ *   section: ReturnType<typeof readUnreleasedSection>
+ * }}
+ */
+function recommendBumpFromChangelog(changelogPath) {
+  const section = readUnreleasedSection(changelogPath);
+  if (!section.present || section.bulletCount === 0) {
+    return { bump: null, section };
+  }
+  return { bump: recommendBump(section.headings), section };
+}
+
+/**
+ * Replace `## Unreleased` with `## v<version> (<dateISO>)` and leave a fresh
+ * empty `## Unreleased` placeholder at the top. Idempotent if Unreleased is
+ * missing — returns false instead of throwing.
+ *
+ * @param {string} changelogPath
+ * @param {string} version — bare SemVer (no `v` prefix)
+ * @param {string} dateISO — `YYYY-MM-DD`
+ * @returns {boolean} true if the file was rewritten
+ */
+function promoteUnreleasedToVersion(changelogPath, version, dateISO) {
+  const text = fs.readFileSync(changelogPath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const startLine = lines.findIndex((line) => /^##\s+Unreleased\s*$/i.test(line));
+  if (startLine === -1) return false;
+  const newSection = ['## Unreleased', '', `## v${version} (${dateISO})`];
+  const rewritten = [...lines.slice(0, startLine), ...newSection, ...lines.slice(startLine + 1)];
+  fs.writeFileSync(changelogPath, rewritten.join('\n'));
+  return true;
+}
+
+/**
+ * Ensure `## Unreleased` exists at the top of CHANGELOG.md, immediately after
+ * the `# Changelog` H1. Idempotent; returns true if a section was inserted.
+ *
+ * @param {string} changelogPath
+ * @returns {boolean}
+ */
+function ensureUnreleasedSection(changelogPath) {
+  const text = fs.readFileSync(changelogPath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  if (lines.some((line) => /^##\s+Unreleased\s*$/i.test(line))) return false;
+  const h1Line = lines.findIndex((line) => /^#\s+/.test(line));
+  const insertAt = h1Line === -1 ? 0 : h1Line + 1;
+  const newLines = [...lines.slice(0, insertAt), '', '## Unreleased', '', ...lines.slice(insertAt)];
+  fs.writeFileSync(changelogPath, newLines.join('\n'));
+  return true;
+}
+
+/**
+ * Append a bullet under the right `### Heading` of `## Unreleased`,
+ * creating the section and the heading if either is missing.
+ *
+ * @param {string} changelogPath
+ * @param {{ kind: string, summary: string, detail?: string, issue?: string }} entry
+ *   kind: one of the conventional heading words (features, fixes, breaking, ...)
+ *   summary: bold one-liner without the surrounding `**`
+ *   detail: optional explanatory text
+ *   issue: optional issue number (no `#`)
+ * @returns {void}
+ */
+function appendEntry(changelogPath, { kind, summary, detail, issue }) {
+  if (!kind) throw new Error('appendEntry: kind is required');
+  if (!summary) throw new Error('appendEntry: summary is required');
+  ensureUnreleasedSection(changelogPath);
+  const text = fs.readFileSync(changelogPath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const section = readUnreleasedSection(changelogPath);
+
+  const headingWord = kind.charAt(0).toUpperCase() + kind.slice(1).toLowerCase();
+  const headingRegex = new RegExp(`^###\\s+${headingWord}\\s*$`, 'i');
+
+  let headingLine = -1;
+  for (let i = section.startLine + 1; i < section.endLine; i += 1) {
+    if (headingRegex.test(lines[i])) {
+      headingLine = i;
+      break;
+    }
+  }
+
+  const bulletParts = [`**${summary}**`];
+  if (detail) bulletParts.push(detail.trim());
+  let bullet = `- ${bulletParts.join(' — ')}`;
+  if (issue) bullet += ` (#${issue})`;
+
+  if (headingLine === -1) {
+    const insertAt = section.endLine;
+    const block = ['', `### ${headingWord}`, '', bullet];
+    const updated = [...lines.slice(0, insertAt), ...block, ...lines.slice(insertAt)];
+    fs.writeFileSync(changelogPath, updated.join('\n'));
+    return;
+  }
+
+  let insertAt = headingLine + 1;
+  while (insertAt < section.endLine && lines[insertAt].trim() === '') insertAt += 1;
+  while (insertAt < section.endLine && /^\s*-\s+/.test(lines[insertAt])) insertAt += 1;
+  const updated = [...lines.slice(0, insertAt), bullet, ...lines.slice(insertAt)];
+  fs.writeFileSync(changelogPath, updated.join('\n'));
+}
+
+module.exports = {
+  UNRELEASED_HEADING,
+  HEADING_PRECEDENCE,
+  readUnreleasedSection,
+  recommendBump,
+  recommendBumpFromChangelog,
+  promoteUnreleasedToVersion,
+  ensureUnreleasedSection,
+  appendEntry,
+};

--- a/tests/regression/changelog-parser.test.ts
+++ b/tests/regression/changelog-parser.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  readUnreleasedSection,
+  recommendBump,
+  recommendBumpFromChangelog,
+  promoteUnreleasedToVersion,
+  ensureUnreleasedSection,
+  appendEntry,
+} from '../../scripts/changelog';
+
+const CHANGELOG_NAME = 'CHANGELOG.md';
+
+function writeChangelog(dir: string, body: string): string {
+  const path = join(dir, CHANGELOG_NAME);
+  writeFileSync(path, body);
+  return path;
+}
+
+describe('changelog parser', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'changelog-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('reports absent when no Unreleased section exists', () => {
+    const path = writeChangelog(workDir, '# Changelog\n\n## v1.0.0 (2025-01-01)\n');
+    const section = readUnreleasedSection(path);
+    expect(section.present).toBe(false);
+    expect(section.bulletCount).toBe(0);
+  });
+
+  it('parses headings and counts bullets inside Unreleased', () => {
+    const path = writeChangelog(
+      workDir,
+      [
+        '# Changelog',
+        '',
+        '## Unreleased',
+        '',
+        '### Features',
+        '',
+        '- **Add X** — detail',
+        '- **Add Y** — detail',
+        '',
+        '### Fixes',
+        '',
+        '- **Fix Z** — detail',
+        '',
+        '## v1.0.0 (2025-01-01)',
+        '',
+      ].join('\n'),
+    );
+    const section = readUnreleasedSection(path);
+    expect(section.present).toBe(true);
+    expect(section.headings).toEqual(['features', 'fixes']);
+    expect(section.bulletCount).toBe(3);
+  });
+
+  it('stops reading at the next ## heading', () => {
+    const path = writeChangelog(
+      workDir,
+      [
+        '# Changelog',
+        '',
+        '## Unreleased',
+        '',
+        '### Fixes',
+        '',
+        '- **In unreleased** — yes',
+        '',
+        '## v1.0.0 (2025-01-01)',
+        '',
+        '### Features',
+        '',
+        '- **In v1.0.0, not Unreleased** — must not count',
+      ].join('\n'),
+    );
+    const section = readUnreleasedSection(path);
+    expect(section.headings).toEqual(['fixes']);
+    expect(section.bulletCount).toBe(1);
+  });
+
+  it('recommends patch for fixes-only sections', () => {
+    expect(recommendBump(['fixes'])).toBe('patch');
+    expect(recommendBump(['fixes', 'docs', 'tests'])).toBe('patch');
+  });
+
+  it('recommends minor when any feature is present', () => {
+    expect(recommendBump(['features'])).toBe('minor');
+    expect(recommendBump(['fixes', 'features'])).toBe('minor');
+  });
+
+  it('recommends major when any breaking is present', () => {
+    expect(recommendBump(['breaking'])).toBe('major');
+    expect(recommendBump(['fixes', 'features', 'breaking'])).toBe('major');
+  });
+
+  it('returns null for empty headings list', () => {
+    expect(recommendBump([])).toBeNull();
+    expect(recommendBump(undefined as unknown as string[])).toBeNull();
+  });
+
+  it('treats unknown headings as patch precedence', () => {
+    expect(recommendBump(['chore'])).toBe('patch');
+    expect(recommendBump(['mystery-section'])).toBe('patch');
+  });
+
+  it('recommendBumpFromChangelog returns null when Unreleased exists but has no bullets', () => {
+    const path = writeChangelog(
+      workDir,
+      ['# Changelog', '', '## Unreleased', '', '## v1.0.0 (2025-01-01)', ''].join('\n'),
+    );
+    const { bump } = recommendBumpFromChangelog(path);
+    expect(bump).toBeNull();
+  });
+
+  it('promoteUnreleasedToVersion replaces Unreleased and leaves a fresh placeholder', () => {
+    const path = writeChangelog(
+      workDir,
+      [
+        '# Changelog',
+        '',
+        '## Unreleased',
+        '',
+        '### Features',
+        '',
+        '- **Add X** — detail',
+        '',
+        '## v1.0.0 (2025-01-01)',
+        '',
+      ].join('\n'),
+    );
+    const changed = promoteUnreleasedToVersion(path, '1.1.0', '2025-02-01');
+    expect(changed).toBe(true);
+    const text = readFileSync(path, 'utf8');
+    expect(text).toContain('## Unreleased');
+    expect(text).toContain('## v1.1.0 (2025-02-01)');
+    expect(text.indexOf('## Unreleased')).toBeLessThan(text.indexOf('## v1.1.0'));
+    expect(text.indexOf('## v1.1.0')).toBeLessThan(text.indexOf('- **Add X**'));
+    expect(text.indexOf('- **Add X**')).toBeLessThan(text.indexOf('## v1.0.0'));
+  });
+
+  it('ensureUnreleasedSection inserts the section just after the H1 when missing', () => {
+    const path = writeChangelog(workDir, '# Changelog\n\n## v1.0.0 (2025-01-01)\n');
+    const inserted = ensureUnreleasedSection(path);
+    expect(inserted).toBe(true);
+    const text = readFileSync(path, 'utf8');
+    expect(text.indexOf('## Unreleased')).toBeLessThan(text.indexOf('## v1.0.0'));
+  });
+
+  it('ensureUnreleasedSection is idempotent', () => {
+    const path = writeChangelog(
+      workDir,
+      ['# Changelog', '', '## Unreleased', '', '## v1.0.0', ''].join('\n'),
+    );
+    const inserted = ensureUnreleasedSection(path);
+    expect(inserted).toBe(false);
+  });
+
+  it('appendEntry creates Unreleased, the heading, and the bullet on a clean changelog', () => {
+    const path = writeChangelog(workDir, '# Changelog\n\n## v1.0.0 (2025-01-01)\n');
+    appendEntry(path, { kind: 'fixes', summary: 'Bug fix', detail: 'detail here', issue: '42' });
+    const text = readFileSync(path, 'utf8');
+    expect(text).toContain('## Unreleased');
+    expect(text).toContain('### Fixes');
+    expect(text).toContain('- **Bug fix** — detail here (#42)');
+  });
+
+  it('appendEntry adds a bullet under the existing heading without duplicating it', () => {
+    const path = writeChangelog(
+      workDir,
+      [
+        '# Changelog',
+        '',
+        '## Unreleased',
+        '',
+        '### Fixes',
+        '',
+        '- **First fix** — old',
+        '',
+        '## v1.0.0 (2025-01-01)',
+      ].join('\n'),
+    );
+    appendEntry(path, { kind: 'fixes', summary: 'Second fix' });
+    const text = readFileSync(path, 'utf8');
+    const matches = text.match(/^### Fixes$/gm) ?? [];
+    expect(matches.length).toBe(1);
+    expect(text).toContain('- **First fix** — old');
+    expect(text).toContain('- **Second fix**');
+    expect(text.indexOf('- **First fix**')).toBeLessThan(text.indexOf('- **Second fix**'));
+  });
+
+  it('appendEntry adds a new heading for a kind not yet present', () => {
+    const path = writeChangelog(
+      workDir,
+      [
+        '# Changelog',
+        '',
+        '## Unreleased',
+        '',
+        '### Fixes',
+        '',
+        '- **First fix** — old',
+        '',
+        '## v1.0.0',
+      ].join('\n'),
+    );
+    appendEntry(path, { kind: 'features', summary: 'New feature' });
+    const text = readFileSync(path, 'utf8');
+    expect(text).toContain('### Fixes');
+    expect(text).toContain('### Features');
+    expect(text).toContain('- **New feature**');
+  });
+});

--- a/tests/regression/changelog-parser.test.ts
+++ b/tests/regression/changelog-parser.test.ts
@@ -220,4 +220,32 @@ describe('changelog parser', () => {
     expect(text).toContain('### Features');
     expect(text).toContain('- **New feature**');
   });
+
+  it('appendEntry maps singular kind aliases to canonical plural headings', () => {
+    const path = writeChangelog(
+      workDir,
+      ['# Changelog', '', '## Unreleased', '', '## v1.0.0'].join('\n'),
+    );
+    appendEntry(path, { kind: 'fix', summary: 'Singular fix' });
+    appendEntry(path, { kind: 'feature', summary: 'Singular feature' });
+    appendEntry(path, { kind: 'perf', summary: 'Perf bump' });
+    const text = readFileSync(path, 'utf8');
+    expect(text).toContain('### Fixes');
+    expect(text).toContain('### Features');
+    expect(text).toContain('### Performance');
+    expect(text).not.toMatch(/^### Fix\s*$/m);
+    expect(text).not.toMatch(/^### Feature\s*$/m);
+    expect(text).not.toMatch(/^### Perf\s*$/m);
+  });
+
+  it('appendEntry preserves a blank line between new section block and the next ## heading', () => {
+    const path = writeChangelog(
+      workDir,
+      ['# Changelog', '', '## Unreleased', '', '## v1.0.0', '', '### Release', ''].join('\n'),
+    );
+    appendEntry(path, { kind: 'fix', summary: 'Patch' });
+    const text = readFileSync(path, 'utf8');
+    // The new ### Fixes block must not abut the next ## heading.
+    expect(text).toMatch(/- \*\*Patch\*\*\n\n+## v1\.0\.0/);
+  });
 });

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -63,10 +63,17 @@ describe('packaging scripts', () => {
 
     const bumpInsiders = readFileSync('scripts/bump-insiders-version.js', 'utf-8');
     expect(bumpInsiders).toContain("INSIDERS_TAG = 'insiders'");
-    expect(bumpInsiders).toContain("'npm', ['version', nextVersion, '--no-git-tag-version']");
+    // Model B: bump computes target stable from CHANGELOG ## Unreleased,
+    // then appends -insiders.<N> using existing tag history.
+    expect(bumpInsiders).toContain("require('./changelog')");
+    expect(bumpInsiders).toContain('recommendBumpFromChangelog');
+    expect(bumpInsiders).toContain('listInsiderCountersForBase');
+    expect(bumpInsiders).toContain('stableTagExists');
+    expect(bumpInsiders).toContain('--allow-same-version');
     expect(bumpInsiders).toContain("'npm', ['install']");
-    expect(bumpInsiders).toContain('readLatestInsidersTag');
     expect(bumpInsiders).not.toContain('--package-lock-only');
+    // Model B invariant: master must hold a clean (non-prerelease) version.
+    expect(bumpInsiders).toContain('Master must hold the last shipped stable version');
 
     const validateBuilderChannel = readFileSync('scripts/validate-builder-release.js', 'utf-8');
     expect(validateBuilderChannel).toContain("args.get('channel') ?? 'latest'");
@@ -79,6 +86,8 @@ describe('packaging scripts', () => {
     expect(insidersWorkflow).toContain('CHAMBER_BUILDER_UPDATE_URL');
     expect(insidersWorkflow).toContain('https://chamberinsiders.blob.core.windows.net/releases/');
     expect(insidersWorkflow).toContain('bump-insiders-version.js');
+    expect(insidersWorkflow).toContain('--override-bump=');
+    expect(insidersWorkflow).toContain('override_bump:');
     expect(insidersWorkflow).toContain('client-id: ${{ vars.AZURE_CLIENT_ID }}');
     expect(insidersWorkflow).toContain('az storage blob upload-batch');
     expect(insidersWorkflow).toContain('--auth-mode login');
@@ -88,11 +97,18 @@ describe('packaging scripts', () => {
     expect(insidersWorkflow).toContain('git push origin "${{ steps.bump.outputs.tag }}"');
     expect(insidersWorkflow).not.toContain('git push origin HEAD');
     expect(insidersWorkflow).not.toContain('softprops/action-gh-release');
+    // Model B: the tag points at master's SHA, not a synthetic
+    // version-bump commit. The Tag step must not commit package.json.
+    expect(insidersWorkflow).not.toMatch(/git\s+add\s+package\.json/);
+    expect(insidersWorkflow).not.toMatch(/git\s+commit\s+-m\s+["']chore\(release\):/);
 
     const stableWorkflow = readFileSync('.github/workflows/release.yml', 'utf-8');
     expect(stableWorkflow).toContain('source_ref:');
     expect(stableWorkflow).not.toMatch(/on:\s*\n\s*push:/);
-    expect(stableWorkflow).toContain('STABLE_VERSION="${SOURCE_VERSION%-insiders.*}"');
+    // Model B: stable version derived from insider tag name (master pkg.json
+    // is stale between releases) or computed from ## Unreleased.
+    expect(stableWorkflow).toContain('INSIDER_TAG_REGEX');
+    expect(stableWorkflow).toContain('recommendBumpFromChangelog');
     expect(stableWorkflow).toContain('ref: ${{ needs.check-version.outputs.source_ref }}');
     expect(stableWorkflow).toContain('Apply promoted version');
     expect(stableWorkflow).toContain('--allow-same-version');


### PR DESCRIPTION
Move Chamber to Model B release-time versioning. Master's `package.json#version` now stays at the **last shipped stable version** between releases. Ship appends bullets to `## Unreleased` under conventional `### Headings` (Breaking / Features / Fixes / …). Insider and stable releases compute the next version at dispatch time from the highest-precedence heading.

This is the migration the team aligned on after surveying VS Code, Electron, Node.js, Chrome, Firefox, GitHub CLI, `semantic-release`, and `release-please`. Trade-off accepted: master's `package.json` is stale between releases. Released artifacts (installer + GitHub Release tag) carry the truthful version.

## What changed

**Scripts**
- `scripts/changelog.js` (new) — parser/writer for `## Unreleased`. Functions: `readUnreleasedSection`, `recommendBumpFromChangelog`, `appendEntry`, `promoteUnreleasedToVersion`.
- `scripts/append-changelog-entry.js` (new) — ship-time CLI used to add a bullet under the right `### Heading`.
- `scripts/bump-insiders-version.js` — rewritten. Reads master version + Unreleased + git tags → computes `v<target>-insiders.<N>`. Refuses to run if master holds a prerelease; refuses if target stable already shipped.

**Workflows**
- `.github/workflows/release-insiders.yml` — `bump` input renamed to `override_bump`. Tag step no longer commits the package.json mutation. The insider tag points at master's SHA directly.
- `.github/workflows/release.yml` — derives stable target from the insider tag name (master pkg.json is stale between releases). Falls back to Unreleased compute for direct-from-master dispatch.

**Skills**
- `.github/skills/ship/SKILL.md` — version-bump phase removed. Ship now classifies the change kind and calls `append-changelog-entry.js`.
- `.github/skills/release/SKILL.md` — Flow B (promote insider) is now default. New phase 3b.6 opens a post-release bump PR that advances master to the freshly shipped stable and promotes `## Unreleased`.

**Docs**
- `ai-docs/release-channels.md` — rewritten for Model B (Mental Model, Git Shape, Decision Log).
- `INSIDERS.md` — small note that the version preview previews the next stable.

**Tests**
- `tests/regression/changelog-parser.test.ts` (new) — 15 tests covering parse, recommend, promote, append.
- `tests/regression/packaging-scripts.test.ts` — updated assertions for the new bump-script and workflow shape.

## Live validation

Dispatched `release-insiders.yml` from this branch (via temporary federated credentials on both Azure apps, since prod fed creds are master-scoped). Run [25968857955](https://github.com/ianphil/chamber/actions/runs/25968857955) succeeded end-to-end in 5m5s:

- Computed insider version: `v0.63.0-insiders.0` (master 0.62.4 + `### Features` in Unreleased → minor bump → 0.63.0, counter 0).
- Tag `v0.63.0-insiders.0` points at this branch's HEAD commit `b580e05`. No orphan commit.
- `package.json` at the tag = `"0.62.4"` (master's stale value). The `0.63.0-insiders.0` string lives only in the built installer, as designed.
- Build, sign (Trusted Signing), validate manifest, upload to Azure blob, tag push — all green.

Temporary federated credentials have been deleted; both apps are back to master-only.

## Test evidence

- `npm run lint` — clean.
- `npm test` — 1597 passed; 13 pre-existing failures in `packages/services/` (unchanged, verified pre-existing before this work).
- Dry-run: `node scripts/bump-insiders-version.js --dry-run` → `0.62.4 + Features → 0.63.0-insiders.0`.

## First Model B ship

This PR itself is the first Model B ship. Notice it does **not** bump `package.json` — master stays at `0.62.4` until the next stable cut, which will compute `0.63.0` from the `### Features` bullet this PR adds to `## Unreleased`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>