### PR TITLE
chore(release): bump master to v0.64.1 post-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.1] - 2026-06-01
+
 ### Fixed
 
 - **Load marketplace-installed skills in SDK sessions** — Mind sessions now pass each mind's `.github/skills` parent directory through `skillDirectories` when creating or resuming Copilot SDK sessions, so the SDK `skill` tool can discover marketplace-installed skills like `ttasks` and `automation`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chamber",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chamber",
-      "version": "0.64.0",
+      "version": "0.64.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chamber",
   "productName": "Chamber",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Genesis Mind Interface — desktop chat UI for Genesis agents",
   "//copilotPin": "@github/copilot is pinned in devDependencies AND chamber-copilot-runtime/package.json — both must match. Pin drift / make:sandbox version-mismatch? See ai-docs/copilot-runtime-version-pin.html.",
   "main": ".vite/build/main.js",


### PR DESCRIPTION
Post-release bump anchored to build SHA \\$buildSha\\ (tag \\0.64.1-insiders.0\\). Master now reflects the freshly shipped stable version. \\## [Unreleased]\\ content at build time has been promoted to \\## [0.64.1] - 2026-06-01\\ in CHANGELOG.md (Keep a Changelog 1.1.0 format).

Build-SHA: 9d779eba1a43bfd160c9c44e85b00bdb09053b98
Source-Ref: v0.64.1-insiders.0

If commits landed on master after the build SHA, the PR merge will surface a 3-way conflict in CHANGELOG.md — resolution is mechanical: keep the new \\## [0.64.1] - 2026-06-01\\ section AS-IS, and keep any \\## [Unreleased]\\ bullets that landed during the build window under a fresh \\## [Unreleased]\\ block above it. **Do not rebase or merge master into this branch** — that would defeat Pattern E anchoring and the \\model-b-gates\\ PR check will fail. Resolve at PR-merge time only.

This PR is mechanical and CI-validated; merge after green checks.