### PR TITLE
refactor: consolidate duplicated helpers into shared utilities

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain, powerMonitor, session, shell, Notification, type MessageBoxOptions, type NativeImage, type Tray as ElectronTray } from 'electron';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -641,7 +642,7 @@ const handleProtocolUrl = (rawUrl: string): void => {
     })
     .catch((error: unknown) => {
       log.warn('Protocol registry enrollment failed:', error);
-      showMarketplaceProtocolMessage('error', 'Unable to add marketplace', error instanceof Error ? error.message : String(error));
+      showMarketplaceProtocolMessage('error', 'Unable to add marketplace', getErrorMessage(error));
     });
 };
 

--- a/apps/desktop/src/main/ipc/a2a.ts
+++ b/apps/desktop/src/main/ipc/a2a.ts
@@ -1,4 +1,5 @@
 import { ipcMain, BrowserWindow } from 'electron';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { EventEmitter } from 'events';
 import { IPC } from '@chamber/shared';
 import type { AppConfig } from '@chamber/shared/types';
@@ -137,7 +138,7 @@ export function setupA2AIPC(
       return nextStatus;
     } catch (error) {
       await relayOptions.relayModeService.disconnect().catch(() => undefined);
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       const nextStatus: A2ARelayStatus = {
         ...createDisconnectedStatus(request.relayBaseUrl),
         state: 'error',

--- a/apps/desktop/src/main/ipc/byoLlm.ts
+++ b/apps/desktop/src/main/ipc/byoLlm.ts
@@ -2,6 +2,7 @@
 // custom OpenAI-compatible LLM endpoint surface in Settings.
 
 import { ipcMain, BrowserWindow } from 'electron';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { IPC } from '@chamber/shared';
 import type { ByoLlmConfig, ByoLlmProbeResult, ByoLlmSaveResult } from '@chamber/shared/types';
 import {
@@ -68,7 +69,7 @@ export function setupByoLlmIPC(
       broadcast(savedConfig);
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       log.error('Failed to save BYO LLM config:', message);
       return { success: false, error: message };
     }
@@ -82,7 +83,7 @@ export function setupByoLlmIPC(
       broadcast(null);
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       log.error('Failed to disable BYO LLM config:', message);
       return { success: false, error: message };
     }
@@ -103,7 +104,7 @@ export function setupByoLlmIPC(
       const result = await mindManager.restartAllMindsForByoChange(config?.enabled === true ? undefined : null);
       return { success: true, restartedCount: result.restartedCount };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       log.error('Failed to restart agents after BYO change:', message);
       return { success: false, restartedCount: 0, error: message };
     }

--- a/apps/desktop/src/main/ipc/genesis.ts
+++ b/apps/desktop/src/main/ipc/genesis.ts
@@ -1,5 +1,6 @@
 // Genesis IPC handlers — wire MindScaffold to renderer
 import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
@@ -80,7 +81,7 @@ export function setupGenesisIPC(
       const mindPath = await scaffold.create(config);
       return await activateCreatedMind(mindManager, mindPath);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       if (win) win.webContents.send(IPC.GENESIS.PROGRESS, { step: 'error', detail: message });
       return { success: false, error: message };
     }
@@ -97,7 +98,7 @@ export function setupGenesisIPC(
       if (win) win.webContents.send(IPC.GENESIS.PROGRESS, { step: 'complete', detail: 'Genesis template install complete.' });
       return result;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       if (win) win.webContents.send(IPC.GENESIS.PROGRESS, { step: 'error', detail: message });
       return { success: false, error: message };
     }
@@ -117,7 +118,7 @@ async function activateCreatedMind(mindManager: MindManager, mindPath: string): 
     mindManager.setActiveMind(mind.mindId);
     return { success: true, mindId: mind.mindId, mindPath };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     return { success: false, error: message };
   }
 }

--- a/apps/desktop/src/main/ipc/mindProfile.ts
+++ b/apps/desktop/src/main/ipc/mindProfile.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, dialog, ipcMain } from 'electron';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import fs from 'node:fs';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -56,7 +57,7 @@ export function setupMindProfileIPC(profileService: MindProfileService, mindMana
         },
       };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return { success: false, error: getErrorMessage(error) };
     }
   });
 

--- a/apps/desktop/src/main/squirrelMigration.ts
+++ b/apps/desktop/src/main/squirrelMigration.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -100,7 +101,7 @@ export async function cleanupLegacySquirrelInstall(
       uninstallExitCode = await runSquirrelUninstall(updateExe, spawnFile);
       logger.info(`[squirrel-migration] Legacy Squirrel uninstall exited with ${uninstallExitCode ?? 'null'}.`);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       logger.warn(`[squirrel-migration] Legacy Squirrel uninstall failed: ${message}`);
       return {
         status: 'failed',
@@ -118,7 +119,7 @@ export async function cleanupLegacySquirrelInstall(
   try {
     fsImpl.rmSync(legacyDir, { recursive: true, force: true });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = getErrorMessage(error);
     logger.warn(`[squirrel-migration] Could not remove legacy Squirrel directory: ${message}`);
     return {
       status: 'partial',

--- a/apps/desktop/src/main/updater/UpdaterService.ts
+++ b/apps/desktop/src/main/updater/UpdaterService.ts
@@ -1,5 +1,6 @@
 import { autoUpdater, type AppUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater';
 import type { DesktopUpdateActionResult, DesktopUpdateState } from '@chamber/shared/types';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 
 import {
   canCheckForUpdates,
@@ -31,10 +32,6 @@ export interface UpdaterServiceOptions {
   readonly logger?: UpdaterLogger;
   readonly allowDevUpdates?: boolean;
   readonly setQuitting?: () => void;
-}
-
-function formatError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 export class UpdaterService {
@@ -102,7 +99,7 @@ export class UpdaterService {
       await this.updater.checkForUpdates();
       return { success: true };
     } catch (error) {
-      const message = formatError(error);
+      const message = getErrorMessage(error);
       this.setState(reduceOnError(this.state, message, 'check'));
       return { success: false, message };
     } finally {
@@ -120,7 +117,7 @@ export class UpdaterService {
       await this.updater.downloadUpdate();
       return { success: true };
     } catch (error) {
-      const message = formatError(error);
+      const message = getErrorMessage(error);
       this.setState(reduceOnError(this.state, message, 'download'));
       return { success: false, message };
     } finally {
@@ -168,7 +165,7 @@ export class UpdaterService {
       if (this.installInFlight) {
         this.installInFlight = false;
       }
-      const message = formatError(error);
+      const message = getErrorMessage(error);
       this.setState(reduceOnError(this.state, message, 'event'));
       this.logger.error(`[updater] ${message}`);
     });

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -1,4 +1,5 @@
 import type { ChamberCtx, ChamberRequest, ChamberResponse } from './types';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { ChatAttachmentDto, CommandResponse, ListModelsResponse, SendChatRequest } from '@chamber/wire-contracts';
 
 export async function healthHandler(): Promise<ChamberResponse> {
@@ -19,7 +20,7 @@ export async function addMindHandler(request: ChamberRequest, ctx: ChamberCtx): 
   try {
     return { status: 200, body: { mind: await ctx.addMind(mindPath) } };
   } catch (error) {
-    return { status: 400, body: { error: error instanceof Error ? error.message : String(error) } };
+    return { status: 400, body: { error: getErrorMessage(error) } };
   }
 }
 

--- a/apps/server/src/honoAdapter.ts
+++ b/apps/server/src/honoAdapter.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { Context } from 'hono';
 import { getRequestListener } from '@hono/node-server';
 import { createServer } from 'node:http';
@@ -62,7 +63,7 @@ function streamAuthLogin(ctx: ChamberCtx): Response {
       void ctx.startAuthLogin((progress) => write({ type: 'progress', progress }))
         .then((result) => write({ type: 'result', result }))
         .catch((error: unknown) => {
-          const message = error instanceof Error ? error.message : String(error);
+          const message = getErrorMessage(error);
           write({ type: 'result', result: { success: false, error: message } });
         })
         .finally(() => controller.close());

--- a/apps/web/src/renderer/components/a2a/A2ARelayView.tsx
+++ b/apps/web/src/renderer/components/a2a/A2ARelayView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { A2ARelayStatus } from '@chamber/shared/a2a-types';
 import { RadioTower, ShieldCheck, Unplug, RefreshCw } from 'lucide-react';
 import { Badge } from '../ui/badge';
@@ -40,7 +41,7 @@ export function A2ARelayView() {
         if (nextStatus.authMode) setAuthMode(nextStatus.authMode);
       })
       .catch((err: unknown) => {
-        if (mounted) setError(err instanceof Error ? err.message : String(err));
+        if (mounted) setError(getErrorMessage(err));
       });
     const unsubscribe = window.electronAPI.a2a.onRelayStateChanged((nextStatus) => {
       setStatus(nextStatus);
@@ -69,7 +70,7 @@ export function A2ARelayView() {
           });
       setStatus(nextStatus);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     }
   };
 
@@ -78,7 +79,7 @@ export function A2ARelayView() {
     try {
       setStatus(await window.electronAPI.a2a.relayDisconnect());
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     }
   };
 
@@ -87,7 +88,7 @@ export function A2ARelayView() {
     try {
       setStatus(await window.electronAPI.a2a.relayStatus());
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     }
   };
 

--- a/apps/web/src/renderer/components/auth/AuthScreen.tsx
+++ b/apps/web/src/renderer/components/auth/AuthScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { TypeWriter } from '../genesis/TypeWriter';
 
 interface Props {
@@ -41,7 +42,7 @@ export function AuthScreen({ onAuthenticated }: Props) {
       setError(result.error ?? 'Authentication did not complete.');
       setStage('error');
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
       setStage('error');
     } finally {
       unsub();

--- a/apps/web/src/renderer/components/chat/MessageList.tsx
+++ b/apps/web/src/renderer/components/chat/MessageList.tsx
@@ -7,13 +7,7 @@ import type { AgentProfileSummary } from '../../lib/store/state';
 import { AgentAvatar } from '../profile/AgentAvatar';
 import { useMindProfiles } from '../../hooks/useMindProfiles';
 import { useUserProfile } from '../../hooks/useUserProfile';
-
-const AGENT_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
-
-function agentColor(minds: MindContext[], mindId: string): string {
-  const idx = minds.findIndex(m => m.mindId === mindId);
-  return AGENT_COLORS[(idx >= 0 ? idx : 0) % AGENT_COLORS.length];
-}
+import { agentColor } from './agentColors';
 
 function displayName(name: string, fallback: string): string {
   const trimmed = name.trim();

--- a/apps/web/src/renderer/components/chat/agentColors.ts
+++ b/apps/web/src/renderer/components/chat/agentColors.ts
@@ -1,0 +1,8 @@
+import type { MindContext } from '@chamber/shared/types';
+
+export const AGENT_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
+
+export function agentColor(minds: MindContext[], mindId: string): string {
+  const idx = minds.findIndex(m => m.mindId === mindId);
+  return AGENT_COLORS[(idx >= 0 ? idx : 0) % AGENT_COLORS.length];
+}

--- a/apps/web/src/renderer/components/chatroom/ChatroomPanel.tsx
+++ b/apps/web/src/renderer/components/chatroom/ChatroomPanel.tsx
@@ -11,17 +11,7 @@ import type { AgentProfileSummary } from '../../lib/store/state';
 import { AgentAvatar } from '../profile/AgentAvatar';
 import { useMindProfiles } from '../../hooks/useMindProfiles';
 import { useUserProfile } from '../../hooks/useUserProfile';
-
-// ---------------------------------------------------------------------------
-// Colour palette for agent badges
-// ---------------------------------------------------------------------------
-
-const AGENT_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
-
-function agentColor(minds: MindContext[], mindId: string): string {
-  const idx = minds.findIndex(m => m.mindId === mindId);
-  return AGENT_COLORS[(idx >= 0 ? idx : 0) % AGENT_COLORS.length];
-}
+import { AGENT_COLORS, agentColor } from '../chat/agentColors';
 
 function profileDisplayName(profile: AgentProfileSummary | undefined, fallback: string): string {
   return profile?.displayName?.trim() || fallback;

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { useAppDispatch } from '../../lib/store';
 import { Logger } from '../../lib/logger';
 import { VoidScreen } from './VoidScreen';
@@ -34,7 +35,7 @@ export function GenesisFlow({ onComplete }: Props) {
     try {
       setTemplates(await window.electronAPI.genesis.listTemplates());
     } catch (error) {
-      setTemplateError(error instanceof Error ? error.message : String(error));
+      setTemplateError(getErrorMessage(error));
     }
   }, []);
 
@@ -66,7 +67,7 @@ export function GenesisFlow({ onComplete }: Props) {
       basePath: defaultPath,
     }).catch((error: unknown) => ({
       success: false,
-      error: error instanceof Error ? error.message : String(error),
+      error: getErrorMessage(error),
     }));
     creationPromiseRef.current = creationPromise;
     const result = await creationPromise;
@@ -97,7 +98,7 @@ export function GenesisFlow({ onComplete }: Props) {
       basePath: defaultPath,
     }).catch((error: unknown) => ({
       success: false,
-      error: error instanceof Error ? error.message : String(error),
+      error: getErrorMessage(error),
     }));
     creationPromiseRef.current = creationPromise;
     const result = await creationPromise;

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeft, ChevronRight, Pencil, Plus, Trash2 } from 'lucide-react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ConversationSummary } from '@chamber/shared/types';
 import { useAppDispatch, useAppState } from '../../lib/store';
@@ -64,7 +65,7 @@ export function ConversationHistoryPanel() {
       applyResumeResult(mindId, result);
       return result;
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       dispatch({ type: 'CONVERSATION_HYDRATE_FAILED', payload: { mindId, sessionId, error: message } });
       log.warn('Failed to hydrate conversation:', error);
       throw error;

--- a/apps/web/src/renderer/components/profile/AgentProfileModal.tsx
+++ b/apps/web/src/renderer/components/profile/AgentProfileModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { Camera, FileText, Trash2 } from 'lucide-react';
 import {
   Dialog,
@@ -55,7 +56,7 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
         if (!cancelled) setProfile(loadedProfile);
       })
       .catch((loadError: unknown) => {
-        if (!cancelled) setError(loadError instanceof Error ? loadError.message : String(loadError));
+        if (!cancelled) setError(getErrorMessage(loadError));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -99,7 +100,7 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
       setProfile(updatedProfile);
       onProfileChanged?.(updatedProfile);
     } catch (restartError) {
-      setError(restartError instanceof Error ? restartError.message : String(restartError));
+      setError(getErrorMessage(restartError));
     } finally {
       setRestarting(false);
     }

--- a/apps/web/src/renderer/components/settings/AddAccountModal.tsx
+++ b/apps/web/src/renderer/components/settings/AddAccountModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 
 import {
   Dialog,
@@ -86,7 +87,7 @@ export function AddAccountModal({ open, openId, onClose, onRetry }: Props) {
           }
         } catch (err) {
           if (cancelled) return;
-          setError(err instanceof Error ? err.message : String(err));
+          setError(getErrorMessage(err));
           setStage('error');
         }
       })();

--- a/apps/web/src/renderer/components/settings/LocalLlmSettingsSection.tsx
+++ b/apps/web/src/renderer/components/settings/LocalLlmSettingsSection.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { ByoLlmConfig, ByoLlmProbeResult } from '@chamber/shared/types';
 import { cn } from '../../lib/utils';
 
@@ -118,7 +119,7 @@ export function LocalLlmSettingsSection() {
       }
       return { headers, error: null };
     } catch (err) {
-      return { error: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}` };
+      return { error: `Invalid JSON: ${getErrorMessage(err)}` };
     }
   };
 

--- a/apps/web/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/web/src/renderer/components/settings/SettingsView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { Camera, LogOut, UserRound } from 'lucide-react';
 import type { MarketplaceRegistry, UserProfile } from '@chamber/shared/types';
 import { APP_VERSION } from '@/renderer/lib/appVersion';
@@ -78,7 +79,7 @@ export function SettingsView() {
         if (!cancelled) applyUserProfile(profile);
       })
       .catch((err: unknown) => {
-        if (!cancelled) setProfileMessage(err instanceof Error ? err.message : String(err));
+        if (!cancelled) setProfileMessage(getErrorMessage(err));
       });
     return () => {
       cancelled = true;
@@ -91,7 +92,7 @@ export function SettingsView() {
 
   useEffect(() => {
     void refreshMarketplaces().catch((err: unknown) => {
-      setMarketplaceMessage(err instanceof Error ? err.message : String(err));
+      setMarketplaceMessage(getErrorMessage(err));
     });
   }, []);
 
@@ -140,7 +141,7 @@ export function SettingsView() {
       applyUserProfile(profile);
       setProfileMessage('Profile saved.');
     } catch (err) {
-      setProfileMessage(err instanceof Error ? err.message : String(err));
+      setProfileMessage(getErrorMessage(err));
     } finally {
       setProfileSaving(false);
     }
@@ -158,7 +159,7 @@ export function SettingsView() {
       applyUserProfile(result.profile);
       setProfileMessage('Imported Microsoft 365 profile. You can edit the fields and save local changes.');
     } catch (err) {
-      setProfileMessage(err instanceof Error ? err.message : String(err));
+      setProfileMessage(getErrorMessage(err));
     } finally {
       setProfileImporting(false);
     }

--- a/packages/services/src/a2a/A2ARelayModeService.ts
+++ b/packages/services/src/a2a/A2ARelayModeService.ts
@@ -1,4 +1,5 @@
 import { ActiveA2AResolver } from './ActiveA2AResolver';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { AgentCardRegistry } from './AgentCardRegistry';
 import { RelayA2ARegistryClient, type RelayA2ARegistryClientOptions } from './RelayA2ARegistryClient';
 import type { A2ARelayQueuedMessage, AgentCard, SendMessageRequest, SendMessageResponse } from './types';
@@ -168,7 +169,7 @@ export class A2ARelayModeService {
       await this.pollOnce();
       this.lastPollError = null;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = getErrorMessage(error);
       this.lastPollError = message;
       log.warn(`A2A relay poll failed: ${message}`, error);
     } finally {

--- a/packages/services/src/a2a/TaskManager.ts
+++ b/packages/services/src/a2a/TaskManager.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { AgentCardRegistry } from './AgentCardRegistry';
 import type { CopilotSession, UserInputHandler, UserInputResponse } from '../mind/types';
 import { Logger } from '../logger';
@@ -413,6 +414,6 @@ function getSessionErrorMessage(event: unknown): string {
   try {
     return getSdkSessionErrorMessage(event);
   } catch (error) {
-    return error instanceof Error ? error.message : String(error);
+    return getErrorMessage(error);
   }
 }

--- a/packages/services/src/a2a/tools.ts
+++ b/packages/services/src/a2a/tools.ts
@@ -1,4 +1,5 @@
 import type { MessageRouter } from './MessageRouter';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { A2AAgentResolver } from './ActiveA2AResolver';
 import type { TaskManager } from './TaskManager';
 import type { TaskState } from './types';
@@ -171,7 +172,7 @@ function buildTaskTools(mindId: string, taskManager: TaskManager): SessionTool[]
       try {
         return taskManager.cancelTask(task_id);
       } catch (err: unknown) {
-        return { error: err instanceof Error ? err.message : String(err) };
+        return { error: getErrorMessage(err) };
       }
     },
   };

--- a/packages/services/src/auth/AuthService.ts
+++ b/packages/services/src/auth/AuthService.ts
@@ -2,6 +2,7 @@
 // Stores the token in the exact Windows credential shape the CLI reads.
 
 import * as https from 'https';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { CredentialStore } from '../ports';
 import { Logger } from '../logger';
 
@@ -252,7 +253,7 @@ export class AuthService {
       onProgress?.({ step: 'error', error: 'Timed out waiting for authorization' });
       return { success: false };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       onProgress?.({ step: 'error', error: message });
       return { success: false };
     }

--- a/packages/services/src/byo-llm/ByoLlmStore.ts
+++ b/packages/services/src/byo-llm/ByoLlmStore.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { ByoLlmConfig } from '@chamber/shared/types';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { Logger } from '../logger';
 import type { CredentialStore } from '../ports';
 
@@ -72,7 +73,7 @@ export class ByoLlmStore {
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code === 'ENOENT') return null;
-      log.warn(`Failed to read BYO LLM config from ${this.filePath}: ${stringifyError(err)}`);
+      log.warn(`Failed to read BYO LLM config from ${this.filePath}: ${getErrorMessage(err)}`);
       return null;
     }
   }
@@ -125,7 +126,7 @@ export class ByoLlmStore {
       const parsed = JSON.parse(credential.password) as unknown;
       return coerceSecrets(parsed);
     } catch (err) {
-      throw new Error(`Failed to read BYO LLM secrets from credential store: ${stringifyError(err)}`, { cause: err });
+      throw new Error(`Failed to read BYO LLM secrets from credential store: ${getErrorMessage(err)}`, { cause: err });
     }
   }
 
@@ -251,10 +252,6 @@ export function redactUrlCredentials(rawUrl: string): string {
   } catch {
     return rawUrl;
   }
-}
-
-function stringifyError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 function stripSecrets(config: ByoLlmConfig): ByoLlmConfig {

--- a/packages/services/src/byo-llm/probeEndpoint.ts
+++ b/packages/services/src/byo-llm/probeEndpoint.ts
@@ -9,6 +9,7 @@
 // Electron context. The IPC adapter remains a thin wrapper.
 
 import * as http from 'node:http';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import * as https from 'node:https';
 
 import type { ByoLlmConfig, ByoLlmProbeResult } from '@chamber/shared/types';
@@ -78,7 +79,7 @@ export async function probeEndpoint(
 
     return { ok: true, modelCount: models.length, models };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     return { ok: false, error: redactSecrets(message, config) };
   }
 }

--- a/packages/services/src/canvas/CanvasServer.ts
+++ b/packages/services/src/canvas/CanvasServer.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { URL } from 'node:url';
+import { isPathInside } from './pathUtils';
 import type { CanvasAction, CanvasServerLike } from './types';
 
 const MIME_TYPES: Record<string, string> = {
@@ -117,17 +118,6 @@ function injectBridge(html: string, filename: string): string {
     return html.replace('</html>', `${additions}\n</html>`);
   }
   return `${html}${additions}`;
-}
-
-function normalizePath(value: string): string {
-  const resolved = path.resolve(value);
-  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
-}
-
-function isPathInside(parent: string, child: string): boolean {
-  const normalizedParent = normalizePath(parent);
-  const normalizedChild = normalizePath(child);
-  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}${path.sep}`);
 }
 
 function readRequestBody(req: IncomingMessage, maxBytes = 64 * 1024): Promise<string> {

--- a/packages/services/src/canvas/CanvasService.ts
+++ b/packages/services/src/canvas/CanvasService.ts
@@ -8,6 +8,7 @@ const log = Logger.create('canvas');
 import type { Tool } from '../mind/types';
 import type { ExternalOpener } from '../ports';
 import { CanvasServer } from './CanvasServer';
+import { isPathInside } from './pathUtils';
 import { buildCanvasTools } from './tools';
 import type {
   CanvasAction,
@@ -35,17 +36,6 @@ function validateCanvasName(name: string): void {
   if (!VALID_CANVAS_NAME.test(name)) {
     throw new Error(`Invalid canvas name "${name}". Use letters, numbers, dots, underscores, or hyphens.`);
   }
-}
-
-function normalizePath(value: string): string {
-  const resolved = path.resolve(value);
-  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
-}
-
-function isPathInside(parent: string, child: string): boolean {
-  const normalizedParent = normalizePath(parent);
-  const normalizedChild = normalizePath(child);
-  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}${path.sep}`);
 }
 
 function wrapHtml(name: string, html: string, title?: string): string {

--- a/packages/services/src/canvas/pathUtils.ts
+++ b/packages/services/src/canvas/pathUtils.ts
@@ -1,0 +1,12 @@
+import path from 'node:path';
+
+export function normalizePath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+export function isPathInside(parent: string, child: string): boolean {
+  const normalizedParent = normalizePath(parent);
+  const normalizedChild = normalizePath(child);
+  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}${path.sep}`);
+}

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -2,6 +2,7 @@
 // Gets sessions from MindManager, streams SDK events via callback.
 
 import type { MindManager } from '../mind';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { ChatEvent, ChatImageAttachment, ConversationResumeResult, ConversationSummary, ModelInfo } from '@chamber/shared/types';
 import { modelSelectionKeyFromModel } from '@chamber/shared/model-selection';
 import type { CopilotSession } from '../mind/types';
@@ -90,7 +91,7 @@ export class ChatService {
         }
       } catch (err) {
         if (abortController.signal.aborted) return;
-        const rawMessage = err instanceof Error ? err.message : String(err);
+        const rawMessage = getErrorMessage(err);
         emit({ type: 'error', message: mapByoLlmError(rawMessage) });
       } finally {
         const active = this.abortControllers.get(mindId);

--- a/packages/services/src/chatroom/ChatroomService.ts
+++ b/packages/services/src/chatroom/ChatroomService.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -292,7 +293,7 @@ export class ChatroomService extends EventEmitter {
       mindName: 'System',
       messageId: randomUUID(),
       roundId,
-      event: { type: 'error', message: `Orchestration error: ${err instanceof Error ? err.message : String(err)}` },
+      event: { type: 'error', message: `Orchestration error: ${getErrorMessage(err)}` },
     } satisfies ChatroomStreamEvent);
   }
 

--- a/packages/services/src/cron/CronService.ts
+++ b/packages/services/src/cron/CronService.ts
@@ -1,4 +1,5 @@
 import { Cron } from 'croner';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { SqliteStore } from '@ianphil/ttasks-ts';
@@ -225,7 +226,7 @@ export class CronService implements ChamberToolProvider {
       return record;
     } catch (err) {
       const endedAt = new Date().toISOString();
-      const error = err instanceof Error ? err.message : String(err);
+      const error = getErrorMessage(err);
       try {
         runStore.recordRun({
           mindId,

--- a/packages/services/src/cron/migrations/v1-to-v2.ts
+++ b/packages/services/src/cron/migrations/v1-to-v2.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import * as path from 'node:path';
 import type { CronJob, CronMigrationError, StoredCronJobs, StoredCronMigrationErrors } from '../types';
 import { STORED_CRON_SCHEMA_VERSION } from '../types';
@@ -68,7 +69,7 @@ export function runMigrations(mindPath: string): void {
         legacyId: legacy.id,
         legacyType: (legacy as { type?: string }).type ?? 'unknown',
         legacyName: legacy.name,
-        reason: err instanceof Error ? err.message : String(err),
+        reason: getErrorMessage(err),
         capturedAt: new Date().toISOString(),
       });
     }
@@ -306,7 +307,7 @@ function readLegacyJobs(
       const raw = JSON.parse(fs.readFileSync(p, 'utf8'));
       return { sourcePath: p, raw };
     } catch (err) {
-      throw new Error(`Cron migration aborted: corrupt JSON at ${p}: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+      throw new Error(`Cron migration aborted: corrupt JSON at ${p}: ${getErrorMessage(err)}`, { cause: err });
     }
   }
   return { sourcePath: null, raw: null };

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { isSafeRelativePath } from './pathSafety';
 import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
 import type {
   GenesisMindTemplate,
@@ -168,12 +169,6 @@ function stringField(record: Record<string, unknown>, key: string): string {
     throw new Error(`Expected string field: ${key}`);
   }
   return value;
-}
-
-function isSafeRelativePath(value: string): boolean {
-  if (!value || path.posix.isAbsolute(value)) return false;
-  const normalized = path.posix.normalize(value);
-  return normalized === '.' || (!normalized.startsWith('..') && !normalized.includes('/../'));
 }
 
 function marketplaceId(source: GenesisMindTemplateMarketplaceSource): string {

--- a/packages/services/src/genesis/GitHubRegistryClient.ts
+++ b/packages/services/src/genesis/GitHubRegistryClient.ts
@@ -1,4 +1,5 @@
 import { listStoredGitHubCredentials, DEFAULT_USER_AGENT } from '../auth';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { CredentialStore } from '../ports';
 
 export interface TreeEntry {
@@ -133,7 +134,7 @@ export class GitHubRegistryClient {
       const account = login ? ` using stored credential "${login}"` : ' anonymously';
       return {
         ok: false,
-        error: new Error(`GitHub API request failed${account}: ${error instanceof Error ? error.message : String(error)}`),
+        error: new Error(`GitHub API request failed${account}: ${getErrorMessage(error)}`),
       };
     } finally {
       clearTimeout(timeout);

--- a/packages/services/src/genesis/MarketplaceRegistryService.ts
+++ b/packages/services/src/genesis/MarketplaceRegistryService.ts
@@ -1,4 +1,6 @@
 import path from 'node:path';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import { isSafeRelativePath } from './pathSafety';
 import { DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE } from './GenesisMindTemplateCatalog';
 import { GitHubRegistryClient, type TreeEntry } from './GitHubRegistryClient';
 import type { AppConfig, MarketplaceRegistry, MarketplaceRegistryActionResult } from '@chamber/shared/types';
@@ -36,7 +38,7 @@ export class MarketplaceRegistryService {
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       };
     }
 
@@ -241,12 +243,6 @@ function safeJoin(base: string, relativePath: string, message: string): string {
     throw new MarketplaceManifestError(message);
   }
   return path.posix.normalize(path.posix.join(base, relativePath));
-}
-
-function isSafeRelativePath(value: string): boolean {
-  if (!value || path.posix.isAbsolute(value)) return false;
-  const normalized = path.posix.normalize(value);
-  return normalized === '.' || (!normalized.startsWith('..') && !normalized.includes('/../'));
 }
 
 function marketplaceValidationMessage(

--- a/packages/services/src/genesis/pathSafety.ts
+++ b/packages/services/src/genesis/pathSafety.ts
@@ -1,0 +1,7 @@
+import path from 'node:path';
+
+export function isSafeRelativePath(value: string): boolean {
+  if (!value || path.posix.isAbsolute(value)) return false;
+  const normalized = path.posix.normalize(value);
+  return normalized === '.' || (!normalized.startsWith('..') && !normalized.includes('/../'));
+}

--- a/packages/services/src/lens/MindBootstrap.ts
+++ b/packages/services/src/lens/MindBootstrap.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
 import { Logger } from '../logger';
+import { computeManagedFileHash } from '../skills/MarketplaceSkillMaterializer';
 import type { ManagedSkillAsset, ManagedSkillAssetFile, ManagedSkillManifest, ManagedSkillMarketplaceSource } from '../skills/skillTypes';
 
 const log = Logger.create('MindBootstrap');
@@ -148,7 +149,7 @@ function getInstalledManagedSkillState(
     const buffer = Buffer.isBuffer(content) ? content : Buffer.from(String(content));
     const installedSha256 = metadata.algorithm === 'sha256-legacy-single-file'
       ? sha256Buffer(buffer)
-      : sha256ManagedFile(file.path, buffer);
+      : computeManagedFileHash(file.path, buffer);
     if (installedSha256 !== file.sha256) return 'modified';
   }
 
@@ -268,17 +269,6 @@ interface LegacyManagedSkillMetadata {
 
 function sha256Buffer(content: Buffer): string {
   return createHash('sha256').update(content).digest('hex');
-}
-
-function sha256ManagedFile(filePath: string, content: Buffer): string {
-  return createHash('sha256')
-    .update(filePath)
-    .update('\0')
-    .update(String(content.byteLength))
-    .update('\0')
-    .update(content)
-    .update('\0')
-    .digest('hex');
 }
 
 function sha256Text(content: string): string {

--- a/packages/services/src/mindProfile/MindProfileService.ts
+++ b/packages/services/src/mindProfile/MindProfileService.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import * as path from 'path';
 import type {
   AgentProfile,
@@ -49,7 +50,7 @@ export class MindProfileService {
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
         profile: this.getProfile(request.mindId),
       };
     }
@@ -94,7 +95,7 @@ export class MindProfileService {
       restorePrevious(targetPath, previous);
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
         profile: this.getProfile(request.mindId),
       };
     }

--- a/packages/services/src/sdk/SdkBootstrap.ts
+++ b/packages/services/src/sdk/SdkBootstrap.ts
@@ -1,6 +1,7 @@
 // SDK bootstrap — pure runtime path resolution and validation for dev/packaged builds.
 
 import * as fs from 'fs';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import * as path from 'path';
 import type { SdkRuntimeLayout } from '../ports';
 import { Logger } from '../logger';
@@ -66,7 +67,7 @@ function readJsonFile<T>(filePath: string): T {
     return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
   } catch (error) {
     throw new Error(
-      `Failed to read JSON file at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to read JSON file at ${filePath}: ${getErrorMessage(error)}`,
       { cause: error },
     );
   }

--- a/packages/services/src/session-group/orchestrators/ConcurrentStrategy.ts
+++ b/packages/services/src/session-group/orchestrators/ConcurrentStrategy.ts
@@ -1,4 +1,5 @@
 import type { MindContext } from '@chamber/shared/types';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { OrchestrationStrategy, OrchestrationContext } from './legacy-types';
 import type { CopilotSession } from '../../mind';
 import { isStaleSessionError } from '@chamber/shared/sessionErrors';
@@ -101,7 +102,7 @@ export class ConcurrentStrategy implements OrchestrationStrategy {
       } catch (err) {
         if (!abortController.signal.aborted) {
           if (isStaleSessionError(err)) throw err;
-          const message = err instanceof Error ? err.message : String(err);
+          const message = getErrorMessage(err);
           context.emitEvent({
             mindId: mind.mindId,
             mindName: mind.identity.name,

--- a/packages/services/src/session-group/orchestrators/GroupChatStrategy.ts
+++ b/packages/services/src/session-group/orchestrators/GroupChatStrategy.ts
@@ -1,4 +1,5 @@
 import type { MindContext } from '@chamber/shared/types';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type {
   GroupChatConfig,
 } from '@chamber/shared/chatroom-types';
@@ -138,7 +139,7 @@ export class GroupChatStrategy extends BaseStrategy {
         mindName: moderator.identity.name,
         messageId: '',
         roundId,
-        event: { type: 'error', message: `Moderator failed: ${err instanceof Error ? err.message : String(err)}` },
+        event: { type: 'error', message: `Moderator failed: ${getErrorMessage(err)}` },
       });
       return;
     }

--- a/packages/services/src/session-group/orchestrators/MagenticStrategy.ts
+++ b/packages/services/src/session-group/orchestrators/MagenticStrategy.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { MindContext } from '@chamber/shared/types';
 import type {
   MagenticConfig,
@@ -132,7 +133,7 @@ export class MagenticStrategy extends BaseStrategy {
         silent: true,
       }));
     } catch (err) {
-      obs.failure(`Planning failed: ${err instanceof Error ? err.message : String(err)}`);
+      obs.failure(`Planning failed: ${getErrorMessage(err)}`);
       obs.end({ terminationReason: 'ERROR' });
       return;
     }
@@ -221,7 +222,7 @@ export class MagenticStrategy extends BaseStrategy {
           silent: true,
         }));
       } catch (err) {
-        obs.failure(`Assignment failed: ${err instanceof Error ? err.message : String(err)}`, { step });
+        obs.failure(`Assignment failed: ${getErrorMessage(err)}`, { step });
         break;
       }
       const assignDecision = parseManagerResponse(assignRawContent);

--- a/packages/services/src/session-group/stream-session.ts
+++ b/packages/services/src/session-group/stream-session.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { MindContext } from '@chamber/shared/types';
 import type { ChatroomStreamEvent, OrchestrationMode, ChatroomMessage } from '@chamber/shared/chatroom-types';
 import type { OrchestrationContext } from './orchestrators/legacy-types';
@@ -207,7 +208,7 @@ export async function streamAgentTurn(opts: StreamAgentOptions): Promise<StreamA
     } else {
       emitEvent({
         type: 'error',
-        message: err instanceof Error ? err.message : String(err),
+        message: getErrorMessage(err),
       });
     }
     throw err;

--- a/packages/services/src/skills/ManagedSkillService.ts
+++ b/packages/services/src/skills/ManagedSkillService.ts
@@ -1,4 +1,5 @@
 import { Logger } from '../logger';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { installManagedSkillAsset } from '../lens/MindBootstrap';
 import type { MarketplaceSkillCatalog } from './MarketplaceSkillCatalog';
 import type { MarketplaceSkillMaterializer } from './MarketplaceSkillMaterializer';
@@ -48,7 +49,7 @@ export class ManagedSkillService {
       try {
         this.installAsset(mindPath, asset);
       } catch (error) {
-        log.warn(`Managed skill install failed for ${asset.manifest.name}: ${error instanceof Error ? error.message : String(error)}`);
+        log.warn(`Managed skill install failed for ${asset.manifest.name}: ${getErrorMessage(error)}`);
       }
     }
 
@@ -67,7 +68,7 @@ export class ManagedSkillService {
         errors.push({
           marketplaceId: skill.source.marketplaceId,
           skillId: skill.id,
-          message: error instanceof Error ? error.message : String(error),
+          message: getErrorMessage(error),
         });
       }
     }

--- a/packages/services/src/skills/MarketplaceSkillCatalog.ts
+++ b/packages/services/src/skills/MarketplaceSkillCatalog.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { DEFAULT_GENESIS_MIND_TEMPLATE_SOURCE, GitHubRegistryClient, type TreeEntry } from '../genesis';
 import type { MarketplaceSkillEntry, SkillMarketplaceSource } from './skillTypes';
 
@@ -34,7 +35,7 @@ export class MarketplaceSkillCatalog {
       } catch (error) {
         errors.push({
           marketplaceId: marketplaceId(source),
-          message: error instanceof Error ? error.message : String(error),
+          message: getErrorMessage(error),
         });
       }
     }

--- a/packages/services/src/tools/GitHubReleaseAssetClient.ts
+++ b/packages/services/src/tools/GitHubReleaseAssetClient.ts
@@ -1,4 +1,5 @@
 import { listStoredGitHubCredentials, DEFAULT_USER_AGENT } from '../auth';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { CredentialStore } from '../ports';
 import type { GitHubRegistryCredential, GitHubRegistryCredentialProvider } from '../genesis/GitHubRegistryClient';
 
@@ -144,7 +145,7 @@ export class GitHubReleaseAssetClient {
     try {
       return await this.fetchImpl(url, { ...init, signal: abort.signal });
     } catch (error) {
-      throw new Error(`GitHub release request failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+      throw new Error(`GitHub release request failed: ${getErrorMessage(error)}`, { cause: error });
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/services/src/tools/MarketplaceToolCatalog.ts
+++ b/packages/services/src/tools/MarketplaceToolCatalog.ts
@@ -1,4 +1,5 @@
 import { GitHubRegistryClient, type TreeEntry } from '../genesis/GitHubRegistryClient';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { GitHubReleaseAssetSelector, MarketplaceToolEntry, MarketplaceToolInstall } from '@chamber/shared/types';
 import type { ToolMarketplaceSource } from './toolTypes';
 
@@ -36,7 +37,7 @@ export class MarketplaceToolCatalog {
       } catch (error) {
         errors.push({
           marketplaceId: source.id ?? `github:${source.owner}/${source.repo}`,
-          message: error instanceof Error ? error.message : String(error),
+          message: getErrorMessage(error),
         });
       }
     }

--- a/packages/services/src/tools/ToolsService.ts
+++ b/packages/services/src/tools/ToolsService.ts
@@ -1,4 +1,5 @@
 import type { AppConfig, InstalledTool, MarketplaceToolEntry, ToolActionResult, ToolCatalogEntry } from '@chamber/shared/types';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { Logger } from '../logger';
 import { MarketplaceToolCatalog } from './MarketplaceToolCatalog';
 import { ToolInstaller } from './ToolInstaller';
@@ -58,7 +59,7 @@ export class ToolsService {
     try {
       await this.installer.uninstall(tool);
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return { success: false, error: getErrorMessage(error) };
     }
     this.persist(installed.filter((entry) => entry.id !== toolId));
     return { success: true };
@@ -105,7 +106,7 @@ export class ToolsService {
       this.persist(next);
       return { success: true, tool: installed };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return { success: false, error: getErrorMessage(error) };
     }
   }
 

--- a/packages/services/src/userProfile/MicrosoftGraphProfileImporter.ts
+++ b/packages/services/src/userProfile/MicrosoftGraphProfileImporter.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import {
@@ -96,7 +97,7 @@ export class MicrosoftGraphProfileImporter {
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
         profile: this.profileService.getProfile(),
       };
     } finally {

--- a/packages/shared/src/getErrorMessage.test.ts
+++ b/packages/shared/src/getErrorMessage.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { getErrorMessage } from './getErrorMessage';
+
+describe('getErrorMessage', () => {
+  it('returns the message of an Error instance', () => {
+    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('preserves messages from Error subclasses', () => {
+    class CustomError extends Error {}
+    expect(getErrorMessage(new CustomError('custom'))).toBe('custom');
+  });
+
+  it('stringifies a string value', () => {
+    expect(getErrorMessage('plain string')).toBe('plain string');
+  });
+
+  it('stringifies a number value', () => {
+    expect(getErrorMessage(42)).toBe('42');
+  });
+
+  it('stringifies null and undefined', () => {
+    expect(getErrorMessage(null)).toBe('null');
+    expect(getErrorMessage(undefined)).toBe('undefined');
+  });
+
+  it('stringifies a plain object', () => {
+    expect(getErrorMessage({ code: 'E' })).toBe('[object Object]');
+  });
+});

--- a/packages/shared/src/getErrorMessage.ts
+++ b/packages/shared/src/getErrorMessage.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,3 +7,4 @@ export { IPC, type IpcChannel } from './ipc-channels';
 export { parseIpcArgs } from './ipc-validation';
 export { Logger, type LogLevel } from './logger';
 export { escapeXml } from './escapeXml';
+export { getErrorMessage } from './getErrorMessage';


### PR DESCRIPTION
Follow-up to the dead-code cleanup PR #379. This is an independent, surgical refactor that removes five clusters of copy-pasted code by introducing single shared helpers. Behavior is preserved everywhere; security-sensitive guards were extracted byte-for-byte.

## Consolidations

1. **`getErrorMessage(err)`** — new helper in `packages/shared/src/getErrorMessage.ts` (with colocated tests) returning `err instanceof Error ? err.message : String(err)`. Replaces ~60 copies of that idiom across `apps/desktop`, `apps/web`, `apps/server`, and `packages/services`, and replaces the local `formatError` (UpdaterService) and `stringifyError` (ByoLlmStore) wrappers. Lives in `@chamber/shared` (no node/electron imports) so every layer can consume it.
2. **`isSafeRelativePath`** (security-sensitive) — extracted to `packages/services/src/genesis/pathSafety.ts`; imported by `GenesisMindTemplateCatalog` and `MarketplaceRegistryService`. Guard logic preserved exactly. (Intentionally did **not** touch the similarly-named but non-equivalent guards in `GenesisMindTemplateInstaller`/`MarketplaceSkillCatalog`.)
3. **`normalizePath` / `isPathInside`** (security-sensitive) — extracted to `packages/services/src/canvas/pathUtils.ts`; imported by `CanvasServer` and `CanvasService`. Behavior preserved exactly.
4. **Managed-file hash** — deleted the local `sha256ManagedFile` in `lens/MindBootstrap.ts` and reused the already-exported `computeManagedFileHash` from the skills module. `deps:check` confirms the cross-module import introduces no layering violation or cycle.
5. **`AGENT_COLORS` + `agentColor`** — extracted to `apps/web/src/renderer/components/chat/agentColors.ts`; imported by `MessageList` and `ChatroomPanel`. The adjacent display-name helpers were **left alone** — they differ in fallback trimming and are not truly equivalent.

## Verification

- `npm run typecheck` — clean
- `npx eslint .` — clean
- `npm run deps:check` — no dependency violations (514 modules)
- `npm test` — all green except the pre-existing `MindProfileService > rejects symlinked profile files` test, which fails with `EPERM: operation not permitted, symlink` on Windows (environmental, unrelated to this change; passes elsewhere). The `ChatInput` popover test is a pre-existing timing flake under full-suite load and passes in isolation.

`package-lock.json` was restored after `npm install` and is not part of this PR.