### PR TITLE
Fix black-screen on packaged macOS launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fix black-screen launch on packaged macOS builds** — `app.on('ready')` no longer awaits `chamberCopilotService.prewarm()`. When the bundled Copilot CLI hangs during ACP handshake (observed in re-signed darwin-arm64 packages), awaiting prewarm blocked `createWindow()` and the app booted with no visible window. prewarm() is best-effort by design, so it now runs fire-and-forget.
+- **Fix silent `electron-forge package` exit on Node 24** — Added an npm override pinning `yauzl@^3.3.1`. The transitive `yauzl@2.10.0` used by `extract-zip` returns a readable stream that emits no events on Node 24, causing electron-packager's Electron template extraction to abandon mid-extract and the process to exit with no output and no `Chamber-darwin-arm64/` artifact.
 - **Surface ambiguous A2A recipients** — A2A message routing now reports duplicate display-name matches with usable recipient identifiers instead of falling through to an unknown-recipient error. (#322) (#322)
 - **Complete turns after root turn end** — Chat streaming now finishes after a guarded root assistant.turn_end quiescence path when the SDK omits session.idle, while still waiting for outstanding tools and sub-agent turns so late output is preserved. (#297) (#297)
 - **Prevent false chat completion and missed UI updates** — Chat cancellation now requires an active turn, A2A and cron streaming state no longer contaminates chat input, and renderer chat events replay after window refocus so hidden-window work can catch up. Fixes #297. (#297)

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -701,8 +701,15 @@ app.on('ready', async () => {
   // MindManager.doLoadMind calls getSessionTools BEFORE activateProviders;
   // without prewarm the first mind in a fresh process boots without the
   // cli_* tools. prewarm() swallows failures and logs.
+  //
+  // INVARIANT: Do NOT await prewarm here. The child Copilot CLI can hang
+  // during ACP handshake (observed in packaged macOS builds where the
+  // re-signed CLI exits 1 with no output), and awaiting would block
+  // createWindow() below — producing a no-window "black screen" boot.
+  // prewarm() is best-effort by design (swallows errors); the first mind
+  // load racing prewarm is the acceptable tradeoff for guaranteed UI.
   if (chamberCopilotService) {
-    await chamberCopilotService.prewarm();
+    void chamberCopilotService.prewarm();
   }
 
   // --- IPC adapters (thin, parameter-injected) ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -9816,16 +9816,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -17634,14 +17624,17 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+      "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
       "@electron/fuses": "$@electron/fuses"
     },
     "@electron/rebuild": "^4.0.4",
-    "tmp": "^0.2.5"
+    "tmp": "^0.2.5",
+    "yauzl": "^3.3.1"
   }
 }


### PR DESCRIPTION
Two independent regressions made packaged macOS builds unusable. Both are fixed here.

## 1. `prewarm()` await blocks window creation

`apps/desktop/src/main.ts` awaited `chamberCopilotService.prewarm()` in `app.on('ready')` before `createWindow()`. In packaged darwin-arm64 builds the re-signed bundled Copilot CLI hangs during ACP handshake (exits 1 with no output when invoked with `--acp --no-auto-update`), so the await never resolved and the window never opened — black screen behind the menubar.

`prewarm()` is documented as best-effort and swallows its own errors. It now runs fire-and-forget. The packaged-CLI ACP issue itself is not fixed by this PR; `cli_*` tools remain unavailable on packaged macOS until that's addressed separately.

## 2. `electron-forge package` exits silently on Node 24

`npm run package` and `npm run make:mac` finished with exit 0 and no `out/Chamber-darwin-arm64/` artifact. Root cause: `yauzl@2.10.0` (transitive via `extract-zip@2.0.1`) returns a read stream that emits no `data`/`end`/`error` events on Node 24.16.0, so electron-packager's Electron template extraction abandons mid-extract and the event loop drains.

Pinned `yauzl@^3.3.1` via npm `overrides`. The same extraction completes cleanly. `extract-zip` has no release that depends on yauzl@3 yet, so the override is necessary.

## Verification

- `npm start` — still launches dev shell cleanly.
- `npm run make:mac` (unsigned) — produces `out/builder/Chamber-0.63.0-arm64.dmg` (358 MB). Installed DMG launches with a visible window.