### PR TITLE
Classify extension cleanup as changelog maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking
-
-- **Move the A2A client extension out of Chamber** — The repo-scoped `.github/extensions/a2a-client` copy has moved to the standalone [`ipdelete/a2a-client`](https://github.com/ipdelete/a2a-client) extension, which installs to user or repo scope and exposes the `a2a_connection`, `a2a_list_remote_agents`, and `a2a_send_agent_message` tools.
-- **Remove the repo-scoped Canvas extension** — The `.github/extensions/canvas` copy has been removed from Chamber now that Canvas lives as a standalone extension.
-
 ### Fixed
 
 - **Surface ambiguous A2A recipients** — A2A message routing now reports duplicate display-name matches with usable recipient identifiers instead of falling through to an unknown-recipient error. (#322) (#322)
 - **Complete turns after root turn end** — Chat streaming now finishes after a guarded root assistant.turn_end quiescence path when the SDK omits session.idle, while still waiting for outstanding tools and sub-agent turns so late output is preserved. (#297) (#297)
 - **Prevent false chat completion and missed UI updates** — Chat cancellation now requires an active turn, A2A and cron streaming state no longer contaminates chat input, and renderer chat events replay after window refocus so hidden-window work can catch up. Fixes #297. (#297)
+
+### Chore
+
+- **Move the A2A client extension out of Chamber** — The repo-scoped `.github/extensions/a2a-client` copy has moved to the standalone [`ipdelete/a2a-client`](https://github.com/ipdelete/a2a-client) extension, which installs to user or repo scope and exposes the `a2a_connection`, `a2a_list_remote_agents`, and `a2a_send_agent_message` tools.
+- **Remove the repo-scoped Canvas extension** — The `.github/extensions/canvas` copy has been removed from Chamber now that Canvas lives as a standalone extension.
 
 
 ## [0.63.0] - 2026-05-17


### PR DESCRIPTION
## Summary
Reclassifies repo-scoped CLI extension extraction as changelog maintenance instead of a product-breaking change.

## Why
The A2A client and Canvas extension bullets describe cleanup/migration of Copilot CLI extensions into their own repos. They should not mechanically drive Chamber's Model B release flow to target `1.0.0`.

## Validation
- `node scripts/bump-insiders-version.js --dry-run` now computes `0.63.1-insiders.0` from the current Unreleased section.
- `npm run lint:md` passed.

## Release note
This follows rollback of accidental `v1.0.0-insiders.0` feed/tag.
