### PR TITLE
Fix legacy conversation session-state fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,4 @@ When contributing to Chamber:
 - Cron schedules must reference TypeScript automation scripts; do not introduce arbitrary shell execution paths
 - Tool call responses must be sanitized before display in chat UI
 - Multi-agent chatroom changes require review of orchestration safety (delegation limits, approval gates)
+- Invariant test failures are contract violations, not routine test updates. Do not weaken, delete, or rewrite an invariant test just to make a change pass; stop and discuss whether the protected contract must remain, the change should be abandoned, or the invariant needs an explicit, reviewed replacement with the original side effect still documented.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Restore legacy conversation resume fallback** — Conversation resume now falls back from Chamber's current SDK session-state root to the legacy default Copilot session-state root before recreating a missing session, so pre-move chat history hydrates instead of opening empty.
+
+
 ## [0.64.1] - 2026-06-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
-- **Add invariant test suite** — Introduces test:invariants for high-signal Chamber contracts covering session-state fallback order, renderer/shared architecture boundaries, approval default-deny behavior, Electron window preferences, and cron script validation.
+- **Add invariant test suite** — Introduces test:invariants for high-signal Chamber contracts covering session-state fallback order, stable conversation state roots, SDK config discovery, metadata-only history records, renderer/preload and shared architecture boundaries, managed skill/session ordering, approval redaction/default-deny behavior, credential-write boundaries, automation bridge/token safety, startup prewarm ordering, Electron window preferences, and cron script validation.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Restore legacy conversation resume fallback** — Conversation resume now falls back from Chamber's current SDK session-state root to the legacy default Copilot session-state root before recreating a missing session, so pre-move chat history hydrates instead of opening empty.
 
+### Tests
+
+- **Add invariant test suite** — Introduces test:invariants for high-signal Chamber contracts covering session-state fallback order, renderer/shared architecture boundaries, approval default-deny behavior, Electron window preferences, and cron script validation.
+
+
 
 ## [0.64.1] - 2026-06-01
 

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     include: [
       'apps/**/*.{test,spec}.{ts,tsx}',
       'packages/**/*.{test,spec}.{ts,tsx}',
+      'tests/invariants/**/*.{test,spec}.{ts,tsx}',
       'tests/regression/**/*.{test,spec}.{ts,tsx}',
       '.github/extensions/**/*.{test,spec}.mjs',
     ],

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "deps:check": "depcruise apps packages --config config/dependency-cruiser.cjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config config/vitest.config.ts --no-file-parallelism --maxWorkers=1",
+    "test:invariants": "vitest run --config config/vitest.config.ts --no-file-parallelism --maxWorkers=1 tests/invariants",
     "test:coverage": "vitest run --config config/vitest.config.ts --coverage --no-file-parallelism --maxWorkers=1",
     "clean": "node scripts/clean-artifacts.js",
     "capture:hero": "node scripts/capture-readme-hero.js",

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -874,6 +874,7 @@ describe('MindManager', () => {
       manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
       mockCreateSession.mockClear();
       mockResumeSession.mockRejectedValueOnce(new Error('failed to resume session: Session not found: stale-session'));
+      mockResumeSession.mockRejectedValueOnce(new Error('failed to resume session: Session not found: stale-legacy-session'));
       mockCreateSession.mockResolvedValueOnce(reattachedSession);
 
       const recovered = await manager.recoverActiveConversationSession(mind.mindId);
@@ -882,6 +883,10 @@ describe('MindManager', () => {
       expect(mockResumeSession).toHaveBeenCalledWith(
         mind.activeSessionId,
         expect.objectContaining({ workingDirectory: '/tmp/agents/q' }),
+      );
+      expect(mockResumeSession).toHaveBeenCalledWith(
+        mind.activeSessionId,
+        expect.not.objectContaining({ configDir: expect.any(String) }),
       );
       expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
         sessionId: mind.activeSessionId,
@@ -901,6 +906,7 @@ describe('MindManager', () => {
       manager.markActiveConversationHasMessages(mind.mindId, 'Hello Q');
       mockCreateSession.mockClear();
       mockResumeSession.mockRejectedValueOnce(new Error('Session not found: stale-1'));
+      mockResumeSession.mockRejectedValueOnce(new Error('Session not found: stale-legacy'));
       mockCreateSession.mockRejectedValueOnce(new Error('Session not found: stale-2'));
 
       await expect(manager.recoverActiveConversationSession(mind.mindId)).rejects.toThrow(/Session not found/);
@@ -997,6 +1003,54 @@ describe('MindManager', () => {
       expect(result.conversations.map((conversation) => conversation.sessionId)).toEqual(
         historyBeforeResume.map((conversation) => conversation.sessionId),
       );
+    });
+
+    it('falls back to the legacy default session-state root when Chamber runtime state is missing', async () => {
+      const legacySession = createSessionStub();
+      legacySession.getEvents.mockResolvedValue([
+        {
+          type: 'user.message',
+          timestamp: '2026-05-05T22:00:00.000Z',
+          data: { messageId: 'u1', content: 'legacy chat' },
+        },
+      ]);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+      await manager.startNewConversation(mind.mindId);
+      const target = manager.listConversationHistory(mind.mindId)[1];
+      mockResumeSession.mockClear();
+      mockResumeSession
+        .mockRejectedValueOnce(new Error('failed to resume session: Session not found: missing-runtime'))
+        .mockResolvedValueOnce(legacySession);
+
+      const result = await manager.resumeConversation(mind.mindId, target.sessionId);
+
+      expect(mockResumeSession).toHaveBeenCalledTimes(2);
+      expect(mockResumeSession).toHaveBeenNthCalledWith(
+        1,
+        target.sessionId,
+        expect.objectContaining({
+          configDir: COPILOT_RUNTIME_CONFIG_DIR,
+          enableConfigDiscovery: false,
+        }),
+      );
+      expect(mockResumeSession).toHaveBeenNthCalledWith(
+        2,
+        target.sessionId,
+        expect.not.objectContaining({ configDir: expect.any(String) }),
+      );
+      const legacyResumeConfig = mockResumeSession.mock.calls[1][1] as Record<string, unknown>;
+      expect(legacyResumeConfig.enableConfigDiscovery).toBe(false);
+      expect(result.sessionId).toBe(target.sessionId);
+      expect(result.messages).toEqual([
+        {
+          id: 'u1',
+          role: 'user',
+          blocks: [{ type: 'text', content: 'legacy chat' }],
+          timestamp: Date.parse('2026-05-05T22:00:00.000Z'),
+        },
+      ]);
+      expect(mockCreateSession).toHaveBeenCalledTimes(2);
     });
 
     it('wires approveForSessionCompat on resumed sessions and does not short-circuit via setApproveAll (issue #131)', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -1189,6 +1189,7 @@ export class MindManager extends EventEmitter {
     useSetApproveAllShortcut = false,
     model?: string,
     modelProvider?: ModelProvider,
+    configDir: string | null = this.getCopilotRuntimeConfigDir(),
   ): Promise<CopilotSession> {
     this.assertResumeSessionPolicy(kind);
     const mcpServers = loadMcpServersFromMindPath(mindPath);
@@ -1198,7 +1199,6 @@ export class MindManager extends EventEmitter {
     const effectiveModel = this.resolveModelForSdk(model, provider);
     const sessionConfig: ResumeSessionConfig = {
       workingDirectory: mindPath,
-      configDir: this.getCopilotRuntimeConfigDir(),
       enableConfigDiscovery: false,
       tools,
       systemMessage: {
@@ -1211,6 +1211,7 @@ export class MindManager extends EventEmitter {
       onPermissionRequest,
       ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
       ...(skillDirectories.length > 0 ? { skillDirectories } : {}),
+      ...(configDir ? { configDir } : {}),
       ...(chamberMindConfig.excludedTools && chamberMindConfig.excludedTools.length > 0
         ? { excludedTools: chamberMindConfig.excludedTools }
         : {}),
@@ -1277,7 +1278,26 @@ export class MindManager extends EventEmitter {
       );
     } catch (error) {
       if (!isStaleSessionError(error)) throw error;
-      log.warn(`SDK session ${conversationSessionId} was not found; reattaching by recreating the session under the same id.`);
+      log.warn(`SDK session ${conversationSessionId} was not found in Chamber runtime state; trying legacy default session-state.`);
+      try {
+        return await this.resumeSessionForMind(
+          client,
+          kind,
+          conversationSessionId,
+          mindPath,
+          systemMessage,
+          tools,
+          undefined,
+          approveForSessionCompat,
+          false,
+          model,
+          modelProvider,
+          null,
+        );
+      } catch (legacyError) {
+        if (!isStaleSessionError(legacyError)) throw legacyError;
+      }
+      log.warn(`SDK session ${conversationSessionId} was not found in either session-state root; reattaching by recreating the session under the same id.`);
       return this.createSessionForMind({
         kind,
         client,

--- a/tests/invariants/architecture.invariant.test.ts
+++ b/tests/invariants/architecture.invariant.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const repoRoot = process.cwd();
+
+function walkSourceFiles(root: string): string[] {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return walkSourceFiles(fullPath);
+    return /\.(ts|tsx)$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+function importSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const importPattern = /\bimport\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/g;
+  const dynamicImportPattern = /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g;
+  for (const match of source.matchAll(importPattern)) specifiers.push(match[1]);
+  for (const match of source.matchAll(dynamicImportPattern)) specifiers.push(match[1]);
+  return specifiers;
+}
+
+describe('architecture invariants', () => {
+  it('renderer source never imports Electron directly', () => {
+    const rendererRoot = path.join(repoRoot, 'apps', 'web', 'src');
+    const violations = walkSourceFiles(rendererRoot).flatMap((filePath) => {
+      const imports = importSpecifiers(fs.readFileSync(filePath, 'utf8'));
+      return imports.includes('electron') ? [path.relative(repoRoot, filePath)] : [];
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('shared source never imports main-process or renderer modules', () => {
+    const sharedRoot = path.join(repoRoot, 'packages', 'shared', 'src');
+    const forbidden = /^(?:@\/(?:main|renderer)\b|.*\/(?:main|renderer)(?:\/|$))/;
+    const violations = walkSourceFiles(sharedRoot).flatMap((filePath) => {
+      const imports = importSpecifiers(fs.readFileSync(filePath, 'utf8'));
+      return imports
+        .filter((specifier) => forbidden.test(specifier))
+        .map((specifier) => `${path.relative(repoRoot, filePath)} imports ${specifier}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/invariants/architecture.invariant.test.ts
+++ b/tests/invariants/architecture.invariant.test.ts
@@ -33,6 +33,19 @@ describe('architecture invariants', () => {
     expect(violations).toEqual([]);
   });
 
+  it('renderer source only reaches Electron through the preload-exposed API', () => {
+    const rendererRoot = path.join(repoRoot, 'apps', 'web', 'src');
+    const forbidden = /\b(?:ipcRenderer|contextBridge)\b/;
+    const violations = walkSourceFiles(rendererRoot).flatMap((filePath) => {
+      const source = fs.readFileSync(filePath, 'utf8');
+      return forbidden.test(source)
+        ? [`${path.relative(repoRoot, filePath)} bypasses the preload bridge`]
+        : [];
+    });
+
+    expect(violations).toEqual([]);
+  });
+
   it('shared source never imports main-process or renderer modules', () => {
     const sharedRoot = path.join(repoRoot, 'packages', 'shared', 'src');
     const forbidden = /^(?:@\/(?:main|renderer)\b|.*\/(?:main|renderer)(?:\/|$))/;

--- a/tests/invariants/renderer-state.invariant.test.ts
+++ b/tests/invariants/renderer-state.invariant.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { appReducer } from '../../apps/web/src/renderer/lib/store/reducers';
+import { initialState, type AppState } from '../../apps/web/src/renderer/lib/store/state';
+import type { Message } from '@chamber/shared/a2a-types';
+
+const mindId = 'mind-a';
+
+const withActiveMind: AppState = {
+  ...initialState,
+  minds: [{
+    mindId,
+    mindPath: 'C:\\agents\\a',
+    identity: { name: 'Agent A', systemMessage: '' },
+    status: 'ready',
+  }],
+  activeMindId: mindId,
+};
+
+describe('renderer state invariants', () => {
+  it('unsent compose drafts are scoped per mind and clearing one mind preserves the others', () => {
+    let state = appReducer(withActiveMind, {
+      type: 'SET_COMPOSE_DRAFT',
+      payload: { mindId: 'mind-a', draft: 'alpha draft' },
+    });
+    state = appReducer(state, {
+      type: 'SET_COMPOSE_DRAFT',
+      payload: { mindId: 'mind-b', draft: 'beta draft' },
+    });
+
+    expect(state.composeDraftByMind).toEqual({
+      'mind-a': 'alpha draft',
+      'mind-b': 'beta draft',
+    });
+
+    state = appReducer(state, {
+      type: 'SET_COMPOSE_DRAFT',
+      payload: { mindId: 'mind-b', draft: '' },
+    });
+
+    expect(state.composeDraftByMind).toEqual({ 'mind-a': 'alpha draft' });
+  });
+
+  it('sending a user message clears only the active mind draft', () => {
+    const state = appReducer({
+      ...withActiveMind,
+      composeDraftByMind: {
+        [mindId]: 'about to send',
+        'other-mind': 'still typing elsewhere',
+      },
+    }, {
+      type: 'ADD_USER_MESSAGE',
+      payload: { id: 'u1', content: 'about to send', timestamp: 1 },
+    });
+
+    expect(state.composeDraftByMind).toEqual({ 'other-mind': 'still typing elsewhere' });
+  });
+
+  it('inbound A2A messages keep sender attribution instead of rendering as You', () => {
+    const message: Message = {
+      messageId: 'msg-a2a-1',
+      role: 'ROLE_USER',
+      parts: [{ text: 'Inspect the demo transcript.' }],
+      metadata: { fromId: 'ernest-1234', fromName: 'Ernest', hopCount: 1 },
+    };
+
+    const state = appReducer(withActiveMind, {
+      type: 'A2A_INCOMING',
+      payload: { targetMindId: mindId, message, replyMessageId: 'reply-a2a-1' },
+    });
+
+    const messages = state.messagesByMind[mindId] ?? [];
+    expect(messages[0]).toMatchObject({
+      role: 'user',
+      sender: { mindId: 'ernest-1234', name: 'Ernest' },
+      blocks: [{ type: 'text', content: 'Inspect the demo transcript.' }],
+    });
+    expect(messages[0].sender).not.toEqual({ mindId: 'user', name: 'You' });
+    expect(messages[1]).toMatchObject({
+      id: 'reply-a2a-1',
+      role: 'assistant',
+      isStreaming: true,
+    });
+  });
+});

--- a/tests/invariants/security-boundaries.invariant.test.ts
+++ b/tests/invariants/security-boundaries.invariant.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ApprovalGate } from '../../packages/services/src/session-group/approval-gate';
+import { ObservabilityEmitter } from '../../packages/services/src/session-group/observability';
+import { AutomationBridge } from '../../packages/services/src/automation/AutomationBridge';
+import { TokenRegistry } from '../../packages/services/src/automation/TokenRegistry';
 
 const repoRoot = process.cwd();
 
@@ -25,6 +28,138 @@ describe('security boundary invariants', () => {
     expect(result.reason).toMatch(/No approval handler/);
   });
 
+  it('approval and tool observability redact sensitive parameters before logging', async () => {
+    const gate = new ApprovalGate({ demoMode: true });
+    await gate.gate('agent-1', 'send_email', {
+      password: 'plain-secret',
+      token: 'plain-token',
+      body: 'private message body',
+      to: 'user@example.com',
+    }, 'send update');
+
+    const audit = gate.getAuditLog()[0];
+    expect(audit.request.parameters).toMatchObject({
+      password: '[REDACTED]',
+      token: '[REDACTED]',
+      body: '[REDACTED]',
+      to: 'user@example.com',
+    });
+
+    const obs = new ObservabilityEmitter('handoff');
+    const events: unknown[] = [];
+    obs.on((event) => events.push(event));
+    obs.toolCallAttempted('agent-1', 'post_message', {
+      authorization: 'Bearer secret',
+      content: 'private content',
+      channel: 'general',
+    });
+
+    const attempted = events[0] as { data: { parameters: Record<string, unknown> } };
+    expect(attempted.data.parameters).toMatchObject({
+      authorization: '[REDACTED]',
+      content: '[REDACTED]',
+      channel: 'general',
+    });
+  });
+
+  it('credential writes stay behind credential-store ports instead of app config or mind files', () => {
+    const productionFiles = [
+      ...walkSourceFiles(path.join(repoRoot, 'apps')),
+      ...walkSourceFiles(path.join(repoRoot, 'packages')),
+    ].filter((filePath) => !/\.(test|spec)\.tsx?$/.test(filePath));
+    const allowedSetPasswordFiles = new Set([
+      path.join(repoRoot, 'apps', 'desktop', 'src', 'main', 'ipc', 'a2a.ts'),
+      path.join(repoRoot, 'apps', 'server', 'src', 'bin.ts'),
+      path.join(repoRoot, 'apps', 'server', 'src', 'privileged-protocol.ts'),
+      path.join(repoRoot, 'packages', 'services', 'src', 'auth', 'AuthService.ts'),
+      path.join(repoRoot, 'packages', 'services', 'src', 'byo-llm', 'ByoLlmStore.ts'),
+      path.join(repoRoot, 'packages', 'services', 'src', 'ports.ts'),
+    ]);
+    const violations = productionFiles.flatMap((filePath) => {
+      const source = fs.readFileSync(filePath, 'utf8');
+      if (!source.includes('setPassword(')) return [];
+      return allowedSetPasswordFiles.has(filePath)
+        ? []
+        : [`${path.relative(repoRoot, filePath)} writes credentials outside the approved credential-store boundary`];
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('automation bridge tokens are per-run and revoked explicitly', () => {
+    const tokens = new TokenRegistry();
+    const first = tokens.mint('mind-1', 'run-1');
+    const second = tokens.mint('mind-1', 'run-2');
+
+    expect(first.token).not.toBe(second.token);
+    expect(tokens.verify(first.token)).toEqual({ mindId: 'mind-1', runId: 'run-1' });
+    expect(tokens.verify(second.token)).toEqual({ mindId: 'mind-1', runId: 'run-2' });
+
+    tokens.revoke(first.token);
+    expect(tokens.verify(first.token)).toBeNull();
+    expect(tokens.verify(second.token)).toEqual({ mindId: 'mind-1', runId: 'run-2' });
+
+    tokens.revokeRun('run-2');
+    expect(tokens.verify(second.token)).toBeNull();
+    expect(tokens.size()).toBe(0);
+  });
+
+  it('automation bridge binds to loopback and rejects mind-id mismatch', async () => {
+    const bridge = new AutomationBridge({
+      onPrompt: async () => ({ text: 'ok' }),
+      onNotify: async () => undefined,
+    });
+    const started = await bridge.start();
+    try {
+      expect(started.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      const minted = bridge.tokens.mint('mind-1', 'run-1');
+      const response = await fetch(`${started.url}/prompt`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${minted.token}`,
+        },
+        body: JSON.stringify({ mindId: 'mind-2', prompt: 'hello' }),
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: 'mind-mismatch' });
+    } finally {
+      await started.stop();
+    }
+  });
+
+  it('startup never awaits SDK prewarm before creating the main window', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'apps', 'desktop', 'src', 'main.ts'), 'utf8');
+    const readyHandler = source.match(/app\.on\('ready', async \(\) => \{(?<body>[\s\S]*?)\n\}\);/)?.groups?.body;
+
+    expect(readyHandler).toBeDefined();
+    expect(readyHandler).toContain('void chamberCopilotService.prewarm();');
+    expect(readyHandler).not.toMatch(/await\s+chamberCopilotService\.prewarm\(/);
+    expect(readyHandler!.indexOf('void chamberCopilotService.prewarm();')).toBeLessThan(
+      readyHandler!.indexOf('createWindow();'),
+    );
+  });
+
+  it('mind tool providers are registered before startup restores sessions', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'apps', 'desktop', 'src', 'main.ts'), 'utf8');
+
+    const providerConstruction = source.indexOf('const mindToolProviders: ChamberToolProvider[]');
+    const providerRegistration = source.indexOf('mindManager.setProviders(mindToolProviders);');
+    const restoreCall = source.indexOf('mindManager.restoreFromConfig()');
+
+    expect(providerConstruction).toBeGreaterThan(-1);
+    expect(providerRegistration).toBeGreaterThan(providerConstruction);
+    expect(providerRegistration).toBeLessThan(restoreCall);
+  });
+
+  it('script runner redacts bridge tokens from captured output and errors', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'ScriptRunner.ts'), 'utf8');
+
+    expect(source).toMatch(/sanitizeOutput\(stdout,\s*truncatedOut,\s*minted\.token\)/);
+    expect(source).toMatch(/sanitizeOutput\(stderr \|\| `Script exited with code \$\{exitCode\}`,\s*truncatedErr,\s*minted\.token\)/);
+  });
+
   it('cron execution and validation both resolve scripts through validateScriptPath', () => {
     const cronService = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'CronService.ts'), 'utf8');
     const scriptRunner = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'ScriptRunner.ts'), 'utf8');
@@ -34,3 +169,12 @@ describe('security boundary invariants', () => {
     expect(scriptRunner).toMatch(/async validateScript\([\s\S]*?validateScriptPath\(params\.mindPath,\s*params\.scriptPath\)/);
   });
 });
+
+function walkSourceFiles(root: string): string[] {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return walkSourceFiles(fullPath);
+    return /\.(ts|tsx)$/.test(entry.name) ? [fullPath] : [];
+  });
+}

--- a/tests/invariants/security-boundaries.invariant.test.ts
+++ b/tests/invariants/security-boundaries.invariant.test.ts
@@ -160,6 +160,30 @@ describe('security boundary invariants', () => {
     expect(source).toMatch(/sanitizeOutput\(stderr \|\| `Script exited with code \$\{exitCode\}`,\s*truncatedErr,\s*minted\.token\)/);
   });
 
+  it('managed core skills stay lens automation and ttasks from the default marketplace only', () => {
+    const managedService = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'skills', 'ManagedSkillService.ts'), 'utf8');
+    const catalog = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'skills', 'MarketplaceSkillCatalog.ts'), 'utf8');
+
+    expect(managedService).toContain("const CORE_SKILL_IDS = new Set(['lens', 'automation', 'ttasks']);");
+    expect(catalog).toContain("const RESERVED_CORE_SKILL_IDS = new Set(['lens', 'automation', 'ttasks']);");
+    expect(catalog).toMatch(/reserved && marketplaceId\(source\) !== DEFAULT_CORE_SKILL_MARKETPLACE_ID/);
+  });
+
+  it('cron job schema remains script-path based and does not reintroduce inline shell jobs', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'types.ts'), 'utf8');
+    const cronJob = source.match(/export interface CronJob \{(?<body>[\s\S]*?)\n\}/)?.groups?.body;
+    const createInput = source.match(/export interface CreateCronJobInput \{(?<body>[\s\S]*?)\n\}/)?.groups?.body;
+
+    expect(cronJob).toBeDefined();
+    expect(createInput).toBeDefined();
+    expect(cronJob).toContain('scriptPath: string;');
+    expect(createInput).toContain('scriptPath: string;');
+    for (const forbidden of ['type:', 'command:', 'shell:', 'prompt:', 'webhook:', 'notification:']) {
+      expect(cronJob).not.toContain(forbidden);
+      expect(createInput).not.toContain(forbidden);
+    }
+  });
+
   it('cron execution and validation both resolve scripts through validateScriptPath', () => {
     const cronService = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'CronService.ts'), 'utf8');
     const scriptRunner = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'ScriptRunner.ts'), 'utf8');

--- a/tests/invariants/security-boundaries.invariant.test.ts
+++ b/tests/invariants/security-boundaries.invariant.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ApprovalGate } from '../../packages/services/src/session-group/approval-gate';
+
+const repoRoot = process.cwd();
+
+describe('security boundary invariants', () => {
+  it('mind popout windows keep context isolation on and node integration off', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'apps', 'desktop', 'src', 'main', 'ipc', 'mind.ts'), 'utf8');
+    const webPreferences = source.match(/webPreferences:\s*\{(?<body>[\s\S]*?)\n\s*\}/)?.groups?.body;
+
+    expect(webPreferences).toBeDefined();
+    expect(webPreferences).toMatch(/\bcontextIsolation:\s*true\b/);
+    expect(webPreferences).toMatch(/\bnodeIntegration:\s*false\b/);
+    expect(webPreferences).toMatch(/\bsandbox:\s*false\b/);
+  });
+
+  it('side-effect tools are default-denied when no approval handler is registered', async () => {
+    const gate = new ApprovalGate();
+
+    const result = await gate.gate('agent-1', 'delete_resource', { id: 'danger' }, 'cleanup');
+
+    expect(result.approved).toBe(false);
+    expect(result.reason).toMatch(/No approval handler/);
+  });
+
+  it('cron execution and validation both resolve scripts through validateScriptPath', () => {
+    const cronService = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'CronService.ts'), 'utf8');
+    const scriptRunner = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'cron', 'ScriptRunner.ts'), 'utf8');
+
+    expect(cronService).toMatch(/createJob\([\s\S]*?validateScriptPath\(mindPath,\s*input\.scriptPath\)/);
+    expect(scriptRunner).toMatch(/async run\([\s\S]*?validateScriptPath\(params\.mindPath,\s*params\.scriptPath\)/);
+    expect(scriptRunner).toMatch(/async validateScript\([\s\S]*?validateScriptPath\(params\.mindPath,\s*params\.scriptPath\)/);
+  });
+});

--- a/tests/invariants/session-state.invariant.test.ts
+++ b/tests/invariants/session-state.invariant.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'node:path';
+import { MindManager } from '../../packages/services/src/mind/MindManager';
+import type { CopilotClientFactory } from '../../packages/services/src/sdk/CopilotClientFactory';
+import type { IdentityLoader } from '../../packages/services/src/chat/IdentityLoader';
+import type { ConfigService } from '../../packages/services/src/config/ConfigService';
+import type { ViewDiscovery } from '../../packages/services/src/lens/ViewDiscovery';
+import type { AppConfig } from '@chamber/shared/types';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  realpathSync: Object.assign(vi.fn((candidate: string) => candidate), {
+    native: vi.fn((candidate: string) => candidate),
+  }),
+}));
+
+vi.mock('../../packages/services/src/lens/MindBootstrap', () => ({
+  bootstrapMindCapabilities: vi.fn(),
+}));
+
+import * as fs from 'fs';
+
+const COPILOT_RUNTIME_CONFIG_DIR = path.join('C:\\tmp\\chamber-config', 'copilot-runtime');
+
+let sessionCounter = 0;
+function createSessionStub(sessionId = `sdk-session-${sessionCounter += 1}`) {
+  return {
+    sessionId,
+    send: vi.fn(),
+    sendAndWait: vi.fn(async () => ({
+      type: 'assistant.message',
+      data: { content: 'ok' },
+    })),
+    getEvents: vi.fn(async (): Promise<unknown[]> => []),
+    on: vi.fn(),
+    off: vi.fn(),
+    disconnect: vi.fn(async () => undefined),
+    setModel: vi.fn(async () => undefined),
+    rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
+  };
+}
+
+const mockCreateSession = vi.fn((config: Record<string, unknown>) =>
+  createSessionStub(typeof config.sessionId === 'string' ? config.sessionId : undefined));
+const mockResumeSession = vi.fn((sessionId: string, config: Record<string, unknown>) => {
+  void config;
+  return createSessionStub(sessionId);
+});
+
+const mockClientFactory = {
+  createClient: vi.fn(async () => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    createSession: mockCreateSession,
+    resumeSession: mockResumeSession,
+    deleteSession: vi.fn(async () => undefined),
+  })),
+  destroyClient: vi.fn(),
+};
+
+const mockIdentityLoader = {
+  load: vi.fn((mindPath: string) => ({
+    name: mindPath.split('/').pop() ?? 'unknown',
+    systemMessage: `Identity for ${mindPath}`,
+  })),
+};
+
+let currentConfig: AppConfig;
+const mockConfigService = {
+  getConfigDir: vi.fn(() => 'C:\\tmp\\chamber-config'),
+  load: vi.fn(() => currentConfig),
+  save: vi.fn((config: AppConfig) => {
+    currentConfig = config;
+  }),
+};
+
+const mockViewDiscovery = {
+  scan: vi.fn(async () => []),
+  getViews: vi.fn(() => []),
+  startWatching: vi.fn(),
+  stopWatching: vi.fn(),
+  removeMind: vi.fn(),
+  setRefreshHandler: vi.fn(),
+};
+
+function createManager(): MindManager {
+  return new MindManager(
+    mockClientFactory as unknown as CopilotClientFactory,
+    mockIdentityLoader as unknown as IdentityLoader,
+    mockConfigService as unknown as ConfigService,
+    mockViewDiscovery as unknown as ViewDiscovery,
+  );
+}
+
+describe('session-state invariants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionCounter = 0;
+    currentConfig = {
+      version: 2,
+      minds: [],
+      activeMindId: null,
+      activeLogin: null,
+      theme: 'dark',
+    };
+    mockCreateSession.mockImplementation((config: Record<string, unknown>) =>
+      createSessionStub(typeof config.sessionId === 'string' ? config.sessionId : undefined));
+    mockResumeSession.mockImplementation((sessionId: string, config: Record<string, unknown>) => {
+      void config;
+      return createSessionStub(sessionId);
+    });
+    vi.mocked(fs.existsSync).mockImplementation((candidate) => {
+      const s = String(candidate);
+      return !s.endsWith('.mcp.json') && !s.endsWith('.chamber.json');
+    });
+    vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
+    vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => String(candidate));
+  });
+
+  it('persisted conversations resume from Chamber state, then legacy state, before reattaching', async () => {
+    const manager = createManager();
+    const mind = await manager.loadMind('/tmp/agents/q');
+    manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+    await manager.startNewConversation(mind.mindId);
+    const target = manager.listConversationHistory(mind.mindId)[1];
+    const legacySession = createSessionStub(target.sessionId);
+    legacySession.getEvents.mockResolvedValue([
+      {
+        type: 'user.message',
+        timestamp: '2026-05-05T22:00:00.000Z',
+        data: { messageId: 'u1', content: 'legacy chat' },
+      },
+    ]);
+    mockCreateSession.mockClear();
+    mockResumeSession
+      .mockRejectedValueOnce(new Error('failed to resume session: Session not found: missing-runtime'))
+      .mockResolvedValueOnce(legacySession);
+
+    const result = await manager.resumeConversation(mind.mindId, target.sessionId);
+
+    expect(mockResumeSession).toHaveBeenCalledTimes(2);
+    expect(mockResumeSession).toHaveBeenNthCalledWith(
+      1,
+      target.sessionId,
+      expect.objectContaining({
+        configDir: COPILOT_RUNTIME_CONFIG_DIR,
+        enableConfigDiscovery: false,
+      }),
+    );
+    expect(mockResumeSession).toHaveBeenNthCalledWith(
+      2,
+      target.sessionId,
+      expect.not.objectContaining({ configDir: expect.any(String) }),
+    );
+    expect(mockResumeSession.mock.calls[1][1]).toMatchObject({
+      workingDirectory: '/tmp/agents/q',
+      enableConfigDiscovery: false,
+    });
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(result.messages).toEqual([
+      {
+        id: 'u1',
+        role: 'user',
+        blocks: [{ type: 'text', content: 'legacy chat' }],
+        timestamp: Date.parse('2026-05-05T22:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('ephemeral sessions never reuse Chamber conversation session ids', async () => {
+    const manager = createManager();
+    const mind = await manager.loadMind('/tmp/agents/q');
+    mockCreateSession.mockClear();
+
+    await manager.createTaskSession(mind.mindId, 'task-1');
+    await manager.createChatroomSession(mind.mindId);
+    await manager.runIsolatedPrompt(mind.mindId, 'summarize');
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(3);
+    for (const [config] of mockCreateSession.mock.calls) {
+      expect(config).not.toHaveProperty('sessionId');
+      expect(config).toMatchObject({
+        configDir: COPILOT_RUNTIME_CONFIG_DIR,
+        enableConfigDiscovery: false,
+      });
+    }
+  });
+});

--- a/tests/invariants/session-state.invariant.test.ts
+++ b/tests/invariants/session-state.invariant.test.ts
@@ -182,6 +182,81 @@ describe('session-state invariants', () => {
     expect(serialized).not.toContain('assistant');
   });
 
+  it('conversation histories stay isolated by mind', async () => {
+    const manager = createManager();
+    const monica = await manager.loadMind('/tmp/agents/monica');
+    const lucy = await manager.loadMind('/tmp/agents/lucy');
+
+    manager.markActiveConversationHasMessages(monica.mindId, 'Monica only');
+    manager.markActiveConversationHasMessages(lucy.mindId, 'Lucy only');
+
+    expect(manager.listConversationHistory(monica.mindId).map((conversation) => conversation.title)).toEqual(['Monica only']);
+    expect(manager.listConversationHistory(lucy.mindId).map((conversation) => conversation.title)).toEqual(['Lucy only']);
+  });
+
+  it('first user prompt titles the active draft and removes the generic new-chat title', async () => {
+    const manager = createManager();
+    const mind = await manager.loadMind('/tmp/agents/q');
+
+    manager.markActiveConversationHasMessages(mind.mindId, 'History smoke first prompt title');
+
+    const history = manager.listConversationHistory(mind.mindId);
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      title: 'History smoke first prompt title',
+      hasMessages: true,
+      active: true,
+    });
+    expect(history.map((conversation) => conversation.title)).not.toContain(expect.stringMatching(/^New chat ·/));
+  });
+
+  it('deleting an active empty draft returns to the previous real conversation', async () => {
+    const resumedSession = createSessionStub();
+    resumedSession.getEvents.mockResolvedValue([
+      {
+        type: 'user.message',
+        timestamp: '2026-05-05T22:00:00.000Z',
+        data: { messageId: 'u1', content: 'keep this chat' },
+      },
+    ]);
+    mockResumeSession.mockResolvedValueOnce(resumedSession);
+    const manager = createManager();
+    const mind = await manager.loadMind('/tmp/agents/q');
+    const firstSessionId = mind.activeSessionId;
+    manager.markActiveConversationHasMessages(mind.mindId, 'Keep this chat');
+    await manager.startNewConversation(mind.mindId);
+    const activeDraftId = manager.getMind(mind.mindId)?.activeSessionId;
+
+    const result = await manager.deleteConversation(mind.mindId, activeDraftId!);
+
+    expect(result.sessionId).toBe(firstSessionId);
+    expect(result.conversations).toHaveLength(1);
+    expect(result.conversations[0]).toMatchObject({
+      sessionId: firstSessionId,
+      title: 'Keep this chat',
+      active: true,
+      hasMessages: true,
+    });
+    expect(result.messages[0]).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', content: 'keep this chat' }],
+    });
+  });
+
+  it('selected model persists per mind instead of globally', async () => {
+    const manager = createManager();
+    const alpha = await manager.loadMind('/tmp/agents/alpha');
+    const beta = await manager.loadMind('/tmp/agents/beta');
+
+    await manager.setMindModel(alpha.mindId, 'copilot:model-alpha');
+    await manager.setMindModel(beta.mindId, 'copilot:model-beta');
+
+    expect(manager.getMind(alpha.mindId)?.selectedModel).toBe('model-alpha');
+    expect(manager.getMind(beta.mindId)?.selectedModel).toBe('model-beta');
+    expect(currentConfig.minds.find((mind) => mind.id === alpha.mindId)?.selectedModel).toBe('model-alpha');
+    expect(currentConfig.minds.find((mind) => mind.id === beta.mindId)?.selectedModel).toBe('model-beta');
+  });
+
   it('managed skills install before SDK client and session creation', async () => {
     const managedSkillService = {
       installIntoMind: vi.fn(async (): Promise<ManagedSkillSyncResult> => ({ status: 'ok', installed: [], errors: [] })),

--- a/tests/invariants/session-state.invariant.test.ts
+++ b/tests/invariants/session-state.invariant.test.ts
@@ -5,6 +5,7 @@ import type { CopilotClientFactory } from '../../packages/services/src/sdk/Copil
 import type { IdentityLoader } from '../../packages/services/src/chat/IdentityLoader';
 import type { ConfigService } from '../../packages/services/src/config/ConfigService';
 import type { ViewDiscovery } from '../../packages/services/src/lens/ViewDiscovery';
+import type { ManagedSkillSyncResult } from '../../packages/services/src/skills';
 import type { AppConfig } from '@chamber/shared/types';
 
 vi.mock('fs', () => ({
@@ -87,13 +88,28 @@ const mockViewDiscovery = {
   setRefreshHandler: vi.fn(),
 };
 
-function createManager(): MindManager {
+function createManager(managedSkillService?: { installIntoMind: (mindPath: string) => Promise<ManagedSkillSyncResult> }): MindManager {
   return new MindManager(
     mockClientFactory as unknown as CopilotClientFactory,
     mockIdentityLoader as unknown as IdentityLoader,
     mockConfigService as unknown as ConfigService,
     mockViewDiscovery as unknown as ViewDiscovery,
+    () => null,
+    () => undefined,
+    managedSkillService,
   );
+}
+
+function assertConversationConfigDirIsStable(config: Record<string, unknown>): void {
+  if (config.configDir !== COPILOT_RUNTIME_CONFIG_DIR) {
+    throw new Error(
+      [
+        `Conversation SDK configDir changed from ${COPILOT_RUNTIME_CONFIG_DIR} to ${String(config.configDir)}.`,
+        'Changing this path moves session-state roots, so existing conversations listed in the history pane can no longer hydrate and open as empty chats.',
+        'If this is intentional, add an explicit migration/fallback plan before updating this invariant.',
+      ].join(' '),
+    );
+  }
 }
 
 describe('session-state invariants', () => {
@@ -119,6 +135,66 @@ describe('session-state invariants', () => {
     });
     vi.mocked(fs.readFileSync).mockReturnValue('# TestAgent\nSome content');
     vi.mocked(fs.realpathSync.native).mockImplementation((candidate) => String(candidate));
+  });
+
+  it('conversation session-state config path stays stable so history pane entries keep hydrating', async () => {
+    const manager = createManager();
+    const mind = await manager.loadMind('/tmp/agents/q');
+    const createConfig = mockCreateSession.mock.calls[0]?.[0] as Record<string, unknown>;
+
+    assertConversationConfigDirIsStable(createConfig);
+    expect(createConfig).toMatchObject({
+      enableConfigDiscovery: false,
+      sessionId: expect.stringMatching(new RegExp(`^chamber-${mind.mindId}-`)),
+    });
+
+    manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+    await manager.startNewConversation(mind.mindId);
+    const target = manager.listConversationHistory(mind.mindId)[1];
+    mockResumeSession.mockClear();
+
+    await manager.resumeConversation(mind.mindId, target.sessionId);
+
+    const resumeConfig = mockResumeSession.mock.calls[0]?.[1] as Record<string, unknown>;
+    assertConversationConfigDirIsStable(resumeConfig);
+    expect(resumeConfig).toMatchObject({
+      enableConfigDiscovery: false,
+      workingDirectory: '/tmp/agents/q',
+    });
+  });
+
+  it('conversation history metadata never persists transcript contents', async () => {
+    const manager = createManager();
+    const mind = await manager.loadMind('/tmp/agents/q');
+    manager.markActiveConversationHasMessages(mind.mindId, 'Visible title');
+
+    const saved = currentConfig.minds[0];
+    const serialized = JSON.stringify(saved);
+
+    expect(saved.conversations).toEqual([
+      expect.objectContaining({
+        title: 'Visible title',
+        hasMessages: true,
+      }),
+    ]);
+    expect(serialized).not.toContain('messages');
+    expect(serialized).not.toContain('blocks');
+    expect(serialized).not.toContain('assistant');
+  });
+
+  it('managed skills install before SDK client and session creation', async () => {
+    const managedSkillService = {
+      installIntoMind: vi.fn(async (): Promise<ManagedSkillSyncResult> => ({ status: 'ok', installed: [], errors: [] })),
+    };
+    const manager = createManager(managedSkillService);
+
+    await manager.loadMind('/tmp/agents/q');
+
+    expect(managedSkillService.installIntoMind).toHaveBeenCalledWith('/tmp/agents/q');
+    expect(managedSkillService.installIntoMind.mock.invocationCallOrder[0])
+      .toBeLessThan(mockClientFactory.createClient.mock.invocationCallOrder[0]);
+    expect(managedSkillService.installIntoMind.mock.invocationCallOrder[0])
+      .toBeLessThan(mockCreateSession.mock.invocationCallOrder[0]);
   });
 
   it('persisted conversations resume from Chamber state, then legacy state, before reattaching', async () => {
@@ -187,6 +263,31 @@ describe('session-state invariants', () => {
         configDir: COPILOT_RUNTIME_CONFIG_DIR,
         enableConfigDiscovery: false,
       });
+    }
+  });
+
+  it('all SDK sessions keep implicit config discovery disabled', async () => {
+    const manager = createManager();
+    const mind = await manager.loadMind('/tmp/agents/q');
+    manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+    await manager.startNewConversation(mind.mindId);
+    const target = manager.listConversationHistory(mind.mindId)[1];
+    await manager.resumeConversation(mind.mindId, target.sessionId);
+    await manager.createTaskSession(mind.mindId, 'task-1');
+    await manager.createChatroomSession(mind.mindId);
+    await manager.runIsolatedPrompt(mind.mindId, 'summarize');
+
+    const configs = [
+      ...mockCreateSession.mock.calls.map(([config]) => config),
+      ...mockResumeSession.mock.calls.map(([, config]) => config),
+    ];
+
+    for (const config of configs) {
+      if (config.enableConfigDiscovery !== false) {
+        throw new Error(
+          'SDK sessions must keep enableConfigDiscovery:false so the SDK cannot silently pick up MCP servers, skills, or tools outside Chamber\'s explicit tool surface.',
+        );
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

- Resume persisted conversations from Chamber's current SDK session-state root first.
- Fall back to the SDK default `~/.copilot/session-state` root when the Chamber root reports a stale/missing session.
- Preserve existing reattach behavior only when both roots miss, so old conversations hydrate instead of opening empty while newer conversations stay in the current Chamber root.
- Add a dedicated `test:invariants` suite for high-signal Chamber contracts around session-state fallback/order/path stability, SDK config discovery, metadata-only history records, renderer/preload and shared architecture boundaries, managed skill/session ordering, approval redaction/default-deny behavior, credential-write boundaries, automation bridge/token safety, startup prewarm ordering, Electron window preferences, tool-provider ordering, token redaction, and cron script validation.
- Extend invariant coverage from desktop smoke contracts for per-mind history isolation, first-prompt conversation titles, deleting empty drafts back to the prior real chat, per-mind model and compose-draft persistence, A2A sender attribution, stable core skill IDs, and cron's script-only job schema.

## Tests

- `npm run lint`
- `npm run test:invariants`
- `npm test`
- `npm run smoke:sdk`
- Manual check: resumed an old Doof conversation and confirmed it continued writing under `~/.copilot/session-state`.

## Skipped smoke

- Packaging smoke skipped: no packaging, runtime bundling, Electron Forge, installer, or first-launch wiring changed.