### PR TITLE
fix(runtime): align packaged Copilot CLI pin

### DIFF
--- a/chamber-copilot-runtime/package-lock.json
+++ b/chamber-copilot-runtime/package-lock.json
@@ -8,31 +8,31 @@
       "name": "chamber-copilot-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "1.0.48",
+        "@github/copilot": "1.0.49-1",
         "@github/copilot-sdk": "0.3.0"
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.48.tgz",
-      "integrity": "sha512-U5SzyTEq376UU9A4Sd3TEKz+Y2nRUd90cLO4Hc1otaB8yFSy9Ur2UVGcI2/wCoodL3a39k6WbdgNzFxr0gWFRQ==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.49-1.tgz",
+      "integrity": "sha512-1euPT6WXtLWnoqz1SXHdcqmktucdkfwfZn/Eo4iQ1FAjZo7awuN86rVb1feDwxY4vlSGbzNmK+GDKDgs9qZCDg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.48",
-        "@github/copilot-darwin-x64": "1.0.48",
-        "@github/copilot-linux-arm64": "1.0.48",
-        "@github/copilot-linux-x64": "1.0.48",
-        "@github/copilot-win32-arm64": "1.0.48",
-        "@github/copilot-win32-x64": "1.0.48"
+        "@github/copilot-darwin-arm64": "1.0.49-1",
+        "@github/copilot-darwin-x64": "1.0.49-1",
+        "@github/copilot-linux-arm64": "1.0.49-1",
+        "@github/copilot-linux-x64": "1.0.49-1",
+        "@github/copilot-win32-arm64": "1.0.49-1",
+        "@github/copilot-win32-x64": "1.0.49-1"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.48.tgz",
-      "integrity": "sha512-82MLoMQwPVVFM8EYssihFxSEPUYtZADE8rMzQ3jG9HgRg2qjQSfnHQS1mKe64dlXswZUK/onw6/8kjnW5I4pPg==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.49-1.tgz",
+      "integrity": "sha512-EgHdwlkYSJ+RmHAelGGpQxQe5/dgq3BlvToc0VmYEUCWO93ESEql7XBqCWYeASg3USUp8n87kf3mr2eXIECvLA==",
       "cpu": [
         "arm64"
       ],
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.48.tgz",
-      "integrity": "sha512-1VQ5r5F0h8GwboXmZTcutqcJT+iCpPXAF27QqodmpKEvW9aYfG8g9X2kFJOzDZoX+SA3Uaka9qXdYKF2xT6Uog==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.49-1.tgz",
+      "integrity": "sha512-YPtOW5q3vWB9Covn08jxqIdIjcCuJi/MgIlYk1ulKTINi5uK5a6NlsX2mDaGWL/svhDwDlhFEa3oUV41yOjTkg==",
       "cpu": [
         "x64"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.48.tgz",
-      "integrity": "sha512-PmsGnb0DZlI+Bf53l9HM1PAHHkUcMyB4y8v/7tnC/jDOV5dGF124n0HnDNfJLOLiJGiQGodthIif6QtPaAxpeA==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.49-1.tgz",
+      "integrity": "sha512-eEh0ec1UlWg8IdV2/3Zaxr/PAA86GclEFUcGNkwc9JceOgw5nhIdytsjCwXJUcRTzHsGrAoTS+Vad1RSvKSmYQ==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.48.tgz",
-      "integrity": "sha512-b2cc4euSlke9fYHXXsS2EL9UYbctN0h4lZvtAcKUDY+RCnpYAQOVBZK+c1R9dQrtsT6Z/yUv7PuFPSs8qdtc2Q==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.49-1.tgz",
+      "integrity": "sha512-9+HxOVAbgCqcoyfAXyfaFxgIbAfHWCh699WuOfWViX2fjoKO3V0ZVHEergR4gVEgvnjvnmD0TZhT7+kTzqPK6A==",
       "cpu": [
         "x64"
       ],
@@ -107,7 +107,88 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@github/copilot-win32-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.48.tgz",
+      "integrity": "sha512-U5SzyTEq376UU9A4Sd3TEKz+Y2nRUd90cLO4Hc1otaB8yFSy9Ur2UVGcI2/wCoodL3a39k6WbdgNzFxr0gWFRQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.48",
+        "@github/copilot-darwin-x64": "1.0.48",
+        "@github/copilot-linux-arm64": "1.0.48",
+        "@github/copilot-linux-x64": "1.0.48",
+        "@github/copilot-win32-arm64": "1.0.48",
+        "@github/copilot-win32-x64": "1.0.48"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.48.tgz",
+      "integrity": "sha512-82MLoMQwPVVFM8EYssihFxSEPUYtZADE8rMzQ3jG9HgRg2qjQSfnHQS1mKe64dlXswZUK/onw6/8kjnW5I4pPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.48.tgz",
+      "integrity": "sha512-1VQ5r5F0h8GwboXmZTcutqcJT+iCpPXAF27QqodmpKEvW9aYfG8g9X2kFJOzDZoX+SA3Uaka9qXdYKF2xT6Uog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.48.tgz",
+      "integrity": "sha512-PmsGnb0DZlI+Bf53l9HM1PAHHkUcMyB4y8v/7tnC/jDOV5dGF124n0HnDNfJLOLiJGiQGodthIif6QtPaAxpeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.48.tgz",
+      "integrity": "sha512-b2cc4euSlke9fYHXXsS2EL9UYbctN0h4lZvtAcKUDY+RCnpYAQOVBZK+c1R9dQrtsT6Z/yUv7PuFPSs8qdtc2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-arm64": {
       "version": "1.0.48",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.48.tgz",
       "integrity": "sha512-VEEOwddtpJ3DTbXGhnK6K8im4ofl9m08q1m/K++sNvWV8wkkOSOQBTiPdyUsuU/TXAoFhb8tZMIJv+6NnMBtMw==",
@@ -123,10 +204,42 @@
         "copilot-win32-arm64": "copilot.exe"
       }
     },
-    "node_modules/@github/copilot-win32-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-x64": {
       "version": "1.0.48",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.48.tgz",
       "integrity": "sha512-93BzvXLPHTyy1gWBXQY/IWIHor4IAwZuuo7/obG80/Qa6U0WeaN9slz/FBJvrsgVNrrRfEID5Xm3At+S6Kj67Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.49-1.tgz",
+      "integrity": "sha512-nsOz2rdk1Il3KJ24x3Hdv27MvotrKygIC/ok6acvq+xFwsYxR5Kt5bL1veBAGZVEG8K+0r2DfHi9NZHazBYK8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.49-1.tgz",
+      "integrity": "sha512-RZbU3GESkfwd8UC1h5AeceVfCOfXjMA+sDKfIUyk8Pl8EukTNtNSf+WEKK1HzSxbxdbIu9DJyBL375JMwDiH4A==",
       "cpu": [
         "x64"
       ],

--- a/chamber-copilot-runtime/package.json
+++ b/chamber-copilot-runtime/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Pinned packaged runtime for Chamber Copilot SDK + CLI",
   "dependencies": {
-    "@github/copilot": "1.0.48",
+    "@github/copilot": "1.0.49-1",
     "@github/copilot-sdk": "0.3.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
-        "@github/copilot": "1.0.48",
+        "@github/copilot": "1.0.49-1",
         "@github/copilot-sdk": "0.3.0",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1559,27 +1559,27 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.48.tgz",
-      "integrity": "sha512-U5SzyTEq376UU9A4Sd3TEKz+Y2nRUd90cLO4Hc1otaB8yFSy9Ur2UVGcI2/wCoodL3a39k6WbdgNzFxr0gWFRQ==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.49-1.tgz",
+      "integrity": "sha512-1euPT6WXtLWnoqz1SXHdcqmktucdkfwfZn/Eo4iQ1FAjZo7awuN86rVb1feDwxY4vlSGbzNmK+GDKDgs9qZCDg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.48",
-        "@github/copilot-darwin-x64": "1.0.48",
-        "@github/copilot-linux-arm64": "1.0.48",
-        "@github/copilot-linux-x64": "1.0.48",
-        "@github/copilot-win32-arm64": "1.0.48",
-        "@github/copilot-win32-x64": "1.0.48"
+        "@github/copilot-darwin-arm64": "1.0.49-1",
+        "@github/copilot-darwin-x64": "1.0.49-1",
+        "@github/copilot-linux-arm64": "1.0.49-1",
+        "@github/copilot-linux-x64": "1.0.49-1",
+        "@github/copilot-win32-arm64": "1.0.49-1",
+        "@github/copilot-win32-x64": "1.0.49-1"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.48.tgz",
-      "integrity": "sha512-82MLoMQwPVVFM8EYssihFxSEPUYtZADE8rMzQ3jG9HgRg2qjQSfnHQS1mKe64dlXswZUK/onw6/8kjnW5I4pPg==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.49-1.tgz",
+      "integrity": "sha512-EgHdwlkYSJ+RmHAelGGpQxQe5/dgq3BlvToc0VmYEUCWO93ESEql7XBqCWYeASg3USUp8n87kf3mr2eXIECvLA==",
       "cpu": [
         "arm64"
       ],
@@ -1594,9 +1594,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.48.tgz",
-      "integrity": "sha512-1VQ5r5F0h8GwboXmZTcutqcJT+iCpPXAF27QqodmpKEvW9aYfG8g9X2kFJOzDZoX+SA3Uaka9qXdYKF2xT6Uog==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.49-1.tgz",
+      "integrity": "sha512-YPtOW5q3vWB9Covn08jxqIdIjcCuJi/MgIlYk1ulKTINi5uK5a6NlsX2mDaGWL/svhDwDlhFEa3oUV41yOjTkg==",
       "cpu": [
         "x64"
       ],
@@ -1611,9 +1611,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.48.tgz",
-      "integrity": "sha512-PmsGnb0DZlI+Bf53l9HM1PAHHkUcMyB4y8v/7tnC/jDOV5dGF124n0HnDNfJLOLiJGiQGodthIif6QtPaAxpeA==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.49-1.tgz",
+      "integrity": "sha512-eEh0ec1UlWg8IdV2/3Zaxr/PAA86GclEFUcGNkwc9JceOgw5nhIdytsjCwXJUcRTzHsGrAoTS+Vad1RSvKSmYQ==",
       "cpu": [
         "arm64"
       ],
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.48.tgz",
-      "integrity": "sha512-b2cc4euSlke9fYHXXsS2EL9UYbctN0h4lZvtAcKUDY+RCnpYAQOVBZK+c1R9dQrtsT6Z/yUv7PuFPSs8qdtc2Q==",
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.49-1.tgz",
+      "integrity": "sha512-9+HxOVAbgCqcoyfAXyfaFxgIbAfHWCh699WuOfWViX2fjoKO3V0ZVHEergR4gVEgvnjvnmD0TZhT7+kTzqPK6A==",
       "cpu": [
         "x64"
       ],
@@ -1659,7 +1659,93 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@github/copilot-win32-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.48.tgz",
+      "integrity": "sha512-U5SzyTEq376UU9A4Sd3TEKz+Y2nRUd90cLO4Hc1otaB8yFSy9Ur2UVGcI2/wCoodL3a39k6WbdgNzFxr0gWFRQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.48",
+        "@github/copilot-darwin-x64": "1.0.48",
+        "@github/copilot-linux-arm64": "1.0.48",
+        "@github/copilot-linux-x64": "1.0.48",
+        "@github/copilot-win32-arm64": "1.0.48",
+        "@github/copilot-win32-x64": "1.0.48"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.48.tgz",
+      "integrity": "sha512-82MLoMQwPVVFM8EYssihFxSEPUYtZADE8rMzQ3jG9HgRg2qjQSfnHQS1mKe64dlXswZUK/onw6/8kjnW5I4pPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.48.tgz",
+      "integrity": "sha512-1VQ5r5F0h8GwboXmZTcutqcJT+iCpPXAF27QqodmpKEvW9aYfG8g9X2kFJOzDZoX+SA3Uaka9qXdYKF2xT6Uog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.48.tgz",
+      "integrity": "sha512-PmsGnb0DZlI+Bf53l9HM1PAHHkUcMyB4y8v/7tnC/jDOV5dGF124n0HnDNfJLOLiJGiQGodthIif6QtPaAxpeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.48.tgz",
+      "integrity": "sha512-b2cc4euSlke9fYHXXsS2EL9UYbctN0h4lZvtAcKUDY+RCnpYAQOVBZK+c1R9dQrtsT6Z/yUv7PuFPSs8qdtc2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-arm64": {
       "version": "1.0.48",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.48.tgz",
       "integrity": "sha512-VEEOwddtpJ3DTbXGhnK6K8im4ofl9m08q1m/K++sNvWV8wkkOSOQBTiPdyUsuU/TXAoFhb8tZMIJv+6NnMBtMw==",
@@ -1676,10 +1762,44 @@
         "copilot-win32-arm64": "copilot.exe"
       }
     },
-    "node_modules/@github/copilot-win32-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-x64": {
       "version": "1.0.48",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.48.tgz",
       "integrity": "sha512-93BzvXLPHTyy1gWBXQY/IWIHor4IAwZuuo7/obG80/Qa6U0WeaN9slz/FBJvrsgVNrrRfEID5Xm3At+S6Kj67Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.49-1.tgz",
+      "integrity": "sha512-nsOz2rdk1Il3KJ24x3Hdv27MvotrKygIC/ok6acvq+xFwsYxR5Kt5bL1veBAGZVEG8K+0r2DfHi9NZHazBYK8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.49-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.49-1.tgz",
+      "integrity": "sha512-RZbU3GESkfwd8UC1h5AeceVfCOfXjMA+sDKfIUyk8Pl8EukTNtNSf+WEKK1HzSxbxdbIu9DJyBL375JMwDiH4A==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "@github/copilot": "1.0.48",
+    "@github/copilot": "1.0.49-1",
     "@github/copilot-sdk": "0.3.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
## Summary
- Bump the pinned `@github/copilot` CLI runtime from `1.0.48` to `1.0.49-1` in the app and packaged runtime manifests.
- Regenerate both lockfiles so the packaged runtime prep smoke sees the version reported by the shipped CLI binary.

Fixes #325

## Validation
- `npm run smoke:sdk`
- `npm run make:sandbox`

Note: direct `git commit` hit the local pre-commit wrapper stalling while downloading/extracting `actionlint`; the underlying lint steps reached dependency checking successfully in the hook output, and this PR includes the targeted runtime/package validations above.