### PR TITLE
chore(release): bump master to v0.64.0 post-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-06-01
+
 ### Fixed
 
 - **Fix "CLI server exited unexpectedly with code 1" on packaged macOS builds** — The bundled `@github/copilot` CLI is a Node.js Single Executable Application. `electron-osx-sign` was re-signing it with default Electron entitlements (audio, bluetooth, camera, etc.) which lack `com.apple.security.cs.allow-unsigned-executable-memory` and `com.apple.security.cs.disable-library-validation`. Under hardened runtime, V8's JIT could not allocate executable memory and the kernel SIGKILLed the process immediately, producing no stdout/stderr. `scripts/sign-macos-prepackaged.js` now re-signs the SEA binary with a dedicated entitlements plist (`assets/entitlements.copilot-cli.mac.plist`) after the main `electron-osx-sign` pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "//copilotPin": "@github/copilot is pinned in devDependencies AND chamber-copilot-runtime/package.json — both must match. Pin drift / make:sandbox version-mismatch? See ai-docs/copilot-runtime-version-pin.html.",
   "main": ".vite/build/main.js",


### PR DESCRIPTION
Post-release bump anchored to build SHA `61d0fce57e892c7456910bf13a87f32e162bc017` (tag `v0.64.0-insiders.8`). Master now reflects the freshly shipped stable version. `## [Unreleased]` content at build time has been promoted to `## [0.64.0] - 2026-06-01` in CHANGELOG.md (Keep a Changelog 1.1.0 format).

Build-SHA: 61d0fce57e892c7456910bf13a87f32e162bc017
Source-Ref: v0.64.0-insiders.8

The automatic post-release bump workflow did not fire after the stable tag push, so this is the release skill manual fallback.

If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new `## [0.64.0] - 2026-06-01` section AS-IS, and keep any `## [Unreleased]` bullets that landed during the build window under a fresh `## [Unreleased]` block above it. Do not rebase or merge master into this branch.

Review and merge after green checks.