### PR TITLE
Fix chat streaming state edge cases

### DIFF
--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -443,6 +443,106 @@ describe('appReducer', () => {
     expect(titled.conversationHistoryByMind[mindId][0].title).toBe('First prompt');
   });
 
+  it('SET_CONVERSATION_HISTORY binds first-message local ready state to the new active session', () => {
+    const localReady = {
+      ...withActiveMind,
+      messagesByMind: { [mindId]: [makeMessage([makeTextBlock('local prompt')], { id: 'local' })] },
+      conversationViewByMind: {
+        [mindId]: { status: 'ready' as const, streaming: false, modelSwitching: false },
+      },
+    };
+
+    const state = appReducer(localReady, {
+      type: 'SET_CONVERSATION_HISTORY',
+      payload: {
+        mindId,
+        conversations: [
+          { sessionId: 'session-1', title: 'First prompt', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:01.000Z', kind: 'chat', active: true },
+        ],
+      },
+    });
+
+    expect(state.activeConversationByMind[mindId]).toBe('session-1');
+    expect(state.conversationViewByMind[mindId]).toMatchObject({
+      status: 'ready',
+      sessionId: 'session-1',
+      pendingSessionId: undefined,
+    });
+    expect(state.conversationHistoryByMind[mindId].filter((conversation) => conversation.active)).toHaveLength(1);
+  });
+
+  it('SET_CONVERSATION_HISTORY preserves ready local selection over stale active history', () => {
+    const selected = {
+      ...withActiveMind,
+      activeConversationByMind: { [mindId]: 'session-2' },
+      conversationHistoryByMind: {
+        [mindId]: [
+          { sessionId: 'session-2', title: 'Selected chat', createdAt: '2026-01-02T00:00:00.000Z', updatedAt: '2026-01-02T00:00:02.000Z', kind: 'chat' as const, active: true },
+          { sessionId: 'session-1', title: 'Old chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', kind: 'chat' as const, active: false },
+        ],
+      },
+      conversationViewByMind: {
+        [mindId]: { status: 'ready' as const, sessionId: 'session-2', streaming: false, modelSwitching: false },
+      },
+    };
+
+    const state = appReducer(selected, {
+      type: 'SET_CONVERSATION_HISTORY',
+      payload: {
+        mindId,
+        conversations: [
+          { sessionId: 'session-1', title: 'Old chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', kind: 'chat', active: true },
+          { sessionId: 'session-2', title: 'Selected chat', createdAt: '2026-01-02T00:00:00.000Z', updatedAt: '2026-01-02T00:00:01.000Z', kind: 'chat', active: false },
+        ],
+      },
+    });
+
+    expect(state.activeConversationByMind[mindId]).toBe('session-2');
+    expect(state.conversationViewByMind[mindId]).toMatchObject({
+      status: 'ready',
+      sessionId: 'session-2',
+    });
+    expect(state.conversationHistoryByMind[mindId].filter((conversation) => conversation.active)).toEqual([
+      expect.objectContaining({ sessionId: 'session-2' }),
+    ]);
+  });
+
+  it('SET_CONVERSATION_HISTORY preserves hydrating local selection over stale active history', () => {
+    const hydrating = appReducer({
+      ...withActiveMind,
+      activeConversationByMind: { [mindId]: 'session-1' },
+      conversationHistoryByMind: {
+        [mindId]: [
+          { sessionId: 'session-1', title: 'Old chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', kind: 'chat' as const, active: true },
+          { sessionId: 'session-2', title: 'Selected chat', createdAt: '2026-01-02T00:00:00.000Z', updatedAt: '2026-01-02T00:00:00.000Z', kind: 'chat' as const, active: false },
+        ],
+      },
+    }, {
+      type: 'CONVERSATION_HYDRATING',
+      payload: { mindId, sessionId: 'session-2' },
+    });
+
+    const state = appReducer(hydrating, {
+      type: 'SET_CONVERSATION_HISTORY',
+      payload: {
+        mindId,
+        conversations: [
+          { sessionId: 'session-1', title: 'Old chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', kind: 'chat', active: true },
+          { sessionId: 'session-2', title: 'Selected chat', createdAt: '2026-01-02T00:00:00.000Z', updatedAt: '2026-01-02T00:00:00.000Z', kind: 'chat', active: false },
+        ],
+      },
+    });
+
+    expect(state.activeConversationByMind[mindId]).toBe('session-2');
+    expect(state.conversationViewByMind[mindId]).toMatchObject({
+      status: 'hydrating',
+      pendingSessionId: 'session-2',
+    });
+    expect(state.conversationHistoryByMind[mindId].filter((conversation) => conversation.active)).toEqual([
+      expect.objectContaining({ sessionId: 'session-2' }),
+    ]);
+  });
+
   it('CONVERSATION_HYDRATING records the selected session before messages arrive', () => {
     const state = appReducer(withActiveMind, {
       type: 'CONVERSATION_HYDRATING',

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -844,6 +844,38 @@ describe('appReducer', () => {
       expect(state.streamingByMind[mindId]).toBe(false);
     });
 
+    it('CHAT_EVENT terminal event for inactive mind does not clear active mind streaming', () => {
+      const otherMindId = 'other-mind';
+      const prev = {
+        ...withActiveMind,
+        isStreaming: true,
+        streamingByMind: { [mindId]: true, [otherMindId]: true },
+        conversationViewByMind: {
+          [mindId]: { status: 'ready' as const, sessionId: 'active-session', streaming: true, modelSwitching: false },
+          [otherMindId]: { status: 'ready' as const, sessionId: 'other-session', streaming: true, modelSwitching: false },
+        },
+        messagesByMind: {
+          [mindId]: [makeMessage([], { id: 'active-assistant', isStreaming: true })],
+          [otherMindId]: [makeMessage([], { id: 'other-assistant', isStreaming: true })],
+        },
+        activeConversationByMind: {
+          [mindId]: 'active-session',
+          [otherMindId]: 'other-session',
+        },
+      };
+
+      const state = appReducer(prev, {
+        type: 'CHAT_EVENT',
+        payload: { mindId: otherMindId, messageId: 'other-assistant', event: makeChatEvent('done') },
+      });
+
+      expect(state.streamingByMind[otherMindId]).toBe(false);
+      expect(state.conversationViewByMind[otherMindId]).toMatchObject({ streaming: false });
+      expect(state.streamingByMind[mindId]).toBe(true);
+      expect(state.conversationViewByMind[mindId]).toMatchObject({ streaming: true });
+      expect(state.isStreaming).toBe(true);
+    });
+
     it('NEW_CONVERSATION clears streamingByMind for active mind', () => {
       const prev = { ...withActiveMind, streamingByMind: { [mindId]: true }, isStreaming: true };
       const state = appReducer(prev, { type: 'NEW_CONVERSATION' });

--- a/apps/web/src/renderer/lib/store/reducers/conversationReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/conversationReducer.ts
@@ -1,5 +1,5 @@
 import type { AppState, AppAction } from '../state';
-import { conversationViewFor, mergeConversationSummaries, setConversationView } from './helpers';
+import { conversationViewFor, isMindChatStreaming, mergeConversationSummaries, setConversationView } from './helpers';
 
 type Handler<T extends AppAction['type']> = (
   state: AppState,
@@ -97,6 +97,17 @@ function resumeConversation(
 ): Partial<AppState> | AppState {
   const currentView = conversationViewFor(state, action.payload.mindId);
   if (currentView.pendingSessionId && currentView.pendingSessionId !== action.payload.sessionId) return state;
+  const nextStreamingByMind = {
+    ...state.streamingByMind,
+    [action.payload.mindId]: false,
+  };
+  const nextConversationViewByMind = setConversationView(state, action.payload.mindId, {
+    status: 'ready',
+    sessionId: action.payload.sessionId,
+    pendingSessionId: undefined,
+    streaming: false,
+    error: undefined,
+  });
   return {
     messagesByMind: {
       ...state.messagesByMind,
@@ -110,18 +121,11 @@ function resumeConversation(
       ...state.activeConversationByMind,
       [action.payload.mindId]: action.payload.sessionId,
     },
-    streamingByMind: {
-      ...state.streamingByMind,
-      [action.payload.mindId]: false,
-    },
-    conversationViewByMind: setConversationView(state, action.payload.mindId, {
-      status: 'ready',
-      sessionId: action.payload.sessionId,
-      pendingSessionId: undefined,
-      streaming: false,
-      error: undefined,
-    }),
-    isStreaming: state.activeMindId === action.payload.mindId ? false : state.isStreaming,
+    streamingByMind: nextStreamingByMind,
+    conversationViewByMind: nextConversationViewByMind,
+    isStreaming: state.activeMindId
+      ? isMindChatStreaming(state, state.activeMindId, nextStreamingByMind, nextConversationViewByMind)
+      : false,
   };
 }
 

--- a/apps/web/src/renderer/lib/store/reducers/conversationReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/conversationReducer.ts
@@ -1,4 +1,5 @@
 import type { AppState, AppAction } from '../state';
+import type { ConversationSummary } from '@chamber/shared/types';
 import { conversationViewFor, isMindChatStreaming, mergeConversationSummaries, setConversationView } from './helpers';
 
 type Handler<T extends AppAction['type']> = (
@@ -10,18 +11,21 @@ function setConversationHistory(
   state: AppState,
   action: Extract<AppAction, { type: 'SET_CONVERSATION_HISTORY' }>,
 ): Partial<AppState> {
-  const conversations = mergeConversationSummaries(
+  const mergedConversations = mergeConversationSummaries(
     state.conversationHistoryByMind[action.payload.mindId],
     action.payload.conversations,
   );
-  const activeSessionId = conversations.find((conversation) => conversation.active)?.sessionId;
+  const incomingActiveSessionId = mergedConversations.find((conversation) => conversation.active)?.sessionId;
   const currentView = conversationViewFor(state, action.payload.mindId);
   const hasLocalMessages = (state.messagesByMind[action.payload.mindId]?.length ?? 0) > 0;
   const shouldBindLocalReadyView =
-    currentView.status === 'ready' && currentView.sessionId === undefined && hasLocalMessages;
+    currentView.status === 'ready' && currentView.sessionId === undefined && hasLocalMessages && incomingActiveSessionId !== undefined;
+  const selectedSessionId = selectConversationSessionId(mergedConversations, currentView, incomingActiveSessionId);
+  const activeSessionId = shouldBindLocalReadyView ? incomingActiveSessionId : selectedSessionId;
+  const conversations = normalizeActiveConversation(mergedConversations, activeSessionId);
   const shouldPreserveView =
-    (currentView.status === 'ready' && currentView.sessionId === activeSessionId) ||
-    (currentView.status === 'hydrating' && currentView.pendingSessionId === activeSessionId);
+    (currentView.status === 'ready' && currentView.sessionId === activeSessionId)
+    || (currentView.status === 'hydrating' && currentView.pendingSessionId === activeSessionId);
 
   return {
     conversationHistoryByMind: {
@@ -55,6 +59,34 @@ function setConversationHistory(
             })
           : state.conversationViewByMind,
   };
+}
+
+function selectConversationSessionId(
+  conversations: ConversationSummary[],
+  currentView: ReturnType<typeof conversationViewFor>,
+  incomingActiveSessionId: string | undefined,
+): string | undefined {
+  if (currentView.status === 'hydrating' && currentView.pendingSessionId) {
+    return currentView.pendingSessionId;
+  }
+  if (
+    currentView.status === 'ready'
+    && currentView.sessionId
+    && conversations.some((conversation) => conversation.sessionId === currentView.sessionId)
+  ) {
+    return currentView.sessionId;
+  }
+  return incomingActiveSessionId;
+}
+
+function normalizeActiveConversation(
+  conversations: ConversationSummary[],
+  activeSessionId: string | undefined,
+): ConversationSummary[] {
+  return conversations.map((conversation) => {
+    const active = activeSessionId !== undefined && conversation.sessionId === activeSessionId;
+    return conversation.active === active ? conversation : { ...conversation, active };
+  });
 }
 
 function conversationHydrating(

--- a/apps/web/src/renderer/lib/store/reducers/helpers.ts
+++ b/apps/web/src/renderer/lib/store/reducers/helpers.ts
@@ -41,6 +41,15 @@ export function conversationViewFor(state: AppState, mindId: string): Conversati
   return state.conversationViewByMind[mindId] ?? defaultConversationView();
 }
 
+export function isMindChatStreaming(
+  state: AppState,
+  mindId: string,
+  streamingByMind = state.streamingByMind,
+  conversationViewByMind = state.conversationViewByMind,
+): boolean {
+  return Boolean(streamingByMind[mindId] || conversationViewByMind[mindId]?.streaming);
+}
+
 export function setConversationView(
   state: AppState,
   mindId: string,

--- a/apps/web/src/renderer/lib/store/reducers/messagesReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/messagesReducer.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, ContentBlock } from '@chamber/shared/types';
 import type { AppState, AppAction } from '../state';
-import { conversationViewFor, handleChatEvent, setConversationView } from './helpers';
+import { conversationViewFor, handleChatEvent, isMindChatStreaming, setConversationView } from './helpers';
 
 type Handler<T extends AppAction['type']> = (
   state: AppState,
@@ -82,25 +82,29 @@ function chatEvent(state: AppState, action: Extract<AppAction, { type: 'CHAT_EVE
   const newStreamingByMind = isDone
     ? { ...state.streamingByMind, [mindId]: false }
     : state.streamingByMind;
+  const newConversationViewByMind = isDone
+    ? setConversationView(state, mindId, {
+      status: 'ready',
+      sessionId: state.activeConversationByMind[mindId] ?? conversationViewFor(state, mindId).sessionId,
+      pendingSessionId: undefined,
+      streaming: false,
+    })
+    : state.conversationViewByMind;
+  const activeMindIsStreaming = state.activeMindId
+    ? isMindChatStreaming(state, state.activeMindId, newStreamingByMind, newConversationViewByMind)
+    : false;
   return {
     messagesByMind: { ...state.messagesByMind, [mindId]: newMessages },
-    isStreaming: isDone ? false : state.isStreaming,
+    isStreaming: isDone ? activeMindIsStreaming : state.isStreaming,
     streamingByMind: newStreamingByMind,
-    conversationViewByMind: isDone
-      ? setConversationView(state, mindId, {
-        status: 'ready',
-        sessionId: state.activeConversationByMind[mindId] ?? conversationViewFor(state, mindId).sessionId,
-        pendingSessionId: undefined,
-        streaming: false,
-      })
-      : state.conversationViewByMind,
+    conversationViewByMind: newConversationViewByMind,
   };
 }
 
 function hydrateChatState(state: AppState, action: Extract<AppAction, { type: 'HYDRATE_CHAT_STATE' }>): Partial<AppState> {
   const nextConversationViewByMind = action.payload.conversationViewByMind ?? state.conversationViewByMind;
   const isActiveMindStreaming = state.activeMindId
-    ? Boolean(action.payload.streamingByMind[state.activeMindId] || nextConversationViewByMind[state.activeMindId]?.streaming)
+    ? isMindChatStreaming(state, state.activeMindId, action.payload.streamingByMind, nextConversationViewByMind)
     : Object.values(action.payload.streamingByMind).some(Boolean);
   return {
     messagesByMind: action.payload.messagesByMind,

--- a/apps/web/src/renderer/lib/store/reducers/mindsReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/mindsReducer.ts
@@ -1,6 +1,6 @@
 import type { AppState, AppAction } from '../state';
 import { parseModelSelectionKey } from '@chamber/shared/model-selection';
-import { selectedModelForActiveMind } from './helpers';
+import { isMindChatStreaming, selectedModelForActiveMind } from './helpers';
 
 type Handler<T extends AppAction['type']> = (
   state: AppState,
@@ -31,7 +31,7 @@ function setActiveMind(state: AppState, action: Extract<AppAction, { type: 'SET_
     activeMindId: action.payload,
     selectedModel: selectedModelForActiveMind(state, action.payload),
     isStreaming: action.payload
-      ? Boolean(state.streamingByMind[action.payload] || state.conversationViewByMind[action.payload]?.streaming)
+      ? isMindChatStreaming(state, action.payload)
       : false,
   };
 }

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -251,6 +251,31 @@ describe('ChatService', () => {
       }
     });
 
+    it('ignores stale cancel requests for an older message on the same mind', async () => {
+      let resolveSend: (() => void) | undefined;
+      mockSession.on.mockReturnValue(vi.fn());
+      mockSession.send.mockImplementation(() => new Promise<void>((resolve) => {
+        resolveSend = resolve;
+      }));
+
+      const pending = svc.sendMessage('valid-mind', 'hello', 'current-msg', vi.fn());
+      try {
+        await vi.waitFor(() => {
+          expect(mockSession.send).toHaveBeenCalled();
+        });
+
+        await expect(svc.cancelMessage('valid-mind', 'stale-msg')).resolves.toBe(false);
+        expect(mockSession.abort).not.toHaveBeenCalled();
+
+        await expect(svc.cancelMessage('valid-mind', 'current-msg')).resolves.toBe(true);
+        expect(mockSession.abort).toHaveBeenCalledOnce();
+      } finally {
+        resolveSend?.();
+        mockSession.send.mockResolvedValue(undefined);
+        await pending;
+      }
+    });
+
     it('clears the streaming guard immediately when the user stops a wedged send', async () => {
       let resolveSend: (() => void) | undefined;
       mockSession.on.mockReturnValue(vi.fn());

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -33,7 +33,7 @@ const log = Logger.create('ChatService');
 const TURN_END_QUIESCENCE_MS = 1_000;
 
 export class ChatService {
-  private abortControllers = new Map<string, AbortController>();
+  private abortControllers = new Map<string, { messageId: string; controller: AbortController }>();
 
   constructor(
     private readonly mindManager: MindManager,
@@ -60,7 +60,7 @@ export class ChatService {
   ): Promise<void> {
     return this.turnQueue.enqueue(mindId, async () => {
       const abortController = new AbortController();
-      this.abortControllers.set(mindId, abortController);
+      this.abortControllers.set(mindId, { messageId, controller: abortController });
 
       try {
         const context = this.mindManager.getMind(mindId);
@@ -93,7 +93,10 @@ export class ChatService {
         const rawMessage = err instanceof Error ? err.message : String(err);
         emit({ type: 'error', message: mapByoLlmError(rawMessage) });
       } finally {
-        this.abortControllers.delete(mindId);
+        const active = this.abortControllers.get(mindId);
+        if (active?.controller === abortController) {
+          this.abortControllers.delete(mindId);
+        }
       }
     });
   }
@@ -370,11 +373,10 @@ export class ChatService {
     }
   }
 
-  async cancelMessage(mindId: string, _messageId: string): Promise<boolean> {
-    void _messageId;
-    const controller = this.abortControllers.get(mindId);
-    if (!controller) return false;
-    controller.abort();
+  async cancelMessage(mindId: string, messageId: string): Promise<boolean> {
+    const active = this.abortControllers.get(mindId);
+    if (!active || active.messageId !== messageId) return false;
+    active.controller.abort();
     this.abortControllers.delete(mindId);
     const context = this.mindManager.getMind(mindId);
     if (context?.session) {

--- a/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
+++ b/tests/e2e/electron/genesis-landing-add-marketplace.spec.ts
@@ -69,7 +69,10 @@ test.describe('electron Genesis landing Add Marketplace smoke', () => {
     await expect(page.getByRole('button', { name: /Lucy/i }).first()).toBeVisible({ timeout: 90_000 });
 
     const templates = await page.evaluate(async () => window.electronAPI.genesis.listTemplates());
-    expect(templates.filter((template) => template.id === 'lucy').map((template) => template.source.marketplaceId).sort()).toEqual([
+    expect(templates.filter((template) => template.id === 'lucy').map((template) => template.source.marketplaceId)).toEqual([
+      publicMarketplaceId,
+    ]);
+    expect([...new Set(templates.map((template) => template.source.marketplaceId))].sort()).toEqual([
       internalMarketplaceId,
       publicMarketplaceId,
     ]);

--- a/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
+++ b/tests/e2e/electron/genesis-marketplace-aggregation.spec.ts
@@ -47,7 +47,7 @@ test.describe('electron Genesis marketplace aggregation smoke', () => {
     }
   });
 
-  test('shows duplicate public and internal marketplace templates as separate source-aware cards', async () => {
+  test('shows public and internal marketplace templates as separate source-aware cards', async () => {
     const page = await findRendererPage(app?.browser, app?.logs ?? []);
     await page.waitForLoadState('domcontentloaded');
 
@@ -58,11 +58,14 @@ test.describe('electron Genesis marketplace aggregation smoke', () => {
     const templates = await page.evaluate(async () => window.electronAPI.genesis.listTemplates());
     const lucyTemplates = templates.filter((template) => template.id === 'lucy');
 
-    expect(lucyTemplates.map((template) => template.source.marketplaceId).sort()).toEqual([
+    expect(lucyTemplates.map((template) => template.source.marketplaceId)).toEqual([
+      publicMarketplaceId,
+    ]);
+    expect([...new Set(templates.map((template) => template.source.marketplaceId))].sort()).toEqual([
       internalMarketplaceId,
       publicMarketplaceId,
     ]);
-    await expect(page.getByRole('button', { name: /Lucy/i })).toHaveCount(2);
+    await expect(page.getByRole('button', { name: /Lucy/i })).toHaveCount(1);
   });
 });
 

--- a/tests/e2e/electron/settings-marketplace-management.spec.ts
+++ b/tests/e2e/electron/settings-marketplace-management.spec.ts
@@ -72,22 +72,22 @@ test.describe('electron Settings marketplace management smoke', () => {
 
     const internalRow = rowForMarketplaceUrl(page, internalMarketplaceUrl);
     await expect(internalRow.getByText('Enabled')).toBeVisible();
-    await expectMarketplaceSources(page, [internalMarketplaceId, publicMarketplaceId]);
+    await expectTemplateSources(page, [internalMarketplaceId, publicMarketplaceId]);
 
     await internalRow.getByRole('button', { name: 'Disable' }).click();
     await expect(internalRow.getByText('Disabled')).toBeVisible();
-    await expectMarketplaceSources(page, [publicMarketplaceId]);
+    await expectTemplateSources(page, [publicMarketplaceId]);
 
     await internalRow.getByRole('button', { name: 'Enable' }).click();
     await expect(internalRow.getByText('Enabled')).toBeVisible();
     await internalRow.getByRole('button', { name: 'Refresh' }).click();
     await expect(page.getByRole('status')).toContainText('Refreshed agency-microsoft/genesis-minds', { timeout: 90_000 });
-    await expectMarketplaceSources(page, [internalMarketplaceId, publicMarketplaceId]);
+    await expectTemplateSources(page, [internalMarketplaceId, publicMarketplaceId]);
 
     await internalRow.getByRole('button', { name: 'Remove' }).click();
     await expect(page.getByRole('status')).toContainText('Removed agency-microsoft/genesis-minds');
     await expect(page.getByText(internalMarketplaceUrl)).toHaveCount(0);
-    await expectMarketplaceSources(page, [publicMarketplaceId]);
+    await expectTemplateSources(page, [publicMarketplaceId]);
   });
 });
 
@@ -96,16 +96,13 @@ function rowForMarketplaceUrl(page: Awaited<ReturnType<typeof findRendererPage>>
     .locator('xpath=ancestor::div[contains(@class,"rounded-lg") and contains(@class,"border")][1]');
 }
 
-async function expectMarketplaceSources(
+async function expectTemplateSources(
   page: Awaited<ReturnType<typeof findRendererPage>>,
   expectedMarketplaceIds: string[],
 ): Promise<void> {
   await expect.poll(async () => {
     const templates = await page.evaluate(async () => window.electronAPI.genesis.listTemplates());
-    return templates
-      .filter((template) => template.id === 'lucy')
-      .map((template) => template.source.marketplaceId)
-      .sort();
+    return [...new Set(templates.map((template) => template.source.marketplaceId))].sort();
   }, { timeout: 90_000 }).toEqual([...expectedMarketplaceIds].sort());
 }
 


### PR DESCRIPTION
Chat and conversation history state could drift when async events arrived out of order. Terminal chat events for inactive minds could make the active input look idle, stale stop requests could abort the current turn, and stale history list responses could reselect an older active row while a newer local resume was ready or hydrating.

## Summary

- Derive active chat streaming state from the active mind's per-mind stream and conversation-view state after terminal events.
- Share the active-mind streaming predicate across reducers to avoid state-machine drift.
- Require `cancelMessage` to match the active message ID before aborting a mind's current turn.
- Preserve local ready and hydrating conversation selections when stale history list responses arrive.
- Normalize conversation history row `active` flags to match the selected session so the history bar does not highlight multiple rows.
- Add regression coverage for inactive-mind terminal events, stale stop requests, first-message history binding, and stale history list responses.

## Tests

- `npm test -- --run apps/web/src/renderer/lib/store/reducer.test.ts packages/services/src/chat/ChatService.test.ts`
- `npm test -- --run apps/web/src/renderer/lib/store/reducer.test.ts`
- `npm run lint`

No additional smoke was run; this changes renderer state reduction and chat cancellation guards, not packaging, runtime resolution, or SDK/server wiring.