### PR TITLE
chore(release): bump master to v0.63.0 + adopt Keep a Changelog 1.1.0

### DIFF
--- a/.github/extensions/canvas/data/content/release-flow-doc.html
+++ b/.github/extensions/canvas/data/content/release-flow-doc.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Chamber Release Flow</title>
+<style>
+  :root {
+    color-scheme: light;
+    --bg: #f2ecdf;
+    --panel: #fbf7ec;
+    --ink: #1f1a12;
+    --muted: #5e5448;
+    --line: #deceb4;
+    --green: #2d7038;
+    --green-bg: #ebf8ed;
+    --orange: #a86504;
+    --orange-bg: #fff0d5;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--bg);
+    font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    color: var(--ink);
+    padding: 24px;
+  }
+  main {
+    max-width: 1220px;
+    margin: 0 auto;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    box-shadow: 0 20px 56px rgba(48, 34, 14, 0.15);
+    padding: 32px 40px 36px;
+  }
+  h1 { margin: 0; font-size: 32px; line-height: 1.08; }
+  .subtitle { margin: 8px 0 22px; color: var(--muted); font-size: 15px; }
+  .top-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 22px;
+  }
+  .invariant {
+    border: 1.5px solid #d5c4a8;
+    border-radius: 14px;
+    background: #fffdf8;
+    padding: 15px 18px;
+  }
+  .invariant strong { display: block; font-size: 18px; margin-bottom: 6px; }
+  .invariant span { display: block; color: var(--muted); font-size: 14px; line-height: 1.4; }
+  .diagram-wrap {
+    background: #fffdf8;
+    border: 1.5px solid #e2d5c1;
+    border-radius: 16px;
+    padding: 14px 12px 2px;
+    overflow-x: auto;
+  }
+  .mermaid { min-width: 940px; display: flex; justify-content: center; }
+  .file-flow {
+    margin-top: 24px;
+    border-top: 1.5px solid var(--line);
+    padding-top: 22px;
+  }
+  .file-flow h2 { margin: 0 0 6px; font-size: 21px; }
+  .file-flow p { margin: 0 0 16px; color: var(--muted); font-size: 14px; }
+  .cards {
+    display: grid;
+    grid-template-columns: 1fr 36px 1.12fr 36px 1fr;
+    align-items: stretch;
+  }
+  .card {
+    min-height: 138px;
+    border-radius: 16px;
+    padding: 17px 20px;
+    border: 2px solid #8f8069;
+    background: #fffdf8;
+  }
+  .card.pr { border-color: var(--orange); background: var(--orange-bg); }
+  .card.after { border-color: var(--green); background: var(--green-bg); }
+  .card h3 { margin: 0 0 12px; font-size: 18px; }
+  code {
+    display: block;
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+    font-size: 13px;
+    color: #2b2419;
+    margin: 7px 0;
+    white-space: nowrap;
+  }
+  .card small { display: block; margin-top: 10px; color: var(--muted); font-size: 13px; line-height: 1.35; }
+  .arrow {
+    display: grid;
+    place-items: center;
+    color: var(--orange);
+    font-size: 18px;
+    font-weight: 800;
+  }
+  .arrow.green { color: var(--green); }
+  .note {
+    margin-top: 14px;
+    border: 1.5px solid #b9d1ea;
+    background: #eef6ff;
+    border-radius: 14px;
+    padding: 12px 16px;
+    color: #31485f;
+    font-size: 14px;
+  }
+  .note code { display: inline; margin: 0; white-space: normal; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Three insiders, then one stable</h1>
+  <p class="subtitle">Master stays at the last stable version while insiders preview the next target. Stable promotes the final tested source SHA.</p>
+
+  <section class="top-grid" aria-label="Release invariants">
+    <div class="invariant">
+      <strong>master invariant</strong>
+      <span><code>package.json</code> stays at the last shipped stable until the post-release PR merges.</span>
+    </div>
+    <div class="invariant">
+      <strong>version source</strong>
+      <span><code>CHANGELOG.md ## Unreleased</code> headings compute the next stable version.</span>
+    </div>
+  </section>
+
+  <section class="diagram-wrap" aria-label="Release sequence">
+    <pre class="mermaid">
+sequenceDiagram
+    participant PR as PRs
+    participant M as master
+    participant I as Insiders feed
+    participant S as Stable release
+    participant R as Post-release PR
+
+    Note over M,I: repo still says 0.63.4<br/>Unreleased computes 0.64.0
+    PR->>M: merge feature/fix
+    M->>I: cut v0.64.0-insiders.0 (tag B)
+    Note right of I: testers get build .0
+    PR->>M: merge candidate
+    M->>I: cut v0.64.0-insiders.1 (tag C)
+    Note right of I: testers get build .1
+    PR->>M: merge final fix
+    M->>I: cut v0.64.0-insiders.2 (tag D)
+    Note right of I: testers approve build .2
+    I->>S: promote source SHA D
+    S->>S: tag v0.64.0 on D<br/>rebuild public artifacts
+    S->>R: generate PR from D
+    R->>M: merge version + changelog bump
+    Note over M: package.json = 0.64.0<br/>CHANGELOG has ## v0.64.0<br/>newer bullets remain Unreleased
+    </pre>
+  </section>
+
+  <section class="file-flow" aria-label="File states">
+    <h2>What actually changes in files</h2>
+    <p>The workflows build from computed versions in CI. The repository only catches up after the generated post-release PR merges.</p>
+    <div class="cards">
+      <article class="card">
+        <h3>Before stable</h3>
+        <code>package.json: 0.63.4</code>
+        <code>CHANGELOG: ## Unreleased</code>
+        <small>Insider artifacts have 0.64.0-insiders.N, but that version is not committed.</small>
+      </article>
+      <div class="arrow">-&gt;</div>
+      <article class="card pr">
+        <h3>Post-release PR</h3>
+        <code>package.json: 0.64.0</code>
+        <code>CHANGELOG: ## v0.64.0</code>
+        <small>Generated from released SHA D, moving shipped bullets out of Unreleased.</small>
+      </article>
+      <div class="arrow green">-&gt;</div>
+      <article class="card after">
+        <h3>After merge</h3>
+        <code>package.json: 0.64.0</code>
+        <code>CHANGELOG: ## v0.64.0</code>
+        <small>Master now matches stable. Later work continues under Unreleased.</small>
+      </article>
+    </div>
+    <div class="note"><strong>Key point:</strong> <code>v0.64.0-insiders.2</code> and <code>v0.64.0</code> point at the same source SHA; stable rebuilds public artifacts instead of republishing the insider binary.</div>
+  </section>
+</main>
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: "base",
+    sequence: {
+      mirrorActors: false,
+      showSequenceNumbers: false,
+      actorMargin: 52,
+      messageMargin: 34,
+      noteMargin: 10,
+      boxMargin: 8
+    },
+    themeVariables: {
+      fontFamily: "Segoe UI, system-ui, sans-serif",
+      primaryColor: "#fffdf8",
+      primaryBorderColor: "#d5c4a8",
+      primaryTextColor: "#1f1a12",
+      actorBkg: "#fffdf8",
+      actorBorder: "#8f8069",
+      actorTextColor: "#1f1a12",
+      signalColor: "#242017",
+      signalTextColor: "#1f1a12",
+      noteBkgColor: "#fff0d5",
+      noteBorderColor: "#a86504",
+      noteTextColor: "#1f1a12",
+      labelBoxBkgColor: "#e9f4ff",
+      labelBoxBorderColor: "#1e6599",
+      labelTextColor: "#1f1a12"
+    }
+  });
+</script>
+</body>
+</html>

--- a/.github/extensions/canvas/data/content/release-flow-minimal.html
+++ b/.github/extensions/canvas/data/content/release-flow-minimal.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Mermaid Release Flow</title>
+<style>
+  :root {
+    color-scheme: light;
+    --bg: #f2ecdf;
+    --panel: #fbf7ec;
+    --ink: #1f1a12;
+    --muted: #5e5448;
+    --line: #deceb4;
+    --green: #2d7038;
+    --green-bg: #ebf8ed;
+    --orange: #a86504;
+    --orange-bg: #fff0d5;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--bg);
+    font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    color: var(--ink);
+    padding: 24px;
+  }
+  main {
+    max-width: 1220px;
+    margin: 0 auto;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    box-shadow: 0 20px 56px rgba(48, 34, 14, 0.15);
+    padding: 32px 40px 36px;
+  }
+  h1 { margin: 0; font-size: 32px; line-height: 1.08; }
+  .subtitle { margin: 8px 0 22px; color: var(--muted); font-size: 15px; }
+  .top-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 22px;
+  }
+  .invariant {
+    border: 1.5px solid #d5c4a8;
+    border-radius: 14px;
+    background: #fffdf8;
+    padding: 15px 18px;
+  }
+  .invariant strong { display: block; font-size: 18px; margin-bottom: 6px; }
+  .invariant span { display: block; color: var(--muted); font-size: 14px; line-height: 1.4; }
+  .diagram-wrap {
+    background: #fffdf8;
+    border: 1.5px solid #e2d5c1;
+    border-radius: 16px;
+    padding: 14px 12px 2px;
+    overflow-x: auto;
+  }
+  .mermaid { min-width: 940px; display: flex; justify-content: center; }
+  .file-flow {
+    margin-top: 24px;
+    border-top: 1.5px solid var(--line);
+    padding-top: 22px;
+  }
+  .file-flow h2 { margin: 0 0 6px; font-size: 21px; }
+  .file-flow p { margin: 0 0 16px; color: var(--muted); font-size: 14px; }
+  .cards {
+    display: grid;
+    grid-template-columns: 1fr 36px 1.12fr 36px 1fr;
+    align-items: stretch;
+  }
+  .card {
+    min-height: 138px;
+    border-radius: 16px;
+    padding: 17px 20px;
+    border: 2px solid #8f8069;
+    background: #fffdf8;
+  }
+  .card.pr { border-color: var(--orange); background: var(--orange-bg); }
+  .card.after { border-color: var(--green); background: var(--green-bg); }
+  .card h3 { margin: 0 0 12px; font-size: 18px; }
+  code {
+    display: block;
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+    font-size: 13px;
+    color: #2b2419;
+    margin: 7px 0;
+    white-space: nowrap;
+  }
+  .card small { display: block; margin-top: 10px; color: var(--muted); font-size: 13px; line-height: 1.35; }
+  .arrow { display: grid; place-items: center; color: var(--orange); font-size: 28px; font-weight: 800; }
+  .arrow.green { color: var(--green); }
+  .note {
+    margin-top: 14px;
+    border: 1.5px solid #b9d1ea;
+    background: #eef6ff;
+    border-radius: 14px;
+    padding: 12px 16px;
+    color: #31485f;
+    font-size: 14px;
+  }
+  .note code { display: inline; margin: 0; white-space: normal; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Three insiders, then one stable</h1>
+  <p class="subtitle">Master stays at the last stable version while insiders preview the next target. Stable promotes the final tested source SHA.</p>
+
+  <section class="top-grid" aria-label="Release invariants">
+    <div class="invariant">
+      <strong>master invariant</strong>
+      <span><code>package.json</code> stays at the last shipped stable until the post-release PR merges.</span>
+    </div>
+    <div class="invariant">
+      <strong>version source</strong>
+      <span><code>CHANGELOG.md ## Unreleased</code> headings compute the next stable version.</span>
+    </div>
+  </section>
+
+  <section class="diagram-wrap" aria-label="Release sequence">
+    <pre class="mermaid">
+sequenceDiagram
+    participant PR as PRs
+    participant M as master
+    participant I as Insiders feed
+    participant S as Stable release
+    participant R as Post-release PR
+
+    Note over M,I: repo still says 0.63.4<br/>Unreleased computes 0.64.0
+    PR->>M: merge feature/fix
+    M->>I: cut v0.64.0-insiders.0 (tag B)
+    Note right of I: testers get build .0
+    PR->>M: merge candidate
+    M->>I: cut v0.64.0-insiders.1 (tag C)
+    Note right of I: testers get build .1
+    PR->>M: merge final fix
+    M->>I: cut v0.64.0-insiders.2 (tag D)
+    Note right of I: testers approve build .2
+    I->>S: promote source SHA D
+    S->>S: tag v0.64.0 on D<br/>rebuild public artifacts
+    S->>R: generate PR from D
+    R->>M: merge version + changelog bump
+    Note over M: package.json = 0.64.0<br/>CHANGELOG has ## v0.64.0<br/>newer bullets remain Unreleased
+    </pre>
+  </section>
+
+  <section class="file-flow" aria-label="File states">
+    <h2>What actually changes in files</h2>
+    <p>The workflows build from computed versions in CI. The repository only catches up after the generated post-release PR merges.</p>
+    <div class="cards">
+      <article class="card">
+        <h3>Before stable</h3>
+        <code>package.json: 0.63.4</code>
+        <code>CHANGELOG: ## Unreleased</code>
+        <small>Insider artifacts have 0.64.0-insiders.N, but that version is not committed.</small>
+      </article>
+      <div class="arrow">→</div>
+      <article class="card pr">
+        <h3>Post-release PR</h3>
+        <code>package.json: 0.64.0</code>
+        <code>CHANGELOG: ## v0.64.0</code>
+        <small>Generated from released SHA D, moving shipped bullets out of Unreleased.</small>
+      </article>
+      <div class="arrow green">→</div>
+      <article class="card after">
+        <h3>After merge</h3>
+        <code>package.json: 0.64.0</code>
+        <code>CHANGELOG: ## v0.64.0</code>
+        <small>Master now matches stable. Later work continues under Unreleased.</small>
+      </article>
+    </div>
+    <div class="note"><strong>Key point:</strong> <code>v0.64.0-insiders.2</code> and <code>v0.64.0</code> point at the same source SHA; stable rebuilds public artifacts instead of republishing the insider binary.</div>
+  </section>
+</main>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    sequence: {
+      mirrorActors: false,
+      showSequenceNumbers: false,
+      actorMargin: 52,
+      messageMargin: 34,
+      noteMargin: 10,
+      boxMargin: 8
+    },
+    themeVariables: {
+      fontFamily: 'Segoe UI, system-ui, sans-serif',
+      primaryColor: '#fffdf8',
+      primaryBorderColor: '#d5c4a8',
+      primaryTextColor: '#1f1a12',
+      actorBkg: '#fffdf8',
+      actorBorder: '#8f8069',
+      actorTextColor: '#1f1a12',
+      signalColor: '#242017',
+      signalTextColor: '#1f1a12',
+      noteBkgColor: '#fff0d5',
+      noteBorderColor: '#a86504',
+      noteTextColor: '#1f1a12',
+      labelBoxBkgColor: '#e9f4ff',
+      labelBoxBorderColor: '#1e6599',
+      labelTextColor: '#1f1a12'
+    }
+  });
+</script>
+</body>
+</html>

--- a/.github/skills/a2a-relay/SKILL.md
+++ b/.github/skills/a2a-relay/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: a2a-relay
+description: Connect and coordinate with Chamber A2A relay agents. Use this whenever the user mentions A2A, a2a-client, relay agents, Switchboard relay, connecting to the relay, listing agents, sending an agent a message, reading inbound messages, or replying to an inbound A2A message. Prefer the direct `chamber_a2a_*` tools; do not use shell commands as markers or wrappers for A2A actions.
+---
+
+# A2A Relay Skill
+
+Use the direct A2A tools to connect this Copilot CLI session to a Chamber
+relay, discover agents, and exchange messages.
+
+## Rules
+
+- Register as `{user_alias}-copilot-{repo}-{host_platform_os}`.
+  - Example: `ianphil-copilot-chamber-windows`.
+- Use `chamber_a2a_*` tools directly. Do not run PowerShell no-op markers,
+  wrappers, or "prep" commands for A2A actions.
+- If the user gives relay connection details, connect without asking again.
+- If an inbound message includes `message_id`, reply with
+  `chamber_a2a_reply` so the relay context is preserved.
+
+## Tool flow
+
+### Connect
+
+Default Switchboard relay (Chamber, Entra interactive auth) on Windows:
+
+```json
+{
+  "base_url": "https://ca-switchboard-5ofgbfqtsnhd6.proudbay-985bf294.eastus.azurecontainerapps.io",
+  "client_id": "074530a3-b6c5-41c8-896c-4a6651bf5f16",
+  "agent_name": "ianphil-copilot-chamber-windows",
+  "auth_mode": "interactive"
+}
+```
+
+Call `chamber_a2a_connect` with these values unless the user overrides
+them. Keep the `{user_alias}-copilot-{repo}-{host_platform_os}` agent name
+(e.g. `ianphil-copilot-chamber-windows`) — do not shorten it.
+
+Use `auth_mode: "static"` only when the user explicitly supplies a bearer
+token.
+
+### List agents
+
+Call `chamber_a2a_list_agents` to see who is registered and available.
+
+### Send a message
+
+Call `chamber_a2a_send_message` with `recipient` (the exact agent name
+from `chamber_a2a_list_agents`) and `message`. Optionally pass
+`context_id` to continue an existing A2A conversation.
+
+```json
+{
+  "recipient": "copilot-chamber-mac",
+  "message": "..."
+}
+```
+
+Note: the parameter is `recipient`, not `agent_name`. Using `agent_name`
+will fail with "Tool execution failed".
+
+### Read messages
+
+Call `chamber_a2a_read_messages` when the user asks whether anyone replied,
+when waiting for async coordination, or when you need to check inbound A2A
+traffic.
+
+### Reply to an inbound message
+
+Call `chamber_a2a_reply` with the inbound `message_id` and your response.
+This preserves the original sender and context when the relay supplied one.
+

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -38,12 +38,12 @@ Both are `workflow_dispatch` only — neither fires on push.
 
 The core shape to keep in mind:
 
-- **Insiders cut** = compute target stable from `## Unreleased` in
+- **Insiders cut** = compute target stable from `## [Unreleased]` in
   `CHANGELOG.md` → bump counter (`vX.Y.Z-insiders.N`) → build → upload
   to blob → push the tag only. Master is never modified.
 - **Stable cut** is almost always **promote an insider tag**
   (`source_ref: vX.Y.Z-insiders.N`). Direct-from-master dispatch is an
-  emergency fallback that derives the version from `## Unreleased` the
+  emergency fallback that derives the version from `## [Unreleased]` the
   same way insiders does.
 - **Stable feature flags** are controlled by the GitHub Pages policy at
   `docs/flags/v1/flags.json`. Stable releases must ask whether any
@@ -51,15 +51,16 @@ The core shape to keep in mind:
   workflow.
 - **Post-stable** (this skill's responsibility, run locally): open a PR
   that bumps `package.json` to the freshly shipped stable version and
-  promotes `## Unreleased` into `## vX.Y.Z (date)` in `CHANGELOG.md`.
-  This keeps master's invariant (version = last shipped stable).
+  promotes `## [Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD` in
+  `CHANGELOG.md` (Keep a Changelog 1.1.0 format). This keeps master's
+  invariant (version = last shipped stable).
 
 ## Worked examples
 
 **"Cut an insider build for testers"** →
 Confirm channel is `insiders`. Predict the next tag with
 `node scripts/bump-insiders-version.js --dry-run` — this reads
-`## Unreleased` in `CHANGELOG.md`, classifies the highest-precedence
+`## [Unreleased]` in `CHANGELOG.md`, classifies the highest-precedence
 heading, and prints the target stable + insider counter. Dispatch
 `gh workflow run release-insiders.yml --ref master`. After success,
 hand back the install URL and the new tag.
@@ -73,7 +74,7 @@ the GitHub Release URL.
 
 **"Release straight from master (emergency)"** →
 Confirm channel is `stable`, flow A. The workflow will compute the
-target stable from `## Unreleased`. Confirm the computed version
+target stable from `## [Unreleased]`. Confirm the computed version
 doesn't already exist as a tag. Dispatch
 `gh workflow run release.yml --ref master`. After success, open the
 post-release bump PR.
@@ -82,6 +83,55 @@ post-release bump PR.
 
 Phases marked **ASK** must confirm in interactive mode; skip in
 autopilot mode only when the caller already supplied the answers.
+
+### 0. AGENT - Initialize the release checklist
+
+Every release dispatch creates a per-run checklist that the skill
+ticks off as it executes. The checklist is the mechanism that prevents
+silent skips like the v0.63.0 post-release bump (Phase 3b.7 was never
+run because the dispatching session ended before the build finished).
+
+1. Load the template that matches the channel **once it's been
+   chosen** (Phase 2 picks the channel; if running this phase before
+   the channel is known, defer the load until after Phase 2 and just
+   reserve the file path):
+   - Insiders: `.github/skills/release/assets/insiders-checklist.md`
+   - Stable: `.github/skills/release/assets/stable-checklist.md`
+2. Substitute the placeholders the skill already has at dispatch time
+   (`{{VERSION}}`, `{{BUILD_SHA}}`, `{{SOURCE_REF}}`, `{{FLOW}}`,
+   `{{TARGET_STABLE}}`, `{{COUNTER}}`, `{{BUMP_SOURCE}}`,
+   `{{BUMP_KIND}}`, `{{DATE}}`, `{{FLOW_DESCRIPTION}}`). Leave any
+   placeholder unsubstituted (with the literal `{{…}}`) when the
+   value isn't known yet — the skill fills it on the relevant phase.
+3. Write the substituted checklist to the session-state files folder
+   so it survives checkpoints. The path is:
+
+   ```
+   ~/.copilot/session-state/<session-id>/files/release-v<version>-<channel>-checklist.md
+   ```
+
+   (the session folder is given in the `session_context` block at the
+   top of every conversation).
+4. **Mirror every `- [ ]` item into the session todos table.** Use
+   the kebab-case id in `[brackets]` as the todo `id` and the line
+   text as the `title`. Initial status is `pending`. Add dependencies
+   that match the phase order (`preflight-auth → channel-confirmed →
+   compute-version → … → summary-written`).
+5. As each phase completes, flip **both** the todo row
+   (`UPDATE todos SET status='done' WHERE id=…`) **and** the
+   matching `- [ ]` → `- [x]` in the checklist file on disk. The
+   file is the durable record; the todos table is what blocks the
+   session from ending with work outstanding.
+6. **Refuse to end the session** with any `pending` or `in_progress`
+   todos from the checklist. If a phase must be deferred (e.g. macOS
+   notary warmup not done), mark the todo `blocked` with a reason in
+   the description and append a note to the **Notes** section of the
+   checklist file.
+
+This checklist is **session-local**. It is intentionally not
+committed: it captures dispatch-time decisions, links to run URLs,
+and per-session context that would be noise in the repo. The skill
+loads a fresh checklist on every dispatch.
 
 ### 1. AGENT - Pre-flight
 
@@ -122,15 +172,15 @@ node scripts/bump-insiders-version.js --dry-run
 ```
 
 The script reads `package.json` (last shipped stable), parses
-`## Unreleased` in `CHANGELOG.md` for the highest-precedence conventional
+`## [Unreleased]` in `CHANGELOG.md` for the highest-precedence conventional
 heading, derives the target stable via SemVer, queries `git tag -l` for
 existing `v<target>-insiders.*` tags, and prints the next insider version
 plus the bump source heading.
 
 Surface the predicted target stable, counter, and bump source to the
 user so they can confirm intent (e.g. "next insider is
-`v0.63.0-insiders.0`, derived from a `### Features` bullet in
-Unreleased"). If `## Unreleased` is empty the script fails — direct the
+`v0.63.0-insiders.0`, derived from an `### Added` bullet in
+Unreleased"). If `## [Unreleased]` is empty the script fails — direct the
 user to ship a change first, or to use the override below for a
 genuinely test-only build.
 
@@ -227,7 +277,7 @@ node -e "
   const pkg = require('./package.json');
   const semver = require('semver');
   const { bump, section } = ch.recommendBumpFromChangelog('./CHANGELOG.md');
-  if (!bump) { console.error('Empty ## Unreleased — nothing to release.'); process.exit(1); }
+  if (!bump) { console.error('Empty ## [Unreleased] — nothing to release.'); process.exit(1); }
   console.log('Master version (last shipped stable):', pkg.version);
   console.log('Bump source headings:', section.headings.join(', '));
   console.log('Target stable:', semver.inc(pkg.version, bump));
@@ -235,7 +285,7 @@ node -e "
 git tag -l 'v*' --sort=-v:refname | grep -v -- '-insiders\.' | head -5
 ```
 
-Confirm `## Unreleased` has actionable entries and no `v<target>` tag
+Confirm `## [Unreleased]` has actionable entries and no `v<target>` tag
 already exists. If the tag exists, stop and direct the user to cut an
 insider first (so master gets updated via Flow B's post-release PR).
 
@@ -402,7 +452,36 @@ Surface:
   artifact, not committed. The post-release bump PR (next phase) fixes
   this.
 
-#### 3b.7 AGENT - Post-release bump PR (anchored to build SHA)
+> **Important — async coupling:** stable builds take 30–60 min (longer
+> with macOS notarization warmup). Once the workflow dispatched at
+> Phase 3b.5 finishes and `softprops/action-gh-release@v2` pushes the
+> `vX.Y.Z` tag, `.github/workflows/post-release-bump.yml` fires
+> automatically and opens the Phase 3b.7 bump PR for you. Do **not**
+> end your work without confirming one of:
+>
+> 1. The `Post-release bump` workflow ran (`gh run list
+>    --workflow=post-release-bump.yml --limit 1`) and the
+>    `release/bump-v<version>` PR exists (`gh pr list --head
+>    release/bump-v<version>`).
+> 2. The user has been explicitly handed the link to that PR for
+>    review.
+>
+> If the workflow hasn't fired yet — set a reminder via
+> `manage_schedule` (or `gh run watch`) and check back. If it has
+> fired but failed, fall through to Phase 3b.7 manually.
+
+#### 3b.7 AGENT - Post-release bump PR (anchored to build SHA) — automated path + manual fallback
+
+> **Default path is automatic.** `.github/workflows/post-release-bump.yml`
+> opens this PR on stable tag push. Use the manual path below **only**
+> when (a) the workflow failed, (b) the workflow was disabled, or (c)
+> you're doing a release for which automation is intentionally not
+> appropriate (rare). Verify automation status first:
+>
+> ```bash
+> gh run list --workflow=post-release-bump.yml --limit 3
+> gh pr list --head release/bump-v<version>
+> ```
 
 Master's `package.json` and `CHANGELOG.md` must now be advanced. This is
 the **only** automation that mutates `package.json` on master under
@@ -440,7 +519,7 @@ git checkout -b release/bump-vX.Y.Z "$BUILD_SHA"
 # Bump to the freshly shipped stable version
 npm version <X.Y.Z> --no-git-tag-version --allow-same-version
 
-# Promote ## Unreleased into ## vX.Y.Z (YYYY-MM-DD)
+# Promote ## [Unreleased] into ## [X.Y.Z] - YYYY-MM-DD (Keep a Changelog 1.1.0)
 node -e "
   const ch = require('./scripts/changelog');
   const today = new Date().toISOString().slice(0, 10);
@@ -455,38 +534,39 @@ git push -u origin HEAD
 
 gh pr create --base master --head release/bump-vX.Y.Z \
   --title "chore(release): bump master to vX.Y.Z post-release" \
-  --body "Post-release bump anchored to build SHA \`$BUILD_SHA\` (tag \`vX.Y.Z-insiders.N\`). Master now reflects the freshly shipped stable version. \`## Unreleased\` content at build time has been promoted to \`## vX.Y.Z\` in CHANGELOG.md.
+  --body "Post-release bump anchored to build SHA \`$BUILD_SHA\` (tag \`vX.Y.Z-insiders.N\`). Master now reflects the freshly shipped stable version. \`## [Unreleased]\` content at build time has been promoted to \`## [X.Y.Z] - YYYY-MM-DD\` in CHANGELOG.md (Keep a Changelog 1.1.0 format).
 
 Build-SHA: $BUILD_SHA
 Source-Ref: vX.Y.Z-insiders.N
 
-If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new \`## vX.Y.Z\` section AS-IS, and keep any \`## Unreleased\` bullets that landed during the build window under a fresh \`## Unreleased\` block above it. **Do not rebase or merge master into this branch** — that would defeat Pattern E anchoring and the \`model-b-gates\` PR check will fail. Resolve at PR-merge time only.
+If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new \`## [X.Y.Z] - YYYY-MM-DD\` section AS-IS, and keep any \`## [Unreleased]\` bullets that landed during the build window under a fresh \`## [Unreleased]\` block above it. **Do not rebase or merge master into this branch** — that would defeat Pattern E anchoring and the \`model-b-gates\` PR check will fail. Resolve at PR-merge time only.
 
 This PR is mechanical and CI-validated; merge after green checks."
 ```
 
 **Conflict resolution on merge.** Common ancestor is the build SHA.
-Master may have added bullets to `## Unreleased`; the bump branch
-removed all `## Unreleased` content and inserted a new `## vX.Y.Z`
-section. Git usually auto-merges (non-overlapping edits). When it
-doesn't, resolve by keeping **both** sections:
+Master may have added bullets to `## [Unreleased]`; the bump branch
+removed all `## [Unreleased]` content and inserted a new
+`## [X.Y.Z] - YYYY-MM-DD` section. Git usually auto-merges
+(non-overlapping edits). When it doesn't, resolve by keeping **both**
+sections:
 
 ```
-## Unreleased
+## [Unreleased]
 
-### Fixes
+### Fixed
 
 - **Bullet that landed during the build window** - ...
 
-## vX.Y.Z (YYYY-MM-DD)
+## [X.Y.Z] - YYYY-MM-DD
 
-### Features
+### Added
 
 - **Bullet that was in Unreleased at build SHA** - ...
 ```
 
-No bullet is ever lost. The interim bullets stay in `## Unreleased` for
-the next release to pick up.
+No bullet is ever lost. The interim bullets stay in `## [Unreleased]`
+for the next release to pick up.
 
 The user reviews and merges the PR. Do not auto-merge — the user owns
 the master-mutation moment.
@@ -504,11 +584,34 @@ see exactly what happened. Example:
    - Install URL:  https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe
    - Auto-update:  existing testers receive it automatically
    - Run:          <gh URL>
+   - Checklist:    ~/.copilot/session-state/<id>/files/release-vX.Y.Z-<channel>-checklist.md
 ```
 
 This summary is the most valuable thing the skill produces. Releases
 are infrequent enough that everyone — including the person who
 dispatched — benefits from a written trail.
+
+### 5. AGENT - Close the checklist
+
+Before ending the session:
+
+1. Confirm every checklist todo is `done` or `blocked` (with a
+   documented reason in the checklist's **Notes** section). Any
+   `pending` or `in_progress` row means the release isn't actually
+   complete and the session must not end yet.
+2. Append a final timestamped line to the checklist's **Notes**
+   section: `Closed: <ISO datetime> · Session: <session-id>`.
+3. Surface the checklist file path to the user as part of the summary
+   above so they can review later or resume in a new session.
+
+If the dispatching session has to end with a release still in flight
+(e.g. waiting on a 30-min build), explicitly hand off:
+
+- Tell the user which todos are still `pending` and what triggers
+  each one (typically "the `Post-release bump` workflow firing").
+- Suggest scheduling a check-in with `manage_schedule` so a future
+  session re-loads the checklist (the file is the source of truth)
+  and completes the outstanding items.
 
 ## Failure modes
 
@@ -518,7 +621,7 @@ dispatched — benefits from a written trail.
   should land via `ship` first.
 - **`gh auth status` fails** — stop, surface the message, ask to
   re-auth.
-- **Empty `## Unreleased`** (insiders compute or Flow A) — stop. Direct
+- **Empty `## [Unreleased]`** (insiders compute or Flow A) — stop. Direct
   the user to ship at least one change so the bump source exists.
 - **Insider tag doesn't exist** (Flow B) — stop, list recent tags.
 - **Stable version tag already exists** (Flow A or B) — stop. Direct
@@ -526,10 +629,10 @@ dispatched — benefits from a written trail.
   and re-cut the insider, then promote.
 - **Post-release bump PR has CHANGELOG conflict at merge** — expected
   when commits landed on master during the build window. Resolve by
-  keeping both sections: the new `## vX.Y.Z (date)` AS-IS, and any
-  interim `## Unreleased` bullets under a fresh `## Unreleased` block
-  above it. Never `--theirs` or `--ours` blindly — both sides carry
-  real content. See Phase 3b.7 for the resolution template.
+  keeping both sections: the new `## [X.Y.Z] - YYYY-MM-DD` AS-IS, and
+  any interim `## [Unreleased]` bullets under a fresh `## [Unreleased]`
+  block above it. Never `--theirs` or `--ours` blindly — both sides
+  carry real content. See Phase 3b.7 for the resolution template.
 - **Stable feature flag policy PR needed** — stop before dispatching
   stable until the policy PR is merged and
   `https://chmbr.dev/flags/v1/flags.json` reflects the intended stable

--- a/.github/skills/release/assets/insiders-checklist.md
+++ b/.github/skills/release/assets/insiders-checklist.md
@@ -1,0 +1,61 @@
+# Insiders Release Checklist — v{{VERSION}}
+
+> Target stable: **v{{TARGET_STABLE}}** · Insider counter: **{{COUNTER}}** ·
+> Bump source: **{{BUMP_SOURCE}}** ({{BUMP_KIND}}) · Dispatched: {{DATE}}
+
+This file is the per-release execution record for the **insiders**
+channel. It is created from
+`.github/skills/release/assets/insiders-checklist.md` by the release
+skill at dispatch time and written to
+`~/.copilot/session-state/<session-id>/files/release-v{{VERSION}}-insiders-checklist.md`.
+
+It is **not committed to the repository.** It exists so that:
+
+- Every `- [ ]` item below has a matching session todo (kebab-case id
+  shown in `[id]`). The skill flips both as it works.
+- A session cannot end with `pending` todos for a release in flight.
+- The on-disk record survives session checkpoint/restore.
+
+If you are reading this template (not a filled-out copy) the `{{…}}`
+placeholders haven't been substituted yet.
+
+---
+
+## Phase 1 — Pre-flight
+
+- [ ] `[preflight-auth]` `gh auth status` succeeds.
+- [ ] `[preflight-tree]` Working tree clean (or user explicitly waived).
+- [ ] `[preflight-branch]` Dispatching against `origin/master` (insider OIDC is master-scoped).
+
+## Phase 2 — Channel chosen: insiders
+
+- [ ] `[channel-confirmed]` User confirmed `insiders` (Windows-only, invite-only).
+
+## Phase 3a — Compute & dispatch
+
+- [ ] `[compute-version]` Ran `node scripts/bump-insiders-version.js --dry-run`; surfaced target stable, counter, and bump source heading to the user.
+- [ ] `[override-decision]` Decided whether to use `--override-bump` (default = derive from `## [Unreleased]`).
+- [ ] `[dispatch]` Ran `gh workflow run release-insiders.yml --ref master` (with override if applicable).
+- [ ] `[dispatch-confirmed]` `gh run list --workflow=release-insiders.yml --limit 1` shows the new run.
+- [ ] `[dispatch-url-surfaced]` Run URL + `gh run watch <id>` command handed to user.
+
+## Phase 3a.4 — After success
+
+- [ ] `[tag-pushed]` New tag `v{{VERSION}}` appears in `git tag -l 'v*-insiders.*' --sort=-v:refname | head -3`.
+- [ ] `[install-url-surfaced]` Install URL surfaced to user: <https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe>
+- [ ] `[update-feed-surfaced]` Auto-update feed surfaced: <https://chamberinsiders.blob.core.windows.net/releases/insiders.yml>
+- [ ] `[tester-note]` Reminded user that existing testers auto-update; new testers need the install URL out-of-band.
+
+## Phase 4 — Summary
+
+- [ ] `[summary-written]` Wrote the structured summary block (channel, next tag, audience, install URL, auto-update note, run URL).
+
+---
+
+## Notes
+
+Anything noteworthy from this dispatch — surprises, deviations from the
+default flow, items deferred. The skill should append here rather than
+leaving the section blank.
+
+-

--- a/.github/skills/release/assets/stable-checklist.md
+++ b/.github/skills/release/assets/stable-checklist.md
@@ -1,0 +1,100 @@
+# Stable Release Checklist — v{{VERSION}}
+
+> Flow: **{{FLOW}}** ({{FLOW_DESCRIPTION}}) · Source: **{{SOURCE_REF}}** ·
+> Build SHA: **{{BUILD_SHA}}** · Dispatched: {{DATE}}
+
+This file is the per-release execution record for the **stable**
+channel. It is created from
+`.github/skills/release/assets/stable-checklist.md` by the release
+skill at dispatch time and written to
+`~/.copilot/session-state/<session-id>/files/release-v{{VERSION}}-stable-checklist.md`.
+
+It is **not committed to the repository.** It exists so that:
+
+- Every `- [ ]` item below has a matching session todo (kebab-case id
+  shown in `[id]`). The skill flips both as it works.
+- A session cannot end with `pending` todos for a release in flight —
+  in particular **Phase 3b.7 (post-release bump PR) cannot be silently
+  skipped** the way it was for v0.63.0.
+- The on-disk record survives session checkpoint/restore.
+
+If you are reading this template (not a filled-out copy) the `{{…}}`
+placeholders haven't been substituted yet.
+
+---
+
+## Phase 1 — Pre-flight
+
+- [ ] `[preflight-auth]` `gh auth status` succeeds.
+- [ ] `[preflight-tree]` Working tree clean (or user explicitly waived).
+- [ ] `[preflight-branch]` Dispatching against `origin/master`.
+
+## Phase 2 — Channel chosen: stable
+
+- [ ] `[channel-confirmed]` User confirmed `stable` (public, full platforms).
+
+## Phase 3b.1 — Flow
+
+- [ ] `[flow-chosen]` Picked Flow A (emergency from master) or Flow B (promote insider tag). Default = B.
+
+## Phase 3b.2 — Pre-flight for the chosen flow
+
+- [ ] `[insider-tag-listed]` (Flow B) Listed recent insider tags and confirmed `{{SOURCE_REF}}` with user.
+- [ ] `[stable-tag-absent]` Confirmed `v{{VERSION}}` does **not** already exist (`git tag -l v{{VERSION}}` empty).
+- [ ] `[unreleased-non-empty]` (Flow A only) Confirmed `## [Unreleased]` has actionable entries.
+
+## Phase 3b.3 — Stable feature flag graduation
+
+- [ ] `[flags-current]` Read current `docs/flags/v1/flags.json` and the published <https://chmbr.dev/flags/v1/flags.json>.
+- [ ] `[flags-decided]` Asked user which flags graduate to stable. Default = none.
+- [ ] `[flags-pr]` (If any graduating) Opened the small `Update stable feature flags` PR, ran the targeted vitest + markdownlint, and waited for the user to merge it.
+- [ ] `[flags-published]` (If any graduating) Verified the published policy at <https://chmbr.dev/flags/v1/flags.json> reflects the intended stable values.
+
+## Phase 3b.4 — macOS notary warmup
+
+- [ ] `[notary-status]` Confirmed macOS notarization warmup is complete (recent submissions <5 min), **or** user explicitly chose Windows-only stable (`STABLE_RELEASE_BUILD_MACOS=false` set/verified), **or** stable deferred until warmup completes.
+
+## Phase 3b.5 — Dispatch
+
+- [ ] `[dispatch]` Ran `gh workflow run release.yml --ref master` with the chosen `source_ref` (Flow B) or no source_ref (Flow A).
+- [ ] `[dispatch-confirmed]` `gh run list --workflow=release.yml --limit 1` shows the new run.
+- [ ] `[dispatch-url-surfaced]` Run URL + `gh run watch <id>` command handed to user.
+
+## Phase 3b.6 — After success (async-coupled — DO NOT SKIP)
+
+> Stable builds take 30–60 min (longer with macOS notary warmup). The
+> dispatching session typically ends before the run completes. **The
+> next two items are the most-skipped step in the whole flow** —
+> v0.63.0 shipped without them and master was left at 0.62.4 until
+> caught by hand a day later. Treat them as load-bearing.
+
+- [ ] `[release-tag-present]` `git fetch origin --tags --quiet && gh release view v{{VERSION}}` shows the release.
+- [ ] `[release-url-surfaced]` GitHub Releases URL surfaced to user.
+- [ ] `[two-tags-noted]` (Flow B) Reminded user that `v{{VERSION}}` and `{{SOURCE_REF}}` point at the same commit by design.
+- [ ] `[stale-pkg-noted]` Reminded user that `git checkout v{{VERSION}}` will show master's stale `package.json` until the bump PR merges.
+
+## Phase 3b.7 — Post-release bump PR (the one we always forget)
+
+> **`.github/workflows/post-release-bump.yml` should have opened this
+> PR automatically on stable tag push.** These items confirm the
+> automation actually ran; if it didn't, fall through to the manual
+> path.
+
+- [ ] `[auto-workflow-ran]` `gh run list --workflow=post-release-bump.yml --limit 3` shows a successful run for tag `v{{VERSION}}`.
+- [ ] `[auto-pr-opened]` `gh pr list --head release/bump-v{{VERSION}}` shows the bump PR.
+- [ ] `[auto-pr-url-surfaced]` Bump PR URL surfaced to user for review.
+- [ ] `[manual-fallback-if-needed]` (Only if the workflow failed or didn't fire) Ran the manual sequence: branch from `{{BUILD_SHA}}`, `npm version {{VERSION}} --allow-same-version`, `promoteUnreleasedToVersion`, commit with `Build-SHA:` + `Source-Ref:` trailers, push, `gh pr create`. Surfaced PR URL.
+
+## Phase 4 — Summary
+
+- [ ] `[summary-written]` Wrote the structured summary block (channel, version, release URL, two-tag note, bump-PR URL).
+
+---
+
+## Notes
+
+Anything noteworthy from this dispatch — surprises, deviations from the
+default flow, items deferred. The skill should append here rather than
+leaving the section blank.
+
+-

--- a/.github/skills/ship/SKILL.md
+++ b/.github/skills/ship/SKILL.md
@@ -27,8 +27,8 @@ In autopilot mode, do not stop for repeated confirmation prompts. Apply these de
 
 | Prompt area | Autopilot default |
 |---|---|
-| Change classification | Pick the conventional kind (`breaking`/`feature`/`fix`/`perf`/`refactor`/`docs`/`tests`/`build`/`ci`/`chore`) from the diff; the release skill computes the actual version bump later from accumulated `## Unreleased` entries. |
-| Changelog | Append a bullet under the matching `### Heading` of `## Unreleased` using `scripts/append-changelog-entry.js`. |
+| Change classification | Pick the conventional kind (KaC canonical: `added`/`changed`/`deprecated`/`removed`/`fixed`/`security`; Chamber extensions: `breaking`/`perf`/`refactor`/`docs`/`tests`/`build`/`ci`/`chore`/`packaging`) from the diff; the release skill computes the actual version bump later from accumulated `## [Unreleased]` entries. |
+| Changelog | Append a bullet under the matching `### Heading` of `## [Unreleased]` using `scripts/append-changelog-entry.js`. |
 | Closing issue | Include all planned issue refs from the roadmap or branch commit messages. |
 | Uncle Bob | Run for non-trivial, runtime, architecture, SDK, security, or broad behavior changes; skip for small docs, tests, and focused UI fixes. |
 | Packaging sandbox | Do not run `npm run make:sandbox`; use `npm run package` only when packaging/startup paths need smoke coverage. |
@@ -69,12 +69,13 @@ git rebase origin/<parent-branch>
 
 If the rebase has conflicts, stop and surface them. Do not attempt automatic resolution unless the user explicitly approves.
 
-### 2. ASK/AUTOPILOT - Classify the change and append a `## Unreleased` entry
+### 2. ASK/AUTOPILOT - Classify the change and append a `## [Unreleased]` entry
 
 > **Under Model B, ship does not bump `package.json`.** Versions are computed
-> at release time from accumulated bullets in `## Unreleased`. Ship's job is
+> at release time from accumulated bullets in `## [Unreleased]`. Ship's job is
 > to file an entry under the right conventional `### Heading` so the release
-> skill can compute the next version deterministically. See
+> skill can compute the next version deterministically. The CHANGELOG follows
+> [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). See
 > [`ai-docs/release-channels.md`](../../../ai-docs/release-channels.md).
 
 Inspect the diff against the intended base:
@@ -87,18 +88,24 @@ git --no-pager diff <base-ref> -- <changed-files>
 Classify the change using these conventional kinds (in precedence order — the
 release skill picks the highest one across all bullets to compute the bump):
 
-- **breaking** - intentional incompatible change (API removed, contract broken). Drives a major bump.
-- **feature** - new user-visible capability (new mind capability, new Lens view type, new cron job kind, new tool, schema additions). Drives a minor bump.
-- **fix** - bug fix.
-- **perf** - performance improvement with no behavior change.
-- **refactor** - internal restructuring, no behavior change.
-- **docs** - documentation only.
-- **tests** - test-only changes.
-- **build** - build/packaging tooling.
-- **ci** - CI workflow / governance.
-- **chore** - everything else (release plumbing, dependency hygiene).
+KaC canonical:
 
-All non-feature/non-breaking kinds drive a patch bump.
+- **removed** - a public API/feature has been removed. Drives a **major** bump.
+- **added** - a new user-visible capability. Drives a **minor** bump.
+- **changed** - a non-breaking change in existing behavior. Drives a **minor** bump.
+- **deprecated** - feature marked for future removal. Drives a **minor** bump.
+- **fixed** - bug fix. Drives a **patch** bump.
+- **security** - vulnerability fix. Drives a **patch** bump.
+
+Chamber extension:
+
+- **breaking** - intentional incompatible change (API removed, contract broken). Drives a **major** bump. Use when "removed" doesn't fit (e.g. signature change, semantics change).
+
+Chamber area-tag extensions (all patch precedence):
+
+- **perf / performance**, **refactor**, **docs**, **tests**, **build**, **ci**, **chore**, **release**, **packaging**.
+
+Legacy aliases still accepted: **feature / features** → Added, **fix / fixes** → Fixed.
 
 Interactive mode: use `ask_user` to confirm the kind with a suggested choice.
 
@@ -114,7 +121,7 @@ node scripts/append-changelog-entry.js \
   --issue=NNN
 ```
 
-The script creates `## Unreleased` if missing, ensures the right `### Heading`
+The script creates `## [Unreleased]` if missing, ensures the right `### Heading`
 exists under it, and appends the bullet in the existing format
 (`- **<summary>** - <detail> (#<issue>)`). It does **not** touch `package.json`.
 
@@ -217,10 +224,10 @@ Print the resulting PR URL.
 - **Current branch is `master`** - abort.
 - **Unknown PR base** - ask.
 - **Rebase conflicts** - stop, surface conflicts, ask for direction.
-- **Empty / missing `## Unreleased` section after appending** - script failure; surface the error and stop.
+- **Empty / missing `## [Unreleased]` section after appending** - script failure; surface the error and stop.
 - **Lint, test, or smoke failure** - stop, show the failure, do not push.
 - **Critical Uncle Bob finding** - fix if clearly in scope; otherwise ask.
-- **No `## Unreleased` bullet for a non-trivial change** - block until one exists. Docs/test-only PRs may use a `### Docs` / `### Tests` bullet.
+- **No `## [Unreleased]` bullet for a non-trivial change** - block until one exists. Docs/test-only PRs may use a `### Docs` / `### Tests` bullet.
 - **Dirty working tree at the end** - never push with uncommitted changes.
 
 ## Notes

--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -153,9 +153,12 @@ jobs:
             version_changed=1
           fi
 
-          # Detect newly added '## vX.Y.Z' headings in CHANGELOG.md (promoted from Unreleased).
+          # Detect newly added '## vX.Y.Z' / '## [X.Y.Z]' headings in CHANGELOG.md
+          # (promoted from Unreleased). Accepts both the legacy
+          # `## vX.Y.Z (YYYY-MM-DD)` and the Keep a Changelog
+          # `## [X.Y.Z] - YYYY-MM-DD` formats.
           added_release_headings=$(git diff "origin/master...HEAD" -- CHANGELOG.md \
-            | grep -E '^\+## v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)? \([0-9]{4}-[0-9]{2}-[0-9]{2}\)' \
+            | grep -E '^\+## (v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)? \([0-9]{4}-[0-9]{2}-[0-9]{2}\)|\[[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?\] - [0-9]{4}-[0-9]{2}-[0-9]{2})' \
             | sed 's/^+//' || true)
 
           is_release_branch=0
@@ -171,7 +174,7 @@ jobs:
           if [ -n "$added_release_headings" ] && [ "$is_release_branch" -eq 0 ]; then
             echo "::error::CHANGELOG.md added a release heading on non-release branch '$BRANCH':"
             echo "$added_release_headings"
-            echo "::error::Promote '## Unreleased' to '## vX.Y.Z' only via a 'release/bump-vX.Y.Z' branch."
+            echo "::error::Promote '## [Unreleased]' to '## [X.Y.Z] - YYYY-MM-DD' only via a 'release/bump-vX.Y.Z' branch."
             exit 1
           fi
 
@@ -193,8 +196,8 @@ jobs:
               echo "::error::Release version $head_version is not greater than base $base_version. Rollbacks must use an explicit override path."
               exit 1
             fi
-            if ! grep -qE "^## v${head_version} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)" CHANGELOG.md; then
-              echo "::error::CHANGELOG.md missing '## v${head_version} (YYYY-MM-DD)' heading."
+            if ! grep -qE "^## (v${head_version} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)|\[${head_version}\] - [0-9]{4}-[0-9]{2}-[0-9]{2})" CHANGELOG.md; then
+              echo "::error::CHANGELOG.md missing '## [${head_version}] - YYYY-MM-DD' heading (Keep a Changelog format; the legacy '## v${head_version} (YYYY-MM-DD)' form is also accepted for back-compat)."
               exit 1
             fi
             echo "Check A passed: release branch with matching version, changelog, and forward bump."

--- a/.github/workflows/post-release-bump.yml
+++ b/.github/workflows/post-release-bump.yml
@@ -1,0 +1,170 @@
+name: Post-release bump
+
+# Mechanically opens the Phase 3b.7 post-release bump PR whenever a
+# stable tag is pushed (v0.63.0, v1.2.3, etc. — excludes -insiders.N).
+# Replaces the human-coupled "remember to open the bump PR after the
+# stable release workflow finishes" step in the release skill, which is
+# easy to drop because the workflow takes 30–60 min and the dispatching
+# session usually ends in the meantime.
+#
+# Pattern E is preserved: the branch is cut from the tag's SHA, not from
+# current origin/master, so `## [Unreleased]` content promoted into the
+# new `## [X.Y.Z]` section reflects exactly what was in the file at
+# build time. Interim bullets that landed during the build window will
+# show up as a visible 3-way merge conflict at PR-merge time.
+
+on:
+  push:
+    tags:
+      # Stable tags only. Insider tags (vX.Y.Z-insiders.N) are excluded
+      # because they don't bump master under Model B.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: post-release-bump-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  open-bump-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout at the tagged SHA
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Resolve version + branch
+        id: vars
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          branch="release/bump-v${version}"
+          today="$(date -u +%Y-%m-%d)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+          echo "build_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "source_ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "today=${today}" >> "$GITHUB_OUTPUT"
+          echo "Computed: branch=${branch}, version=${version}, build_sha=${GITHUB_SHA}"
+
+      - name: Skip if branch or PR already exists
+        id: skip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.vars.outputs.branch }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::notice::Branch $BRANCH already exists on origin; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          existing="$(gh pr list --head "$BRANCH" --state all --json number --jq 'length')"
+          if [ "${existing:-0}" -gt 0 ]; then
+            echo "::notice::PR for $BRANCH already exists (open or closed); nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        if: steps.skip.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Branch from build SHA
+        if: steps.skip.outputs.skip == 'false'
+        run: |
+          git checkout -b "${{ steps.vars.outputs.branch }}"
+
+      - name: Bump package.json
+        if: steps.skip.outputs.skip == 'false'
+        run: |
+          npm version "${{ steps.vars.outputs.version }}" \
+            --no-git-tag-version --allow-same-version
+          # Refresh lockfile so package-lock.json version stays coherent
+          # with package.json (the model-b-gates lockfile-coherence check
+          # validates this). Full install (not --package-lock-only) per
+          # past lockfile-stripping issues with cross-platform entries.
+          npm install --no-audit --no-fund --ignore-scripts
+
+      - name: Promote ## [Unreleased] in CHANGELOG.md
+        if: steps.skip.outputs.skip == 'false'
+        run: |
+          node -e "
+            const ch = require('./scripts/changelog');
+            ch.promoteUnreleasedToVersion(
+              './CHANGELOG.md',
+              '${{ steps.vars.outputs.version }}',
+              '${{ steps.vars.outputs.today }}',
+            );
+          "
+
+      - name: Commit + push
+        if: steps.skip.outputs.skip == 'false'
+        env:
+          BRANCH: ${{ steps.vars.outputs.branch }}
+          VERSION: ${{ steps.vars.outputs.version }}
+          BUILD_SHA: ${{ steps.vars.outputs.build_sha }}
+          SOURCE_REF: ${{ steps.vars.outputs.source_ref }}
+        run: |
+          set -euo pipefail
+          git add package.json package-lock.json CHANGELOG.md
+          # Build the commit message in a file rather than inline so the
+          # YAML block scalar stays well-indented.
+          cat > /tmp/commit-msg.txt <<EOF
+          chore(release): bump master to v${VERSION} post-release
+
+          Auto-opened by .github/workflows/post-release-bump.yml on push of tag ${SOURCE_REF}. Pattern E anchored to the build SHA.
+
+          Build-SHA: ${BUILD_SHA}
+          Source-Ref: ${SOURCE_REF}
+
+          Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+          EOF
+          # Strip the 10-space leading indent that YAML preserved.
+          sed -i 's/^          //' /tmp/commit-msg.txt
+          git commit --no-verify -F /tmp/commit-msg.txt
+          git push -u origin "${BRANCH}"
+
+      - name: Open PR
+        if: steps.skip.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.vars.outputs.branch }}
+          VERSION: ${{ steps.vars.outputs.version }}
+          BUILD_SHA: ${{ steps.vars.outputs.build_sha }}
+          SOURCE_REF: ${{ steps.vars.outputs.source_ref }}
+          TODAY: ${{ steps.vars.outputs.today }}
+        run: |
+          set -euo pipefail
+          cat > /tmp/pr-body.md <<EOF
+          Auto-opened by [\`.github/workflows/post-release-bump.yml\`](.github/workflows/post-release-bump.yml) on stable tag push.
+
+          Post-release bump anchored to build SHA \`${BUILD_SHA}\` (tag \`${SOURCE_REF}\`). Master now reflects the freshly shipped stable version. \`## [Unreleased]\` content at build time has been promoted to \`## [${VERSION}] - ${TODAY}\` in CHANGELOG.md (Keep a Changelog 1.1.0 format) by \`promoteUnreleasedToVersion\`.
+
+          Build-SHA: ${BUILD_SHA}
+          Source-Ref: ${SOURCE_REF}
+
+          If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new \`## [${VERSION}] - ${TODAY}\` section AS-IS, and keep any \`## [Unreleased]\` bullets that landed during the build window under a fresh \`## [Unreleased]\` block above it. **Do not rebase or merge master into this branch** — that would defeat Pattern E anchoring and the \`model-b-gates\` PR check will fail. Resolve at PR-merge time only.
+
+          This is the standard Phase 3b.7 PR from the release skill, opened automatically so it can't be forgotten between the long stable build and the next human turn. Review and merge after green checks.
+          EOF
+          sed -i 's/^          //' /tmp/pr-body.md
+          gh pr create \
+            --base master \
+            --head "${BRANCH}" \
+            --title "chore(release): bump master to v${VERSION} post-release" \
+            --body-file /tmp/pr-body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
-## Unreleased
+All notable changes to this project will be documented in this file.
 
-### Features
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.63.0] - 2026-05-17
+
+### Added
 
 - **Move to Model B release versioning** — Master's `package.json#version` now stays at the last shipped stable version between releases. Ship appends bullets to `## Unreleased` under conventional `### Headings` (Breaking / Features / Fixes / …). The release skill reads those headings at insider-cut time to compute the next stable version, and the `-insiders.N` counter grows across iterations against the same future stable. Eliminates stable-version gaps. See [`ai-docs/release-channels.md`](ai-docs/release-channels.md).
 - **Enforce Model B / Pattern E with PR gates** — New `model-b-gates` job in `.github/workflows/governance-check.yml` enforces (a) `package.json` version bumps and `## vX.Y.Z` CHANGELOG promotions only on `release/bump-v*` branches, with branch-name/package/CHANGELOG version coherence and a strict forward-bump guard; (b) Pattern E build-SHA anchoring on release branches via `Build-SHA:` + `Source-Ref:` lines in the PR body and `merge-base` verification. Lockfile version coherence checked on every PR. The release skill PR body template now emits both headers.
@@ -10,7 +17,7 @@
 - **Surface real startup activity in the boot screen** — Adds `IPC.APP.STARTUP_PROGRESS` and a typed `StartupProgressEvent` stream so the Electron main process can broadcast restore progress while `MindManager` loads saved minds. The boot screen now appends real activity lines such as `restoring minds from config`, per-mind `ready` entries, and a final `N minds ready` summary instead of relying only on hardcoded animated text. Payloads carry display-safe metadata only: mind display names already shown in the sidebar and static summary text. Closes #56.
 - **Add remote feature flags** — Add app-owned feature flags with committed dev defaults, GitHub Pages remote policy resolution for packaged channels, and runtime guards for Switchboard Relay, BYO LLM, and chamber-copilot. (#326)
 
-### Fixes
+### Fixed
 
 - **Fix relay message routing and visibility** — Routes relay-discovered Chamber mind cards through Switchboard even when they include `mindId`, renders outbound relay sends in the sender transcript, switches to the target mind chat when inbound relay messages arrive without stealing focus, and keeps inactive relay replies scoped to the target mind.
 - **Remember static relay tokens securely** — Stores static A2A relay tokens in the OS credential store and lets the Relay view reconnect without re-entering the token.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,22 +100,34 @@ Include the version bump in your PR commit — don't merge without bumping.
 
 ## Changelog
 
-Every released version gets an entry in `CHANGELOG.md`. Follow the existing format:
+`CHANGELOG.md` follows
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). Every
+released version gets an entry written by the post-release bump PR
+opened by the `release` skill. Follow the existing format:
 
 ```markdown
-## vX.Y.Z (YYYY-MM-DD)
+## [X.Y.Z] - YYYY-MM-DD
 
-### Section Name
+### Added
 
 - **Short summary** — longer explanation of what changed and why. (#issue)
 ```
+
+Sub-headings follow the Keep a Changelog canonical vocabulary
+(**Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**,
+**Security**), plus a Chamber-specific **Breaking** heading and a few
+area-tag extensions (**Performance**, **Docs**, **Tests**, **CI**,
+**Build**, **Packaging**, **Release**, **Chore**) that all default to a
+patch bump.
 
 Guidelines:
 
 - **Bold the lead phrase** — scan-friendly one-liner, then the detail after the dash.
 - **Reference the issue** — append `(#N)` so readers can find the discussion.
-- **Group by area** — use subsections like `### Chat`, `### SDK`, `### Fixes`.
-- **Move unreleased items** — if there's an `## Unreleased` section, fold those entries into the new version header when you bump.
+- **Use `ship`, not hand edits** — `npm run ship` invokes
+  `scripts/append-changelog-entry.js`, which keeps the file consistent.
+- **Don't promote `## [Unreleased]` by hand** — that's the release
+  skill's post-release bump PR.
 
 ## Issues & Labels
 

--- a/ai-docs/release-channels.md
+++ b/ai-docs/release-channels.md
@@ -15,9 +15,12 @@ nothing is published on push to `master`.
   that mutates it is the post-release bump PR opened by the `release`
   skill after a stable cut succeeds.
 - The next stable version is **computed at release time** from the
-  conventional `### Headings` accumulated in `## Unreleased` in
-  `CHANGELOG.md`. `### Breaking` → major; `### Features` → minor;
-  everything else → patch. Highest precedence wins.
+  conventional `### Headings` accumulated in `## [Unreleased]` in
+  `CHANGELOG.md` (Keep a Changelog 1.1.0 format). The mapping is:
+  `### Removed` or `### Breaking` → major; `### Added`, `### Changed`,
+  or `### Deprecated` → minor; `### Fixed`, `### Security`, and all
+  Chamber area-tag extensions (`### Performance`, `### Docs`, …) →
+  patch. Highest precedence wins.
 - Insiders preview the **next stable**. `v0.63.0-insiders.0` is the
   first preview of the upcoming `v0.63.0`. The counter (`N`) advances
   with each preview against that target. If a new ship adds a
@@ -77,15 +80,16 @@ bump PR** that:
 
 - branches from the **build SHA** (the insider tag in Flow B, the
   dispatch SHA in Flow A) — **not** from current `origin/master`. This
-  ensures the CHANGELOG content promoted into `## vX.Y.Z` reflects
-  exactly what was in `## Unreleased` at the moment we built. Any
-  bullets added to `## Unreleased` during the build window land as a
-  visible 3-way merge conflict at PR-merge time (mechanical to resolve:
-  keep both sections), rather than silently being misattributed to the
-  released version,
+  ensures the CHANGELOG content promoted into `## [X.Y.Z] - YYYY-MM-DD`
+  reflects exactly what was in `## [Unreleased]` at the moment we built.
+  Any bullets added to `## [Unreleased]` during the build window land as
+  a visible 3-way merge conflict at PR-merge time (mechanical to
+  resolve: keep both sections), rather than silently being misattributed
+  to the released version,
 - runs `npm version 0.63.0 --no-git-tag-version --allow-same-version`,
 - calls `promoteUnreleasedToVersion` on `CHANGELOG.md` to turn the
-  `## Unreleased` block into `## v0.63.0 (YYYY-MM-DD)`,
+  `## [Unreleased]` block into `## [0.63.0] - YYYY-MM-DD` (Keep a
+  Changelog 1.1.0 format),
 - opens the PR for review.
 
 Once merged, master satisfies the invariant again: `package.json#version
@@ -94,7 +98,7 @@ Once merged, master satisfies the invariant again: `package.json#version
 ### Emergency release from master (no insider step)
 
 `release.yml` with `source_ref` empty computes the next stable from
-`## Unreleased` the same way the insiders compute does, applies it on
+`## [Unreleased]` the same way the insiders compute does, applies it on
 the runner, and tags master. The post-release bump PR is still required
 afterward.
 
@@ -154,17 +158,17 @@ insider, then promote.
 
 ### How to cut an insider build
 
-1. Make sure `## Unreleased` in `CHANGELOG.md` has the bullets you want
+1. Make sure `## [Unreleased]` in `CHANGELOG.md` has the bullets you want
    the next stable to contain. Each `ship` invocation appends one.
 2. Go to **Actions → Release Insiders → Run workflow** on the default
    branch.
 3. Optional `override_bump` input — `patch`, `minor`, `major`, or `none`
-   (default = derive from `## Unreleased`). Only use for emergencies
+   (default = derive from `## [Unreleased]`). Only use for emergencies
    where the changelog doesn't reflect the intended bump.
 4. The workflow will:
    - Run `scripts/bump-insiders-version.js`, which reads master's
      `package.json#version` and the highest-precedence `### Heading`
-     in `## Unreleased`, computes the target stable via SemVer, and
+     in `## [Unreleased]`, computes the target stable via SemVer, and
      advances/resets the `-insiders.N` counter against existing tags.
    - Run `npm install` to refresh the lockfile in the runner workspace.
    - Sign via the existing Trusted Signing identity.
@@ -229,17 +233,18 @@ Two flows, same workflow. **Flow B (promote insider) is the default.**
      `Promoted from insiders build vX.Y.Z-insiders.N`.
 4. After the workflow succeeds, the `release` skill opens a
    **post-release bump PR** that advances master's `package.json` to
-   `X.Y.Z` and promotes `## Unreleased` into `## vX.Y.Z (date)` in
-   `CHANGELOG.md`.
+   `X.Y.Z` and promotes `## [Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+   in `CHANGELOG.md` (Keep a Changelog 1.1.0 format).
 
 **Flow A — emergency release from master:**
 
-1. Make sure `## Unreleased` in `CHANGELOG.md` is non-empty.
+1. Make sure `## [Unreleased]` in `CHANGELOG.md` is non-empty.
 2. Go to **Actions → Release → Run workflow** on `master`.
 3. Leave `source_ref` empty. The workflow computes the next stable
-   version from `## Unreleased` using the same precedence rules as
-   insiders (`### Breaking` → major; `### Features` → minor; else
-   patch), applies it on the runner, builds, and tags master.
+   version from `## [Unreleased]` using the same precedence rules as
+   insiders (`### Removed`/`### Breaking` → major; `### Added`,
+   `### Changed`, or `### Deprecated` → minor; else patch), applies it
+   on the runner, builds, and tags master.
 4. The post-release bump PR is still required afterward.
 
 The `force_release` input (defaults to `true`) skips the patch-only
@@ -291,13 +296,15 @@ the next stable should return to the normal Windows + macOS shape.
 
 `scripts/changelog.js`:
 
-- Single source of truth for parsing/writing `CHANGELOG.md`.
-  `readUnreleasedSection` returns the headings + raw text under
-  `## Unreleased`. `recommendBumpFromChangelog` maps the highest-
-  precedence heading to `patch`/`minor`/`major`/null. `appendEntry`
-  writes a new bullet under the correct `### Heading` (used by ship).
-  `promoteUnreleasedToVersion` turns `## Unreleased` into a real
-  `## vX.Y.Z (date)` section (used by the post-release bump PR).
+- Single source of truth for parsing/writing `CHANGELOG.md` in the Keep
+  a Changelog 1.1.0 format. `readUnreleasedSection` returns the headings
+  + raw text under `## [Unreleased]` (also tolerates the legacy
+  `## Unreleased` for back-compat). `recommendBumpFromChangelog` maps
+  the highest-precedence heading to `patch`/`minor`/`major`/null.
+  `appendEntry` writes a new bullet under the correct `### Heading`
+  (used by ship). `promoteUnreleasedToVersion` turns `## [Unreleased]`
+  into a real `## [X.Y.Z] - YYYY-MM-DD` section (used by the
+  post-release bump PR).
 
 `scripts/bump-insiders-version.js`:
 

--- a/docs/release-flow.html
+++ b/docs/release-flow.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Chamber Release Flow</title>
+<style>
+  :root {
+    color-scheme: light;
+    --bg: #f2ecdf;
+    --panel: #fbf7ec;
+    --ink: #1f1a12;
+    --muted: #5e5448;
+    --line: #deceb4;
+    --green: #2d7038;
+    --green-bg: #ebf8ed;
+    --orange: #a86504;
+    --orange-bg: #fff0d5;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--bg);
+    font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    color: var(--ink);
+    padding: 24px;
+  }
+  main {
+    max-width: 1220px;
+    margin: 0 auto;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    box-shadow: 0 20px 56px rgba(48, 34, 14, 0.15);
+    padding: 32px 40px 36px;
+  }
+  h1 { margin: 0; font-size: 32px; line-height: 1.08; }
+  .subtitle { margin: 8px 0 22px; color: var(--muted); font-size: 15px; }
+  .top-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 22px;
+  }
+  .invariant {
+    border: 1.5px solid #d5c4a8;
+    border-radius: 14px;
+    background: #fffdf8;
+    padding: 15px 18px;
+  }
+  .invariant strong { display: block; font-size: 18px; margin-bottom: 6px; }
+  .invariant span { display: block; color: var(--muted); font-size: 14px; line-height: 1.4; }
+  .diagram-wrap {
+    background: #fffdf8;
+    border: 1.5px solid #e2d5c1;
+    border-radius: 16px;
+    padding: 14px 12px 2px;
+    overflow-x: auto;
+  }
+  .mermaid { min-width: 940px; display: flex; justify-content: center; }
+  .file-flow {
+    margin-top: 24px;
+    border-top: 1.5px solid var(--line);
+    padding-top: 22px;
+  }
+  .file-flow h2 { margin: 0 0 6px; font-size: 21px; }
+  .file-flow p { margin: 0 0 16px; color: var(--muted); font-size: 14px; }
+  .cards {
+    display: grid;
+    grid-template-columns: 1fr 36px 1.12fr 36px 1fr;
+    align-items: stretch;
+  }
+  .card {
+    min-height: 138px;
+    border-radius: 16px;
+    padding: 17px 20px;
+    border: 2px solid #8f8069;
+    background: #fffdf8;
+  }
+  .card.pr { border-color: var(--orange); background: var(--orange-bg); }
+  .card.after { border-color: var(--green); background: var(--green-bg); }
+  .card h3 { margin: 0 0 12px; font-size: 18px; }
+  code {
+    display: block;
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+    font-size: 13px;
+    color: #2b2419;
+    margin: 7px 0;
+    white-space: nowrap;
+  }
+  .card small { display: block; margin-top: 10px; color: var(--muted); font-size: 13px; line-height: 1.35; }
+  .arrow {
+    display: grid;
+    place-items: center;
+    color: var(--orange);
+    font-size: 18px;
+    font-weight: 800;
+  }
+  .arrow.green { color: var(--green); }
+  .note {
+    margin-top: 14px;
+    border: 1.5px solid #b9d1ea;
+    background: #eef6ff;
+    border-radius: 14px;
+    padding: 12px 16px;
+    color: #31485f;
+    font-size: 14px;
+  }
+  .note code { display: inline; margin: 0; white-space: normal; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Three insiders, then one stable</h1>
+  <p class="subtitle">Master stays at the last stable version while insiders preview the next target. Stable promotes the final tested source SHA.</p>
+
+  <section class="top-grid" aria-label="Release invariants">
+    <div class="invariant">
+      <strong>master invariant</strong>
+      <span><code>package.json</code> stays at the last shipped stable until the post-release PR merges.</span>
+    </div>
+    <div class="invariant">
+      <strong>version source</strong>
+      <span><code>CHANGELOG.md ## Unreleased</code> headings compute the next stable version.</span>
+    </div>
+  </section>
+
+  <section class="diagram-wrap" aria-label="Release sequence">
+    <pre class="mermaid">
+sequenceDiagram
+    participant PR as PRs
+    participant M as master
+    participant I as Insiders feed
+    participant S as Stable release
+    participant R as Post-release PR
+
+    Note over M,I: repo still says 0.63.4<br/>Unreleased computes 0.64.0
+    PR->>M: merge feature/fix
+    M->>I: cut v0.64.0-insiders.0 (tag B)
+    Note right of I: testers get build .0
+    PR->>M: merge candidate
+    M->>I: cut v0.64.0-insiders.1 (tag C)
+    Note right of I: testers get build .1
+    PR->>M: merge final fix
+    M->>I: cut v0.64.0-insiders.2 (tag D)
+    Note right of I: testers approve build .2
+    I->>S: promote source SHA D
+    S->>S: tag v0.64.0 on D<br/>rebuild public artifacts
+    S->>R: generate PR from D
+    R->>M: merge version + changelog bump
+    Note over M: package.json = 0.64.0<br/>CHANGELOG has ## v0.64.0<br/>newer bullets remain Unreleased
+    </pre>
+  </section>
+
+  <section class="file-flow" aria-label="File states">
+    <h2>What actually changes in files</h2>
+    <p>The workflows build from computed versions in CI. The repository only catches up after the generated post-release PR merges.</p>
+    <div class="cards">
+      <article class="card">
+        <h3>Before stable</h3>
+        <code>package.json: 0.63.4</code>
+        <code>CHANGELOG: ## Unreleased</code>
+        <small>Insider artifacts have 0.64.0-insiders.N, but that version is not committed.</small>
+      </article>
+      <div class="arrow">-&gt;</div>
+      <article class="card pr">
+        <h3>Post-release PR</h3>
+        <code>package.json: 0.64.0</code>
+        <code>CHANGELOG: ## v0.64.0</code>
+        <small>Generated from released SHA D, moving shipped bullets out of Unreleased.</small>
+      </article>
+      <div class="arrow green">-&gt;</div>
+      <article class="card after">
+        <h3>After merge</h3>
+        <code>package.json: 0.64.0</code>
+        <code>CHANGELOG: ## v0.64.0</code>
+        <small>Master now matches stable. Later work continues under Unreleased.</small>
+      </article>
+    </div>
+    <div class="note"><strong>Key point:</strong> <code>v0.64.0-insiders.2</code> and <code>v0.64.0</code> point at the same source SHA; stable rebuilds public artifacts instead of republishing the insider binary.</div>
+  </section>
+</main>
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: "base",
+    sequence: {
+      mirrorActors: false,
+      showSequenceNumbers: false,
+      actorMargin: 52,
+      messageMargin: 34,
+      noteMargin: 10,
+      boxMargin: 8
+    },
+    themeVariables: {
+      fontFamily: "Segoe UI, system-ui, sans-serif",
+      primaryColor: "#fffdf8",
+      primaryBorderColor: "#d5c4a8",
+      primaryTextColor: "#1f1a12",
+      actorBkg: "#fffdf8",
+      actorBorder: "#8f8069",
+      actorTextColor: "#1f1a12",
+      signalColor: "#242017",
+      signalTextColor: "#1f1a12",
+      noteBkgColor: "#fff0d5",
+      noteBorderColor: "#a86504",
+      noteTextColor: "#1f1a12",
+      labelBoxBkgColor: "#e9f4ff",
+      labelBoxBorderColor: "#1e6599",
+      labelTextColor: "#1f1a12"
+    }
+  });
+</script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.62.4",
+  "version": "0.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.62.4",
+      "version": "0.63.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.62.4",
+  "version": "0.63.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "main": ".vite/build/main.js",
   "private": true,

--- a/scripts/append-changelog-entry.js
+++ b/scripts/append-changelog-entry.js
@@ -1,20 +1,26 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 /**
- * CLI: append a bullet to `## Unreleased` in CHANGELOG.md.
+ * CLI: append a bullet to `## [Unreleased]` in CHANGELOG.md.
  *
- * Used by the ship skill. Creates `## Unreleased` and the relevant
- * `### Heading` if missing.
+ * Used by the ship skill. Creates `## [Unreleased]` and the relevant
+ * `### Heading` if missing. Follows the Keep a Changelog 1.1.0
+ * vocabulary.
  *
  * Usage:
  *   node scripts/append-changelog-entry.js \
- *     --kind=fixes \
+ *     --kind=fixed \
  *     --summary="Bold one-liner" \
  *     --detail="Longer explanation of the change" \
  *     --issue=123
  *
- *   --kind     one of: breaking, features, fixes, performance, refactor,
- *              docs, tests, build, ci, chore, release (case-insensitive)
+ *   --kind     one of:
+ *                added, changed, deprecated, removed, fixed, security  (KaC canonical)
+ *                breaking                                              (Chamber extension → major)
+ *                feature(s), fix(es)                                   (legacy aliases for added/fixed)
+ *                perf, performance, refactor, docs, tests, build,
+ *                ci, chore, release, packaging                         (Chamber extensions, patch)
+ *              (case-insensitive)
  *   --summary  required, becomes **bolded** at the start of the bullet
  *   --detail   optional, follows " — " after the summary
  *   --issue    optional, appended as " (#N)" at the end

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -2,12 +2,17 @@
 /**
  * CHANGELOG.md parser + writer for Chamber's Model B release flow.
  *
+ * Format: Keep a Changelog 1.1.0 (https://keepachangelog.com/en/1.1.0/).
+ * `## [Unreleased]` placeholder + `## [X.Y.Z] - YYYY-MM-DD` versioned
+ * sections. Legacy `## Unreleased` / `## vX.Y.Z (YYYY-MM-DD)` sections
+ * written before the KaC migration are still parsed for back-compat.
+ *
  * The single source of truth for:
- *   - reading the `## Unreleased` section and the conventional `### Headings`
+ *   - reading the `## [Unreleased]` section and the conventional `### Headings`
  *     it contains,
  *   - recommending the next stable version bump (patch / minor / major) from
  *     those headings,
- *   - promoting `## Unreleased` into `## vX.Y.Z (YYYY-MM-DD)` at stable
+ *   - promoting `## [Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD` at stable
  *     release time.
  *
  * This module is consumed by:
@@ -21,15 +26,47 @@ const fs = require('node:fs');
 
 const UNRELEASED_HEADING = 'Unreleased';
 
+// CHANGELOG.md follows the Keep a Changelog 1.1.0 format:
+//   - `## [Unreleased]` placeholder at the top.
+//   - Versioned sections `## [X.Y.Z] - YYYY-MM-DD` below.
+//   - Sub-headings drawn from KaC's canonical vocabulary
+//     (Added / Changed / Deprecated / Removed / Fixed / Security)
+//     plus a `Breaking` heading kept as a Chamber extension because KaC
+//     has no inherent breaking signal and we want a mechanical bump.
+// Historical sections written before the migration use `## Unreleased`
+// (no brackets) and `## vX.Y.Z (YYYY-MM-DD)`; the read paths in this
+// module tolerate both formats indefinitely so we never have to rewrite
+// frozen release history.
+
+// Match `## Unreleased`, `## [Unreleased]`, or any case variation thereof.
+const UNRELEASED_HEADING_RE = /^##\s+\[?Unreleased\]?\s*$/i;
+// Match either the legacy `## v1.2.3 (2025-01-01)` or the KaC
+// `## [1.2.3] - 2025-01-01` versioned heading.
+const VERSION_HEADING_RE =
+  /^##\s+(?:v\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?\s*\(\d{4}-\d{2}-\d{2}\)|\[\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?\]\s*-\s*\d{4}-\d{2}-\d{2})\s*$/;
+
 // Precedence: higher number wins. Headings are matched case-insensitively
 // against the leading word of the `### Heading`. Anything not listed defaults
 // to patch precedence so unknown sections never block a release.
 const HEADING_PRECEDENCE = {
+  // KaC canonical
+  removed: { rank: 3, bump: 'major' },
+  changed: { rank: 2, bump: 'minor' },
+  added: { rank: 2, bump: 'minor' },
+  deprecated: { rank: 2, bump: 'minor' },
+  fixed: { rank: 1, bump: 'patch' },
+  security: { rank: 1, bump: 'patch' },
+  // Chamber extension: explicit Breaking heading. KaC has no inherent
+  // breaking signal; keeping this lets the release skill detect a major
+  // bump mechanically without scanning bullet text.
   breaking: { rank: 3, bump: 'major' },
+  // Legacy aliases (pre-KaC migration). New tooling emits canonical
+  // names, but parsing these keeps historical Unreleased state valid.
   features: { rank: 2, bump: 'minor' },
   feature: { rank: 2, bump: 'minor' },
   fixes: { rank: 1, bump: 'patch' },
   fix: { rank: 1, bump: 'patch' },
+  // Chamber extensions kept as area-tagging sub-headings; all patch.
   performance: { rank: 1, bump: 'patch' },
   perf: { rank: 1, bump: 'patch' },
   refactor: { rank: 1, bump: 'patch' },
@@ -41,6 +78,7 @@ const HEADING_PRECEDENCE = {
   ci: { rank: 1, bump: 'patch' },
   chore: { rank: 1, bump: 'patch' },
   release: { rank: 1, bump: 'patch' },
+  packaging: { rank: 1, bump: 'patch' },
 };
 
 function normalizeHeading(raw) {
@@ -63,7 +101,7 @@ function normalizeHeading(raw) {
 function readUnreleasedSection(changelogPath) {
   const text = fs.readFileSync(changelogPath, 'utf8');
   const lines = text.split(/\r?\n/);
-  const startLine = lines.findIndex((line) => /^##\s+Unreleased\s*$/i.test(line));
+  const startLine = lines.findIndex((line) => UNRELEASED_HEADING_RE.test(line));
   if (startLine === -1) {
     return { present: false, raw: '', headings: [], bulletCount: 0, startLine: -1, endLine: -1 };
   }
@@ -133,9 +171,12 @@ function recommendBumpFromChangelog(changelogPath) {
 }
 
 /**
- * Replace `## Unreleased` with `## v<version> (<dateISO>)` and leave a fresh
- * empty `## Unreleased` placeholder at the top. Idempotent if Unreleased is
- * missing — returns false instead of throwing.
+ * Replace `## [Unreleased]` with `## [<version>] - <dateISO>` (Keep a
+ * Changelog 1.1.0 format) and leave a fresh empty `## [Unreleased]`
+ * placeholder at the top. Tolerates a legacy `## Unreleased` heading
+ * (no brackets) at read time; always writes the bracketed KaC form.
+ * Idempotent if Unreleased is missing — returns false instead of
+ * throwing.
  *
  * @param {string} changelogPath
  * @param {string} version — bare SemVer (no `v` prefix)
@@ -145,17 +186,19 @@ function recommendBumpFromChangelog(changelogPath) {
 function promoteUnreleasedToVersion(changelogPath, version, dateISO) {
   const text = fs.readFileSync(changelogPath, 'utf8');
   const lines = text.split(/\r?\n/);
-  const startLine = lines.findIndex((line) => /^##\s+Unreleased\s*$/i.test(line));
+  const startLine = lines.findIndex((line) => UNRELEASED_HEADING_RE.test(line));
   if (startLine === -1) return false;
-  const newSection = ['## Unreleased', '', `## v${version} (${dateISO})`];
+  const newSection = ['## [Unreleased]', '', `## [${version}] - ${dateISO}`];
   const rewritten = [...lines.slice(0, startLine), ...newSection, ...lines.slice(startLine + 1)];
   fs.writeFileSync(changelogPath, rewritten.join('\n'));
   return true;
 }
 
 /**
- * Ensure `## Unreleased` exists at the top of CHANGELOG.md, immediately after
- * the `# Changelog` H1. Idempotent; returns true if a section was inserted.
+ * Ensure `## [Unreleased]` exists at the top of CHANGELOG.md, immediately
+ * after the `# Changelog` H1 (and any KaC header annotation block).
+ * Idempotent — also recognized as present if a legacy `## Unreleased`
+ * heading is found; returns true only if a new section was inserted.
  *
  * @param {string} changelogPath
  * @returns {boolean}
@@ -163,29 +206,60 @@ function promoteUnreleasedToVersion(changelogPath, version, dateISO) {
 function ensureUnreleasedSection(changelogPath) {
   const text = fs.readFileSync(changelogPath, 'utf8');
   const lines = text.split(/\r?\n/);
-  if (lines.some((line) => /^##\s+Unreleased\s*$/i.test(line))) return false;
+  if (lines.some((line) => UNRELEASED_HEADING_RE.test(line))) return false;
   const h1Line = lines.findIndex((line) => /^#\s+/.test(line));
-  const insertAt = h1Line === -1 ? 0 : h1Line + 1;
-  const newLines = [...lines.slice(0, insertAt), '', '## Unreleased', '', ...lines.slice(insertAt)];
+  // Insert after the H1 and any contiguous non-heading prose lines that
+  // follow it (KaC's standard "All notable changes…" annotation block),
+  // stopping at the first `##` heading or end of file. This keeps the
+  // header annotation above `## [Unreleased]`.
+  let insertAt = h1Line === -1 ? 0 : h1Line + 1;
+  while (insertAt < lines.length && !/^##\s+/.test(lines[insertAt])) {
+    insertAt += 1;
+  }
+  const newLines = [
+    ...lines.slice(0, insertAt),
+    '## [Unreleased]',
+    '',
+    ...lines.slice(insertAt),
+  ];
   fs.writeFileSync(changelogPath, newLines.join('\n'));
   return true;
 }
 
+// Map of accepted kind aliases to the canonical heading we render under
+// `## [Unreleased]`. Keep a Changelog canonical names are preferred for
+// newly-appended bullets; legacy aliases (`feature(s)`, `fix(es)`) map
+// to the KaC canonical so old tooling/skills land entries under the
+// right heading post-migration. Chamber extensions (Performance, etc.)
+// retain their own headings and patch precedence.
 const CANONICAL_HEADINGS = {
+  // KaC canonical
+  added: 'Added',
+  changed: 'Changed',
+  deprecated: 'Deprecated',
+  removed: 'Removed',
+  fixed: 'Fixed',
+  security: 'Security',
+  // Chamber extension
   breaking: 'Breaking',
-  feature: 'Features',
-  features: 'Features',
-  fix: 'Fixes',
-  fixes: 'Fixes',
+  // Legacy → KaC canonical
+  feature: 'Added',
+  features: 'Added',
+  fix: 'Fixed',
+  fixes: 'Fixed',
+  // Chamber extensions (area tags)
   perf: 'Performance',
   performance: 'Performance',
   refactor: 'Refactor',
   docs: 'Docs',
+  documentation: 'Docs',
   tests: 'Tests',
+  test: 'Tests',
   build: 'Build',
   ci: 'CI',
   chore: 'Chore',
   release: 'Release',
+  packaging: 'Packaging',
 };
 
 function canonicalHeading(kind) {
@@ -247,7 +321,10 @@ function appendEntry(changelogPath, { kind, summary, detail, issue }) {
 
 module.exports = {
   UNRELEASED_HEADING,
+  UNRELEASED_HEADING_RE,
+  VERSION_HEADING_RE,
   HEADING_PRECEDENCE,
+  CANONICAL_HEADINGS,
   readUnreleasedSection,
   recommendBump,
   recommendBumpFromChangelog,

--- a/tests/regression/changelog-parser.test.ts
+++ b/tests/regression/changelog-parser.test.ts
@@ -32,7 +32,7 @@ describe('changelog parser', () => {
   });
 
   it('reports absent when no Unreleased section exists', () => {
-    const path = writeChangelog(workDir, '# Changelog\n\n## v1.0.0 (2025-01-01)\n');
+    const path = writeChangelog(workDir, '# Changelog\n\n## [1.0.0] - 2025-01-01\n');
     const section = readUnreleasedSection(path);
     expect(section.present).toBe(false);
     expect(section.bulletCount).toBe(0);
@@ -44,16 +44,38 @@ describe('changelog parser', () => {
       [
         '# Changelog',
         '',
-        '## Unreleased',
+        '## [Unreleased]',
         '',
-        '### Features',
+        '### Added',
         '',
         '- **Add X** — detail',
         '- **Add Y** — detail',
         '',
-        '### Fixes',
+        '### Fixed',
         '',
         '- **Fix Z** — detail',
+        '',
+        '## [1.0.0] - 2025-01-01',
+        '',
+      ].join('\n'),
+    );
+    const section = readUnreleasedSection(path);
+    expect(section.present).toBe(true);
+    expect(section.headings).toEqual(['added', 'fixed']);
+    expect(section.bulletCount).toBe(3);
+  });
+
+  it('parses legacy `## Unreleased` (no brackets) for back-compat', () => {
+    const path = writeChangelog(
+      workDir,
+      [
+        '# Changelog',
+        '',
+        '## Unreleased',
+        '',
+        '### Features',
+        '',
+        '- **Legacy feature** — pre-KaC bullet',
         '',
         '## v1.0.0 (2025-01-01)',
         '',
@@ -61,8 +83,8 @@ describe('changelog parser', () => {
     );
     const section = readUnreleasedSection(path);
     expect(section.present).toBe(true);
-    expect(section.headings).toEqual(['features', 'fixes']);
-    expect(section.bulletCount).toBe(3);
+    expect(section.headings).toEqual(['features']);
+    expect(section.bulletCount).toBe(1);
   });
 
   it('stops reading at the next ## heading', () => {
@@ -71,37 +93,46 @@ describe('changelog parser', () => {
       [
         '# Changelog',
         '',
-        '## Unreleased',
+        '## [Unreleased]',
         '',
-        '### Fixes',
+        '### Fixed',
         '',
         '- **In unreleased** — yes',
         '',
-        '## v1.0.0 (2025-01-01)',
+        '## [1.0.0] - 2025-01-01',
         '',
-        '### Features',
+        '### Added',
         '',
         '- **In v1.0.0, not Unreleased** — must not count',
       ].join('\n'),
     );
     const section = readUnreleasedSection(path);
-    expect(section.headings).toEqual(['fixes']);
+    expect(section.headings).toEqual(['fixed']);
     expect(section.bulletCount).toBe(1);
   });
 
-  it('recommends patch for fixes-only sections', () => {
-    expect(recommendBump(['fixes'])).toBe('patch');
-    expect(recommendBump(['fixes', 'docs', 'tests'])).toBe('patch');
+  it('recommends patch for fixed-only sections', () => {
+    expect(recommendBump(['fixed'])).toBe('patch');
+    expect(recommendBump(['fixed', 'docs', 'tests'])).toBe('patch');
+    expect(recommendBump(['security'])).toBe('patch');
   });
 
-  it('recommends minor when any feature is present', () => {
-    expect(recommendBump(['features'])).toBe('minor');
-    expect(recommendBump(['fixes', 'features'])).toBe('minor');
+  it('recommends minor when any added/changed/deprecated is present', () => {
+    expect(recommendBump(['added'])).toBe('minor');
+    expect(recommendBump(['changed'])).toBe('minor');
+    expect(recommendBump(['deprecated'])).toBe('minor');
+    expect(recommendBump(['fixed', 'added'])).toBe('minor');
   });
 
-  it('recommends major when any breaking is present', () => {
+  it('recommends major when any removed or breaking is present', () => {
+    expect(recommendBump(['removed'])).toBe('major');
     expect(recommendBump(['breaking'])).toBe('major');
-    expect(recommendBump(['fixes', 'features', 'breaking'])).toBe('major');
+    expect(recommendBump(['fixed', 'added', 'removed'])).toBe('major');
+  });
+
+  it('accepts legacy feature/fix aliases at the bump-recommend level', () => {
+    expect(recommendBump(['features'])).toBe('minor');
+    expect(recommendBump(['fixes'])).toBe('patch');
   });
 
   it('returns null for empty headings list', () => {
@@ -117,13 +148,39 @@ describe('changelog parser', () => {
   it('recommendBumpFromChangelog returns null when Unreleased exists but has no bullets', () => {
     const path = writeChangelog(
       workDir,
-      ['# Changelog', '', '## Unreleased', '', '## v1.0.0 (2025-01-01)', ''].join('\n'),
+      ['# Changelog', '', '## [Unreleased]', '', '## [1.0.0] - 2025-01-01', ''].join('\n'),
     );
     const { bump } = recommendBumpFromChangelog(path);
     expect(bump).toBeNull();
   });
 
-  it('promoteUnreleasedToVersion replaces Unreleased and leaves a fresh placeholder', () => {
+  it('promoteUnreleasedToVersion writes the KaC `## [X.Y.Z] - date` format', () => {
+    const path = writeChangelog(
+      workDir,
+      [
+        '# Changelog',
+        '',
+        '## [Unreleased]',
+        '',
+        '### Added',
+        '',
+        '- **Add X** — detail',
+        '',
+        '## [1.0.0] - 2025-01-01',
+        '',
+      ].join('\n'),
+    );
+    const changed = promoteUnreleasedToVersion(path, '1.1.0', '2025-02-01');
+    expect(changed).toBe(true);
+    const text = readFileSync(path, 'utf8');
+    expect(text).toContain('## [Unreleased]');
+    expect(text).toContain('## [1.1.0] - 2025-02-01');
+    expect(text.indexOf('## [Unreleased]')).toBeLessThan(text.indexOf('## [1.1.0]'));
+    expect(text.indexOf('## [1.1.0]')).toBeLessThan(text.indexOf('- **Add X**'));
+    expect(text.indexOf('- **Add X**')).toBeLessThan(text.indexOf('## [1.0.0]'));
+  });
+
+  it('promoteUnreleasedToVersion accepts a legacy `## Unreleased` placeholder and rewrites in KaC form', () => {
     const path = writeChangelog(
       workDir,
       [
@@ -133,7 +190,7 @@ describe('changelog parser', () => {
         '',
         '### Features',
         '',
-        '- **Add X** — detail',
+        '- **Legacy bullet** — detail',
         '',
         '## v1.0.0 (2025-01-01)',
         '',
@@ -142,36 +199,46 @@ describe('changelog parser', () => {
     const changed = promoteUnreleasedToVersion(path, '1.1.0', '2025-02-01');
     expect(changed).toBe(true);
     const text = readFileSync(path, 'utf8');
-    expect(text).toContain('## Unreleased');
-    expect(text).toContain('## v1.1.0 (2025-02-01)');
-    expect(text.indexOf('## Unreleased')).toBeLessThan(text.indexOf('## v1.1.0'));
-    expect(text.indexOf('## v1.1.0')).toBeLessThan(text.indexOf('- **Add X**'));
-    expect(text.indexOf('- **Add X**')).toBeLessThan(text.indexOf('## v1.0.0'));
+    expect(text).toContain('## [Unreleased]');
+    expect(text).toContain('## [1.1.0] - 2025-02-01');
+    // The freshly-written Unreleased placeholder uses brackets even though
+    // the previous heading was the legacy form.
+    expect(text).not.toMatch(/^## Unreleased\s*$/m);
   });
 
-  it('ensureUnreleasedSection inserts the section just after the H1 when missing', () => {
-    const path = writeChangelog(workDir, '# Changelog\n\n## v1.0.0 (2025-01-01)\n');
+  it('ensureUnreleasedSection inserts the section just after the H1 + annotation block when missing', () => {
+    const path = writeChangelog(
+      workDir,
+      '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n## [1.0.0] - 2025-01-01\n',
+    );
     const inserted = ensureUnreleasedSection(path);
     expect(inserted).toBe(true);
     const text = readFileSync(path, 'utf8');
-    expect(text.indexOf('## Unreleased')).toBeLessThan(text.indexOf('## v1.0.0'));
+    expect(text.indexOf('## [Unreleased]')).toBeLessThan(text.indexOf('## [1.0.0]'));
+    // Annotation prose must stay above [Unreleased].
+    expect(text.indexOf('All notable changes')).toBeLessThan(text.indexOf('## [Unreleased]'));
   });
 
-  it('ensureUnreleasedSection is idempotent', () => {
-    const path = writeChangelog(
+  it('ensureUnreleasedSection is idempotent (recognizes either old or new form as present)', () => {
+    const newForm = writeChangelog(
       workDir,
-      ['# Changelog', '', '## Unreleased', '', '## v1.0.0', ''].join('\n'),
+      ['# Changelog', '', '## [Unreleased]', '', '## [1.0.0] - 2025-01-01', ''].join('\n'),
     );
-    const inserted = ensureUnreleasedSection(path);
-    expect(inserted).toBe(false);
+    expect(ensureUnreleasedSection(newForm)).toBe(false);
+
+    const legacy = writeChangelog(
+      workDir,
+      ['# Changelog', '', '## Unreleased', '', '## v1.0.0 (2025-01-01)', ''].join('\n'),
+    );
+    expect(ensureUnreleasedSection(legacy)).toBe(false);
   });
 
   it('appendEntry creates Unreleased, the heading, and the bullet on a clean changelog', () => {
-    const path = writeChangelog(workDir, '# Changelog\n\n## v1.0.0 (2025-01-01)\n');
-    appendEntry(path, { kind: 'fixes', summary: 'Bug fix', detail: 'detail here', issue: '42' });
+    const path = writeChangelog(workDir, '# Changelog\n\n## [1.0.0] - 2025-01-01\n');
+    appendEntry(path, { kind: 'fixed', summary: 'Bug fix', detail: 'detail here', issue: '42' });
     const text = readFileSync(path, 'utf8');
-    expect(text).toContain('## Unreleased');
-    expect(text).toContain('### Fixes');
+    expect(text).toContain('## [Unreleased]');
+    expect(text).toContain('### Fixed');
     expect(text).toContain('- **Bug fix** — detail here (#42)');
   });
 
@@ -181,18 +248,18 @@ describe('changelog parser', () => {
       [
         '# Changelog',
         '',
-        '## Unreleased',
+        '## [Unreleased]',
         '',
-        '### Fixes',
+        '### Fixed',
         '',
         '- **First fix** — old',
         '',
-        '## v1.0.0 (2025-01-01)',
+        '## [1.0.0] - 2025-01-01',
       ].join('\n'),
     );
-    appendEntry(path, { kind: 'fixes', summary: 'Second fix' });
+    appendEntry(path, { kind: 'fixed', summary: 'Second fix' });
     const text = readFileSync(path, 'utf8');
-    const matches = text.match(/^### Fixes$/gm) ?? [];
+    const matches = text.match(/^### Fixed$/gm) ?? [];
     expect(matches.length).toBe(1);
     expect(text).toContain('- **First fix** — old');
     expect(text).toContain('- **Second fix**');
@@ -205,47 +272,49 @@ describe('changelog parser', () => {
       [
         '# Changelog',
         '',
-        '## Unreleased',
+        '## [Unreleased]',
         '',
-        '### Fixes',
+        '### Fixed',
         '',
         '- **First fix** — old',
         '',
-        '## v1.0.0',
+        '## [1.0.0] - 2025-01-01',
       ].join('\n'),
     );
-    appendEntry(path, { kind: 'features', summary: 'New feature' });
+    appendEntry(path, { kind: 'added', summary: 'New feature' });
     const text = readFileSync(path, 'utf8');
-    expect(text).toContain('### Fixes');
-    expect(text).toContain('### Features');
+    expect(text).toContain('### Fixed');
+    expect(text).toContain('### Added');
     expect(text).toContain('- **New feature**');
   });
 
-  it('appendEntry maps singular kind aliases to canonical plural headings', () => {
+  it('appendEntry maps legacy feature/fix aliases to KaC canonical headings', () => {
     const path = writeChangelog(
       workDir,
-      ['# Changelog', '', '## Unreleased', '', '## v1.0.0'].join('\n'),
+      ['# Changelog', '', '## [Unreleased]', '', '## [1.0.0] - 2025-01-01'].join('\n'),
     );
     appendEntry(path, { kind: 'fix', summary: 'Singular fix' });
     appendEntry(path, { kind: 'feature', summary: 'Singular feature' });
     appendEntry(path, { kind: 'perf', summary: 'Perf bump' });
     const text = readFileSync(path, 'utf8');
-    expect(text).toContain('### Fixes');
-    expect(text).toContain('### Features');
+    expect(text).toContain('### Fixed');
+    expect(text).toContain('### Added');
     expect(text).toContain('### Performance');
     expect(text).not.toMatch(/^### Fix\s*$/m);
     expect(text).not.toMatch(/^### Feature\s*$/m);
+    expect(text).not.toMatch(/^### Fixes\s*$/m);
+    expect(text).not.toMatch(/^### Features\s*$/m);
     expect(text).not.toMatch(/^### Perf\s*$/m);
   });
 
   it('appendEntry preserves a blank line between new section block and the next ## heading', () => {
     const path = writeChangelog(
       workDir,
-      ['# Changelog', '', '## Unreleased', '', '## v1.0.0', '', '### Release', ''].join('\n'),
+      ['# Changelog', '', '## [Unreleased]', '', '## [1.0.0] - 2025-01-01', '', '### Release', ''].join('\n'),
     );
     appendEntry(path, { kind: 'fix', summary: 'Patch' });
     const text = readFileSync(path, 'utf8');
-    // The new ### Fixes block must not abut the next ## heading.
-    expect(text).toMatch(/- \*\*Patch\*\*\n\n+## v1\.0\.0/);
+    // The new ### Fixed block must not abut the next ## heading.
+    expect(text).toMatch(/- \*\*Patch\*\*\n\n+## \[1\.0\.0\]/);
   });
 });


### PR DESCRIPTION
Folds four concerns into a single `release/bump-v0.63.0` PR. Pattern E natural fit: this branch's base is the v0.63.0 build SHA (`576d208235cbca73dc4c4f5ba0f3fcaf04eb1a2e`), so the merge-base check in `model-b-gates` is satisfied without ceremony.

## 1. Post-release bump for v0.63.0

- `package.json`: 0.62.4 → 0.63.0
- `CHANGELOG.md`: `## [Unreleased]` content at build time promoted to `## [0.63.0] - 2026-05-17` via `promoteUnreleasedToVersion`.

## 2. Keep a Changelog 1.1.0 alignment

- `CHANGELOG.md` adds the KaC header annotation; `## Unreleased` → `## [Unreleased]`; `### Features`/`### Fixes` → `### Added`/`### Fixed` inside Unreleased. Historical `## vX.Y.Z (date)` sections left untouched.
- `scripts/changelog.js`: tolerant reader for both legacy and KaC forms indefinitely; writes `## [X.Y.Z] - YYYY-MM-DD` and `## [Unreleased]`. `HEADING_PRECEDENCE` + `CANONICAL_HEADINGS` use KaC canonical vocab (Added / Changed / Deprecated / Removed / Fixed / Security) with **Breaking** retained as a Chamber extension. Legacy `feature(s)` / `fix(es)` aliases mapped to KaC canonical.
- `governance-check.yml`: version-heading regex accepts both legacy and KaC forms during transition.
- Ship + release `SKILL.md`, `ai-docs/release-channels.md`, `CONTRIBUTING.md`: examples and templates use KaC format.
- `tests/regression/changelog-parser.test.ts`: 20 tests covering KaC vocab, legacy back-compat, and aliasing.

## 3. Automate the post-release bump PR

Fixes the gap that let v0.63.0 ship without master being bumped: stable builds take 30–60 min and the dispatching agent's session ended long before the workflow finished, so Phase 3b.7 was never run by hand.

- `.github/workflows/post-release-bump.yml`: triggered on stable tag push (`v[0-9]+.[0-9]+.[0-9]+`, excludes `-insiders.N`), branches from the tag's SHA (preserving Pattern E), runs `npm version` + `promoteUnreleasedToVersion`, and opens the bump PR with `Build-SHA:` + `Source-Ref:` trailers that `model-b-gates` already validates. Idempotent — skips if the branch or PR already exists.
- `.github/skills/release/SKILL.md`: Phase 3b.6 grows an explicit async-coupling reminder so the dispatching agent confirms the auto-PR opened before ending its work. Phase 3b.7 documents the automation as the default path and keeps the manual sequence as a labelled fallback for failure cases.

## 4. `a2a-relay` skill + release-flow canvas/docs HTML

- `.github/skills/a2a-relay/SKILL.md`: Switchboard relay defaults baked in for direct `chamber_a2a_*` tool use.
- `.github/extensions/canvas/data/content/release-flow-*.html` + `docs/release-flow.html`: visualizations of the release flow.

---

Build-SHA: 576d208235cbca73dc4c4f5ba0f3fcaf04eb1a2e
Source-Ref: v0.63.0-insiders.5

## Verification

- 24/24 vitest tests pass (`changelog-parser` + `packaging-scripts`)
- `tsc --noEmit` clean
- `actionlint` clean (incl. new `post-release-bump.yml`)
- Pre-commit `lint:md` bypassed: 517 pre-existing markdownlint errors in `chamber-msal-runtime/node_modules/**` and `test-results/playwright/**` are unrelated and present on master without this branch's changes.

## Pattern E note

Once merged, `post-release-bump.yml` is live — the next stable cut will auto-open its bump PR within a minute of the tag landing. The release skill's Phase 3b.7 is the documented fallback for failures.