### PR TITLE
feat(governance): enforce Model B and Pattern E with PR gates

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -356,7 +356,10 @@ gh pr create --base master --head release/bump-vX.Y.Z \
   --title "chore(release): bump master to vX.Y.Z post-release" \
   --body "Post-release bump anchored to build SHA \`$BUILD_SHA\` (tag \`vX.Y.Z-insiders.N\`). Master now reflects the freshly shipped stable version. \`## Unreleased\` content at build time has been promoted to \`## vX.Y.Z\` in CHANGELOG.md.
 
-If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new \`## vX.Y.Z\` section AS-IS, and keep any \`## Unreleased\` bullets that landed during the build window under a fresh \`## Unreleased\` block above it.
+Build-SHA: $BUILD_SHA
+Source-Ref: vX.Y.Z-insiders.N
+
+If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new \`## vX.Y.Z\` section AS-IS, and keep any \`## Unreleased\` bullets that landed during the build window under a fresh \`## Unreleased\` block above it. **Do not rebase or merge master into this branch** — that would defeat Pattern E anchoring and the \`model-b-gates\` PR check will fail. Resolve at PR-merge time only.
 
 This PR is mechanical and CI-validated; merge after green checks."
 ```

--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -82,8 +82,158 @@ jobs:
           echo "=== Running npm audit ==="
           npm audit --omit=dev 2>&1 || echo "::warning::npm audit found vulnerabilities"
 
+  model-b-gates:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch master and tags
+        run: |
+          git fetch origin +refs/heads/master:refs/remotes/origin/master --tags --force
+
+      - name: Lockfile version coherence (always)
+        run: |
+          echo "=== Checking package.json / package-lock.json version coherence ==="
+          pkg=$(jq -r .version package.json)
+          lock_top=$(jq -r .version package-lock.json)
+          lock_root=$(jq -r '.packages[""].version' package-lock.json)
+          echo "package.json: $pkg"
+          echo "package-lock.json (top): $lock_top"
+          echo "package-lock.json (root pkg): $lock_root"
+          if [ "$pkg" != "$lock_top" ] || [ "$pkg" != "$lock_root" ]; then
+            echo "::error::Version mismatch between package.json ($pkg), package-lock.json top ($lock_top), and root pkg ($lock_root). Run 'npm install' to reconcile."
+            exit 1
+          fi
+
+      - name: Check A — version bumps & changelog promotions confined to release branches
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          echo "=== Check A: Model B version-bump confinement ==="
+          echo "PR branch: $BRANCH"
+
+          base_version=$(git show origin/master:package.json | jq -r .version)
+          head_version=$(jq -r .version package.json)
+          echo "base version: $base_version"
+          echo "head version: $head_version"
+
+          version_changed=0
+          if [ "$base_version" != "$head_version" ]; then
+            version_changed=1
+          fi
+
+          # Detect newly added '## vX.Y.Z' headings in CHANGELOG.md (promoted from Unreleased).
+          added_release_headings=$(git diff "origin/master...HEAD" -- CHANGELOG.md \
+            | grep -E '^\+## v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)? \([0-9]{4}-[0-9]{2}-[0-9]{2}\)' \
+            | sed 's/^+//' || true)
+
+          is_release_branch=0
+          if [[ "$BRANCH" =~ ^release/bump-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            is_release_branch=1
+          fi
+
+          if [ "$version_changed" -eq 1 ] && [ "$is_release_branch" -eq 0 ]; then
+            echo "::error::package.json version bumped from $base_version to $head_version on non-release branch '$BRANCH'. Model B forbids ship-time version bumps. Bumps belong on a 'release/bump-vX.Y.Z' branch opened by the release skill after a build succeeds."
+            exit 1
+          fi
+
+          if [ -n "$added_release_headings" ] && [ "$is_release_branch" -eq 0 ]; then
+            echo "::error::CHANGELOG.md added a release heading on non-release branch '$BRANCH':"
+            echo "$added_release_headings"
+            echo "::error::Promote '## Unreleased' to '## vX.Y.Z' only via a 'release/bump-vX.Y.Z' branch."
+            exit 1
+          fi
+
+          if [ "$is_release_branch" -eq 1 ]; then
+            expected_version="${BRANCH#release/bump-v}"
+            echo "release branch — expected version: $expected_version"
+
+            if [ "$version_changed" -eq 0 ]; then
+              echo "::error::Release branch '$BRANCH' must bump package.json (still at $head_version)."
+              exit 1
+            fi
+            if [ "$expected_version" != "$head_version" ]; then
+              echo "::error::Branch name claims v$expected_version but package.json has v$head_version."
+              exit 1
+            fi
+            # Rollback guard: head_version must be strictly greater than base_version (SemVer-aware via sort -V).
+            highest=$(printf '%s\n%s\n' "$base_version" "$head_version" | sort -V | tail -1)
+            if [ "$highest" != "$head_version" ] || [ "$head_version" = "$base_version" ]; then
+              echo "::error::Release version $head_version is not greater than base $base_version. Rollbacks must use an explicit override path."
+              exit 1
+            fi
+            if ! grep -qE "^## v${head_version} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)" CHANGELOG.md; then
+              echo "::error::CHANGELOG.md missing '## v${head_version} (YYYY-MM-DD)' heading."
+              exit 1
+            fi
+            echo "Check A passed: release branch with matching version, changelog, and forward bump."
+          else
+            echo "Check A passed: non-release branch, no version bump, no release heading."
+          fi
+
+      - name: Check B — Pattern E build-SHA anchoring (release branches only)
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$BRANCH" =~ ^release/bump-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Check B skipped: not a release branch."
+            exit 0
+          fi
+          echo "=== Check B: Pattern E build-SHA anchoring ==="
+
+          build_sha=$(printf '%s\n' "$PR_BODY" | grep -oE 'Build-SHA: [0-9a-f]{40}' | head -1 | awk '{print $2}' || true)
+          source_ref=$(printf '%s\n' "$PR_BODY" | grep -oE 'Source-Ref: [A-Za-z0-9._/+-]+' | head -1 | awk '{print $2}' || true)
+
+          if [ -z "$build_sha" ]; then
+            echo "::error::Pattern E requires a 'Build-SHA: <40-char-sha>' line in the PR body. The release skill emits this."
+            exit 1
+          fi
+          if [ -z "$source_ref" ]; then
+            echo "::error::Pattern E requires a 'Source-Ref: <tag-or-ref>' line in the PR body (e.g. 'Source-Ref: v0.63.0-insiders.0' for Flow B, or the dispatch ref for Flow A)."
+            exit 1
+          fi
+
+          echo "Declared Build-SHA: $build_sha"
+          echo "Declared Source-Ref: $source_ref"
+
+          # Cross-check: the source ref must resolve to the build SHA.
+          git fetch origin "$build_sha" 2>/dev/null || true
+          if ! git cat-file -e "${build_sha}^{commit}" 2>/dev/null; then
+            echo "::error::Declared Build-SHA $build_sha is not reachable from this repository."
+            exit 1
+          fi
+          if ! resolved=$(git rev-list -n1 "$source_ref" 2>/dev/null); then
+            echo "::error::Declared Source-Ref '$source_ref' does not resolve to a commit. For insider promotions, ensure the tag exists and was fetched."
+            exit 1
+          fi
+          if [ "$resolved" != "$build_sha" ]; then
+            echo "::error::Source-Ref '$source_ref' resolves to $resolved, which does not match declared Build-SHA $build_sha."
+            exit 1
+          fi
+
+          # The bump branch's merge-base with master must equal the build SHA.
+          mb=$(git merge-base HEAD refs/remotes/origin/master)
+          echo "merge-base(HEAD, origin/master) = $mb"
+          if [ "$mb" != "$build_sha" ]; then
+            echo "::error::Branch was not anchored to the build SHA per Pattern E."
+            echo "::error::Expected merge-base with master to equal $build_sha; got $mb."
+            echo "::error::Do not rebase or merge master into 'release/bump-v*' branches — interim conflicts must be resolved at PR merge time."
+            exit 1
+          fi
+          echo "Check B passed: branch anchored to declared build SHA."
+
   governance-status:
-    needs: [governance]
+    needs: [governance, model-b-gates]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -91,6 +241,10 @@ jobs:
         run: |
           if [ "${{ needs.governance.result }}" != "success" ]; then
             echo "::error::Governance checks failed. Please fix issues above."
+            exit 1
+          fi
+          if [ "${{ needs.model-b-gates.result }}" != "success" ]; then
+            echo "::error::Model B PR gates failed. See model-b-gates job for details."
             exit 1
           fi
           echo "All governance checks passed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - **Move to Model B release versioning** — Master's `package.json#version` now stays at the last shipped stable version between releases. Ship appends bullets to `## Unreleased` under conventional `### Headings` (Breaking / Features / Fixes / …). The release skill reads those headings at insider-cut time to compute the next stable version, and the `-insiders.N` counter grows across iterations against the same future stable. Eliminates stable-version gaps. See [`ai-docs/release-channels.md`](ai-docs/release-channels.md).
+- **Enforce Model B / Pattern E with PR gates** — New `model-b-gates` job in `.github/workflows/governance-check.yml` enforces (a) `package.json` version bumps and `## vX.Y.Z` CHANGELOG promotions only on `release/bump-v*` branches, with branch-name/package/CHANGELOG version coherence and a strict forward-bump guard; (b) Pattern E build-SHA anchoring on release branches via `Build-SHA:` + `Source-Ref:` lines in the PR body and `merge-base` verification. Lockfile version coherence checked on every PR. The release skill PR body template now emits both headers.
 
 ### Fixes
 

--- a/ai-docs/release-channels.md
+++ b/ai-docs/release-channels.md
@@ -277,6 +277,18 @@ auto-skip guard — keep it `true` for manual dispatches.
 
 ## Decision log
 
+- **Why enforce Model B with CI gates?** The release skill is the
+  intended path, but skill drift, hand-edits, or alternate tooling
+  could silently violate Model B/Pattern E. The `model-b-gates` job in
+  `.github/workflows/governance-check.yml` makes the invariants
+  mechanical: (1) `package.json` version bumps and `## vX.Y.Z` CHANGELOG
+  promotions are only allowed on `release/bump-vX.Y.Z` branches; (2)
+  release branches must declare `Build-SHA: <sha>` and
+  `Source-Ref: <tag>` in the PR body, the source ref must resolve to
+  the build SHA, and the branch's merge-base with master must equal
+  the build SHA (proving Pattern E anchoring). Lockfile version
+  coherence (`package.json` vs. `package-lock.json` top + root) is
+  checked on every PR.
 - **Why anchor the post-release bump PR to the build SHA?** Stable
   builds take 30–60 minutes (macOS notarization). Ship PRs can merge
   during that window and add bullets to `## Unreleased`. If the bump PR


### PR DESCRIPTION
## Summary

Backs Model B / Pattern E (PR #319) with CI enforcement so accidental violations are caught before merge instead of corrupting CHANGELOG history after a stable release.

## What's enforced

A new `model-b-gates` job in `.github/workflows/governance-check.yml`:

- **Lockfile coherence (every PR):** `package.json#version` must match `package-lock.json` top-level + root package version.
- **Check A — version bumps confined to release branches:** `package.json` bumps and new `## vX.Y.Z (YYYY-MM-DD)` CHANGELOG headings are only allowed on `release/bump-vX.Y.Z` branches. Release branches additionally require: branch name = package version = CHANGELOG heading, and head version > base version.
- **Check B — Pattern E anchoring (release branches only):** PR body must include `Build-SHA: <40-hex>` and `Source-Ref: <tag-or-ref>`; the source ref must resolve to the build SHA; and `merge-base(HEAD, origin/master)` must equal the build SHA — proving the bump branch was anchored to the build commit (not rebased into master).

The aggregator `governance-status` now requires `model-b-gates`.

## Why

PR #319 made Model B / Pattern E the **intended** flow via the release skill. But skill drift, hand-edits, or alternate tooling could silently violate it — and the failure mode (CHANGELOG misattribution after a 30–60 min stable build) is invisible without enforcement. The gate makes the invariants mechanical.

## Notable design choices

- Checkout uses `github.event.pull_request.head.sha` with `fetch-depth: 0` so `merge-base` reflects the real branch head, not the synthetic PR merge ref (rubber-duck flagged this).
- `Source-Ref` cross-check makes self-attested `Build-SHA` non-forgeable — you can't claim a SHA that isn't the resolved tag.
- Forward-only bump guard (`sort -V`) blocks accidental version regressions.
- Release skill PR body template updated to emit both required headers and warns against rebasing/merging master into release branches.

## Test evidence

- This PR exercises the new gate as a non-release branch: no `package.json` bump, no `## vX.Y.Z` heading added (only `### Features` / `### Fixes` bullets under `## Unreleased`) → Check A passes, Check B skipped, lockfile coherent.
- `npm run lint` clean.
- Workflow YAML validates with `js-yaml`.

## Bootstrap note

This must land before the next stable release so the bump PR template emits the required headers.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>