### PR TITLE
Correct insiders channel platform coverage in release skill

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Dispatch a Chamber release build to either the insiders channel (Azure blob, Windows-only, invite-only testers) or the stable channel (public GitHub Releases, Windows + macOS). Use this skill whenever the user asks to release, cut, publish, promote, ship a build, push to insiders, send to testers, go public, or make a new version available — even if they don't explicitly name a channel. This skill picks the channel, runs pre-flight checks, handles stable remote feature-flag graduation when needed, dispatches the matching workflow via `gh`, and reports back. It may open mechanical release/policy PRs but never merges anything without explicit user approval.
+description: Dispatch a Chamber release build to either the insiders channel (Azure blob, Windows + macOS, invite-only testers) or the stable channel (public GitHub Releases, Windows + macOS). Use this skill whenever the user asks to release, cut, publish, promote, ship a build, push to insiders, send to testers, go public, or make a new version available — even if they don't explicitly name a channel. This skill picks the channel, runs pre-flight checks, handles stable remote feature-flag graduation when needed, dispatches the matching workflow via `gh`, and reports back. It may open mechanical release/policy PRs but never merges anything without explicit user approval.
 ---
 
 # Release Skill
@@ -31,7 +31,7 @@ ask once. If the channel is ambiguous, ask once.
 
 | Channel  | Audience    | Workflow                                  | Distribution                     | Platforms                           |
 | -------- | ----------- | ----------------------------------------- | -------------------------------- | ----------------------------------- |
-| Insiders | Invite-only | `.github/workflows/release-insiders.yml`  | Azure Blob `chamberinsiders`     | Windows only                        |
+| Insiders | Invite-only | `.github/workflows/release-insiders.yml`  | Azure Blob `chamberinsiders`     | Windows + macOS arm64 (signed + notarized) |
 | Stable   | Public      | `.github/workflows/release.yml`           | GitHub Releases                  | Windows + macOS arm64 (+x64 opt-in; macOS can be disabled by repo variable) |
 
 Both are `workflow_dispatch` only — neither fires on push.
@@ -157,7 +157,7 @@ Required state:
 
 ```
 Which channel?
-  insiders  – Windows-only, invite-only, fast cadence, no notarization
+  insiders  – Windows + macOS arm64 (signed + notarized), invite-only, fast cadence
   stable    – public, full platforms, requires macOS notary warmup
 ```
 
@@ -225,11 +225,14 @@ git fetch origin --tags --quiet
 git tag -l 'v*-insiders.*' --sort=-v:refname | head -3
 ```
 
-Surface the new tag, the install URL
+Surface the new tag, the Windows install URL
 (`https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe`),
-and the auto-update feed
-(`https://chamberinsiders.blob.core.windows.net/releases/insiders.yml`).
-Existing testers auto-update; new testers need the install URL
+the macOS DMG
+(`https://chamberinsiders.blob.core.windows.net/releases/Chamber-<version>-arm64.dmg`),
+and the auto-update feeds
+(`https://chamberinsiders.blob.core.windows.net/releases/insiders.yml` for Windows;
+`https://chamberinsiders.blob.core.windows.net/releases/latest-mac.yml` for macOS).
+Existing testers auto-update on both platforms; new testers need the install URL
 out-of-band.
 
 ### 3b. Stable dispatch
@@ -578,11 +581,12 @@ see exactly what happened. Example:
 
 ```
 ✅ Dispatched insiders release
-   - Channel:      insiders (Windows only)
+   - Channel:      insiders (Windows + macOS arm64)
    - Next tag:     v0.62.4-insiders.4
    - Audience:     invited testers only
    - Install URL:  https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe
-   - Auto-update:  existing testers receive it automatically
+   - macOS DMG:    https://chamberinsiders.blob.core.windows.net/releases/Chamber-<version>-arm64.dmg
+   - Auto-update:  existing testers receive it automatically (both platforms)
    - Run:          <gh URL>
    - Checklist:    ~/.copilot/session-state/<id>/files/release-vX.Y.Z-<channel>-checklist.md
 ```

--- a/.github/skills/release/assets/insiders-checklist.md
+++ b/.github/skills/release/assets/insiders-checklist.md
@@ -29,7 +29,7 @@ placeholders haven't been substituted yet.
 
 ## Phase 2 — Channel chosen: insiders
 
-- [ ] `[channel-confirmed]` User confirmed `insiders` (Windows-only, invite-only).
+- [ ] `[channel-confirmed]` User confirmed `insiders` (Windows + macOS arm64, invite-only).
 
 ## Phase 3a — Compute & dispatch
 
@@ -42,8 +42,8 @@ placeholders haven't been substituted yet.
 ## Phase 3a.4 — After success
 
 - [ ] `[tag-pushed]` New tag `v{{VERSION}}` appears in `git tag -l 'v*-insiders.*' --sort=-v:refname | head -3`.
-- [ ] `[install-url-surfaced]` Install URL surfaced to user: <https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe>
-- [ ] `[update-feed-surfaced]` Auto-update feed surfaced: <https://chamberinsiders.blob.core.windows.net/releases/insiders.yml>
+- [ ] `[install-url-surfaced]` Install URLs surfaced to user: Windows <https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe> and macOS arm64 DMG at `Chamber-{{VERSION}}-arm64.dmg` under the same blob root.
+- [ ] `[update-feed-surfaced]` Auto-update feeds surfaced: <https://chamberinsiders.blob.core.windows.net/releases/insiders.yml> (Windows) and <https://chamberinsiders.blob.core.windows.net/releases/latest-mac.yml> (macOS).
 - [ ] `[tester-note]` Reminded user that existing testers auto-update; new testers need the install URL out-of-band.
 
 ## Phase 4 — Summary


### PR DESCRIPTION
The release skill described the insiders channel as 'Windows-only' in five places, but `.github/workflows/release-insiders.yml` has had a signed + notarized `build-macos` job as a hard `publish` dependency for a while. Insiders ships both Windows and macOS arm64 in lockstep — when I dispatched v0.64.0-insiders.3 today the skill told the user the build was Windows-only, which is wrong.

## Changes

`SKILL.md`:
- Frontmatter `description` — insiders now says 'Windows + macOS, invite-only testers'.
- Channel-table 'Platforms' column for insiders — 'Windows + macOS arm64 (signed + notarized)'.
- Phase 2 channel-picker prompt.
- Phase 3a.4 'After success' block — surfaces the macOS DMG path and `latest-mac.yml` feed alongside the existing Windows EXE and `insiders.yml` feed.
- Phase 4 summary template — extra `macOS DMG` line.

`assets/insiders-checklist.md`:
- `[channel-confirmed]` line.
- `[install-url-surfaced]` and `[update-feed-surfaced]` lines updated to cover both platforms.

No workflow changes — purely a documentation correction. The stable-side `STABLE_RELEASE_BUILD_MACOS=false` opt-in (which legitimately produces Windows-only stable artifacts) is unchanged.