### PR TITLE
docs: teamMemory learning-loop roadmap (slate weeks 1-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Inject team memory into chat turns** — `ChatService.streamTurn` now reads `<mindPath>/.chamber/team/rules.md` and the most-recent decisions from `<mindPath>/.chamber/team/decisions.md` at turn time via the new `packages/services/src/teamMemory/promptContext.ts` module, and prepends a single bounded `<team_memory>` block ahead of the date/time context. Defaults: 10 newest decisions, 4096-byte budget; oldest decisions dropped first when over budget; rules are never truncated mid-rule. Returns null and emits no block when `.chamber/team/` is absent so existing minds are unaffected. A defensive `safeTeamMemoryContext` wrapper guarantees a misbehaving provider can never block a turn. Closes #345.
+
 ### Breaking
 
 - **Move the A2A client extension out of Chamber** — The repo-scoped `.github/extensions/a2a-client` copy has moved to the standalone [`ipdelete/a2a-client`](https://github.com/ipdelete/a2a-client) extension, which installs to user or repo scope and exposes the `a2a_connection`, `a2a_list_remote_agents`, and `a2a_send_agent_message` tools.

--- a/ai-docs/teammemory-learning-loop-roadmap.md
+++ b/ai-docs/teammemory-learning-loop-roadmap.md
@@ -1,0 +1,246 @@
+# Roadmap — teamMemory learning loop (weeks 1–3)
+
+> **Status**: draft slate. Issues filed; implementation not started. This document is the slate's persistent record.
+
+## Goal
+
+Close the gap between Chamber's current file-based teamMemory and the
+"persistent agents that learn a developer's standards, preferences, and
+constraints over time" claim. Deliver in three weeks:
+
+1. **Week 1** — teamMemory becomes **observed** at turn time and at
+   delegation time, and chamber-copilot's policy + verify seams ship
+   sensible Chamber-side defaults so guardrails are on by design.
+2. **Week 2** — a scribe observer pass extracts proposed preference
+   deltas from each turn, and the operator confirms them through an
+   accept/reject UI. The "learns from operators" claim becomes
+   demonstrable with an artifact (`proposals.journal.ndjson` →
+   `rules.md` / `decisions.md`).
+3. **Week 3** — chamber-copilot job outcomes (verify failures,
+   approval rejects) feed the same observer, closing the end-to-end
+   loop. Optional stretch: cross-mind team knowledge share via A2A
+   relay.
+
+## Scope (in)
+
+- `packages/services/src/teamMemory/` — new modules (`promptContext`,
+  `observer`, `proposals`, `teamSync`).
+- `packages/services/src/chamberCopilot/` — new modules
+  (`teamMemoryGuard`, `policyLoader`, `verifyResolver`); changes to
+  `MindScopedJobs.ts`.
+- `packages/services/src/chat/ChatService.ts` — turn-time injection
+  and observer trigger.
+- `apps/web/src/renderer/components/teamMemory/` — read-only panel +
+  proposal tray.
+- `apps/desktop/src/main/ipc/teamMemory.ts` (new) — IPC channels.
+- `resources/chamberCopilot/default-policy.yaml` (new) — packaged
+  default policy.
+
+## Scope (out)
+
+- ML-based preference learning (LLM-summarization + operator
+  confirmation is sufficient).
+- Auto-apply of proposals (operator approval is the gate by design).
+- chamber-copilot runtime changes — none expected; see
+  [chamber-copilot tracking issue #285](https://github.com/patschmitt91/chamber-copilot/issues/285).
+- Authoring UI for `policy.yaml`.
+
+## Autopilot defaults (carry into the `ship` skill)
+
+| Prompt area | Default answer |
+|---|---|
+| Version bump | Accept `ship` recommendation; sequential for stacked PRs. |
+| Changelog | Draft + apply automatically using existing format. |
+| Closing issue | Include `Closes #N` for every issue addressed. |
+| Uncle Bob | Run for all `packages/services/**` changes; skip docs-only PRs. |
+| Smoke | `npm run smoke:sdk` for #345, #346, #349, #351 (touch the SDK turn path). `npm run smoke:web` for #348, #350 (renderer). `npm run smoke:desktop` for #347 (packaged policy resource). |
+| Packaging sandbox | Never run. |
+| PR base | `master` (independent PRs — slate stacking is overkill at this size). |
+
+Merging stays a human gate.
+
+## Cross-repo
+
+- **chamber-copilot tracking epic**:
+  [patschmitt91/chamber-copilot#285](https://github.com/patschmitt91/chamber-copilot/issues/285) —
+  pins the chamber-copilot seams this slate consumes (`preDelegateGuard`,
+  `JobStore` status events, `lastVerify` snapshot, `cli_approve` decision
+  codes, `MindTrustScorer.record/tier`, `PolicyEngine.evaluate`). No
+  chamber-copilot code changes expected.
+
+## PR map
+
+```text
+345 promptContext.ts                                 → ChatService injects teamMemory
+   ├──► 346 teamMemoryGuard.ts                       → MindScopedJobs default preDelegateGuard
+   ├──► 347 policyLoader + verifyResolver            → MindScopedJobs default policy + verify
+   ├──► 348 TeamMemoryPanel.tsx                      → renderer surfaces rules + decisions
+   └──► 349 observer.ts                              → post-turn scribe proposes deltas
+        └──► 350 ProposalTray.tsx                    → operator accepts/rejects
+             └──► 351 job-outcome feedback           → MindScopedJobs feeds observer
+                  └──► 352 teamSync.ts (stretch)     → A2A relay for cross-mind share
+```
+
+Independent PRs (no Git Town stack). Logical dependency edges captured
+in the per-issue "Dependencies" sections.
+
+## Slate items
+
+### Week 1 — defaults that make the email's claims defensible
+
+#### #345 — teamMemory prompt injection
+
+- **Branch**: `feat/teammemory-prompt-injection`
+- **Base**: `master`
+- **Issue**: [#345](https://github.com/ianphil/chamber/issues/345)
+- **TMLST design checkpoint**: not applicable — pure additive read of
+  existing files, no trust-boundary widening.
+- **TDD mini-plan**: see issue #345.
+- **Ship skill notes**: `enhancement`; default smoke `npm run smoke:sdk`.
+
+#### #346 — default `preDelegateGuard` from teamMemory
+
+- **Branch**: `feat/chambercopilot-default-pre-delegate-guard`
+- **Base**: `master`
+- **Issue**: [#346](https://github.com/ianphil/chamber/issues/346)
+- **Depends on**: #345.
+- **TMLST design checkpoint**: consumer of the chamber-copilot
+  `preDelegateGuard` seam. Does not change the seam contract. If
+  chamber-copilot tightens the contract during this slate, coordinate
+  via tracking issue #285.
+- **TDD mini-plan**: see issue #346.
+- **Ship skill notes**: `enhancement`; smoke `npm run smoke:sdk`.
+
+#### #347 — default policy.yaml + verify for `MindScopedJobs`
+
+- **Branch**: `feat/chambercopilot-default-policy-and-verify`
+- **Base**: `master`
+- **Issue**: [#347](https://github.com/ianphil/chamber/issues/347)
+- **TMLST design checkpoint**: ships a default `policy.yaml` in
+  `audit` mode (logs, does not block). Defines no new trust boundary;
+  consumes the existing `PolicyEngine.evaluate` contract.
+- **TDD mini-plan**: see issue #347.
+- **Ship skill notes**: `enhancement`; smoke `npm run smoke:desktop`
+  to verify the packaged resource ships.
+
+#### #348 — renderer panel for team memory (read-only)
+
+- **Branch**: `feat/team-memory-ui-panel`
+- **Base**: `master`
+- **Issue**: [#348](https://github.com/ianphil/chamber/issues/348)
+- **TMLST design checkpoint**: not applicable — renderer-only,
+  read-only.
+- **TDD mini-plan**: see issue #348.
+- **Ship skill notes**: `enhancement`; smoke `npm run smoke:web`.
+
+### Week 2 — the scribe + the operator confirmation flow
+
+#### #349 — post-turn observer pass proposes deltas
+
+- **Branch**: `feat/scribe-mind-observer-pass`
+- **Base**: `master`
+- **Issue**: [#349](https://github.com/ianphil/chamber/issues/349)
+- **Depends on**: #345, #348.
+- **TMLST design checkpoint**: introduces a new write surface
+  (`proposals.journal.ndjson`). The surface is **operator-confirmed-write**
+  by design — the observer cannot mutate `rules.md` or `decisions.md`
+  directly. Marked load-bearing; covered by observer persistence tests
+  and an integration test in #349.
+- **TDD mini-plan**: see issue #349.
+- **Ship skill notes**: `enhancement`; smoke `npm run smoke:sdk`.
+
+#### #350 — operator accept/reject for proposed deltas
+
+- **Branch**: `feat/operator-confirmed-preference-deltas`
+- **Base**: `master`
+- **Issue**: [#350](https://github.com/ianphil/chamber/issues/350)
+- **Depends on**: #349, #348.
+- **TMLST design checkpoint**: acceptance path MUST flow through
+  existing `appendRule` / `appendDecision` writers so consolidation
+  and dedup invariants hold for both human-written and accepted-from-scribe
+  entries. Covered by an integration test that round-trips
+  proposal → accept → `readRules` sees it.
+- **TDD mini-plan**: see issue #350.
+- **Ship skill notes**: `enhancement`; smoke `npm run smoke:web`.
+
+### Week 3 — close the loop with chamber-copilot outcomes
+
+#### #351 — feed chamber-copilot job outcomes into the observer
+
+- **Branch**: `feat/copilot-outcome-feedback-loop`
+- **Base**: `master`
+- **Issue**: [#351](https://github.com/ianphil/chamber/issues/351)
+- **Depends on**: #349 (#350 strongly recommended so the resulting
+  proposals are actionable).
+- **TMLST design checkpoint**: consumer of chamber-copilot's
+  `JobStore` status-change events and `lastVerify` snapshot field. Does
+  not change either contract. Coalesces identical outcomes within a
+  24h window so the observer is not fed a flood of duplicates.
+- **TDD mini-plan**: see issue #351.
+- **Ship skill notes**: `enhancement`; smoke `npm run smoke:sdk`.
+
+#### #352 — cross-mind team knowledge share via A2A relay (stretch)
+
+- **Branch**: `feat/cross-mind-team-knowledge-share`
+- **Base**: `master`
+- **Issue**: [#352](https://github.com/ianphil/chamber/issues/352)
+- **Status**: **stretch** — drop from the slate if weeks 1–2 over-run.
+- **Depends on**: #349, #350.
+- **TMLST design checkpoint**: published payload is sanitized,
+  size-bounded, and goes only to explicitly-configured `teamId`s.
+  Pulled rules/decisions arrive as **proposals**, never as direct
+  writes, so the operator-confirmed-write invariant from #349/#350
+  extends across the boundary.
+- **TDD mini-plan**: see issue #352.
+- **Ship skill notes**: `enhancement`; smoke `npm run smoke:sdk`.
+
+## Execution workflow
+
+For each ready slate item (no unmet dependency), repeat:
+
+1. `git switch master && git pull --ff-only origin master`
+2. `git switch -c <branch>`
+3. Read the issue and the nearest sibling code; copy its shape.
+4. Write the failing test(s) per the issue's TDD plan.
+5. Implement minimally; do not fix unrelated pre-existing issues.
+6. Run focused tests, then `npm run lint && npm test`, then the chosen
+   smoke.
+7. Commit with `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+8. Invoke the chamber `ship` skill in autopilot mode using the
+   defaults above; pass `Closes #N`.
+9. Record the PR URL in this roadmap; mark the slate todo `done`.
+
+## Open questions
+
+- **Observer model choice (#349)** — which model does the scribe use?
+  Cheapest viable wins. Configurable per mind. Default = the same model
+  the mind is currently configured for, unless a `scribeModel` is set.
+- **Proposal staleness (#350)** — should proposals auto-expire after N
+  days if unresolved? Probably yes (default 14 days, configurable).
+- **Cross-repo coordination cadence (#347, #351)** — any
+  chamber-copilot seam tightening during this slate must surface in
+  tracking issue [#285](https://github.com/patschmitt91/chamber-copilot/issues/285).
+  If a tightening would break #347 or #351, the chamber slate stalls
+  until coordinated.
+- **Stretch decision (#352)** — make the call at end of week 2 based
+  on burn-down.
+
+## Closeout criteria
+
+- All eight chamber issues #345–#352 are closed or intentionally
+  deferred (with deferral noted on the issue).
+- chamber-copilot tracking issue [#285](https://github.com/patschmitt91/chamber-copilot/issues/285)
+  is closed with a one-paragraph summary of any cross-repo changes
+  actually required.
+- A demo path exists end-to-end: open Chamber → activate a mind →
+  have a conversation that triggers an observer proposal → accept it
+  → run a delegated job whose verify-gate failure also triggers a
+  proposal → accept it → restart the mind and see the accepted
+  rules/decisions injected into the next turn.
+
+## Provenance
+
+This slate exists to close gaps between the email pitched to Will Guyman
+(via Lorraine Bardeen's introduction) and the artifacts currently in
+the chamber + chamber-copilot repos. The audit that produced this slate
+is summarized in the linked tracking epic.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -297,7 +297,7 @@ async function initializeRuntime(): Promise<void> {
       log.warn(`BYO LLM models provider probe failed (baseUrl=${redactUrlCredentials(config.baseUrl)}):`, err);
     },
   });
-  chatService = new ChatService(mindManager, turnQueue, undefined, byoLlmModelsProvider);
+  chatService = new ChatService(mindManager, turnQueue, undefined, undefined, byoLlmModelsProvider);
   const messageRouter = new MessageRouter(chatService, activeA2AResolver, a2aEventBus);
   a2aRelayModeService = new A2ARelayModeService(agentCardRegistry, activeA2AResolver, undefined, messageRouter);
   const chatroomApprovalGate = new ApprovalGate();

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -77,13 +77,13 @@ const validModelClient = {
 const mockMindManager = {
   getMind: vi.fn((mindId: string) => {
     if (mindId === 'valid-mind') {
-      return { session: mockSession, client: validModelClient };
+      return { session: mockSession, client: validModelClient, mindPath: '/fake/mind' };
     }
     if (mindId === 'broken-models') {
-      return { session: mockSession, client: { listModels: vi.fn(async () => { throw new Error('model discovery failed'); }) } };
+      return { session: mockSession, client: { listModels: vi.fn(async () => { throw new Error('model discovery failed'); }) }, mindPath: '/fake/mind' };
     }
     if (mindId === 'drifted-models') {
-      return { session: mockSession, client: { listModels: vi.fn(async () => [{ modelId: 'm1', displayName: 'Model 1' }]) } };
+      return { session: mockSession, client: { listModels: vi.fn(async () => [{ modelId: 'm1', displayName: 'Model 1' }]) }, mindPath: '/fake/mind' };
     }
     return undefined;
   }),
@@ -155,6 +155,82 @@ describe('ChatService', () => {
       const emit = vi.fn();
       await svc.sendMessage('nonexistent', 'hello', 'msg-1', emit);
       expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+
+    it('prepends the team-memory block to the prompt when the provider returns one (#345)', async () => {
+      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          setTimeout(() => cb(), 0);
+        }
+        return vi.fn();
+      });
+
+      const teamMemoryProvider = vi.fn((mindPath: string) => {
+        expect(mindPath).toBe('/fake/mind');
+        return '<team_memory>\n<rules>\n- Always cite sources.\n</rules>\n</team_memory>';
+      });
+
+      const svcWithTeam = new ChatService(
+        mockMindManager as unknown as MindManager,
+        turnQueue,
+        () => ({ currentDateTime: '2026-05-05T15:37:12.065Z', timezone: 'America/New_York' }),
+        teamMemoryProvider,
+      );
+
+      const emit = vi.fn();
+      await svcWithTeam.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+      expect(teamMemoryProvider).toHaveBeenCalledTimes(1);
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\n<team_memory>\n<rules>\n- Always cite sources.\n</rules>\n</team_memory>\n\nhello',
+      });
+    });
+
+    it('leaves the prompt untouched when the team-memory provider returns null (#345)', async () => {
+      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          setTimeout(() => cb(), 0);
+        }
+        return vi.fn();
+      });
+
+      const svcWithTeam = new ChatService(
+        mockMindManager as unknown as MindManager,
+        turnQueue,
+        () => ({ currentDateTime: '2026-05-05T15:37:12.065Z', timezone: 'America/New_York' }),
+        () => null,
+      );
+
+      const emit = vi.fn();
+      await svcWithTeam.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
+      });
+    });
+
+    it('continues the turn when the team-memory provider throws (#345)', async () => {
+      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          setTimeout(() => cb(), 0);
+        }
+        return vi.fn();
+      });
+
+      const svcWithTeam = new ChatService(
+        mockMindManager as unknown as MindManager,
+        turnQueue,
+        () => ({ currentDateTime: '2026-05-05T15:37:12.065Z', timezone: 'America/New_York' }),
+        () => { throw new Error('boom'); },
+      );
+
+      const emit = vi.fn();
+      await svcWithTeam.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: '<current_datetime>\n2026-05-05T15:37:12.065Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nhello',
+      });
+      expect(emit).toHaveBeenCalledWith({ type: 'done' });
     });
 
     it('does not arm a wall-clock fallback timer; long turns wait indefinitely for the SDK or user cancel (#222)', async () => {
@@ -336,6 +412,7 @@ describe('ChatService', () => {
         mockMindManager as unknown as MindManager,
         turnQueue,
         () => ({ currentDateTime: '2026-05-08T12:00:00Z', timezone: 'UTC' }),
+        undefined,
         async () => [{ id: 'gemma-4-26b', name: 'gemma-4-26b', provider: 'byo' as const }],
       );
       const models = await svcWithByo.listModels('valid-mind');
@@ -350,6 +427,7 @@ describe('ChatService', () => {
         mockMindManager as unknown as MindManager,
         turnQueue,
         () => ({ currentDateTime: '2026-05-08T12:00:00Z', timezone: 'UTC' }),
+        undefined,
         async () => [{ id: 'm1', name: 'Different Name', provider: 'byo' as const }],
       );
       const models = await svcWithByo.listModels('valid-mind');
@@ -364,6 +442,7 @@ describe('ChatService', () => {
         mockMindManager as unknown as MindManager,
         turnQueue,
         () => ({ currentDateTime: '2026-05-08T12:00:00Z', timezone: 'UTC' }),
+        undefined,
         async () => [{ id: 'gemma', name: 'gemma', provider: 'byo' as const }],
       );
       const models = await svcWithByo.listModels('broken-models');
@@ -375,6 +454,7 @@ describe('ChatService', () => {
         mockMindManager as unknown as MindManager,
         turnQueue,
         () => ({ currentDateTime: '2026-05-08T12:00:00Z', timezone: 'UTC' }),
+        undefined,
         async () => [],
       );
       await expect(svcWithByo.listModels('broken-models')).rejects.toThrow('model discovery failed');
@@ -385,6 +465,7 @@ describe('ChatService', () => {
         mockMindManager as unknown as MindManager,
         turnQueue,
         () => ({ currentDateTime: '2026-05-08T12:00:00Z', timezone: 'UTC' }),
+        undefined,
         async () => null,
       );
       const models = await svcWithByo.listModels('valid-mind');

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -25,8 +25,11 @@ import { mapSdkModelList } from '../sdk/sdkModelMapper';
 import { TurnQueue } from './TurnQueue';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext, type DateTimeContextProvider } from './currentDateTimeContext';
 import { TurnLifecycleTrace } from './turnLifecycleTrace';
+import { buildTeamMemoryContext } from '../teamMemory';
 
 const log = Logger.create('ChatService');
+
+export type TeamMemoryContextProvider = (mindPath: string) => string | null;
 
 // INVARIANT: this is a post-root-turn_end debounce, not a turn deadline.
 // It is never armed unless the SDK has already signalled the root turn ended.
@@ -39,6 +42,13 @@ export class ChatService {
     private readonly mindManager: MindManager,
     private readonly turnQueue: TurnQueue,
     private readonly dateTimeContextProvider: DateTimeContextProvider = getCurrentDateTimeContext,
+    /**
+     * Reads the mind's team memory (`.chamber/team/rules.md` and
+     * `.chamber/team/decisions.md`) at turn time and returns a block to
+     * prepend to the prompt, or null when there is nothing to inject.
+     * Default reads from disk. Tests inject a deterministic fake.
+     */
+    private readonly teamMemoryContextProvider: TeamMemoryContextProvider = buildTeamMemoryContext,
     /**
      * Optional provider injected by main.ts that returns BYO LLM models when
      * BYO is enabled. Returning null/undefined falls back to the bundled SDK's
@@ -68,11 +78,13 @@ export class ChatService {
           throw new Error(`Mind ${mindId} not found or has no session`);
         }
 
+        const mindPath = context.mindPath;
+
         try {
           const session = model ? await this.mindManager.setMindModel(mindId, model) : null;
           const currentSession = session ? this.mindManager.getMind(mindId)?.session : context.session;
           if (!currentSession) throw new Error(`Mind ${mindId} not found or has no session`);
-          await this.streamTurn(currentSession, prompt, abortController, emit, attachments, () => {
+          await this.streamTurn(currentSession, prompt, mindPath, abortController, emit, attachments, () => {
             this.mindManager.markActiveConversationHasMessages(mindId, prompt);
           });
         } catch (err) {
@@ -84,7 +96,7 @@ export class ChatService {
           emit({ type: 'reconnecting' });
           const recoveredSession = await this.mindManager.recoverActiveConversationSession(mindId);
           if (abortController.signal.aborted) return;
-          await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
+          await this.streamTurn(recoveredSession, prompt, mindPath, abortController, emit, attachments, () => {
             this.mindManager.markActiveConversationHasMessages(mindId, prompt);
           });
         }
@@ -101,6 +113,7 @@ export class ChatService {
   private async streamTurn(
     session: CopilotSession,
     prompt: string,
+    mindPath: string,
     abortController: AbortController,
     emit: (event: ChatEvent) => void,
     attachments?: ChatImageAttachment[],
@@ -347,7 +360,9 @@ export class ChatService {
           mimeType: a.mimeType,
           displayName: a.name,
         }));
-        const promptWithDateTime = injectCurrentDateTimeContext(prompt, this.dateTimeContextProvider());
+        const teamMemoryBlock = this.safeTeamMemoryContext(mindPath);
+        const promptWithTeamMemory = teamMemoryBlock ? `${teamMemoryBlock}\n\n${prompt}` : prompt;
+        const promptWithDateTime = injectCurrentDateTimeContext(promptWithTeamMemory, this.dateTimeContextProvider());
         await Promise.race([session.send(sdkAttachments ? { prompt: promptWithDateTime, attachments: sdkAttachments } : { prompt: promptWithDateTime }), sendTimeout]);
         guard(() => onSendAccepted?.());
       } finally {
@@ -363,6 +378,16 @@ export class ChatService {
       clearTurnEndQuiescence();
       for (const unsub of unsubs) unsub();
       logTraceSummary();
+    }
+  }
+
+  private safeTeamMemoryContext(mindPath: string): string | null {
+    try {
+      return this.teamMemoryContextProvider(mindPath);
+    } catch (err) {
+      // A misbehaving provider must never block a turn. Log and continue.
+      log.warn('teamMemory.context.failed', err);
+      return null;
     }
   }
 

--- a/packages/services/src/teamMemory/index.ts
+++ b/packages/services/src/teamMemory/index.ts
@@ -1,0 +1,1 @@
+export { buildTeamMemoryContext, type BuildTeamMemoryContextOptions } from './promptContext';

--- a/packages/services/src/teamMemory/promptContext.test.ts
+++ b/packages/services/src/teamMemory/promptContext.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { buildTeamMemoryContext } from './promptContext';
+
+describe('buildTeamMemoryContext', () => {
+  let mindPath: string;
+
+  beforeEach(() => {
+    mindPath = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-team-mem-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(mindPath, { recursive: true, force: true });
+  });
+
+  it('returns null when .chamber/team/ does not exist', () => {
+    expect(buildTeamMemoryContext(mindPath)).toBeNull();
+  });
+
+  it('returns null when the team dir exists but rules and decisions are both empty', () => {
+    writeTeamFile('rules.md', '   \n\n  ');
+    writeTeamFile('decisions.md', '');
+    expect(buildTeamMemoryContext(mindPath)).toBeNull();
+  });
+
+  it('returns a rules-only block when only rules.md has content', () => {
+    writeTeamFile('rules.md', '- Always cite sources.\n- Never delete user files without confirmation.');
+
+    const block = buildTeamMemoryContext(mindPath);
+
+    expect(block).not.toBeNull();
+    expect(block).toContain('<team_memory>');
+    expect(block).toContain('<rules>');
+    expect(block).toContain('- Always cite sources.');
+    expect(block).toContain('- Never delete user files without confirmation.');
+    expect(block).not.toContain('<recent_decisions>');
+    expect(block!.endsWith('</team_memory>')).toBe(true);
+  });
+
+  it('returns a decisions-only block when only decisions.md has content', () => {
+    writeTeamFile('decisions.md', '## 2026-05-19\nUse PostgreSQL for the metadata store.');
+
+    const block = buildTeamMemoryContext(mindPath);
+
+    expect(block).not.toBeNull();
+    expect(block).toContain('<recent_decisions>');
+    expect(block).toContain('Use PostgreSQL for the metadata store.');
+    expect(block).not.toContain('<rules>');
+  });
+
+  it('returns both sections when both files have content, with rules before decisions', () => {
+    writeTeamFile('rules.md', 'Always run lint before push.');
+    writeTeamFile('decisions.md', '## 2026-05-19\nPicked vitest over jest.');
+
+    const block = buildTeamMemoryContext(mindPath);
+
+    expect(block).not.toBeNull();
+    const rulesIdx = block!.indexOf('<rules>');
+    const decisionsIdx = block!.indexOf('<recent_decisions>');
+    expect(rulesIdx).toBeGreaterThan(-1);
+    expect(decisionsIdx).toBeGreaterThan(rulesIdx);
+  });
+
+  it('takes the most recent N decision entries (newest at end of file)', () => {
+    const journal = [
+      '## 2026-05-15',
+      'oldest decision',
+      '',
+      '## 2026-05-16',
+      'middle decision',
+      '',
+      '## 2026-05-17',
+      'newest decision',
+    ].join('\n');
+    writeTeamFile('decisions.md', journal);
+
+    const block = buildTeamMemoryContext(mindPath, { maxDecisions: 2 });
+
+    expect(block).not.toBeNull();
+    expect(block).toContain('newest decision');
+    expect(block).toContain('middle decision');
+    expect(block).not.toContain('oldest decision');
+  });
+
+  it('orders kept decisions newest-first in the output', () => {
+    const journal = [
+      '## 2026-05-16',
+      'middle decision',
+      '',
+      '## 2026-05-17',
+      'newest decision',
+    ].join('\n');
+    writeTeamFile('decisions.md', journal);
+
+    const block = buildTeamMemoryContext(mindPath);
+
+    expect(block).not.toBeNull();
+    const newestIdx = block!.indexOf('newest decision');
+    const middleIdx = block!.indexOf('middle decision');
+    expect(newestIdx).toBeGreaterThan(-1);
+    expect(middleIdx).toBeGreaterThan(newestIdx);
+  });
+
+  it('treats decisions without H2 headings as a single entry', () => {
+    writeTeamFile('decisions.md', 'Just a free-form note, no headings.\nSecond line of the same entry.');
+
+    const block = buildTeamMemoryContext(mindPath);
+
+    expect(block).not.toBeNull();
+    expect(block).toContain('Just a free-form note, no headings.');
+    expect(block).toContain('Second line of the same entry.');
+  });
+
+  it('drops oldest decisions first when over the byte budget; never splits a decision entry', () => {
+    const longBody = (label: string) => `${label} ${'x'.repeat(200)}`;
+    const journal = [
+      `## 2026-05-15\n${longBody('OLD')}`,
+      `## 2026-05-16\n${longBody('MID')}`,
+      `## 2026-05-17\n${longBody('NEW')}`,
+    ].join('\n\n');
+    writeTeamFile('decisions.md', journal);
+
+    const block = buildTeamMemoryContext(mindPath, { maxBytes: 350 });
+
+    expect(block).not.toBeNull();
+    expect(block).toContain('NEW xxxxx');
+    expect(block).not.toContain('OLD ');
+    // The kept entry was included intact (not truncated mid-body).
+    expect(block).toContain('x'.repeat(200));
+  });
+
+  it('keeps all rules even when the rules content alone exceeds the byte budget', () => {
+    const bigRules = `- ${'r'.repeat(8000)}`;
+    writeTeamFile('rules.md', bigRules);
+    writeTeamFile('decisions.md', '## 2026-05-17\ndropped decision');
+
+    const block = buildTeamMemoryContext(mindPath, { maxBytes: 1024 });
+
+    expect(block).not.toBeNull();
+    expect(block).toContain('r'.repeat(8000));
+    expect(block).not.toContain('dropped decision');
+  });
+
+  it('is idempotent: same inputs produce identical output', () => {
+    writeTeamFile('rules.md', 'Always be kind.');
+    writeTeamFile('decisions.md', '## 2026-05-17\nAdopted ESM everywhere.');
+
+    const first = buildTeamMemoryContext(mindPath);
+    const second = buildTeamMemoryContext(mindPath);
+
+    expect(first).toBe(second);
+  });
+
+  function writeTeamFile(name: string, contents: string): void {
+    const teamDir = path.join(mindPath, '.chamber', 'team');
+    fs.mkdirSync(teamDir, { recursive: true });
+    fs.writeFileSync(path.join(teamDir, name), contents, 'utf-8');
+  }
+});

--- a/packages/services/src/teamMemory/promptContext.ts
+++ b/packages/services/src/teamMemory/promptContext.ts
@@ -1,0 +1,129 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface BuildTeamMemoryContextOptions {
+  /**
+   * Maximum number of decision entries to include (newest first). Default 10.
+   */
+  maxDecisions?: number;
+  /**
+   * Soft byte budget for the assembled block. Decisions are dropped
+   * oldest-first (within the most-recent slice) until the block fits.
+   * Rules are NEVER truncated; if rules alone exceed the budget, the
+   * returned block includes all rules and zero decisions. Default 4096.
+   */
+  maxBytes?: number;
+}
+
+const TEAM_DIR_SEGMENTS = ['.chamber', 'team'];
+const RULES_FILENAME = 'rules.md';
+const DECISIONS_FILENAME = 'decisions.md';
+const DEFAULT_MAX_DECISIONS = 10;
+const DEFAULT_MAX_BYTES = 4096;
+
+interface DecisionEntry {
+  body: string;
+}
+
+/**
+ * Reads the team-memory files for a mind and returns a single markdown-ish
+ * block suitable for prepending to a chat turn. Returns null when there is
+ * no team memory to inject (no directory, no files, or both files empty).
+ */
+export function buildTeamMemoryContext(
+  mindPath: string,
+  options: BuildTeamMemoryContextOptions = {},
+): string | null {
+  const maxDecisions = options.maxDecisions ?? DEFAULT_MAX_DECISIONS;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  const teamDir = path.join(mindPath, ...TEAM_DIR_SEGMENTS);
+  if (!directoryExists(teamDir)) return null;
+
+  const rules = readFileTrimmed(path.join(teamDir, RULES_FILENAME));
+  const decisionsRaw = readFileTrimmed(path.join(teamDir, DECISIONS_FILENAME));
+
+  if (!rules && !decisionsRaw) return null;
+
+  const decisions = parseDecisions(decisionsRaw).slice(-maxDecisions).reverse();
+
+  return assembleBlock(rules, decisions, maxBytes);
+}
+
+function directoryExists(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function readFileTrimmed(file: string): string {
+  try {
+    return fs.readFileSync(file, 'utf-8').trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Splits a decisions journal into entries delimited by H2 headings (`## `).
+ * Content before the first heading is treated as a single implicit entry so
+ * journals without headings still work. Entries are returned in file order
+ * (caller is responsible for choosing slice + direction).
+ */
+function parseDecisions(content: string): DecisionEntry[] {
+  if (!content) return [];
+
+  const lines = content.split(/\r?\n/);
+  const entries: string[] = [];
+  let current: string[] = [];
+
+  const flush = () => {
+    const body = current.join('\n').trim();
+    if (body.length > 0) entries.push(body);
+    current = [];
+  };
+
+  for (const line of lines) {
+    if (/^##\s+/.test(line)) {
+      flush();
+    }
+    current.push(line);
+  }
+  flush();
+
+  return entries.map((body) => ({ body }));
+}
+
+function assembleBlock(
+  rules: string,
+  decisionsNewestFirst: DecisionEntry[],
+  maxBytes: number,
+): string {
+  const fits = (rulesPart: string, decisionsPart: DecisionEntry[]): { text: string; bytes: number } => {
+    const sections: string[] = [];
+    if (rulesPart) {
+      sections.push(`<rules>\n${rulesPart}\n</rules>`);
+    }
+    if (decisionsPart.length > 0) {
+      const body = decisionsPart.map((d) => d.body).join('\n\n');
+      sections.push(`<recent_decisions>\n${body}\n</recent_decisions>`);
+    }
+    const text = `<team_memory>\n${sections.join('\n\n')}\n</team_memory>`;
+    return { text, bytes: Buffer.byteLength(text, 'utf-8') };
+  };
+
+  const kept = [...decisionsNewestFirst];
+  let assembled = fits(rules, kept);
+
+  // Drop oldest decisions first (within the most-recent slice). With
+  // `decisionsNewestFirst` the oldest kept entry is at the end of the array,
+  // so we pop from the tail.
+  while (assembled.bytes > maxBytes && kept.length > 0) {
+    kept.pop();
+    assembled = fits(rules, kept);
+  }
+
+  return assembled.text;
+}


### PR DESCRIPTION
## Summary

Add `ai-docs/teammemory-learning-loop-roadmap.md` as the persistent record for the **teamMemory learning-loop** slate. The slate's goal is to close the gap between Chamber's current file-based teamMemory and a defensible "agents that learn a developer's standards, preferences, and constraints over time" story, in three weeks of focused work.

**This PR is roadmap-only. No code changes.** It is filed as a draft so the slate shape can be reviewed before any implementation issue is picked up.

## What ships in this PR

One file: `ai-docs/teammemory-learning-loop-roadmap.md`. It includes:

- Goal, in-scope, out-of-scope.
- Autopilot defaults for the `ship` skill.
- PR map across the eight chamber issues, with logical dependency edges.
- One section per slate item: branch, base, issue number, TMLST design checkpoint, TDD pointer, ship-skill smoke choice.
- Execution workflow, open questions, closeout criteria, provenance.

## Slate items

Filed as separate issues so each can be picked up independently with the `ship` skill:

### Week 1 — defaults that make the email's claims defensible
- #345 — Inject `rules.md` + recent decisions into chat-turn system context
- #346 — Default `preDelegateGuard` in `MindScopedJobs` from teamMemory
- #347 — Default `policy.yaml` + verify command for `MindScopedJobs`
- #348 — Renderer panel surfacing `.chamber/team/` (read-only first)

### Week 2 — the scribe + operator confirmation
- #349 — Post-turn observer pass proposes preference deltas
- #350 — Operator accept/reject UI for proposed deltas

### Week 3 — close the loop with chamber-copilot outcomes
- #351 — Feed chamber-copilot job outcomes (verify fails, `reject_*`) into the observer
- #352 — Cross-mind team knowledge share via A2A relay (**stretch**; drop if weeks 1–2 over-run)

## Cross-repo coordination

- [`patschmitt91/chamber-copilot#285`](https://github.com/patschmitt91/chamber-copilot/issues/285) — tracking epic. Pins the chamber-copilot seams this slate consumes (`preDelegateGuard`, `JobStore` status events, `lastVerify` snapshot, `cli_approve` decision codes, `MindTrustScorer.record/tier`, `PolicyEngine.evaluate`). No chamber-copilot code changes expected.

## Why a draft PR (not direct merge)

The slate is opinionated about:
- **Where the "learning" actually lives** (Chamber's `teamMemory`, not in chamber-copilot — the latter stays a delegation substrate).
- **Operator-confirmed writes** as the gate on every preference change (the observer never edits `rules.md`/`decisions.md` directly).
- **Defaults that turn host-wired seams into "by design" guardrails** (default `policy.yaml`, default verify, default `preDelegateGuard`).

Worth a read-through before any of the eight issues moves to `in_progress`.

## Out of scope for this PR

- All implementation. Each slate item has its own issue and will become its own PR via the `ship` skill.
- TMLST-positioning changes in chamber-copilot (separate decision; not part of this slate).
- Authoring UI for `policy.yaml` (deferred to a follow-up slate).

## Validation

- `npx markdownlint-cli2 ai-docs/teammemory-learning-loop-roadmap.md` — clean.
- No code changes, so no `npm test` / `npm run lint` impact.

## Next step for the reviewer

Read the roadmap. If the slate shape, scope split, and TMLST design checkpoints look right, approve to start picking up issues — beginning with #345 since it unblocks #346, #348, and #349.
