### PR TITLE
fix: complete chat turns after root turn end

### DIFF
--- a/.github/skills/issue-slate/SKILL.md
+++ b/.github/skills/issue-slate/SKILL.md
@@ -99,7 +99,7 @@ Do not invent new smoke scripts. If no existing smoke covers the path, document 
    - For larger slates, create several short stacks, one per cluster.
    - Independent PRs are allowed for design-heavy, uncertain, urgent, or intentionally deferred-version work.
    - Avoid one long stack across unrelated clusters.
-   - Use the repo's automatic branch deletion/retargeting behavior: merge stack parents first, then let GitHub retarget child PRs to `master`.
+   - Do not rely on GitHub to retarget child PRs after a stack parent branch is deleted. Merge stack parents without deleting the parent branch, retarget/rebase child PRs to the next base, then delete the parent branch only after children are safely updated.
 
 7. Choose the release metadata strategy for the slate:
 
@@ -185,7 +185,7 @@ Open each PR against its stack parent:
 - Root PR: `gh pr create --base master --head <parent-branch>`.
 - Child PR: `gh pr create --base <parent-branch> --head <child-branch>`.
 
-Merge stack parents first. Because the repo deletes merged head branches, GitHub should retarget child PRs to `master`; verify this after each merge.
+Merge stack parents first, but do **not** delete the merged parent branch until every child PR has been retargeted/rebased. GitHub may close child PRs instead of retargeting them when their base branch is deleted.
 
 ### 3. Inspect the issue and code
 
@@ -269,10 +269,18 @@ When the user explicitly approves a PR merge:
    gh pr checks <pr-number> --repo ianphil/chamber
    ```
 
-2. Admin squash merge only if the user asks for admin merge:
+2. Admin squash merge only if the user asks for admin merge.
+
+   For independent PRs, delete the branch during merge:
 
    ```powershell
    gh pr merge <pr-number> --repo ianphil/chamber --admin --squash --delete-branch
+   ```
+
+   For stack parent PRs, preserve the branch during merge:
+
+   ```powershell
+   gh pr merge <pr-number> --repo ianphil/chamber --admin --squash
    ```
 
 3. Pull latest `master`:
@@ -282,7 +290,22 @@ When the user explicitly approves a PR merge:
    git pull --ff-only origin master
    ```
 
-4. For stacked child PRs, verify GitHub retargeted correctly. If needed, rebase the child branch and update its base with `gh pr edit --base`.
+4. For stacked child PRs, retarget and rebase explicitly before deleting the parent branch:
+
+   ```powershell
+   gh pr edit <child-pr-number> --repo ianphil/chamber --base master
+   git switch <child-branch>
+   git fetch origin master --quiet
+   git rebase origin/master
+   git push --force-with-lease origin <child-branch>
+   git push origin --delete <parent-branch>
+   ```
+
+   If `gh pr edit` hits the GitHub Projects classic GraphQL deprecation path, use REST instead:
+
+   ```powershell
+   gh api -X PATCH repos/ianphil/chamber/pulls/<child-pr-number> -f base=master
+   ```
 
 ## Phase 6 - Closeout
 

--- a/.github/skills/ship/SKILL.md
+++ b/.github/skills/ship/SKILL.md
@@ -36,6 +36,27 @@ In autopilot mode, do not stop for repeated confirmation prompts. Apply these de
 
 Autopilot still stops for dirty working trees, being on `master`, rebase conflicts, failing checks, destructive operations, serious review findings, missing issue refs, or anything that would merge code. Opening a PR is allowed; merging still requires explicit user approval.
 
+## Stack merge safety
+
+Do not delete a merged stack parent branch until every child PR has been
+retargeted and rebased. GitHub may close child PRs instead of retargeting them
+when their base branch is deleted.
+
+Safe stack-parent merge sequence:
+
+1. Merge the parent PR without `--delete-branch`.
+2. Pull latest `master`.
+3. Retarget each child PR to its next base (`master` after the root parent lands, or the next stack parent).
+4. Rebase each child branch on its new base and force-push with `--force-with-lease`.
+5. Delete the merged parent branch only after all child PRs are open on the correct base.
+
+If `gh pr edit --base` hits GitHub's Projects classic GraphQL deprecation path,
+retarget through REST:
+
+```powershell
+gh api -X PATCH repos/ianphil/chamber/pulls/<child-pr-number> -f base=<new-base>
+```
+
 ## Prerequisites
 
 Before doing anything, verify:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Surface ambiguous A2A recipients** — A2A message routing now reports duplicate display-name matches with usable recipient identifiers instead of falling through to an unknown-recipient error. (#322) (#322)
+- **Complete turns after root turn end** — Chat streaming now finishes after a guarded root assistant.turn_end quiescence path when the SDK omits session.idle, while still waiting for outstanding tools and sub-agent turns so late output is preserved. (#297) (#297)
 
 
 ## [0.63.0] - 2026-05-17

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -650,35 +650,97 @@ describe('ChatService', () => {
       expect(allEventsHandlers).toHaveLength(0);
     });
 
-    it('logs a lifecycle summary at info level when assistant.turn_end arrives without session.idle (the #299 fingerprint)', async () => {
-      const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    it('defensively completes after root assistant.turn_end when no tools or sub-agents remain', async () => {
+      vi.useFakeTimers();
       try {
         mockSession.send.mockImplementation(async () => {
-          // assistant.turn_end has no typed listener in ChatService, so we can fire it
-          // without tripping the Zod contract validators.
+          fireSdkEvent({ type: 'assistant.message', data: { messageId: 'm1', content: 'final output' } });
           fireSdkEvent({ type: 'assistant.turn_end', data: { turnId: 't1' } });
-          // NO session.idle ever fires — exactly the #299 bug scenario.
         });
 
-        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', vi.fn());
-
-        // Wait for send + microtasks; then the user gives up and hits Stop.
-        await new Promise((r) => setTimeout(r, 10));
-        await svc.cancelMessage('valid-mind', 'msg-1');
+        const emit = vi.fn();
+        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+        await vi.advanceTimersByTimeAsync(1_000);
         await pending;
 
-        const fingerprintCall = infoSpy.mock.calls.find(([tag, label, payload]) =>
-          tag === '[ChatService]'
-          && label === 'chat.turn.lifecycle'
-          && payload
-          && typeof payload === 'object'
-          && (payload as { reason?: string }).reason === 'aborted'
-          && (payload as { sawTurnEnd?: boolean }).sawTurnEnd === true
-          && (payload as { sawIdle?: boolean }).sawIdle === false,
-        );
-        expect(fingerprintCall, 'expected a chat.turn.lifecycle log matching the #299 fingerprint').toBeDefined();
+        expect(emit).toHaveBeenCalledWith({ type: 'message_final', sdkMessageId: 'm1', content: 'final output' });
+        expect(emit).toHaveBeenCalledWith({ type: 'done' });
       } finally {
-        infoSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    it('waits for outstanding tools to finish after root assistant.turn_end before completing defensively', async () => {
+      vi.useFakeTimers();
+      try {
+        mockSession.send.mockImplementation(async () => {
+          fireSdkEvent({ type: 'tool.execution_start', data: { toolCallId: 't1', toolName: 'shell' } });
+          fireSdkEvent({ type: 'assistant.turn_end', data: { turnId: 't1' } });
+        });
+
+        const emit = vi.fn();
+        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+
+        fireSdkEvent({
+          type: 'tool.execution_complete',
+          data: { toolCallId: 't1', success: true, result: { content: 'tool output' } },
+        });
+        await vi.advanceTimersByTimeAsync(1_000);
+        await pending;
+
+        expect(emit).toHaveBeenCalledWith({ type: 'done' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('delays defensive completion when more output arrives during turn-end quiescence', async () => {
+      vi.useFakeTimers();
+      try {
+        mockSession.send.mockImplementation(async () => {
+          fireSdkEvent({ type: 'assistant.turn_end', data: { turnId: 't1' } });
+        });
+
+        const emit = vi.fn();
+        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+        await vi.advanceTimersByTimeAsync(500);
+
+        fireSdkEvent({ type: 'assistant.message', data: { messageId: 'm1', content: 'late final output' } });
+        await vi.advanceTimersByTimeAsync(999);
+        expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+
+        await vi.advanceTimersByTimeAsync(1);
+        await pending;
+
+        expect(emit).toHaveBeenCalledWith({ type: 'message_final', sdkMessageId: 'm1', content: 'late final output' });
+        expect(emit).toHaveBeenCalledWith({ type: 'done' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not complete from root assistant.turn_end while a sub-agent turn is active', async () => {
+      vi.useFakeTimers();
+      try {
+        mockSession.send.mockImplementation(async () => {
+          fireSdkEvent({ type: 'assistant.turn_start', agentId: 'sub-1', data: { turnId: 't-sub' } });
+          fireSdkEvent({ type: 'assistant.turn_end', data: { turnId: 't-root' } });
+        });
+
+        const emit = vi.fn();
+        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+
+        fireSdkEvent({ type: 'assistant.turn_end', agentId: 'sub-1', data: { turnId: 't-sub' } });
+        await vi.advanceTimersByTimeAsync(1_000);
+        await pending;
+
+        expect(emit).toHaveBeenCalledWith({ type: 'done' });
+      } finally {
+        vi.useRealTimers();
       }
     });
 

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -721,6 +721,44 @@ describe('ChatService', () => {
       }
     });
 
+    it('does not complete from root assistant.turn_end while a permission request is pending', async () => {
+      vi.useFakeTimers();
+      try {
+        mockSession.send.mockImplementation(async () => {
+          fireSdkEvent({
+            type: 'permission.requested',
+            data: {
+              requestId: 'perm-1',
+              permissionRequest: {
+                kind: 'shell',
+                fullCommandText: 'echo hello',
+              },
+            },
+          });
+          fireSdkEvent({ type: 'assistant.turn_end', data: { turnId: 't-root' } });
+        });
+
+        const emit = vi.fn();
+        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+
+        fireSdkEvent({
+          type: 'permission.completed',
+          data: {
+            requestId: 'perm-1',
+            result: { kind: 'approved' },
+          },
+        });
+        await vi.advanceTimersByTimeAsync(1_000);
+        await pending;
+
+        expect(emit).toHaveBeenCalledWith({ type: 'done' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('does not complete from root assistant.turn_end while a sub-agent turn is active', async () => {
       vi.useFakeTimers();
       try {

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -28,6 +28,10 @@ import { TurnLifecycleTrace } from './turnLifecycleTrace';
 
 const log = Logger.create('ChatService');
 
+// INVARIANT: this is a post-root-turn_end debounce, not a turn deadline.
+// It is never armed unless the SDK has already signalled the root turn ended.
+const TURN_END_QUIESCENCE_MS = 1_000;
+
 export class ChatService {
   private abortControllers = new Map<string, AbortController>();
 
@@ -131,20 +135,11 @@ export class ChatService {
     // metadata-only entries (no payload contents) so we can distinguish missing
     // `session.idle` from a Chamber typed-listener miss after the fact.
     //
-    // TODO(#299 follow-up): once live evidence from this trace confirms the
-    // SDK terminal semantics, add a defensive completion path. Per rubber-duck
-    // review, that path must require ALL of:
-    //   (a) `assistant.turn_end` from the root agent (`!event.agentId`) —
-    //       sub-agent turn_end fires routinely in multi-agent / delegated
-    //       work and is NOT terminal for the root chat turn; completing on
-    //       any turn_end would prematurely clear the UI while sub-agents or
-    //       their tools are still active.
-    //   (b) `outstandingToolCount === 0` — root turn_end can still arrive
-    //       while tools are pending; completing then would orphan tool
-    //       output and confuse the next user turn.
-    //   (c) A corroborating signal (e.g. `session.task_complete`, or a short
-    //       quiescence window with no further events) — the SDK does not
-    //       document `assistant.turn_end` alone as terminal.
+    // Defensive completion path (#297): if the SDK emits root
+    // `assistant.turn_end` but never follows with `session.idle`, complete
+    // only after a post-turn quiescence window with no tools or sub-agent
+    // turns still active. This is intentionally NOT a wall-clock turn
+    // deadline: no root turn_end means no timer is armed.
     const trace = new TurnLifecycleTrace();
     // Default to 'threw' so that any pathway which escapes via an exception
     // before the idle / error / abort handlers fire (e.g. `session.send`
@@ -153,7 +148,13 @@ export class ChatService {
     // to 'completed'. Without this default, the summary would lie about
     // turns that failed before reaching `await turnDone` — defeating the
     // forensic purpose of the trace.
-    let terminalReason: 'completed' | 'aborted' | 'sdk_error' | 'sdk_contract' | 'threw' = 'threw';
+    let terminalReason:
+      | 'completed'
+      | 'turn_end_quiescence'
+      | 'aborted'
+      | 'sdk_error'
+      | 'sdk_contract'
+      | 'threw' = 'threw';
     const logTraceSummary = () => {
       const summary = trace.summary(terminalReason);
       // Fingerprint of the #299 stuck-streaming bug: the SDK signalled the
@@ -168,9 +169,60 @@ export class ChatService {
         log.debug('chat.turn.lifecycle', summary);
       }
     };
+    const outstandingToolIds = new Set<string>();
+    const activeSubAgentIds = new Set<string>();
+    let sawRootTurnEnd = false;
+    let turnEndQuiescenceTimer: ReturnType<typeof setTimeout> | undefined;
+    let resolveTurnEndQuiescence: (() => void) | undefined;
+    const clearTurnEndQuiescence = () => {
+      if (turnEndQuiescenceTimer) {
+        clearTimeout(turnEndQuiescenceTimer);
+        turnEndQuiescenceTimer = undefined;
+      }
+    };
+    const maybeArmTurnEndQuiescence = () => {
+      if (
+        abortController.signal.aborted ||
+        !sawRootTurnEnd ||
+        outstandingToolIds.size > 0 ||
+        activeSubAgentIds.size > 0
+      ) {
+        return;
+      }
+      clearTurnEndQuiescence();
+      turnEndQuiescenceTimer = setTimeout(() => {
+        turnEndQuiescenceTimer = undefined;
+        terminalReason = 'turn_end_quiescence';
+        resolveTurnEndQuiescence?.();
+      }, TURN_END_QUIESCENCE_MS);
+    };
+    const trackTerminalCandidate = (event: Parameters<TurnLifecycleTrace['record']>[0]) => {
+      clearTurnEndQuiescence();
+
+      if (event.type === 'tool.execution_start' && typeof event.data?.toolCallId === 'string') {
+        outstandingToolIds.add(event.data.toolCallId);
+      }
+      if (event.type === 'tool.execution_complete' && typeof event.data?.toolCallId === 'string') {
+        outstandingToolIds.delete(event.data.toolCallId);
+      }
+      if (event.type === 'assistant.turn_start' && typeof event.agentId === 'string') {
+        activeSubAgentIds.add(event.agentId);
+      }
+      if (event.type === 'assistant.turn_end') {
+        if (typeof event.agentId === 'string') {
+          activeSubAgentIds.delete(event.agentId);
+        } else {
+          sawRootTurnEnd = true;
+        }
+      }
+
+      maybeArmTurnEndQuiescence();
+    };
     try {
       const unsubTrace = session.on((event) => {
-        trace.record(event as Parameters<TurnLifecycleTrace['record']>[0]);
+        const sdkEvent = event as Parameters<TurnLifecycleTrace['record']>[0];
+        trace.record(sdkEvent);
+        trackTerminalCandidate(sdkEvent);
       });
       unsubs.push(unsubTrace);
 
@@ -235,6 +287,7 @@ export class ChatService {
       const turnDone = new Promise<void>((resolve, reject) => {
         const unsubIdle = session.on('session.idle', () => {
           unsubIdle();
+          clearTurnEndQuiescence();
           terminalReason = 'completed';
           resolve();
         });
@@ -242,6 +295,7 @@ export class ChatService {
 
         const unsubError = session.on('session.error', (event) => {
           unsubError();
+          clearTurnEndQuiescence();
           try {
             terminalReason = 'sdk_error';
             reject(new Error(getSdkSessionErrorMessage(event)));
@@ -258,11 +312,13 @@ export class ChatService {
         unsubs.push(unsubError);
 
         abortController.signal.addEventListener('abort', () => {
+          clearTurnEndQuiescence();
           // failSdkContract aborts after setting sdkContractFailed; preserve
           // that classification rather than overwriting with 'aborted'.
           terminalReason = sdkContractFailed ? 'sdk_contract' : 'aborted';
           resolve();
         }, { once: true });
+        resolveTurnEndQuiescence = resolve;
       });
       // Defensive no-op catch: if `session.send` throws and we never reach
       // `await turnDone` below, this guarantees a later SDK error rejection is
@@ -296,6 +352,7 @@ export class ChatService {
       if (abortController.signal.aborted) return;
       emit({ type: 'done' });
     } finally {
+      clearTurnEndQuiescence();
       for (const unsub of unsubs) unsub();
       logTraceSummary();
     }

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -170,6 +170,7 @@ export class ChatService {
       }
     };
     const outstandingToolIds = new Set<string>();
+    const pendingPermissionIds = new Set<string>();
     const activeSubAgentIds = new Set<string>();
     let sawRootTurnEnd = false;
     let turnEndQuiescenceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -185,6 +186,7 @@ export class ChatService {
         abortController.signal.aborted ||
         !sawRootTurnEnd ||
         outstandingToolIds.size > 0 ||
+        pendingPermissionIds.size > 0 ||
         activeSubAgentIds.size > 0
       ) {
         return;
@@ -204,6 +206,12 @@ export class ChatService {
       }
       if (event.type === 'tool.execution_complete' && typeof event.data?.toolCallId === 'string') {
         outstandingToolIds.delete(event.data.toolCallId);
+      }
+      if (event.type === 'permission.requested' && typeof event.data?.requestId === 'string') {
+        pendingPermissionIds.add(event.data.requestId);
+      }
+      if (event.type === 'permission.completed' && typeof event.data?.requestId === 'string') {
+        pendingPermissionIds.delete(event.data.requestId);
       }
       if (event.type === 'assistant.turn_start' && typeof event.agentId === 'string') {
         activeSubAgentIds.add(event.agentId);


### PR DESCRIPTION
## Summary

- Add a guarded quiescence completion path for SDK turns that emit root `assistant.turn_end` without `session.idle`.
- Preserve late output by resetting the quiescence window on every SDK event.
- Avoid false completion while tools, permission requests, or sub-agent turns are still active.

## Validation

- Rubber Duck plan critique run; adopted tool-drain and sub-agent-turn safeguards.
- Uncle Bob review run; addressed pending-permission false-completion finding.
- `npx vitest run --config config/vitest.config.ts packages/services/src/chat/ChatService.test.ts --no-file-parallelism --maxWorkers=1`
- `npx vitest run --config config/vitest.config.ts packages/services/src/chat --no-file-parallelism --maxWorkers=1`
- `npm run lint`
- `npm test`

Packaging smoke skipped: no packaging, runtime wiring, Forge, installer, icon, or first-launch paths changed.

Replaces closed stacked PR #335 after #334 merged.
Closes #297