### PR TITLE
Add chamber:a2a ttasks runtime support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Restore legacy conversation resume fallback** — Conversation resume now falls back from Chamber's current SDK session-state root to the legacy default Copilot session-state root before recreating a missing session, so pre-move chat history hydrates instead of opening empty.
+- **Refresh packaged Copilot runtime pin** — Aligns the committed @github/copilot runtime pin with the launcher-resolved 1.0.58 build so package smoke validates the bundled CLI.
 
 ### Tests
 
 - **Add invariant test suite** — Introduces test:invariants for high-signal Chamber contracts covering session-state fallback order, stable conversation state roots, SDK config discovery, metadata-only history records, renderer/preload and shared architecture boundaries, managed skill/session ordering, approval redaction/default-deny behavior, credential-write boundaries, automation bridge/token safety, startup prewarm ordering, Electron window preferences, and cron script validation.
+
+### Added
+
+- **Add chamber:a2a ttasks runtime support** — Adds a chamber:a2a custom task type, production A2A bridge wiring, durable ttasks persistence, and invariants for the runtime contract.
+
 
 
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import started from 'electron-squirrel-startup';
 import { DEFAULT_APP_FEATURE_FLAGS, IPC } from '@chamber/shared';
 import type { MindContext, StartupProgressEvent } from '@chamber/shared/types';
@@ -87,6 +87,7 @@ import {
   type Notifier,
 } from '@chamber/services';
 import { Logger } from '@chamber/services';
+import { SqliteStore } from '@ianphil/ttasks-ts';
 import { createAppTray, loadAppIcon } from './main/tray/Tray';
 import { installContextMenu } from './main/contextMenu/ContextMenu';
 import { installExternalNavigationGuard } from './main/navigationGuard';
@@ -331,11 +332,19 @@ async function initializeRuntime(): Promise<void> {
       tenantId: process.env.CHAMBER_MICROSOFT_GRAPH_TENANT_ID,
     }),
   );
+  const createTTasksStore = (mindId: string) => {
+    const mindPath = mindManager.getMind(mindId)?.mindPath;
+    if (!mindPath) return undefined;
+    const runsDir = path.join(mindPath, '.chamber', 'runs');
+    fs.mkdirSync(runsDir, { recursive: true });
+    return new SqliteStore({ path: path.join(runsDir, 'ttasks.db') });
+  };
   taskManager = new TaskManager(mindManager, agentCardRegistry, {
     getLedgerForMind: (mindId) => {
       const mindPath = mindManager.getMind(mindId)?.mindPath;
       return mindPath ? createTaskLedger(mindPath) : undefined;
     },
+    createTTasksStore,
   });
   // The SDK model catalog does not include BYO endpoint models, so keep the
   // saved BYO model visible through this side-channel when the flag is enabled.
@@ -396,6 +405,29 @@ async function initializeRuntime(): Promise<void> {
     },
     onNotify: async ({ title, body }) => {
       notifier.notify({ kind: 'info', title, body });
+    },
+    onA2a: async ({ mindId, recipient, message, contextId, referenceTaskIds }) => {
+      if (!mindManager.getMind(mindId)) {
+        throw new Error(`mind ${mindId} not active`);
+      }
+
+      const task = await taskManager.sendTask({
+        recipient,
+        message: {
+          messageId: randomUUID(),
+          role: 'ROLE_USER',
+          parts: [{ text: message, mediaType: 'text/plain' }],
+          metadata: { fromId: mindId, fromName: 'automation' },
+          ...(contextId ? { contextId } : {}),
+          ...(referenceTaskIds?.length ? { referenceTaskIds } : {}),
+        },
+      });
+
+      return {
+        id: task.id,
+        contextId: task.contextId,
+        status: task.status.state,
+      };
     },
   });
   const bridgeStart = await automationBridge.start();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -236,6 +236,7 @@ let authService: AuthService;
 let chamberCopilotService: ChamberCopilotService | null = null;
 let updaterService: UpdaterService;
 const taskLedgersByMindPath = new Map<string, TaskLedger>();
+const ttasksStoresByMindPath = new Map<string, SqliteStore>();
 
 const createTaskLedger = (mindPath: string): TaskLedger => {
   const existing = taskLedgersByMindPath.get(mindPath);
@@ -245,6 +246,23 @@ const createTaskLedger = (mindPath: string): TaskLedger => {
   );
   taskLedgersByMindPath.set(mindPath, ledger);
   return ledger;
+};
+
+const createTTasksStore = (mindPath: string): SqliteStore => {
+  const existing = ttasksStoresByMindPath.get(mindPath);
+  if (existing) return existing;
+  const runsDir = path.join(mindPath, '.chamber', 'runs');
+  fs.mkdirSync(runsDir, { recursive: true });
+  const store = new SqliteStore({ path: path.join(runsDir, 'ttasks.db') });
+  ttasksStoresByMindPath.set(mindPath, store);
+  return store;
+};
+
+const closeTTasksStores = (): void => {
+  for (const store of ttasksStoresByMindPath.values()) {
+    store.close();
+  }
+  ttasksStoresByMindPath.clear();
 };
 
 async function initializeRuntime(): Promise<void> {
@@ -332,19 +350,15 @@ async function initializeRuntime(): Promise<void> {
       tenantId: process.env.CHAMBER_MICROSOFT_GRAPH_TENANT_ID,
     }),
   );
-  const createTTasksStore = (mindId: string) => {
-    const mindPath = mindManager.getMind(mindId)?.mindPath;
-    if (!mindPath) return undefined;
-    const runsDir = path.join(mindPath, '.chamber', 'runs');
-    fs.mkdirSync(runsDir, { recursive: true });
-    return new SqliteStore({ path: path.join(runsDir, 'ttasks.db') });
-  };
   taskManager = new TaskManager(mindManager, agentCardRegistry, {
     getLedgerForMind: (mindId) => {
       const mindPath = mindManager.getMind(mindId)?.mindPath;
       return mindPath ? createTaskLedger(mindPath) : undefined;
     },
-    createTTasksStore,
+    createTTasksStore: (mindId) => {
+      const mindPath = mindManager.getMind(mindId)?.mindPath;
+      return mindPath ? createTTasksStore(mindPath) : undefined;
+    },
   });
   // The SDK model catalog does not include BYO endpoint models, so keep the
   // saved BYO model visible through this side-channel when the flag is enabled.
@@ -931,6 +945,7 @@ app.on('before-quit', (e) => {
 app.on('will-quit', () => {
   appTray?.destroy();
   appTray = null;
+  closeTTasksStores();
   if (automationBridgeStop) {
     void automationBridgeStop().catch(() => { /* noop */ });
     automationBridgeStop = null;

--- a/chamber-copilot-runtime/package-lock.json
+++ b/chamber-copilot-runtime/package-lock.json
@@ -8,14 +8,14 @@
       "name": "chamber-copilot-runtime",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "1.0.57-2",
+        "@github/copilot": "1.0.58",
         "@github/copilot-sdk": "1.0.0-beta.8"
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.57-2.tgz",
-      "integrity": "sha512-VuUUAfvoyRhgebVMqcFO8wNNcBfkyXYnRhdYspitT86y2yoJiPCEVeeUzSpYBkF1a0nlGwtaDvKt1OOxaBlRBw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.58.tgz",
+      "integrity": "sha512-B5s05UYjRD/MCUraK3MFc8WAKuVZTuCrhOsVxtaT0b/BjWHkrZiSXStfYTjuFAkT5y8a/NUCMOMZuAzViYl4aQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -24,20 +24,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.57-2",
-        "@github/copilot-darwin-x64": "1.0.57-2",
-        "@github/copilot-linux-arm64": "1.0.57-2",
-        "@github/copilot-linux-x64": "1.0.57-2",
-        "@github/copilot-linuxmusl-arm64": "1.0.57-2",
-        "@github/copilot-linuxmusl-x64": "1.0.57-2",
-        "@github/copilot-win32-arm64": "1.0.57-2",
-        "@github/copilot-win32-x64": "1.0.57-2"
+        "@github/copilot-darwin-arm64": "1.0.58",
+        "@github/copilot-darwin-x64": "1.0.58",
+        "@github/copilot-linux-arm64": "1.0.58",
+        "@github/copilot-linux-x64": "1.0.58",
+        "@github/copilot-linuxmusl-arm64": "1.0.58",
+        "@github/copilot-linuxmusl-x64": "1.0.58",
+        "@github/copilot-win32-arm64": "1.0.58",
+        "@github/copilot-win32-x64": "1.0.58"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-Tmat4qt9W4sGMaUoegFVpO2OzNEEh0Cdf0SJlr6Cj3sGaivFSlEXb2QWeiITUuK/L5odbbEdHS+iqED7Ou33Gg==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.58.tgz",
+      "integrity": "sha512-OdK1zIMca1rW9SjdDsjAQy2wJPYgXYfYY5Ia96RcUQH3nkrrQtaQ6zyQRWqueIg4rL0IZf8sqqYxNW+iKdSnyQ==",
       "cpu": [
         "arm64"
       ],
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.57-2.tgz",
-      "integrity": "sha512-JM8V+ZUExpphIG8zh6US6WJrWBI/D9o6UYd9wjHfWIqvlXJXvC682eUdPBDG2CWovidSySmvT/yHVAjjoFP7Ow==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.58.tgz",
+      "integrity": "sha512-OexNIomHyqCblLSs9JPu68WbmMX31rPU0GxpLrs9CuKEnEueGcFqGOlFHBoXMg/c0R80bGD/GtSALR2mv64NMQ==",
       "cpu": [
         "x64"
       ],
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-DSlqeyiy/Ze0ove5hkAMZIhDIVJbyNeteVlMjmpTciL49ssqSynoZvc1DttJ3o/R1IQ8SXaJE1boCIy6cgV4YA==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.58.tgz",
+      "integrity": "sha512-hP4ed+KQ45YrJfq8aLbTYGuYZJ2wzfycfj3ZDLd0rhSNcxog+OhAM3SWs/TNgrn/8xLK0xBWGk4yeasjJBSvKg==",
       "cpu": [
         "arm64"
       ],
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.57-2.tgz",
-      "integrity": "sha512-aHXhrjZQpIX/ddtJz+bYx89qra2Xr9RdHMZF3pRzK+ebmnKBiCq4oQ6rvUPDWEH149+49phJdHi07ZSdgKUnEg==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.58.tgz",
+      "integrity": "sha512-sc1gGwJbAYYZB+Tt/ZxbtZDMkIr8AvUmPsC9NAdVD0Sng5BB5Ujtku/5Xh7hj/psokEnzqFnZRa0V3wR/40Fng==",
       "cpu": [
         "x64"
       ],
@@ -99,9 +99,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-Vfy9n6h+30wXOVSUIx75Uzuz5pIlc4VRPNq7jZxM1YFcbMq9R1NZWV8ZKRnBb4vVzxggz7iV3fxBkfr5+tIrSA==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.58.tgz",
+      "integrity": "sha512-A8jaXmS0Hymt7aYxhK7UKB3tFQSLBaljwZRKWKVxKRHeHOGAlm0xszvPsTAyVZJj0Lf0bIErxAwpU5C8P2QEpQ==",
       "cpu": [
         "arm64"
       ],
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.57-2.tgz",
-      "integrity": "sha512-lPfPcyFKbdE7Vk7n2a1aWFhX7BOyX2HBtZc0wltaXGS0kh0V7WFq0mxifSg9vHC0D8sq0svLqb3C2VGo/+PnBw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.58.tgz",
+      "integrity": "sha512-GrBHvnLNC1qO1rCQR7Vp/pduYFYk5XTC/pHFh2qA95ntR/Uis58J0y9O4jNYc+q0/3NK9RVdL+RxLGTyxApwpA==",
       "cpu": [
         "x64"
       ],
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-LdzGoyVS5UZOyaBPl05hALYgyFjRCHD6zkayX5+lhMmwpHkyUCrRTY95oMtNfdbHAUXTtXIplgJtRJt/Bm0voQ==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.58.tgz",
+      "integrity": "sha512-CT8d3ryh+nQHND2KWOaYMXwCCQbKD7pcTwHj2AJWTD0kVURqr0xWZdEI0YGOqr+dveK8y8j7+WRy+aWoXBxp4A==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.57-2.tgz",
-      "integrity": "sha512-GeVThYX4ibb01tSqKNBiqztQIJrr3TnpxcyW7BbS4Knk4eCpOHKlNZ36VLE2+BSQeaJ979SRD25F5coRjMziXw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.58.tgz",
+      "integrity": "sha512-eaXFT2/rZLbZbkhUFupk6uqSeWexVv3+PxA49TV6RR7BHMvG7wbyGhCbqwUDrmIRlLVSyDwriEStey7e2fvXkw==",
       "cpu": [
         "x64"
       ],

--- a/chamber-copilot-runtime/package.json
+++ b/chamber-copilot-runtime/package.json
@@ -5,7 +5,7 @@
   "description": "Pinned packaged runtime for Chamber Copilot SDK + CLI",
   "//": "Pin drift / make:sandbox version-mismatch? See ai-docs/copilot-runtime-version-pin.html. This pin must match the root package.json @github/copilot pin.",
   "dependencies": {
-    "@github/copilot": "1.0.57-2",
+    "@github/copilot": "1.0.58",
     "@github/copilot-sdk": "1.0.0-beta.8"
   },
   "overrides": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
-        "@github/copilot": "1.0.57-2",
+        "@github/copilot": "1.0.58",
         "@github/copilot-sdk": "1.0.0-beta.8",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1565,9 +1565,9 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.57-2.tgz",
-      "integrity": "sha512-VuUUAfvoyRhgebVMqcFO8wNNcBfkyXYnRhdYspitT86y2yoJiPCEVeeUzSpYBkF1a0nlGwtaDvKt1OOxaBlRBw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.58.tgz",
+      "integrity": "sha512-B5s05UYjRD/MCUraK3MFc8WAKuVZTuCrhOsVxtaT0b/BjWHkrZiSXStfYTjuFAkT5y8a/NUCMOMZuAzViYl4aQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -1577,20 +1577,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.57-2",
-        "@github/copilot-darwin-x64": "1.0.57-2",
-        "@github/copilot-linux-arm64": "1.0.57-2",
-        "@github/copilot-linux-x64": "1.0.57-2",
-        "@github/copilot-linuxmusl-arm64": "1.0.57-2",
-        "@github/copilot-linuxmusl-x64": "1.0.57-2",
-        "@github/copilot-win32-arm64": "1.0.57-2",
-        "@github/copilot-win32-x64": "1.0.57-2"
+        "@github/copilot-darwin-arm64": "1.0.58",
+        "@github/copilot-darwin-x64": "1.0.58",
+        "@github/copilot-linux-arm64": "1.0.58",
+        "@github/copilot-linux-x64": "1.0.58",
+        "@github/copilot-linuxmusl-arm64": "1.0.58",
+        "@github/copilot-linuxmusl-x64": "1.0.58",
+        "@github/copilot-win32-arm64": "1.0.58",
+        "@github/copilot-win32-x64": "1.0.58"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-Tmat4qt9W4sGMaUoegFVpO2OzNEEh0Cdf0SJlr6Cj3sGaivFSlEXb2QWeiITUuK/L5odbbEdHS+iqED7Ou33Gg==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.58.tgz",
+      "integrity": "sha512-OdK1zIMca1rW9SjdDsjAQy2wJPYgXYfYY5Ia96RcUQH3nkrrQtaQ6zyQRWqueIg4rL0IZf8sqqYxNW+iKdSnyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.57-2.tgz",
-      "integrity": "sha512-JM8V+ZUExpphIG8zh6US6WJrWBI/D9o6UYd9wjHfWIqvlXJXvC682eUdPBDG2CWovidSySmvT/yHVAjjoFP7Ow==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.58.tgz",
+      "integrity": "sha512-OexNIomHyqCblLSs9JPu68WbmMX31rPU0GxpLrs9CuKEnEueGcFqGOlFHBoXMg/c0R80bGD/GtSALR2mv64NMQ==",
       "cpu": [
         "x64"
       ],
@@ -1622,9 +1622,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-DSlqeyiy/Ze0ove5hkAMZIhDIVJbyNeteVlMjmpTciL49ssqSynoZvc1DttJ3o/R1IQ8SXaJE1boCIy6cgV4YA==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.58.tgz",
+      "integrity": "sha512-hP4ed+KQ45YrJfq8aLbTYGuYZJ2wzfycfj3ZDLd0rhSNcxog+OhAM3SWs/TNgrn/8xLK0xBWGk4yeasjJBSvKg==",
       "cpu": [
         "arm64"
       ],
@@ -1639,9 +1639,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.57-2.tgz",
-      "integrity": "sha512-aHXhrjZQpIX/ddtJz+bYx89qra2Xr9RdHMZF3pRzK+ebmnKBiCq4oQ6rvUPDWEH149+49phJdHi07ZSdgKUnEg==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.58.tgz",
+      "integrity": "sha512-sc1gGwJbAYYZB+Tt/ZxbtZDMkIr8AvUmPsC9NAdVD0Sng5BB5Ujtku/5Xh7hj/psokEnzqFnZRa0V3wR/40Fng==",
       "cpu": [
         "x64"
       ],
@@ -1656,9 +1656,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-Vfy9n6h+30wXOVSUIx75Uzuz5pIlc4VRPNq7jZxM1YFcbMq9R1NZWV8ZKRnBb4vVzxggz7iV3fxBkfr5+tIrSA==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.58.tgz",
+      "integrity": "sha512-A8jaXmS0Hymt7aYxhK7UKB3tFQSLBaljwZRKWKVxKRHeHOGAlm0xszvPsTAyVZJj0Lf0bIErxAwpU5C8P2QEpQ==",
       "cpu": [
         "arm64"
       ],
@@ -1673,9 +1673,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.57-2.tgz",
-      "integrity": "sha512-lPfPcyFKbdE7Vk7n2a1aWFhX7BOyX2HBtZc0wltaXGS0kh0V7WFq0mxifSg9vHC0D8sq0svLqb3C2VGo/+PnBw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.58.tgz",
+      "integrity": "sha512-GrBHvnLNC1qO1rCQR7Vp/pduYFYk5XTC/pHFh2qA95ntR/Uis58J0y9O4jNYc+q0/3NK9RVdL+RxLGTyxApwpA==",
       "cpu": [
         "x64"
       ],
@@ -1705,9 +1705,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.57-2.tgz",
-      "integrity": "sha512-LdzGoyVS5UZOyaBPl05hALYgyFjRCHD6zkayX5+lhMmwpHkyUCrRTY95oMtNfdbHAUXTtXIplgJtRJt/Bm0voQ==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.58.tgz",
+      "integrity": "sha512-CT8d3ryh+nQHND2KWOaYMXwCCQbKD7pcTwHj2AJWTD0kVURqr0xWZdEI0YGOqr+dveK8y8j7+WRy+aWoXBxp4A==",
       "cpu": [
         "arm64"
       ],
@@ -1722,9 +1722,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.57-2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.57-2.tgz",
-      "integrity": "sha512-GeVThYX4ibb01tSqKNBiqztQIJrr3TnpxcyW7BbS4Knk4eCpOHKlNZ36VLE2+BSQeaJ979SRD25F5coRjMziXw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.58.tgz",
+      "integrity": "sha512-eaXFT2/rZLbZbkhUFupk6uqSeWexVv3+PxA49TV6RR7BHMvG7wbyGhCbqwUDrmIRlLVSyDwriEStey7e2fvXkw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "@github/copilot": "1.0.57-2",
+    "@github/copilot": "1.0.58",
     "@github/copilot-sdk": "1.0.0-beta.8",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/packages/automation-runtime/src/bridge-client.ts
+++ b/packages/automation-runtime/src/bridge-client.ts
@@ -29,7 +29,7 @@ export class BridgeError extends Error {
 }
 
 export async function bridgeRequest<TResponse>(
-  endpoint: '/prompt' | '/notify',
+  endpoint: '/prompt' | '/notify' | '/a2a',
   body: Record<string, unknown>,
 ): Promise<TResponse> {
   const url = process.env.CHAMBER_BRIDGE_URL;

--- a/packages/automation-runtime/src/handlers/a2a.test.ts
+++ b/packages/automation-runtime/src/handlers/a2a.test.ts
@@ -1,0 +1,55 @@
+import { TaskExecutor, TaskStatus, type TaskContext } from '@ianphil/ttasks-ts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { bridgeRequest } from '../bridge-client';
+import { a2aHandler, chamberA2A } from './a2a';
+
+vi.mock('../bridge-client', () => ({
+  bridgeRequest: vi.fn(),
+}));
+
+const bridgeRequestMock = vi.mocked(bridgeRequest);
+
+function contextFor(task: ReturnType<typeof chamberA2A>): TaskContext {
+  return {
+    payload: task.payload,
+    upstream: new Map(),
+  } as unknown as TaskContext;
+}
+
+describe('chamberA2A', () => {
+  beforeEach(() => {
+    bridgeRequestMock.mockReset();
+    bridgeRequestMock.mockResolvedValue({ id: 'task-123', status: 'submitted' });
+  });
+
+  it('posts the delegated A2A request to the bridge', async () => {
+    const task = chamberA2A({
+      recipient: 'mind-b',
+      message: 'draft the report',
+      contextId: 'ctx-42',
+      referenceTaskIds: ['task-1'],
+    });
+
+    await a2aHandler(contextFor(task));
+
+    expect(bridgeRequestMock).toHaveBeenCalledWith('/a2a', {
+      recipient: 'mind-b',
+      message: 'draft the report',
+      contextId: 'ctx-42',
+      referenceTaskIds: ['task-1'],
+    });
+  });
+
+  it('records the serialized A2A result when run through the executor', async () => {
+    bridgeRequestMock.mockResolvedValue({ id: 'task-123', status: 'submitted' });
+    const executor = new TaskExecutor();
+    executor.register('chamber:a2a', a2aHandler);
+
+    const task = chamberA2A({ recipient: 'mind-b', message: 'draft the report' }, { title: 'delegate report' });
+
+    await executor.execute(task);
+
+    expect(task.status).toBe(TaskStatus.SUCCEEDED);
+    expect(task.result?.output).toBe(JSON.stringify({ id: 'task-123', status: 'submitted' }));
+  });
+});

--- a/packages/automation-runtime/src/handlers/a2a.ts
+++ b/packages/automation-runtime/src/handlers/a2a.ts
@@ -1,0 +1,38 @@
+import { Task, type TaskHandler, type TaskInit } from '@ianphil/ttasks-ts';
+import { bridgeRequest } from '../bridge-client';
+
+export interface ChamberA2AInput {
+  recipient: string;
+  message: string;
+  contextId?: string;
+  referenceTaskIds?: string[];
+}
+
+export interface ChamberA2AOutput {
+  id: string;
+  contextId?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+/** Factory: build a `chamber:a2a` task to add to a ttasks graph. */
+export function chamberA2A(input: ChamberA2AInput, init?: TaskInit): Task {
+  return Task.custom('chamber:a2a', JSON.stringify(input), {
+    title: init?.title ?? 'chamber:a2a',
+    ...init,
+  });
+}
+
+/** Handler: register on a TaskExecutor to run `chamber:a2a` tasks. */
+export const a2aHandler: TaskHandler = async (context) => {
+  const input = JSON.parse(context.payload) as ChamberA2AInput;
+  const result = await bridgeRequest<ChamberA2AOutput>('/a2a', {
+    recipient: input.recipient,
+    message: input.message,
+    ...(input.contextId ? { contextId: input.contextId } : {}),
+    ...(input.referenceTaskIds ? { referenceTaskIds: input.referenceTaskIds } : {}),
+  });
+  // Return a JSON string so the ttasks executor records the A2A task snapshot
+  // as durable output text for downstream inspection.
+  return JSON.stringify(result);
+};

--- a/packages/automation-runtime/src/index.ts
+++ b/packages/automation-runtime/src/index.ts
@@ -11,7 +11,9 @@
 export { bridgeRequest, BridgeUnconfiguredError, BridgeError } from './bridge-client';
 export { promptHandler, chamberPrompt } from './handlers/prompt';
 export { notifyHandler, chamberNotify } from './handlers/notify';
+export { a2aHandler, chamberA2A } from './handlers/a2a';
 export { httpHandler } from './handlers/http';
+export { registerChamberHandlers } from './registerHandlers';
 export { httpTask } from './task-helpers';
 export type { ChamberPromptInput, ChamberPromptOutput } from './handlers/prompt';
 export type { ChamberNotifyInput, ChamberNotifyOutput } from './handlers/notify';

--- a/packages/automation-runtime/src/registerHandlers.test.ts
+++ b/packages/automation-runtime/src/registerHandlers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerChamberHandlers } from './registerHandlers';
+
+describe('registerChamberHandlers', () => {
+  it('registers the Chamber custom task handlers on the executor', () => {
+    const executor = {
+      register: vi.fn(),
+    } as unknown as { register: (type: string, handler: unknown) => void };
+
+    registerChamberHandlers(executor as never);
+
+    expect(executor.register).toHaveBeenCalledTimes(4);
+    expect(executor.register).toHaveBeenNthCalledWith(1, 'chamber:prompt', expect.any(Function));
+    expect(executor.register).toHaveBeenNthCalledWith(2, 'chamber:notify', expect.any(Function));
+    expect(executor.register).toHaveBeenNthCalledWith(3, 'chamber:a2a', expect.any(Function));
+    expect(executor.register).toHaveBeenNthCalledWith(4, 'http', expect.any(Function));
+  });
+});

--- a/packages/automation-runtime/src/registerHandlers.ts
+++ b/packages/automation-runtime/src/registerHandlers.ts
@@ -1,0 +1,13 @@
+import { TaskExecutor } from '@ianphil/ttasks-ts';
+import { a2aHandler } from './handlers/a2a';
+import { httpHandler } from './handlers/http';
+import { notifyHandler } from './handlers/notify';
+import { promptHandler } from './handlers/prompt';
+
+/** Register all built-in Chamber ttasks handlers on an executor. */
+export function registerChamberHandlers(executor: TaskExecutor): void {
+  executor.register('chamber:prompt', promptHandler);
+  executor.register('chamber:notify', notifyHandler);
+  executor.register('chamber:a2a', a2aHandler);
+  executor.register('http', httpHandler);
+}

--- a/packages/services/src/a2a/TaskManager.test.ts
+++ b/packages/services/src/a2a/TaskManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SqliteStore } from '@ianphil/ttasks-ts';
 import { TaskManager } from './TaskManager';
 import type { TaskSessionFactory } from './TaskManager';
 import type { UserInputHandler } from '../mind/types';
@@ -199,7 +200,23 @@ describe('TaskManager', () => {
     });
   });
 
-  it('sendTask() skips audit ledger writes when suppressLedgerWrite is set', async () => {
+  it('sendTask() persists a chamber:a2a ttasks row when a store is configured', async () => {
+    const store = new SqliteStore({ path: ':memory:' });
+    tm = new TaskManager(
+      mockMindManager as unknown as TaskSessionFactory,
+      mockRegistry as unknown as AgentCardRegistry,
+      { ttasksStore: store },
+    );
+
+    const task = await tm.sendTask(makeRequest('target-1', 'hello'));
+
+    const persisted = store.tasks.get(task.id);
+    expect(persisted).toBeDefined();
+    expect(persisted?.type).toBe('chamber:a2a');
+    expect(persisted?.metadata).toMatchObject({ runtime: 'a2a', ownerMindId: 'target-1', a2aTaskId: task.id });
+   });
+
+   it('sendTask() skips audit ledger writes when suppressLedgerWrite is set', async () => {
     const ledger = new TaskLedger(new InMemoryLedgerStore(), {
       createLedgerId: () => 'ledger-1',
       now: () => '2026-05-21T21:45:00.000Z',

--- a/packages/services/src/a2a/TaskManager.test.ts
+++ b/packages/services/src/a2a/TaskManager.test.ts
@@ -214,7 +214,30 @@ describe('TaskManager', () => {
     expect(persisted).toBeDefined();
     expect(persisted?.type).toBe('chamber:a2a');
     expect(persisted?.metadata).toMatchObject({ runtime: 'a2a', ownerMindId: 'target-1', a2aTaskId: task.id });
-   });
+  });
+
+  it('sendTask() tolerates ttasks persistence failures', async () => {
+   const badStore = {
+     tasks: {
+       save: vi.fn(() => {
+         throw new Error('db unavailable');
+       }),
+     },
+   };
+   tm = new TaskManager(
+     mockMindManager as unknown as TaskSessionFactory,
+     mockRegistry as unknown as AgentCardRegistry,
+     { ttasksStore: badStore as never },
+   );
+
+   const task = await tm.sendTask(makeRequest('target-1', 'hello'));
+   await flushPromises();
+
+   latestMockSession._emit('session.idle');
+   await flushPromises();
+
+   expect(tm.getTask(task.id)?.status.state).toBe('TASK_STATE_COMPLETED');
+  });
 
    it('sendTask() skips audit ledger writes when suppressLedgerWrite is set', async () => {
     const ledger = new TaskLedger(new InMemoryLedgerStore(), {
@@ -573,6 +596,27 @@ describe('TaskManager', () => {
       expect(inputRequiredEvent!.status.message!.parts[0].text).toBe('Need info');
     });
 
+
+    it('cancelTask clears pending input state for input-required tasks', async () => {
+      const task = await tm.sendTask(makeRequest('target-1', 'hello'));
+      await flushPromises();
+
+      if (!capturedOnUserInputRequest) throw new Error('Expected callback');
+      capturedOnUserInputRequest({ question: 'Pick a color' }, { sessionId: 'sess-1' });
+      await flushPromises();
+
+      const internals = tm as unknown as {
+        pendingInputs: Map<string, (answer: { answer: string; wasFreeform: boolean }) => void>;
+        taskTargets: Map<string, string>;
+      };
+      expect(internals.pendingInputs.has(task.id)).toBe(true);
+
+      tm.cancelTask(task.id);
+
+      expect(internals.pendingInputs.has(task.id)).toBe(false);
+      expect(internals.taskTargets.has(task.id)).toBe(false);
+      expect(tm.getTask(task.id)?.status.state).toBe('TASK_STATE_CANCELED');
+    });
 
     it('resumeTask sends answer to session callback', async () => {
       const task = await tm.sendTask(makeRequest('target-1', 'hello'));

--- a/packages/services/src/a2a/TaskManager.test.ts
+++ b/packages/services/src/a2a/TaskManager.test.ts
@@ -213,6 +213,11 @@ describe('TaskManager', () => {
     const persisted = store.tasks.get(task.id);
     expect(persisted).toBeDefined();
     expect(persisted?.type).toBe('chamber:a2a');
+    expect(JSON.parse(persisted?.payload ?? '{}')).toMatchObject({
+      recipient: 'target-1',
+      message: 'hello',
+      contextId: task.contextId,
+    });
     expect(persisted?.metadata).toMatchObject({ runtime: 'a2a', ownerMindId: 'target-1', a2aTaskId: task.id });
   });
 
@@ -459,6 +464,15 @@ describe('TaskManager', () => {
     const task = await tm.sendTask(makeRequest('target-1', 'hello'));
     const canceled = tm.cancelTask(task.id);
     expect(canceled.status.state).toBe('TASK_STATE_CANCELED');
+  });
+
+  it('cancelTask() aborts the active session before cleanup', async () => {
+    const task = await tm.sendTask(makeRequest('target-1', 'hello'));
+    await flushPromises();
+
+    tm.cancelTask(task.id);
+
+    expect(latestMockSession.abort).toHaveBeenCalledOnce();
   });
 
 

--- a/packages/services/src/a2a/TaskManager.ts
+++ b/packages/services/src/a2a/TaskManager.ts
@@ -166,15 +166,12 @@ export class TaskManager extends EventEmitter {
       throw new Error(`Cannot cancel task in terminal state: ${task.status.state}`);
     }
 
-    this.transitionState(task, 'TASK_STATE_CANCELED');
-
-    // Abort session if exists
     const session = this.sessions.get(id);
     if (session) {
-      // CopilotSession type may not expose abort() — use optional chaining
       (session as { abort?: () => Promise<void> }).abort?.().catch(() => { /* noop */ });
-      this.sessions.delete(id);
     }
+
+    this.transitionState(task, 'TASK_STATE_CANCELED');
 
     return this.snapshotTask(task);
   }
@@ -400,7 +397,7 @@ export class TaskManager extends EventEmitter {
 
       const ttasksTask = TTasksTask.custom('chamber:a2a', JSON.stringify({
         recipient: request.recipient,
-        message: request.message,
+        message: getMessageText(request.message),
         contextId: task.contextId,
         referenceTaskIds: request.message.referenceTaskIds,
       }), {
@@ -527,6 +524,10 @@ function summarizeArtifacts(artifacts: A2ATask['artifacts']): string {
 
 function summarizeStatusMessage(message: A2ATask['status']['message']): string {
   return message?.parts.map((part) => part.text ?? '').filter(Boolean).join('\n') ?? '';
+}
+
+function getMessageText(message: Message): string {
+  return message.parts.map((part) => part.text ?? '').filter(Boolean).join('\n');
 }
 
 function getSessionErrorMessage(event: unknown): string {

--- a/packages/services/src/a2a/TaskManager.ts
+++ b/packages/services/src/a2a/TaskManager.ts
@@ -53,6 +53,7 @@ interface TaskManagerOptions {
   ledger?: TaskLedger;
   getLedgerForMind?: (mindId: string) => TaskLedger | undefined;
   ttasksStore?: Store;
+  createTTasksStore?: (mindId: string) => Store | undefined;
 }
 
 export class TaskManager extends EventEmitter {
@@ -301,6 +302,10 @@ export class TaskManager extends EventEmitter {
     return this.options.getLedgerForMind?.(mindId) ?? this.options.ledger;
   }
 
+  private getTTasksStore(mindId: string): Store | undefined {
+    return this.options.createTTasksStore?.(mindId) ?? this.options.ttasksStore;
+  }
+
   private toLedgerStatus(state: TaskState): 'succeeded' | 'failed' | 'timed-out' | 'cancelled' {
     switch (state) {
       case 'TASK_STATE_COMPLETED':
@@ -384,66 +389,76 @@ export class TaskManager extends EventEmitter {
     if (TERMINAL_STATES.has(state)) {
       this.finalizeTaskLedger(task);
       this.evictOldTasks();
+      this.cleanupTaskResources(task.id);
     }
   }
 
   private persistTTasksTask(task: A2ATask, targetMindId: string, request: SendTaskRequest): void {
-    const store = this.options.ttasksStore;
-    if (!store) return;
+    try {
+      const store = this.getTTasksStore(targetMindId);
+      if (!store) return;
 
-    const ttasksTask = TTasksTask.custom('chamber:a2a', JSON.stringify({
-      recipient: request.recipient,
-      message: request.message,
-      contextId: task.contextId,
-      referenceTaskIds: request.message.referenceTaskIds,
-    }), {
-      id: task.id,
-      title: `A2A task ${task.id}`,
-      description: request.message.parts.find((part) => part.text)?.text ?? 'A2A delegated task',
-      createdAt: new Date(),
-      metadata: {
-        runtime: 'a2a',
-        ownerMindId: targetMindId,
-        scopeKind: 'system',
-        sourceId: task.id,
-        a2aTaskId: task.id,
+      const ttasksTask = TTasksTask.custom('chamber:a2a', JSON.stringify({
+        recipient: request.recipient,
+        message: request.message,
         contextId: task.contextId,
-      },
-    });
+        referenceTaskIds: request.message.referenceTaskIds,
+      }), {
+        id: task.id,
+        title: `A2A task ${task.id}`,
+        description: request.message.parts.find((part) => part.text)?.text ?? 'A2A delegated task',
+        createdAt: new Date(),
+        metadata: {
+          runtime: 'a2a',
+          ownerMindId: targetMindId,
+          scopeKind: 'system',
+          sourceId: task.id,
+          a2aTaskId: task.id,
+          contextId: task.contextId,
+        },
+      });
 
-    this.ttasksTasks.set(task.id, ttasksTask);
-    store.tasks.save(ttasksTask);
+      this.ttasksTasks.set(task.id, ttasksTask);
+      store.tasks.save(ttasksTask);
+    } catch (err) {
+      log.warn(`Failed to persist ttasks row for A2A task ${task.id}:`, err);
+    }
   }
 
   private persistTTasksResult(task: A2ATask, state: TaskState): void {
-    const store = this.options.ttasksStore;
-    const ttasksTask = this.ttasksTasks.get(task.id);
-    if (!store || !ttasksTask) return;
+    try {
+      const targetMindId = this.taskTargets.get(task.id) ?? undefined;
+      const store = targetMindId ? this.getTTasksStore(targetMindId) : this.options.ttasksStore;
+      const ttasksTask = this.ttasksTasks.get(task.id);
+      if (!store || !ttasksTask) return;
 
-    const status = toTTasksStatus(state);
-    const output = summarizeArtifacts(task.artifacts) || summarizeStatusMessage(task.status.message);
-    const errorMessage = task.status.message?.parts.find((part) => part.text)?.text ?? undefined;
-    const error = errorMessage ?? null;
+      const status = toTTasksStatus(state);
+      const output = summarizeArtifacts(task.artifacts) || summarizeStatusMessage(task.status.message);
+      const errorMessage = task.status.message?.parts.find((part) => part.text)?.text ?? undefined;
+      const error = errorMessage ?? null;
 
-    if (status === TaskStatus.RUNNING) {
-      ttasksTask.transitionTo(TaskStatus.RUNNING);
-    } else {
-      const result = new TaskResult({
-        taskId: ttasksTask.id,
-        status,
-        startedAt: new Date(task.status.timestamp ?? Date.now()),
-        finishedAt: new Date(task.status.timestamp ?? Date.now()),
-        duration: 0,
-        output,
-        error,
-        raw: output,
-        returncode: status === TaskStatus.SUCCEEDED ? 0 : 1,
-        terminationReason: null,
-      });
-      ttasksTask.transitionTo(status, { result, error: errorMessage });
+      if (status === TaskStatus.RUNNING) {
+        ttasksTask.transitionTo(TaskStatus.RUNNING);
+      } else {
+        const result = new TaskResult({
+          taskId: ttasksTask.id,
+          status,
+          startedAt: new Date(task.status.timestamp ?? Date.now()),
+          finishedAt: new Date(task.status.timestamp ?? Date.now()),
+          duration: 0,
+          output,
+          error,
+          raw: output,
+          returncode: status === TaskStatus.SUCCEEDED ? 0 : 1,
+          terminationReason: null,
+        });
+        ttasksTask.transitionTo(status, { result, error: errorMessage });
+      }
+
+      store.tasks.save(ttasksTask);
+    } catch (err) {
+      log.warn(`Failed to update ttasks row for A2A task ${task.id}:`, err);
     }
-
-    store.tasks.save(ttasksTask);
   }
 
   private evictOldTasks(): void {
@@ -460,7 +475,15 @@ export class TaskManager extends EventEmitter {
       if (!entry) break;
       const [id] = entry;
       this.tasks.delete(id);
+      this.ttasksTasks.delete(id);
     }
+  }
+
+  private cleanupTaskResources(taskId: string): void {
+    this.pendingInputs.delete(taskId);
+    this.taskTargets.delete(taskId);
+    this.sessions.delete(taskId);
+    this.ttasksTasks.delete(taskId);
   }
 
   private emitStatusUpdate(task: A2ATask): void {

--- a/packages/services/src/a2a/TaskManager.ts
+++ b/packages/services/src/a2a/TaskManager.ts
@@ -1,11 +1,12 @@
 import { EventEmitter } from 'events';
 import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import { Task as TTasksTask, TaskResult, TaskStatus, type Store } from '@ianphil/ttasks-ts';
 import type { AgentCardRegistry } from './AgentCardRegistry';
 import type { CopilotSession, UserInputHandler, UserInputResponse } from '../mind/types';
 import { Logger } from '../logger';
 import type {
   SendMessageRequest,
-  Task,
+  Task as A2ATask,
   TaskState,
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,
@@ -51,15 +52,17 @@ export interface SendTaskRequest extends SendMessageRequest {
 interface TaskManagerOptions {
   ledger?: TaskLedger;
   getLedgerForMind?: (mindId: string) => TaskLedger | undefined;
+  ttasksStore?: Store;
 }
 
 export class TaskManager extends EventEmitter {
   static readonly MAX_COMPLETED_TASKS = 100;
 
-  private tasks = new Map<string, Task>();
+  private tasks = new Map<string, A2ATask>();
   private sessions = new Map<string, CopilotSession>();
   private pendingInputs = new Map<string, (answer: UserInputResponse) => void>();
   private taskTargets = new Map<string, string>();
+  private ttasksTasks = new Map<string, TTasksTask>();
 
   constructor(
     private readonly sessionFactory: TaskSessionFactory,
@@ -69,7 +72,7 @@ export class TaskManager extends EventEmitter {
     super();
   }
 
-  async sendTask(request: SendTaskRequest): Promise<Task> {
+  async sendTask(request: SendTaskRequest): Promise<A2ATask> {
     // 1. Resolve recipient
     const card =
       this.agentCardRegistry.getCard(request.recipient) ??
@@ -84,7 +87,7 @@ export class TaskManager extends EventEmitter {
     const contextId = request.message.contextId || generateContextId();
 
     // 4. Create task
-    const task: Task = {
+    const task: A2ATask = {
       id: taskId,
       contextId,
       status: createTaskStatus('TASK_STATE_SUBMITTED'),
@@ -95,6 +98,7 @@ export class TaskManager extends EventEmitter {
     // 5. Store
     this.tasks.set(taskId, task);
     this.taskTargets.set(taskId, targetMindId);
+    this.persistTTasksTask(task, targetMindId, request);
     if (!request.suppressLedgerWrite) {
       this.recordTaskLedgerSubmitted(task, targetMindId);
     }
@@ -103,7 +107,7 @@ export class TaskManager extends EventEmitter {
     this.emitStatusUpdate(task);
 
     // 7. Snapshot the submitted state before async processing mutates it
-    const snapshot: Task = {
+    const snapshot: A2ATask = {
       ...task,
       status: { ...task.status },
       history: task.history ? [...task.history] : [],
@@ -123,7 +127,7 @@ export class TaskManager extends EventEmitter {
     return snapshot;
   }
 
-  getTask(id: string, historyLength?: number): Task | null {
+  getTask(id: string, historyLength?: number): A2ATask | null {
     const task = this.tasks.get(id);
     if (!task) return null;
 
@@ -154,7 +158,7 @@ export class TaskManager extends EventEmitter {
     };
   }
 
-  cancelTask(id: string): Task {
+  cancelTask(id: string): A2ATask {
     const task = this.tasks.get(id);
     if (!task) throw new Error(`Task ${id} not found`);
     if (TERMINAL_STATES.has(task.status.state)) {
@@ -174,7 +178,7 @@ export class TaskManager extends EventEmitter {
     return this.snapshotTask(task);
   }
 
-  resumeTask(id: string, message: Message): Task {
+  resumeTask(id: string, message: Message): A2ATask {
     const task = this.tasks.get(id);
     if (!task) throw new Error(`Task ${id} not found`);
     if (task.status.state !== 'TASK_STATE_INPUT_REQUIRED') {
@@ -201,7 +205,7 @@ export class TaskManager extends EventEmitter {
   // Private
   // ---------------------------------------------------------------------------
 
-  private snapshotTask(task: Task): Task {
+  private snapshotTask(task: A2ATask): A2ATask {
     return {
       ...task,
       status: { ...task.status },
@@ -211,7 +215,7 @@ export class TaskManager extends EventEmitter {
   }
 
   private async processTask(
-    task: Task,
+    task: A2ATask,
     targetMindId: string,
     message: Message,
     onUserInputOverride?: UserInputHandler,
@@ -258,7 +262,7 @@ export class TaskManager extends EventEmitter {
     }
   }
 
-  private recordTaskLedgerSubmitted(task: Task, targetMindId: string): void {
+  private recordTaskLedgerSubmitted(task: A2ATask, targetMindId: string): void {
     try {
       this.getLedgerForMind(targetMindId)?.writer.createRunning({
         runtime: 'a2a',
@@ -276,7 +280,7 @@ export class TaskManager extends EventEmitter {
     }
   }
 
-  private finalizeTaskLedger(task: Task): void {
+  private finalizeTaskLedger(task: A2ATask): void {
     try {
       const targetMindId = this.taskTargets.get(task.id);
       if (!targetMindId) return;
@@ -317,7 +321,7 @@ export class TaskManager extends EventEmitter {
     }
   }
 
-  private bindTaskSessionListeners(session: CopilotSession, task: Task, targetMindId: string): void {
+  private bindTaskSessionListeners(session: CopilotSession, task: A2ATask, targetMindId: string): void {
     void targetMindId;
     let responseText = '';
 
@@ -372,14 +376,74 @@ export class TaskManager extends EventEmitter {
     });
   }
 
-  private transitionState(task: Task, state: TaskState): void {
+  private transitionState(task: A2ATask, state: TaskState): void {
     task.status = createTaskStatus(state);
     this.emitStatusUpdate(task);
+    this.persistTTasksResult(task, state);
 
     if (TERMINAL_STATES.has(state)) {
       this.finalizeTaskLedger(task);
       this.evictOldTasks();
     }
+  }
+
+  private persistTTasksTask(task: A2ATask, targetMindId: string, request: SendTaskRequest): void {
+    const store = this.options.ttasksStore;
+    if (!store) return;
+
+    const ttasksTask = TTasksTask.custom('chamber:a2a', JSON.stringify({
+      recipient: request.recipient,
+      message: request.message,
+      contextId: task.contextId,
+      referenceTaskIds: request.message.referenceTaskIds,
+    }), {
+      id: task.id,
+      title: `A2A task ${task.id}`,
+      description: request.message.parts.find((part) => part.text)?.text ?? 'A2A delegated task',
+      createdAt: new Date(),
+      metadata: {
+        runtime: 'a2a',
+        ownerMindId: targetMindId,
+        scopeKind: 'system',
+        sourceId: task.id,
+        a2aTaskId: task.id,
+        contextId: task.contextId,
+      },
+    });
+
+    this.ttasksTasks.set(task.id, ttasksTask);
+    store.tasks.save(ttasksTask);
+  }
+
+  private persistTTasksResult(task: A2ATask, state: TaskState): void {
+    const store = this.options.ttasksStore;
+    const ttasksTask = this.ttasksTasks.get(task.id);
+    if (!store || !ttasksTask) return;
+
+    const status = toTTasksStatus(state);
+    const output = summarizeArtifacts(task.artifacts) || summarizeStatusMessage(task.status.message);
+    const errorMessage = task.status.message?.parts.find((part) => part.text)?.text ?? undefined;
+    const error = errorMessage ?? null;
+
+    if (status === TaskStatus.RUNNING) {
+      ttasksTask.transitionTo(TaskStatus.RUNNING);
+    } else {
+      const result = new TaskResult({
+        taskId: ttasksTask.id,
+        status,
+        startedAt: new Date(task.status.timestamp ?? Date.now()),
+        finishedAt: new Date(task.status.timestamp ?? Date.now()),
+        duration: 0,
+        output,
+        error,
+        raw: output,
+        returncode: status === TaskStatus.SUCCEEDED ? 0 : 1,
+        terminationReason: null,
+      });
+      ttasksTask.transitionTo(status, { result, error: errorMessage });
+    }
+
+    store.tasks.save(ttasksTask);
   }
 
   private evictOldTasks(): void {
@@ -399,7 +463,7 @@ export class TaskManager extends EventEmitter {
     }
   }
 
-  private emitStatusUpdate(task: Task): void {
+  private emitStatusUpdate(task: A2ATask): void {
     const event: TaskStatusUpdateEvent & { targetMindId: string } = {
       taskId: task.id,
       contextId: task.contextId,
@@ -408,6 +472,38 @@ export class TaskManager extends EventEmitter {
     };
     this.emit('task:status-update', event);
   }
+}
+
+function toTTasksStatus(state: TaskState): TaskStatus.SUCCEEDED | TaskStatus.FAILED | TaskStatus.CANCELLED | TaskStatus.RUNNING {
+  switch (state) {
+    case 'TASK_STATE_SUBMITTED':
+    case 'TASK_STATE_WORKING':
+    case 'TASK_STATE_INPUT_REQUIRED':
+      return TaskStatus.RUNNING;
+    case 'TASK_STATE_COMPLETED':
+      return TaskStatus.SUCCEEDED;
+    case 'TASK_STATE_FAILED':
+    case 'TASK_STATE_REJECTED':
+    case 'TASK_STATE_AUTH_REQUIRED':
+      return TaskStatus.FAILED;
+    case 'TASK_STATE_CANCELED':
+      return TaskStatus.CANCELLED;
+    default: {
+      const _exhaustive: never = state;
+      throw new Error(`Unknown A2A task state: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function summarizeArtifacts(artifacts: A2ATask['artifacts']): string {
+  return (artifacts ?? [])
+    .map((artifact) => artifact.parts.map((part) => part.text ?? '').filter(Boolean).join('\n'))
+    .filter(Boolean)
+    .join('\n');
+}
+
+function summarizeStatusMessage(message: A2ATask['status']['message']): string {
+  return message?.parts.map((part) => part.text ?? '').filter(Boolean).join('\n') ?? '';
 }
 
 function getSessionErrorMessage(event: unknown): string {

--- a/packages/services/src/automation/AutomationBridge.test.ts
+++ b/packages/services/src/automation/AutomationBridge.test.ts
@@ -19,10 +19,12 @@ afterEach(async () => {
 async function startBridge(handlers: {
   onPrompt?: (req: { mindId: string; prompt: string; recipient?: string }) => Promise<{ text: string }>;
   onNotify?: (req: { mindId: string; title: string; body: string }) => Promise<void>;
+  onA2a?: (req: { mindId: string; recipient: string; message: string; contextId?: string; referenceTaskIds?: string[] }) => Promise<Record<string, unknown>>;
 } = {}): Promise<RunningBridge> {
   const bridge = new AutomationBridge({
     onPrompt: handlers.onPrompt ?? (async () => ({ text: 'queued' })),
     onNotify: handlers.onNotify ?? (async () => {}),
+    onA2a: handlers.onA2a,
   });
   const started = await bridge.start();
   const r: RunningBridge = { url: started.url, bridge, stop: started.stop };
@@ -98,6 +100,37 @@ describe('AutomationBridge', () => {
     );
     expect(res.status).toBe(200);
     expect(seen).toEqual([{ mindId: 'mind-1', title: 'Hi', body: 'There' }]);
+  });
+
+  it('routes /a2a to the configured handler', async () => {
+    const seen: unknown[] = [];
+    const r = await startBridge({
+      onA2a: async (req) => {
+        seen.push(req);
+        return { id: 'task-1', status: 'submitted' };
+      },
+    });
+    const minted = r.bridge.tokens.mint('mind-1', 'run-1');
+    const res = await post(
+      `${r.url}/a2a`,
+      { authorization: `Bearer ${minted.token}` },
+      { recipient: 'mind-b', message: 'draft the report', contextId: 'ctx-1', referenceTaskIds: ['task-0'] },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: 'task-1', status: 'submitted' });
+    expect(seen).toEqual([{ mindId: 'mind-1', recipient: 'mind-b', message: 'draft the report', contextId: 'ctx-1', referenceTaskIds: ['task-0'] }]);
+  });
+
+  it('returns 501 when /a2a has no handler configured', async () => {
+    const r = await startBridge();
+    const minted = r.bridge.tokens.mint('mind-1', 'run-1');
+    const res = await post(
+      `${r.url}/a2a`,
+      { authorization: `Bearer ${minted.token}` },
+      { recipient: 'mind-b', message: 'draft the report' },
+    );
+    expect(res.status).toBe(501);
+    expect(await res.json()).toEqual({ error: 'a2a-handler-not-configured' });
   });
 
   it('returns 404 for unknown routes', async () => {

--- a/packages/services/src/automation/AutomationBridge.ts
+++ b/packages/services/src/automation/AutomationBridge.ts
@@ -19,6 +19,14 @@ export interface BridgeNotifyRequest {
   body: string;
 }
 
+export interface BridgeA2ARequest {
+  mindId: string;
+  recipient: string;
+  message: string;
+  contextId?: string;
+  referenceTaskIds?: string[];
+}
+
 export interface BridgeHandlers {
   /**
    * Invoked when an automation script posts /prompt. Runs unattended (no
@@ -30,6 +38,7 @@ export interface BridgeHandlers {
    */
   onPrompt: (req: BridgePromptRequest) => Promise<{ text: string }>;
   onNotify: (req: BridgeNotifyRequest) => Promise<void>;
+  onA2a?: (req: BridgeA2ARequest) => Promise<Record<string, unknown>>;
 }
 
 interface BridgeStartResult {
@@ -162,6 +171,35 @@ export class AutomationBridge {
         }
         await this.handlers.onNotify({ mindId, title, body: text });
         this.sendJson(res, 200, { ok: true });
+        return;
+      }
+      if (url === '/a2a') {
+        const recipient = (body as { recipient?: unknown }).recipient;
+        const message = (body as { message?: unknown }).message;
+        if (typeof recipient !== 'string' || recipient.trim() === '') {
+          this.sendJson(res, 400, { error: 'recipient-required' });
+          return;
+        }
+        if (typeof message !== 'string' || message.trim() === '') {
+          this.sendJson(res, 400, { error: 'message-required' });
+          return;
+        }
+        if (!this.handlers.onA2a) {
+          this.sendJson(res, 501, { error: 'a2a-handler-not-configured' });
+          return;
+        }
+        const contextId = (body as { contextId?: unknown }).contextId;
+        const referenceTaskIds = (body as { referenceTaskIds?: unknown }).referenceTaskIds;
+        const result = await this.handlers.onA2a({
+          mindId,
+          recipient,
+          message,
+          ...(typeof contextId === 'string' ? { contextId } : {}),
+          ...(Array.isArray(referenceTaskIds) && referenceTaskIds.every((item) => typeof item === 'string')
+            ? { referenceTaskIds }
+            : {}),
+        });
+        this.sendJson(res, 200, result);
         return;
       }
       this.sendJson(res, 404, { error: 'not-found' });

--- a/packages/services/src/cron/migrations/v1-to-v2.test.ts
+++ b/packages/services/src/cron/migrations/v1-to-v2.test.ts
@@ -58,6 +58,7 @@ describe('v1 → v2 cron migration', () => {
     const src = fs.readFileSync(scriptAbs, 'utf8');
     expect(src).toContain('chamberPrompt');
     expect(src).toContain('Give me a status update');
+    expect(src).toContain('registerChamberHandlers(executor);');
   });
 
   it('translates shell, webhook, and notification jobs', () => {
@@ -72,7 +73,9 @@ describe('v1 → v2 cron migration', () => {
     const byId = Object.fromEntries(state.jobs.map((j) => [j.id, j]));
     expect(fs.readFileSync(path.join(mindPath, byId['shell-1'].scriptPath), 'utf8')).toContain('Task.bash');
     expect(fs.readFileSync(path.join(mindPath, byId['web-1'].scriptPath), 'utf8')).toContain('https://example.com');
+    expect(fs.readFileSync(path.join(mindPath, byId['web-1'].scriptPath), 'utf8')).toContain('registerChamberHandlers(executor);');
     expect(fs.readFileSync(path.join(mindPath, byId['notif-1'].scriptPath), 'utf8')).toContain('chamberNotify');
+    expect(fs.readFileSync(path.join(mindPath, byId['notif-1'].scriptPath), 'utf8')).toContain('registerChamberHandlers(executor);');
   });
 
   it('writes a backup at cron.v1.backup.json and is idempotent', () => {

--- a/packages/services/src/cron/migrations/v1-to-v2.ts
+++ b/packages/services/src/cron/migrations/v1-to-v2.ts
@@ -165,7 +165,7 @@ function promptScript(prompt: string, recipient?: string): string {
     : '';
   return `${header()}${recipientNote}
 import { TaskGraph, TaskExecutor, SqliteStore, type Store } from '@ianphil/ttasks-ts';
-import { chamberPrompt, promptHandler } from '@chamber/automation-runtime';
+import { chamberPrompt, registerChamberHandlers } from '@chamber/automation-runtime';
 
 const graphId = process.env.CHAMBER_GRAPH_ID;
 const dbPath = process.env.CHAMBER_TTASKS_DB;
@@ -179,7 +179,7 @@ graph.add(chamberPrompt({
 
 const store: Store = new SqliteStore({ path: dbPath });
 const executor = new TaskExecutor({ store });
-executor.register('chamber:prompt', promptHandler);
+registerChamberHandlers(executor);
 
 try {
   await graph.run(executor);
@@ -231,7 +231,7 @@ function webhookScript(
 ): string {
   return `${header()}
 import { TaskGraph, TaskExecutor, SqliteStore, type Store } from '@ianphil/ttasks-ts';
-import { httpHandler, httpTask } from '@chamber/automation-runtime';
+import { httpTask, registerChamberHandlers } from '@chamber/automation-runtime';
 
 const graphId = process.env.CHAMBER_GRAPH_ID;
 const dbPath = process.env.CHAMBER_TTASKS_DB;
@@ -248,7 +248,7 @@ graph.add(httpTask({
 
 const store: Store = new SqliteStore({ path: dbPath });
 const executor = new TaskExecutor({ store });
-executor.register('http', httpHandler);
+registerChamberHandlers(executor);
 
 try {
   await graph.run(executor);
@@ -261,7 +261,7 @@ try {
 function notificationScript(title: string, body: string): string {
   return `${header()}
 import { TaskGraph, TaskExecutor, SqliteStore, type Store } from '@ianphil/ttasks-ts';
-import { chamberNotify, notifyHandler } from '@chamber/automation-runtime';
+import { chamberNotify, registerChamberHandlers } from '@chamber/automation-runtime';
 
 const graphId = process.env.CHAMBER_GRAPH_ID;
 const dbPath = process.env.CHAMBER_TTASKS_DB;
@@ -276,7 +276,7 @@ graph.add(chamberNotify({
 
 const store: Store = new SqliteStore({ path: dbPath });
 const executor = new TaskExecutor({ store });
-executor.register('chamber:notify', notifyHandler);
+registerChamberHandlers(executor);
 
 try {
   await graph.run(executor);

--- a/tests/invariants/a2a-runtime.invariant.test.ts
+++ b/tests/invariants/a2a-runtime.invariant.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const repoRoot = process.cwd();
+
+describe('A2A runtime invariants', () => {
+  it('desktop production wiring supplies the A2A bridge handler and per-mind ttasks store', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'apps', 'desktop', 'src', 'main.ts'), 'utf8');
+
+    expect(source).toContain('const createTTasksStore = (mindId: string) => {');
+    expect(source).toContain('new TaskManager(mindManager, agentCardRegistry, {');
+    expect(source).toContain('createTTasksStore,');
+    expect(source).toContain('onA2a: async ({ mindId, recipient, message, contextId, referenceTaskIds }) => {');
+    expect(source).toContain('new SqliteStore');
+  });
+
+  it('A2A task persistence stays best-effort when ttasks storage fails', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'a2a', 'TaskManager.ts'), 'utf8');
+
+    expect(source).toContain('private persistTTasksTask(task: A2ATask, targetMindId: string, request: SendTaskRequest): void {');
+    expect(source).toContain('try {');
+    expect(source).toContain('log.warn(`Failed to persist ttasks row for A2A task ${task.id}:`, err);');
+    expect(source).toContain('private persistTTasksResult(task: A2ATask, state: TaskState): void {');
+    expect(source).toContain('log.warn(`Failed to update ttasks row for A2A task ${task.id}:`, err);');
+  });
+
+  it('terminal cleanup evicts ttasks and session state after A2A task completion', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'a2a', 'TaskManager.ts'), 'utf8');
+
+    expect(source).toContain('private evictOldTasks(): void {');
+    expect(source).toContain('this.ttasksTasks.delete(id);');
+    expect(source).toContain('private cleanupTaskResources(taskId: string): void {');
+    expect(source).toContain('this.pendingInputs.delete(taskId);');
+    expect(source).toContain('this.taskTargets.delete(taskId);');
+    expect(source).toContain('this.sessions.delete(taskId);');
+    expect(source).toContain('this.ttasksTasks.delete(taskId);');
+  });
+});

--- a/tests/invariants/a2a-runtime.invariant.test.ts
+++ b/tests/invariants/a2a-runtime.invariant.test.ts
@@ -8,11 +8,26 @@ describe('A2A runtime invariants', () => {
   it('desktop production wiring supplies the A2A bridge handler and per-mind ttasks store', () => {
     const source = fs.readFileSync(path.join(repoRoot, 'apps', 'desktop', 'src', 'main.ts'), 'utf8');
 
-    expect(source).toContain('const createTTasksStore = (mindId: string) => {');
+    expect(source).toContain('const ttasksStoresByMindPath = new Map<string, SqliteStore>();');
+    expect(source).toContain('const createTTasksStore = (mindPath: string): SqliteStore => {');
+    expect(source).toContain('ttasksStoresByMindPath.set(mindPath, store);');
+    expect(source).toContain('const closeTTasksStores = (): void => {');
+    expect(source).toContain('store.close();');
+    expect(source).toContain('closeTTasksStores();');
     expect(source).toContain('new TaskManager(mindManager, agentCardRegistry, {');
-    expect(source).toContain('createTTasksStore,');
+    expect(source).toContain('createTTasksStore: (mindId) => {');
     expect(source).toContain('onA2a: async ({ mindId, recipient, message, contextId, referenceTaskIds }) => {');
     expect(source).toContain('new SqliteStore');
+  });
+
+  it('persisted A2A ttasks rows use the registered chamber:a2a handler payload shape', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'packages', 'services', 'src', 'a2a', 'TaskManager.ts'), 'utf8');
+
+    expect(source).toContain("TTasksTask.custom('chamber:a2a', JSON.stringify({");
+    expect(source).toContain('recipient: request.recipient,');
+    expect(source).toContain('message: getMessageText(request.message),');
+    expect(source).toContain('contextId: task.contextId,');
+    expect(source).toContain('referenceTaskIds: request.message.referenceTaskIds,');
   });
 
   it('A2A task persistence stays best-effort when ttasks storage fails', () => {


### PR DESCRIPTION
## Summary

Adds `chamber:a2a` as a Chamber ttasks custom task type and wires it through the A2A/automation runtime so delegated A2A work can be represented as durable ttasks rows.

## Notable changes

- Adds the `chamber:a2a` task factory/handler and shared Chamber handler registration.
- Extends `AutomationBridge` with `/a2a` handling and wires desktop production `onA2a` dispatch.
- Persists A2A delegated tasks into per-mind ttasks stores with best-effort failure handling.
- Caches and closes desktop ttasks stores to avoid repeated SQLite handle creation.
- Fixes A2A cancel cleanup so active sessions are aborted before terminal resource cleanup.
- Adds A2A runtime invariants for production wiring, payload shape, best-effort persistence, and cleanup.
- Refreshes the packaged Copilot CLI pin to `1.0.58` so package smoke matches the launcher-resolved runtime.

## Issues

No linked closing issue.

## Validation

- `npx vitest run --config config/vitest.config.ts --no-file-parallelism --maxWorkers=1 packages/services/src/a2a/TaskManager.test.ts tests/invariants/a2a-runtime.invariant.test.ts`
- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npm run package`
- `npm run smoke:automation`
- `npm run smoke:web`
- `npm run smoke:server-sdk`
- `npm run smoke:desktop` ran; two unrelated Electron flakes failed on the full run and both passed when rerun directly.

## Review

Uncle Bob review found cancellation, store lifecycle, and persisted payload-shape issues; all were fixed and re-reviewed with no blocking findings remaining.