### PR TITLE
Fix spurious chat cancellation and missed completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Surface ambiguous A2A recipients** — A2A message routing now reports duplicate display-name matches with usable recipient identifiers instead of falling through to an unknown-recipient error. (#322) (#322)
 - **Complete turns after root turn end** — Chat streaming now finishes after a guarded root assistant.turn_end quiescence path when the SDK omits session.idle, while still waiting for outstanding tools and sub-agent turns so late output is preserved. (#297) (#297)
+- **Prevent false chat completion and missed UI updates** — Chat cancellation now requires an active turn, A2A and cron streaming state no longer contaminates chat input, and renderer chat events replay after window refocus so hidden-window work can catch up. Fixes #297. (#297)
 
 
 ## [0.63.0] - 2026-05-17

--- a/apps/desktop/src/main/ipc/chat.ts
+++ b/apps/desktop/src/main/ipc/chat.ts
@@ -1,15 +1,50 @@
 // Chat IPC handlers — thin adapters for ChatService
 import { ipcMain, BrowserWindow } from 'electron';
 import { IPC } from '@chamber/shared';
+import { Logger } from '@chamber/services';
 import type { ChatService, MindManager } from '@chamber/services';
-import type { ChatEvent, ChatImageAttachment } from '@chamber/shared/types';
+import type { ChatEvent, ChatImageAttachment, ChatReplayEvent } from '@chamber/shared/types';
+
+const log = Logger.create('ChatIPC');
+const MAX_REPLAY_EVENTS = 500;
+const replayEvents: ChatReplayEvent[] = [];
+let chatEventSequence = 0;
+
+function recordChatEvent(mindId: string, messageId: string, event: ChatEvent): ChatReplayEvent {
+  const entry = {
+    sequence: ++chatEventSequence,
+    mindId,
+    messageId,
+    event,
+  };
+  replayEvents.push(entry);
+  if (replayEvents.length > MAX_REPLAY_EVENTS) {
+    replayEvents.splice(0, replayEvents.length - MAX_REPLAY_EVENTS);
+  }
+  return entry;
+}
+
+function sendChatEvent(win: BrowserWindow | null, mindId: string, messageId: string, event: ChatEvent): void {
+  const entry = recordChatEvent(mindId, messageId, event);
+  log.debug('chat:event:emit', {
+    sequence: entry.sequence,
+    mindId,
+    messageId,
+    type: event.type,
+    windowVisible: win?.isVisible() ?? false,
+    windowDestroyed: win?.isDestroyed() ?? true,
+  });
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(IPC.CHAT.EVENT, mindId, messageId, event, entry.sequence);
+  }
+}
 
 export function setupChatIPC(chatService: ChatService, mindManager: MindManager): void {
   ipcMain.handle(IPC.CHAT.SEND, async (event, mindId: string, message: string, messageId: string, model?: string, attachments?: ChatImageAttachment[]) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return;
 
-    const emit = (evt: ChatEvent) => win.webContents.send(IPC.CHAT.EVENT, mindId, messageId, evt);
+    const emit = (evt: ChatEvent) => sendChatEvent(win, mindId, messageId, evt);
     await chatService.sendMessage(mindId, message, messageId, emit, model, attachments);
   });
 
@@ -22,11 +57,24 @@ export function setupChatIPC(chatService: ChatService, mindManager: MindManager)
 
   ipcMain.handle(IPC.CHAT.STOP, async (event, mindId: string, messageId: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
-    await chatService.cancelMessage(mindId, messageId);
-    if (win) win.webContents.send(IPC.CHAT.EVENT, mindId, messageId, { type: 'done' });
+    const cancelled = await chatService.cancelMessage(mindId, messageId);
+    if (cancelled) sendChatEvent(win, mindId, messageId, { type: 'done', cancelled: true });
   });
 
   ipcMain.handle(IPC.CHAT.NEW_CONVERSATION, async (_event, mindId: string) => {
     return chatService.newConversation(mindId);
+  });
+
+  ipcMain.handle(IPC.CHAT.GET_EVENT_SEQUENCE, () => chatEventSequence);
+
+  ipcMain.handle(IPC.CHAT.REPLAY_EVENTS, (_event, afterSequence: number) => {
+    const sequence = Number.isFinite(afterSequence) ? afterSequence : chatEventSequence;
+    const missed = replayEvents.filter((entry) => entry.sequence > sequence);
+    log.debug('chat:event:replay', {
+      afterSequence: sequence,
+      count: missed.length,
+      currentSequence: chatEventSequence,
+    });
+    return missed;
   });
 }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -13,6 +13,8 @@ const electronAPI: ElectronAPI = {
     newConversation: (mindId) =>
       ipcRenderer.invoke(IPC.CHAT.NEW_CONVERSATION, mindId),
     listModels: (mindId?) => ipcRenderer.invoke(IPC.CHAT.LIST_MODELS, mindId),
+    getEventSequence: () => ipcRenderer.invoke(IPC.CHAT.GET_EVENT_SEQUENCE),
+    replayEvents: (afterSequence) => ipcRenderer.invoke(IPC.CHAT.REPLAY_EVENTS, afterSequence),
     onEvent: (callback) => createIpcListener(ipcRenderer, IPC.CHAT.EVENT, callback),
   },
   conversationHistory: {

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -52,7 +52,7 @@ export interface ChamberCtx {
   logoutAuth: () => void | Promise<void>;
   listChamberTools: () => unknown;
   saveAttachment: (attachment: { name: string; body: ArrayBuffer }) => Promise<unknown>;
-  cancelChat: (mindId: string, messageId: string) => Promise<void> | void;
+  cancelChat: (mindId: string, messageId: string) => Promise<boolean | void> | boolean | void;
   sendChat: (request: SendChatRequest) => Promise<void> | void;
   newConversation: (mindId: string) => Promise<unknown> | unknown;
   listModels: (mindId?: string) => ModelDto[] | Promise<ModelDto[]>;

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -140,6 +140,8 @@ export function installBrowserApi(): void {
         return { sessionId: '', messages: [], conversations: [] };
       },
       listModels: (): Promise<ModelInfo[]> => client.listModels(),
+      getEventSequence: async () => 0,
+      replayEvents: async () => [],
       onEvent: (callback) => {
         chatEventHandlers.add(callback);
         void openEventSocket();

--- a/apps/web/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.test.tsx
@@ -91,6 +91,24 @@ describe('ChatInput', () => {
     expect(onStop).toHaveBeenCalled();
   });
 
+  it('Enter while streaming does not stop or send', () => {
+    const onSend = vi.fn();
+    const onStop = vi.fn();
+    render(<ChatInput {...defaultProps} isStreaming={true} onSend={onSend} onStop={onStop} />);
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('Escape while streaming calls onStop', () => {
+    const onStop = vi.fn();
+    render(<ChatInput {...defaultProps} isStreaming={true} onStop={onStop} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(onStop).toHaveBeenCalledOnce();
+  });
+
   it('shows Loading models when no models available and not disabled', () => {
     render(<ChatInput {...defaultProps} />);
     expect(screen.getByText('Loading models…')).toBeTruthy();

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -255,7 +255,6 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
 
   const handleSubmit = useCallback(() => {
     if (isStreaming) {
-      onStop();
       return;
     }
     const hasText = input.trim().length > 0;
@@ -279,7 +278,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [input, attachments, isStreaming, disabled, onSend, onStop, closeShortcode, setInput]);
+  }, [input, attachments, isStreaming, disabled, onSend, closeShortcode, setInput]);
 
   const acceptShortcode = useCallback(
     (record: EmojiRecord) => {
@@ -373,6 +372,11 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         setShortcodeIndex((i) => Math.max(i - 1, 0));
         return;
       }
+    }
+    if (e.key === 'Escape' && isStreaming) {
+      e.preventDefault();
+      onStop();
+      return;
     }
     // 3) Default Enter submit / Shift+Enter newline.
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -507,9 +511,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
             </div>
 
             <button
-              onClick={handleSubmit}
+              onClick={isStreaming ? onStop : handleSubmit}
               disabled={disabled && !isStreaming}
-              aria-label={isStreaming ? 'Stop streaming' : 'Send message'}
+              aria-label={isStreaming ? 'Stop streaming (Escape)' : 'Send message'}
               className={cn(
                 'shrink-0 w-8 h-8 rounded-lg flex items-center justify-center transition-colors',
                 isStreaming

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.test.tsx
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { LensViewManifest, MindContext } from '@chamber/shared/types';
-import { installElectronAPI, mockElectronAPI } from '../../test/helpers';
+import { installElectronAPI, makeChatEvent, makeMessage, mockElectronAPI } from '../../test/helpers';
 import { AppStateProvider, useAppState } from '../lib/store';
 import type { AppState } from '../lib/store/state';
 import { useAppSubscriptions } from './useAppSubscriptions';
@@ -115,6 +115,100 @@ describe('useAppSubscriptions', () => {
 
     await waitFor(() => {
       expect(result.current.discoveredViews).toEqual([activeView]);
+    });
+  });
+
+  it('replays missed chat events when the window regains focus', async () => {
+    (api.chat.getEventSequence as ReturnType<typeof vi.fn>).mockResolvedValue(5);
+    (api.chat.replayEvents as ReturnType<typeof vi.fn>).mockResolvedValue([{
+      sequence: 6,
+      mindId: activeMind.mindId,
+      messageId: 'assistant-1',
+      event: makeChatEvent('done'),
+    }]);
+
+    const { result } = renderHook(() => {
+      useAppSubscriptions();
+      return useAppState();
+    }, {
+      wrapper: wrapper({
+        minds: [activeMind],
+        activeMindId: activeMind.mindId,
+        isStreaming: true,
+        streamingByMind: { [activeMind.mindId]: true },
+        messagesByMind: {
+          [activeMind.mindId]: [makeMessage([], { id: 'assistant-1', isStreaming: true })],
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(api.chat.getEventSequence).toHaveBeenCalled();
+    });
+
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => {
+      expect(api.chat.replayEvents).toHaveBeenCalledWith(5);
+      expect(result.current.streamingByMind[activeMind.mindId]).toBe(false);
+      expect(result.current.isStreaming).toBe(false);
+    });
+  });
+
+  it('replays lower missed chat events when a higher live event arrives first', async () => {
+    (api.chat.getEventSequence as ReturnType<typeof vi.fn>).mockResolvedValue(5);
+    let onChatEvent: Parameters<typeof api.chat.onEvent>[0] | undefined;
+    let resolveReplay: (events: Awaited<ReturnType<typeof api.chat.replayEvents>>) => void = () => undefined;
+    (api.chat.onEvent as ReturnType<typeof vi.fn>).mockImplementation((callback) => {
+      onChatEvent = callback;
+      return vi.fn();
+    });
+    (api.chat.replayEvents as ReturnType<typeof vi.fn>).mockReturnValue(new Promise((resolve) => {
+      resolveReplay = resolve;
+    }));
+
+    const { result } = renderHook(() => {
+      useAppSubscriptions();
+      return useAppState();
+    }, {
+      wrapper: wrapper({
+        minds: [activeMind],
+        activeMindId: activeMind.mindId,
+        isStreaming: true,
+        streamingByMind: { [activeMind.mindId]: true },
+        messagesByMind: {
+          [activeMind.mindId]: [makeMessage([], { id: 'assistant-1', isStreaming: true })],
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(api.chat.getEventSequence).toHaveBeenCalled();
+      expect(onChatEvent).toBeDefined();
+    });
+
+    window.dispatchEvent(new Event('focus'));
+    await waitFor(() => {
+      expect(api.chat.replayEvents).toHaveBeenCalledWith(5);
+    });
+
+    act(() => {
+      onChatEvent?.(activeMind.mindId, 'assistant-1', makeChatEvent('chunk', { content: 'late live chunk' }), 8);
+    });
+
+    await act(async () => {
+      resolveReplay([{
+        sequence: 6,
+        mindId: activeMind.mindId,
+        messageId: 'assistant-1',
+        event: makeChatEvent('done'),
+      }]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.streamingByMind[activeMind.mindId]).toBe(false);
+      expect(result.current.isStreaming).toBe(false);
     });
   });
 });

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.ts
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.ts
@@ -12,6 +12,8 @@ export function useAppSubscriptions() {
   const { minds, activeMindId } = useAppState();
   const dispatch = useAppDispatch();
   const viewsLoaded = useRef(false);
+  const lastChatEventSequence = useRef(0);
+  const seenChatEventSequences = useRef(new Set<number>());
 
   // Feature flags are app-owned, not user-configurable renderer state.
   useEffect(() => {
@@ -32,10 +34,67 @@ export function useAppSubscriptions() {
 
   // Chat event listener — must stay alive regardless of active view
   useEffect(() => {
-    const unsub = window.electronAPI.chat.onEvent((mindId, messageId, event) => {
+    let cancelled = false;
+
+    const markChatEventSequenceSeen = (sequence: number) => {
+      seenChatEventSequences.current.add(sequence);
+      lastChatEventSequence.current = Math.max(lastChatEventSequence.current, sequence);
+      if (seenChatEventSequences.current.size > 1_000) {
+        const floor = lastChatEventSequence.current - 1_000;
+        for (const seen of seenChatEventSequences.current) {
+          if (seen < floor) seenChatEventSequences.current.delete(seen);
+        }
+      }
+    };
+
+    const applyMissedEvents = async () => {
+      try {
+        const missed = await window.electronAPI.chat.replayEvents(lastChatEventSequence.current);
+        if (cancelled) return;
+        for (const entry of missed) {
+          if (seenChatEventSequences.current.has(entry.sequence)) continue;
+          markChatEventSequenceSeen(entry.sequence);
+          dispatch({
+            type: 'CHAT_EVENT',
+            payload: { mindId: entry.mindId, messageId: entry.messageId, event: entry.event },
+          });
+        }
+      } catch (err) {
+        log.error('Failed to replay missed chat events:', err);
+      }
+    };
+
+    void window.electronAPI.chat.getEventSequence()
+      .then((sequence) => {
+        if (!cancelled) {
+          lastChatEventSequence.current = Math.max(lastChatEventSequence.current, sequence);
+        }
+      })
+      .catch((err) => {
+        log.error('Failed to initialize chat event replay cursor:', err);
+      });
+
+    const unsub = window.electronAPI.chat.onEvent((mindId, messageId, event, sequence) => {
+      if (typeof sequence === 'number') {
+        if (seenChatEventSequences.current.has(sequence)) return;
+        markChatEventSequenceSeen(sequence);
+      }
       dispatch({ type: 'CHAT_EVENT', payload: { mindId, messageId, event } });
     });
-    return () => { unsub(); };
+
+    const onFocus = () => { void applyMissedEvents(); };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') void applyMissedEvents();
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      unsub();
+    };
   }, [dispatch]);
 
   // Listen for view discovery changes (file watcher)

--- a/apps/web/src/renderer/hooks/useChatStreaming.test.tsx
+++ b/apps/web/src/renderer/hooks/useChatStreaming.test.tsx
@@ -1,15 +1,18 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React from 'react';
 import { act, renderHook } from '@testing-library/react';
-import { AppStateProvider } from '../lib/store';
+import { AppStateProvider, useAppDispatch } from '../lib/store';
+import type { AppState } from '../lib/store/state';
 import { installElectronAPI, mockElectronAPI } from '../../test/helpers';
 import { useChatStreaming } from './useChatStreaming';
 
-function wrapper({ children }: { children: React.ReactNode }) {
-  return <AppStateProvider>{children}</AppStateProvider>;
+function wrapper(testInitialState?: Partial<AppState>) {
+  return function TestWrapper({ children }: { children: React.ReactNode }) {
+    return <AppStateProvider testInitialState={testInitialState}>{children}</AppStateProvider>;
+  };
 }
 
 describe('useChatStreaming', () => {
@@ -20,7 +23,7 @@ describe('useChatStreaming', () => {
   });
 
   it('sendMessage no-ops when no active mind', async () => {
-    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+    const { result } = renderHook(() => useChatStreaming(), { wrapper: wrapper() });
 
     await act(async () => {
       await result.current.sendMessage('Hello');
@@ -31,7 +34,7 @@ describe('useChatStreaming', () => {
   });
 
   it('sendMessage no-ops on empty string', async () => {
-    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+    const { result } = renderHook(() => useChatStreaming(), { wrapper: wrapper() });
 
     await act(async () => {
       await result.current.sendMessage('   ');
@@ -41,7 +44,7 @@ describe('useChatStreaming', () => {
   });
 
   it('stopStreaming no-ops when no active mind', async () => {
-    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+    const { result } = renderHook(() => useChatStreaming(), { wrapper: wrapper() });
 
     await act(async () => {
       await result.current.stopStreaming();
@@ -51,7 +54,45 @@ describe('useChatStreaming', () => {
   });
 
   it('isStreaming reflects state', () => {
-    const { result } = renderHook(() => useChatStreaming(), { wrapper });
+    const { result } = renderHook(() => useChatStreaming(), { wrapper: wrapper() });
     expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('stops the original streaming mind after switching away and back', async () => {
+    const firstMind = {
+      mindId: 'monica-1234',
+      mindPath: 'C:\\agents\\monica',
+      identity: { name: 'Monica', systemMessage: '' },
+      status: 'ready' as const,
+    };
+    const secondMind = {
+      mindId: 'q-1234',
+      mindPath: 'C:\\agents\\q',
+      identity: { name: 'Q', systemMessage: '' },
+      status: 'ready' as const,
+    };
+    const { result } = renderHook(() => ({
+      chat: useChatStreaming(),
+      dispatch: useAppDispatch(),
+    }), {
+      wrapper: wrapper({ minds: [firstMind, secondMind], activeMindId: firstMind.mindId }),
+    });
+
+    await act(async () => {
+      await result.current.chat.sendMessage('Hello');
+    });
+    const messageId = (api.chat.send as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
+
+    act(() => {
+      result.current.dispatch({ type: 'SET_ACTIVE_MIND', payload: secondMind.mindId });
+    });
+    act(() => {
+      result.current.dispatch({ type: 'SET_ACTIVE_MIND', payload: firstMind.mindId });
+    });
+    await act(async () => {
+      await result.current.chat.stopStreaming();
+    });
+
+    expect(api.chat.stop).toHaveBeenCalledWith(firstMind.mindId, messageId);
   });
 });

--- a/apps/web/src/renderer/hooks/useChatStreaming.ts
+++ b/apps/web/src/renderer/hooks/useChatStreaming.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useAppState, useAppDispatch } from '../lib/store';
 import { generateId } from '../lib/utils';
 import type { ChatImageAttachment, ImageBlock } from '@chamber/shared/types';
@@ -7,9 +7,9 @@ import { Logger } from '../lib/logger';
 const log = Logger.create('useChatStreaming');
 
 export function useChatStreaming() {
-  const { activeMindId, isStreaming, selectedModel } = useAppState();
+  const { activeMindId, isStreaming, selectedModel, streamingByMind } = useAppState();
   const dispatch = useAppDispatch();
-  const currentMessageId = useRef<string | null>(null);
+  const currentMessageIdByMind = useRef<Record<string, string>>({});
 
   const sendMessage = useCallback(async (content: string, attachments?: ChatImageAttachment[]) => {
     const hasText = content.trim().length > 0;
@@ -32,7 +32,7 @@ export function useChatStreaming() {
     dispatch({ type: 'ADD_USER_MESSAGE', payload: userMessage });
 
     const assistantId = generateId();
-    currentMessageId.current = assistantId;
+    currentMessageIdByMind.current[activeMindId] = assistantId;
     dispatch({
       type: 'ADD_ASSISTANT_MESSAGE',
       payload: { id: assistantId, timestamp: Date.now() },
@@ -49,10 +49,16 @@ export function useChatStreaming() {
   }, [activeMindId, isStreaming, selectedModel, dispatch]);
 
   const stopStreaming = useCallback(async () => {
-    if (currentMessageId.current && activeMindId) {
-      await window.electronAPI.chat.stop(activeMindId, currentMessageId.current);
+    if (activeMindId && currentMessageIdByMind.current[activeMindId]) {
+      await window.electronAPI.chat.stop(activeMindId, currentMessageIdByMind.current[activeMindId]);
     }
   }, [activeMindId]);
+
+  useEffect(() => {
+    if (activeMindId && !streamingByMind[activeMindId]) {
+      delete currentMessageIdByMind.current[activeMindId];
+    }
+  }, [activeMindId, streamingByMind]);
 
   return { sendMessage, stopStreaming, isStreaming };
 }

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -528,13 +528,22 @@ describe('appReducer', () => {
     expect(state.selectedModel).toBe('copilot:model-2');
   });
 
-  it('SET_ACTIVE_MIND preserves the selected mind streaming state', () => {
+  it('SET_ACTIVE_MIND preserves the selected mind chat streaming state', () => {
     const state = appReducer({
       ...withActiveMind,
       streamingByMind: { 'other-mind': true },
     }, { type: 'SET_ACTIVE_MIND', payload: 'other-mind' });
 
     expect(state.isStreaming).toBe(true);
+  });
+
+  it('SET_ACTIVE_MIND ignores selected mind A2A streaming state', () => {
+    const state = appReducer({
+      ...withActiveMind,
+      a2aStreamingByMind: { 'other-mind': true },
+    }, { type: 'SET_ACTIVE_MIND', payload: 'other-mind' });
+
+    expect(state.isStreaming).toBe(false);
   });
 
   it('ADD_MIND appends a new mind and sets it active if none active', () => {
@@ -760,14 +769,15 @@ describe('appReducer', () => {
       expect(msgs[1].isStreaming).toBe(true);
     });
 
-    it('sets streamingByMind for target mind', () => {
+    it('sets a2aStreamingByMind for target mind', () => {
       const state = appReducer(withActiveMind, { type: 'A2A_INCOMING', payload: a2aPayload() });
-      expect(state.streamingByMind[mindId]).toBe(true);
+      expect(state.a2aStreamingByMind[mindId]).toBe(true);
+      expect(state.streamingByMind[mindId]).toBeUndefined();
     });
 
-    it('sets global isStreaming true when target is active mind', () => {
+    it('does not set global isStreaming when target is active mind', () => {
       const state = appReducer(withActiveMind, { type: 'A2A_INCOMING', payload: a2aPayload() });
-      expect(state.isStreaming).toBe(true);
+      expect(state.isStreaming).toBe(false);
     });
 
     it('records inactive mind relay messages without stealing focus', () => {
@@ -778,7 +788,8 @@ describe('appReducer', () => {
       expect(state.activeMindId).toBe(mindId);
       expect(state.activeView).toBe(withActiveMind.activeView);
       expect(state.isStreaming).toBe(withActiveMind.isStreaming);
-      expect(state.streamingByMind['other-mind']).toBe(true);
+      expect(state.a2aStreamingByMind['other-mind']).toBe(true);
+      expect(state.streamingByMind['other-mind']).toBeUndefined();
       expect(state.messagesByMind['other-mind']).toHaveLength(2);
     });
 

--- a/apps/web/src/renderer/lib/store/reducers/a2aReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/a2aReducer.ts
@@ -38,8 +38,7 @@ function a2aIncoming(state: AppState, action: Extract<AppAction, { type: 'A2A_IN
       ...state.messagesByMind,
       [targetMindId]: [...targetMsgs, senderMessage, replyPlaceholder],
     },
-    streamingByMind: { ...state.streamingByMind, [targetMindId]: true },
-    isStreaming: targetMindId === state.activeMindId ? true : state.isStreaming,
+    a2aStreamingByMind: { ...state.a2aStreamingByMind, [targetMindId]: true },
   };
 }
 
@@ -61,8 +60,12 @@ function taskStatusUpdate(
     const newTask: Task = { id: taskId, contextId, status };
     updatedTasks = [...existingTasks, newTask];
   }
+  const isTerminal = TERMINAL_TASK_STATES.has(status.state);
   return {
     tasksByMind: { ...state.tasksByMind, [targetMindId]: updatedTasks },
+    ...(isTerminal
+      ? { a2aStreamingByMind: { ...state.a2aStreamingByMind, [targetMindId]: false } }
+      : {}),
   };
 }
 

--- a/apps/web/src/renderer/lib/store/reducers/mindsReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/mindsReducer.ts
@@ -52,12 +52,14 @@ function removeMind(state: AppState, action: Extract<AppAction, { type: 'REMOVE_
   const newActiveConversationByMind = { ...state.activeConversationByMind };
   const newConversationViewByMind = { ...state.conversationViewByMind };
   const newComposeDraftByMind = { ...state.composeDraftByMind };
+  const newA2aStreamingByMind = { ...state.a2aStreamingByMind };
   const newAgentProfileByMindId = { ...state.agentProfileByMindId };
   delete newMsgsByMind[action.payload];
   delete newConversationHistoryByMind[action.payload];
   delete newActiveConversationByMind[action.payload];
   delete newConversationViewByMind[action.payload];
   delete newComposeDraftByMind[action.payload];
+  delete newA2aStreamingByMind[action.payload];
   delete newAgentProfileByMindId[action.payload];
   const newActive = state.activeMindId === action.payload
     ? (newMinds.length > 0 ? newMinds[0].mindId : null)
@@ -70,6 +72,7 @@ function removeMind(state: AppState, action: Extract<AppAction, { type: 'REMOVE_
     activeConversationByMind: newActiveConversationByMind,
     conversationViewByMind: newConversationViewByMind,
     composeDraftByMind: newComposeDraftByMind,
+    a2aStreamingByMind: newA2aStreamingByMind,
     agentProfileByMindId: newAgentProfileByMindId,
     showLanding: newMinds.length === 0,
   };

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -36,6 +36,7 @@ export interface AppState {
   conversationViewByMind: Record<string, ConversationViewState>;
   isStreaming: boolean;
   streamingByMind: Record<string, boolean>;
+  a2aStreamingByMind: Record<string, boolean>;
   /**
    * Per-mind unsent compose draft text. Switching agents preserves and
    * restores each mind's in-progress message so users can stage thoughts
@@ -124,6 +125,7 @@ export const initialState: AppState = {
   conversationViewByMind: {},
   isStreaming: false,
   streamingByMind: {},
+  a2aStreamingByMind: {},
   composeDraftByMind: {},
   availableModels: [],
   selectedModel: null,

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -117,6 +117,8 @@ export function mockElectronAPI(): ElectronAPI {
       stop: vi.fn().mockResolvedValue(undefined),
       newConversation: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
       listModels: vi.fn().mockResolvedValue([]),
+      getEventSequence: vi.fn().mockResolvedValue(0),
+      replayEvents: vi.fn().mockResolvedValue([]),
       onEvent: vi.fn().mockReturnValue(vi.fn()),
     },
     conversationHistory: {

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -223,10 +223,32 @@ describe('ChatService', () => {
   });
 
   describe('cancelMessage', () => {
-    it('aborts the session for a mind', async () => {
+    it('does not abort the session when no message is streaming', async () => {
       mockSession.on.mockReturnValue(vi.fn());
-      await svc.cancelMessage('valid-mind', 'msg-1');
-      expect(mockSession.abort).toHaveBeenCalled();
+      await expect(svc.cancelMessage('valid-mind', 'msg-1')).resolves.toBe(false);
+      expect(mockSession.abort).not.toHaveBeenCalled();
+    });
+
+    it('aborts the session for a mind with an active message', async () => {
+      let resolveSend: (() => void) | undefined;
+      mockSession.on.mockReturnValue(vi.fn());
+      mockSession.send.mockImplementation(() => new Promise<void>((resolve) => {
+        resolveSend = resolve;
+      }));
+
+      const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', vi.fn());
+      try {
+        await vi.waitFor(() => {
+          expect(mockSession.send).toHaveBeenCalled();
+        });
+
+        await expect(svc.cancelMessage('valid-mind', 'msg-1')).resolves.toBe(true);
+        expect(mockSession.abort).toHaveBeenCalled();
+      } finally {
+        resolveSend?.();
+        mockSession.send.mockResolvedValue(undefined);
+        await pending;
+      }
     });
 
     it('clears the streaming guard immediately when the user stops a wedged send', async () => {
@@ -244,7 +266,7 @@ describe('ChatService', () => {
 
         await expect(svc.resumeConversation('valid-mind', 'session-1')).rejects.toThrow('Cannot switch conversations');
 
-        await svc.cancelMessage('valid-mind', 'msg-1');
+        await expect(svc.cancelMessage('valid-mind', 'msg-1')).resolves.toBe(true);
 
         await expect(svc.resumeConversation('valid-mind', 'session-1')).resolves.toEqual({
           sessionId: 'session-1',
@@ -690,6 +712,34 @@ describe('ChatService', () => {
         await vi.advanceTimersByTimeAsync(1_000);
         await pending;
 
+        expect(emit).toHaveBeenCalledWith({ type: 'done' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not complete when a new root turn starts after tool completion', async () => {
+      vi.useFakeTimers();
+      try {
+        mockSession.send.mockImplementation(async () => {
+          fireSdkEvent({ type: 'assistant.message', data: { messageId: 'm1', content: 'I will use the tool.' } });
+          fireSdkEvent({ type: 'tool.execution_start', data: { toolCallId: 't1', toolName: 'cron_create' } });
+          fireSdkEvent({ type: 'tool.execution_complete', data: { toolCallId: 't1', success: true } });
+          fireSdkEvent({ type: 'assistant.turn_end', data: { turnId: 't1' } });
+          fireSdkEvent({ type: 'assistant.turn_start', data: { turnId: 't2' } });
+        });
+
+        const emit = vi.fn();
+        const pending = svc.sendMessage('valid-mind', 'hello', 'msg-1', emit);
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(emit).not.toHaveBeenCalledWith({ type: 'done' });
+
+        fireSdkEvent({ type: 'assistant.message', data: { messageId: 'm2', content: 'final output' } });
+        fireSdkEvent({ type: 'assistant.turn_end', data: { turnId: 't2' } });
+        await vi.advanceTimersByTimeAsync(1_000);
+        await pending;
+
+        expect(emit).toHaveBeenCalledWith({ type: 'message_final', sdkMessageId: 'm2', content: 'final output' });
         expect(emit).toHaveBeenCalledWith({ type: 'done' });
       } finally {
         vi.useRealTimers();

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -213,8 +213,12 @@ export class ChatService {
       if (event.type === 'permission.completed' && typeof event.data?.requestId === 'string') {
         pendingPermissionIds.delete(event.data.requestId);
       }
-      if (event.type === 'assistant.turn_start' && typeof event.agentId === 'string') {
-        activeSubAgentIds.add(event.agentId);
+      if (event.type === 'assistant.turn_start') {
+        if (typeof event.agentId === 'string') {
+          activeSubAgentIds.add(event.agentId);
+        } else {
+          sawRootTurnEnd = false;
+        }
       }
       if (event.type === 'assistant.turn_end') {
         if (typeof event.agentId === 'string') {
@@ -366,17 +370,17 @@ export class ChatService {
     }
   }
 
-  async cancelMessage(mindId: string, _messageId: string): Promise<void> {
+  async cancelMessage(mindId: string, _messageId: string): Promise<boolean> {
     void _messageId;
     const controller = this.abortControllers.get(mindId);
-    if (controller) {
-      controller.abort();
-      this.abortControllers.delete(mindId);
-    }
+    if (!controller) return false;
+    controller.abort();
+    this.abortControllers.delete(mindId);
     const context = this.mindManager.getMind(mindId);
     if (context?.session) {
       await context.session.abort().catch(() => { /* noop */ });
     }
+    return true;
   }
 
   async setMindModel(mindId: string, model: string | null): Promise<Awaited<ReturnType<MindManager['setMindModel']>>> {

--- a/packages/shared/src/electron-types.test.ts
+++ b/packages/shared/src/electron-types.test.ts
@@ -12,6 +12,8 @@ describe('ElectronAPI contract', () => {
   it('exposes the major namespaces with the expected method shapes', () => {
     expectTypeOf<ElectronAPI['chat']['send']>().toBeFunction();
     expectTypeOf<ElectronAPI['chat']['stop']>().toBeFunction();
+    expectTypeOf<ElectronAPI['chat']['getEventSequence']>().toBeFunction();
+    expectTypeOf<ElectronAPI['chat']['replayEvents']>().toBeFunction();
     expectTypeOf<ElectronAPI['chat']['onEvent']>().toBeFunction();
 
     expectTypeOf<ElectronAPI['mind']['list']>().toBeFunction();

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -32,6 +32,7 @@ import type {
   ByoLlmSaveResult,
   ChatEvent,
   ChatImageAttachment,
+  ChatReplayEvent,
   ConversationResumeResult,
   ConversationSummary,
   DesktopUpdateActionResult,
@@ -56,7 +57,9 @@ export interface ElectronAPI {
     stop: (mindId: string, messageId: string) => Promise<void>;
     newConversation: (mindId: string) => Promise<ConversationResumeResult>;
     listModels: (mindId?: string) => Promise<ModelInfo[]>;
-    onEvent: (callback: (mindId: string, messageId: string, event: ChatEvent) => void) => () => void;
+    getEventSequence: () => Promise<number>;
+    replayEvents: (afterSequence: number) => Promise<ChatReplayEvent[]>;
+    onEvent: (callback: (mindId: string, messageId: string, event: ChatEvent, sequence?: number) => void) => () => void;
   };
   conversationHistory: {
     list: (mindId: string) => Promise<ConversationSummary[]>;

--- a/packages/shared/src/ipc-channels.test.ts
+++ b/packages/shared/src/ipc-channels.test.ts
@@ -7,6 +7,8 @@ describe('IPC channel constants', () => {
     expect(IPC.CHAT.STOP).toBe('chat:stop');
     expect(IPC.CHAT.NEW_CONVERSATION).toBe('chat:newConversation');
     expect(IPC.CHAT.LIST_MODELS).toBe('chat:listModels');
+    expect(IPC.CHAT.GET_EVENT_SEQUENCE).toBe('chat:getEventSequence');
+    expect(IPC.CHAT.REPLAY_EVENTS).toBe('chat:replayEvents');
     expect(IPC.CHAT.EVENT).toBe('chat:event');
 
     expect(IPC.CONVERSATION_HISTORY.LIST).toBe('conversationHistory:list');

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -17,6 +17,8 @@ export const IPC = {
     STOP: 'chat:stop',
     NEW_CONVERSATION: 'chat:newConversation',
     LIST_MODELS: 'chat:listModels',
+    GET_EVENT_SEQUENCE: 'chat:getEventSequence',
+    REPLAY_EVENTS: 'chat:replayEvents',
     EVENT: 'chat:event',
   },
   CONVERSATION_HISTORY: {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -83,9 +83,16 @@ export type ChatEvent =
   | { type: 'permission_request'; requestId: string; kind: PermissionRequestKind; summary: string; toolCallId?: string }
   | { type: 'permission_outcome'; requestId: string; outcome: Exclude<PermissionOutcome, 'pending'> }
   | { type: 'reconnecting' }
-  | { type: 'done' }
+  | { type: 'done'; cancelled?: boolean }
   | { type: 'timeout'; timeoutMs: number }
   | { type: 'error'; message: string };
+
+export interface ChatReplayEvent {
+  sequence: number;
+  mindId: string;
+  messageId: string;
+  event: ChatEvent;
+}
 
 // ---------------------------------------------------------------------------
 // Chat message

--- a/tests/e2e/electron/settings-add-account.spec.ts
+++ b/tests/e2e/electron/settings-add-account.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -44,14 +44,9 @@ test.describe('electron Settings Add Account device-code smoke (#214)', () => {
     await page.waitForLoadState('domcontentloaded');
     await expect(page.locator('#root')).not.toBeEmpty();
 
-    await page.evaluate(async (pathToMind) => {
-      const mind = await window.electronAPI.mind.add(pathToMind);
-      await window.electronAPI.mind.setActive(mind.mindId);
-    }, mindPath);
+    await loadMind(page, mindPath);
 
-    await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible();
-    await page.getByRole('button', { name: 'Settings' }).click();
-    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await openSettings(page);
 
     // Open the account dropdown and choose + Add Account.
     await page.getByRole('combobox').click();
@@ -87,6 +82,7 @@ test.describe('electron Settings Add Account device-code smoke (#214)', () => {
   test('Cancel dismisses the modal and aborts the in-flight login', async () => {
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await page.waitForLoadState('domcontentloaded');
+    await loadMind(page, mindPath);
 
     // Ensure no leftover dialog from a prior test is in the DOM.
     const leftover = page.getByRole('dialog');
@@ -98,7 +94,7 @@ test.describe('electron Settings Add Account device-code smoke (#214)', () => {
       }
     }
 
-    await page.getByRole('button', { name: 'Settings' }).click();
+    await openSettings(page);
     await page.getByRole('combobox').click();
     await page.getByRole('option', { name: '+ Add Account' }).click();
 
@@ -109,6 +105,23 @@ test.describe('electron Settings Add Account device-code smoke (#214)', () => {
     await expect(dialog).toBeHidden();
   });
 });
+
+async function loadMind(page: Page, targetMindPath: string): Promise<void> {
+  await page.evaluate(async (pathToMind) => {
+    const loaded = await window.electronAPI.mind.list();
+    const existing = loaded.find((mind) => mind.mindPath === pathToMind);
+    const mind = existing ?? await window.electronAPI.mind.add(pathToMind);
+    await window.electronAPI.mind.setActive(mind.mindId);
+  }, targetMindPath);
+}
+
+async function openSettings(page: Page): Promise<void> {
+  const heading = page.getByRole('heading', { name: 'Settings' });
+  if (!await heading.isVisible()) {
+    await page.getByRole('button', { name: 'Settings' }).click();
+  }
+  await expect(heading).toBeVisible();
+}
 
 function seedMind(seedPath: string): void {
   fs.mkdirSync(path.join(seedPath, '.github', 'agents'), { recursive: true });


### PR DESCRIPTION
## Summary
Fixes the #297 false-completion and spurious-cancellation paths in single-chat turns, and adds a lightweight renderer catch-up path for missed chat events after window focus/visibility recovery.

## Notable changes
- Makes Enter a no-op while chat is streaming and moves keyboard cancellation to Escape / explicit Stop.
- Separates A2A streaming state from normal chat streaming so relay/cron activity cannot make chat input send a stale Stop.
- Guards `ChatService.cancelMessage()` so `session.abort()` only runs for an active chat turn, and emits cancelled terminal events only when cancellation actually happened.
- Adds main-process chat event sequencing/replay plus renderer focus/visibility replay handling, including duplicate-safe sequence tracking.
- Fixes defensive completion so a new root `assistant.turn_start` after a tool call prevents premature `done`.
- Hardens the Settings Add Account smoke test so each test loads its own mind and opens Settings idempotently.

Fixes #297

## Test evidence
- `npm run lint` passed.
- Focused regression suite passed: `npm test -- --run apps/web/src/renderer/hooks/useAppSubscriptions.test.tsx apps/web/src/renderer/hooks/useChatStreaming.test.tsx apps/web/src/renderer/components/chat/ChatInput.test.tsx apps/web/src/renderer/lib/store/reducer.test.ts packages/services/src/chat/ChatService.test.ts packages/shared/src/ipc-channels.test.ts packages/shared/src/electron-types.test.ts` (218 tests).
- `npm run smoke:sdk` passed.
- `npm test` passed except the known Windows symlink-permission baseline in `packages/services/src/mindProfile/MindProfileService.test.ts` (`EPERM: operation not permitted, symlink`).
- `npm run smoke:desktop`: repaired cron and Settings smokes passed in the full rerun; the run then hit a transient `model-switch-context` renderer-discovery startup timeout. Focused rerun of that smoke passed.
- Focused Electron smoke rerun passed for cron + Settings: `playwright test --config config/playwright.config.ts --project=electron --workers=1 --grep "cron tools smoke|Settings Add Account"`.

## Skipped smoke
- `npm run make:sandbox` / packaging smoke not run; packaging, runtime resources, installer, and first-launch packaging paths were not changed.
