### PR TITLE
feat(voice): Azure Speech voice subsystem (dictation + hands-free, STT/TTS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Add chamber:a2a ttasks runtime support** — Adds a chamber:a2a custom task type, production A2A bridge wiring, durable ttasks persistence, and invariants for the runtime contract.
+- **Azure Speech voice (dictation + hands-free)** — Optional Azure Speech voice subsystem behind a feature flag: microphone dictation into the composer and a hands-free conversation mode (speech-to-text and text-to-speech). The subscription key lives only in the OS keychain via keytar; the renderer authenticates with short-lived issued tokens, never the key.
 
 
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -72,6 +72,7 @@ import {
   SQLiteLedgerStore,
   setSqliteDatabase,
   ByoLlmStore,
+  AzureSpeechStore,
   buildProviderConfig,
   createByoLlmModelsProvider,
   probeEndpoint,
@@ -107,6 +108,7 @@ import { setupToolsIPC } from './main/ipc/tools';
 import { setupTasksIPC } from './main/ipc/tasks';
 import { setupAuthIPC } from './main/ipc/auth';
 import { setupByoLlmIPC } from './main/ipc/byoLlm';
+import { setupAzureSpeechIPC } from './main/ipc/azureSpeech';
 import { setupA2AIPC } from './main/ipc/a2a';
 import { setupChatroomIPC } from './main/ipc/chatroom';
 import { setupConversationHistoryIPC } from './main/ipc/conversationHistory';
@@ -222,6 +224,7 @@ let agentCardRegistry: AgentCardRegistry;
 let taskManager: TaskManager;
 let byoLlmStore: ByoLlmStore;
 let cachedByoLlmConfig: import('@chamber/shared/types').ByoLlmConfig | null = null;
+let azureSpeechStore: AzureSpeechStore;
 let mindManager: MindManager;
 let mindProfileService: MindProfileService;
 let userProfileService: UserProfileService;
@@ -327,6 +330,7 @@ async function initializeRuntime(): Promise<void> {
   const activeA2AResolver = new ActiveA2AResolver(agentCardRegistry);
   const turnQueue = new TurnQueue();
   byoLlmStore = new ByoLlmStore({ storeDir: process.env.CHAMBER_E2E_USER_DATA, credentials: credentialStore });
+  azureSpeechStore = new AzureSpeechStore({ storeDir: process.env.CHAMBER_E2E_USER_DATA, credentials: credentialStore });
   mindManager = new MindManager(
     clientFactory,
     identityLoader,
@@ -763,7 +767,9 @@ app.on('ready', async () => {
   }
 
   installContentSecurityPolicy(session.defaultSession, app.isPackaged ? 'production' : 'development');
-  installPermissionHandlers(session.defaultSession);
+  installPermissionHandlers(session.defaultSession, {
+    isAudioCaptureEnabled: () => appFeatureFlags.azureSpeech,
+  });
 
   cleanupLegacySquirrelInstall({ isPackaged: app.isPackaged })
     .then((result) => {
@@ -835,6 +841,9 @@ app.on('ready', async () => {
   setupByoLlmIPC(byoLlmStore, mindManager, {
     featureEnabled: appFeatureFlags.byoLlm,
     onConfigChanged: (config) => { cachedByoLlmConfig = appFeatureFlags.byoLlm ? config : null; },
+  });
+  setupAzureSpeechIPC(azureSpeechStore, {
+    featureEnabled: appFeatureFlags.azureSpeech,
   });
   setupA2AIPC(a2aEventBus, agentCardRegistry, taskManager, {
     relayModeService: a2aRelayModeService,

--- a/apps/desktop/src/main/devFeatureFlags.ts
+++ b/apps/desktop/src/main/devFeatureFlags.ts
@@ -11,4 +11,5 @@ export const DEV_FEATURE_FLAGS: AppFeatureFlags = {
   switchboardRelay: true,
   byoLlm: true,
   chamberCopilot: true,
+  azureSpeech: true,
 };

--- a/apps/desktop/src/main/ipc/azureSpeech.ts
+++ b/apps/desktop/src/main/ipc/azureSpeech.ts
@@ -1,0 +1,125 @@
+// Azure Speech IPC handlers — get/save/disable/test/mintToken flow for the
+// voice (speech-to-text + text-to-speech) surface in Settings and chat.
+//
+// The renderer never receives the subscription key: GET returns a masked
+// config and MINT_TOKEN returns only a short-lived Azure authorization token.
+
+import { ipcMain, BrowserWindow } from 'electron';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import { IPC } from '@chamber/shared';
+import type {
+  AzureSpeechConfig,
+  AzureSpeechSaveResult,
+  AzureSpeechTestResult,
+  AzureSpeechToken,
+} from '@chamber/shared/types';
+import { AzureSpeechStore, Logger } from '@chamber/services';
+
+const log = Logger.create('AzureSpeech');
+
+const MASKED_SECRET = '********';
+
+function redactConfigForRenderer(config: AzureSpeechConfig | null): AzureSpeechConfig | null {
+  if (!config) return null;
+  const redacted: AzureSpeechConfig = { ...config };
+  if (redacted.apiKey) redacted.apiKey = MASKED_SECRET;
+  return redacted;
+}
+
+function broadcast(config: AzureSpeechConfig | null): void {
+  const rendererConfig = redactConfigForRenderer(config);
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(IPC.AZURE_SPEECH.CHANGED, rendererConfig);
+  }
+}
+
+/** Resolve a masked key back to the stored secret before persisting/testing. */
+async function hydrateMaskedKey(store: AzureSpeechStore, config: AzureSpeechConfig): Promise<AzureSpeechConfig> {
+  if (config.apiKey !== MASKED_SECRET) return config;
+  const current = await store.load();
+  const hydrated: AzureSpeechConfig = { ...config };
+  if (current?.apiKey) hydrated.apiKey = current.apiKey;
+  else delete hydrated.apiKey;
+  return hydrated;
+}
+
+export interface AzureSpeechIpcOptions {
+  featureEnabled?: boolean;
+}
+
+export function setupAzureSpeechIPC(
+  store: AzureSpeechStore,
+  options: AzureSpeechIpcOptions = {},
+): void {
+  const featureEnabled = options.featureEnabled ?? true;
+
+  ipcMain.handle(IPC.AZURE_SPEECH.GET, async (): Promise<AzureSpeechConfig | null> => {
+    if (!featureEnabled) return null;
+    return redactConfigForRenderer(await store.load());
+  });
+
+  ipcMain.handle(IPC.AZURE_SPEECH.SAVE, async (_event, config: AzureSpeechConfig): Promise<AzureSpeechSaveResult> => {
+    if (!featureEnabled) return featureUnavailableSaveResult();
+    try {
+      if (!config || typeof config !== 'object') {
+        return { success: false, error: 'Invalid config payload' };
+      }
+      if (config.enabled && (!config.region || !config.region.trim())) {
+        return { success: false, error: 'Region is required when enabling voice' };
+      }
+      const hydrated = await hydrateMaskedKey(store, config);
+      if (hydrated.enabled && !hydrated.apiKey) {
+        return { success: false, error: 'Subscription key is required when enabling voice' };
+      }
+      await store.save(hydrated);
+      const saved = await store.load();
+      broadcast(saved);
+      return { success: true };
+    } catch (err) {
+      const message = getErrorMessage(err);
+      log.error('Failed to save Azure Speech config:', message);
+      return { success: false, error: message };
+    }
+  });
+
+  ipcMain.handle(IPC.AZURE_SPEECH.DISABLE, async (): Promise<AzureSpeechSaveResult> => {
+    if (!featureEnabled) return featureUnavailableSaveResult();
+    try {
+      await store.clear();
+      broadcast(null);
+      return { success: true };
+    } catch (err) {
+      const message = getErrorMessage(err);
+      log.error('Failed to disable Azure Speech config:', message);
+      return { success: false, error: message };
+    }
+  });
+
+  ipcMain.handle(IPC.AZURE_SPEECH.TEST, async (_event, config: AzureSpeechConfig): Promise<AzureSpeechTestResult> => {
+    if (!featureEnabled) return { ok: false, error: featureUnavailableMessage() };
+    try {
+      const hydrated = config ? await hydrateMaskedKey(store, config) : undefined;
+      return store.testConnection(hydrated ? { region: hydrated.region, apiKey: hydrated.apiKey } : undefined);
+    } catch (err) {
+      return { ok: false, error: getErrorMessage(err) };
+    }
+  });
+
+  ipcMain.handle(IPC.AZURE_SPEECH.MINT_TOKEN, async (): Promise<AzureSpeechToken | null> => {
+    if (!featureEnabled) return null;
+    try {
+      return await store.mintToken();
+    } catch (err) {
+      log.warn('Failed to mint Azure Speech token:', getErrorMessage(err));
+      return null;
+    }
+  });
+}
+
+function featureUnavailableMessage(): string {
+  return 'Voice is unavailable in this release channel';
+}
+
+function featureUnavailableSaveResult(): AzureSpeechSaveResult {
+  return { success: false, error: featureUnavailableMessage() };
+}

--- a/apps/desktop/src/main/security/sessionSecurity.test.ts
+++ b/apps/desktop/src/main/security/sessionSecurity.test.ts
@@ -10,14 +10,14 @@ interface FakeWebRequest {
 }
 interface FakeSession {
   webRequest: FakeWebRequest;
-  setPermissionRequestHandler: (cb: (wc: unknown, permission: string, callback: (allow: boolean) => void) => void) => void;
-  setPermissionCheckHandler: (cb: (wc: unknown, permission: string) => boolean) => void;
+  setPermissionRequestHandler: (cb: (wc: unknown, permission: string, callback: (allow: boolean) => void, details?: unknown) => void) => void;
+  setPermissionCheckHandler: (cb: (wc: unknown, permission: string, origin?: string, details?: unknown) => boolean) => void;
 }
 
 function fakeSession() {
   let headersHandler: ((details: { responseHeaders?: Record<string, string[]>; resourceType?: string }, callback: (response: { responseHeaders?: Record<string, string[]> }) => void) => void) | null = null;
-  let permissionRequestHandler: ((wc: unknown, permission: string, callback: (allow: boolean) => void) => void) | null = null;
-  let permissionCheckHandler: ((wc: unknown, permission: string) => boolean) | null = null;
+  let permissionRequestHandler: ((wc: unknown, permission: string, callback: (allow: boolean) => void, details?: unknown) => void) | null = null;
+  let permissionCheckHandler: ((wc: unknown, permission: string, origin?: string, details?: unknown) => boolean) | null = null;
 
   const session: FakeSession = {
     webRequest: {
@@ -33,13 +33,13 @@ function fakeSession() {
       if (!headersHandler) throw new Error('onHeadersReceived not registered');
       return new Promise((resolve) => headersHandler!(details, resolve));
     },
-    invokePermissionRequest(permission: string): Promise<boolean> {
+    invokePermissionRequest(permission: string, details?: unknown): Promise<boolean> {
       if (!permissionRequestHandler) throw new Error('setPermissionRequestHandler not called');
-      return new Promise((resolve) => permissionRequestHandler!({}, permission, resolve));
+      return new Promise((resolve) => permissionRequestHandler!({}, permission, resolve, details));
     },
-    invokePermissionCheck(permission: string): boolean {
+    invokePermissionCheck(permission: string, details?: unknown): boolean {
       if (!permissionCheckHandler) throw new Error('setPermissionCheckHandler not called');
-      return permissionCheckHandler({}, permission);
+      return permissionCheckHandler({}, permission, '', details);
     },
   };
 }
@@ -87,6 +87,13 @@ describe('buildContentSecurityPolicy', () => {
     expect(csp).not.toMatch(/connect-src [^;]*api\.github\.com/);
     expect(csp).not.toMatch(/connect-src [^;]*api\.githubcopilot\.com/);
     expect(csp).not.toMatch(/connect-src [^;]*[^.]github\.com/);
+  });
+
+  it('allows the Azure Speech STT/TTS endpoints in connect-src for the renderer Speech SDK', () => {
+    const csp = buildContentSecurityPolicy('production');
+    expect(csp).toMatch(/connect-src [^;]*wss:\/\/\*\.stt\.speech\.microsoft\.com/);
+    expect(csp).toMatch(/connect-src [^;]*wss:\/\/\*\.tts\.speech\.microsoft\.com/);
+    expect(csp).toMatch(/connect-src [^;]*https:\/\/\*\.api\.cognitive\.microsoft\.com/);
   });
 });
 
@@ -171,11 +178,36 @@ describe('installPermissionHandlers', () => {
     expect(fake.invokePermissionCheck('notifications')).toBe(true);
   });
 
-  it('denies media, geolocation, midi, and other non-allowlisted permissions', async () => {
+  it('allows microphone capture (audio media) when the voice feature is enabled', async () => {
+    const fake = fakeSession();
+    installPermissionHandlers(fake.session as never, { isAudioCaptureEnabled: () => true });
+
+    expect(await fake.invokePermissionRequest('media', { mediaTypes: ['audio'] })).toBe(true);
+    expect(fake.invokePermissionCheck('media', { mediaType: 'audio' })).toBe(true);
+  });
+
+  it('denies microphone capture when the voice feature is disabled (default)', async () => {
     const fake = fakeSession();
     installPermissionHandlers(fake.session as never);
 
-    for (const permission of ['media', 'geolocation', 'midi', 'pointerLock', 'fullscreen', 'clipboard-read']) {
+    expect(await fake.invokePermissionRequest('media', { mediaTypes: ['audio'] })).toBe(false);
+    expect(fake.invokePermissionCheck('media', { mediaType: 'audio' })).toBe(false);
+  });
+
+  it('denies camera capture (video media) even when the voice feature is enabled', async () => {
+    const fake = fakeSession();
+    installPermissionHandlers(fake.session as never, { isAudioCaptureEnabled: () => true });
+
+    expect(await fake.invokePermissionRequest('media', { mediaTypes: ['video'] })).toBe(false);
+    expect(await fake.invokePermissionRequest('media', { mediaTypes: ['audio', 'video'] })).toBe(false);
+    expect(fake.invokePermissionCheck('media', { mediaType: 'video' })).toBe(false);
+  });
+
+  it('denies geolocation, midi, and other non-allowlisted permissions', async () => {
+    const fake = fakeSession();
+    installPermissionHandlers(fake.session as never, { isAudioCaptureEnabled: () => true });
+
+    for (const permission of ['geolocation', 'midi', 'pointerLock', 'fullscreen', 'clipboard-read']) {
       expect(await fake.invokePermissionRequest(permission)).toBe(false);
       expect(fake.invokePermissionCheck(permission)).toBe(false);
     }

--- a/apps/desktop/src/main/security/sessionSecurity.ts
+++ b/apps/desktop/src/main/security/sessionSecurity.ts
@@ -21,10 +21,15 @@ const COMMON_DIRECTIVES = [
 //   - 'self'     — same-origin (Vite dev server, packaged file://, MVP loopback server)
 //   - localhost  — MVP loopback server + Vite HMR (ws + http variants)
 //   - 127.0.0.1  — same as localhost; MVP server may emit either host name
+//   - *.speech.microsoft.com / *.api.cognitive.microsoft.com — Azure Speech
+//     STT/TTS WebSocket + REST endpoints. The renderer's Speech SDK opens a
+//     wss connection directly to the region endpoint; the subscription key
+//     never reaches the renderer (a short-lived token is minted in main).
 // GitHub OAuth + API calls run in main, not the renderer, so they are not
 // listed here. Shorter allow-list = clearer enforcement boundary.
 const CONNECT_SRC =
-  "connect-src 'self' http://localhost:* ws://localhost:* wss://localhost:* http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*";
+  "connect-src 'self' http://localhost:* ws://localhost:* wss://localhost:* http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:* "
+  + 'https://*.api.cognitive.microsoft.com https://*.stt.speech.microsoft.com wss://*.stt.speech.microsoft.com https://*.tts.speech.microsoft.com wss://*.tts.speech.microsoft.com';
 
 export function buildContentSecurityPolicy(mode: SecurityMode): string {
   const scriptSrc =
@@ -67,11 +72,37 @@ export function installContentSecurityPolicy(session: Session, mode: SecurityMod
   });
 }
 
-export function installPermissionHandlers(session: Session): void {
-  session.setPermissionRequestHandler((_webContents, permission, callback) => {
+export interface PermissionHandlerOptions {
+  /**
+   * Lazily resolves whether microphone capture is currently permitted. Read at
+   * request time (not install time) so it reflects the resolved voice feature
+   * flag even though permission handlers install before the flag resolves.
+   * Defaults to always-deny.
+   */
+  isAudioCaptureEnabled?: () => boolean;
+}
+
+export function installPermissionHandlers(
+  session: Session,
+  options: PermissionHandlerOptions = {},
+): void {
+  const isAudioCaptureEnabled = options.isAudioCaptureEnabled ?? (() => false);
+  session.setPermissionRequestHandler((_webContents, permission, callback, details) => {
+    if (permission === 'media') {
+      // Microphone only, and only when the voice feature is enabled. Camera
+      // (any 'video' request) is always denied.
+      const mediaTypes = (details as { mediaTypes?: Array<'audio' | 'video'> } | undefined)?.mediaTypes;
+      const wantsVideo = mediaTypes?.includes('video') ?? false;
+      callback(isAudioCaptureEnabled() && !wantsVideo);
+      return;
+    }
     callback(ALLOWED_PERMISSIONS.has(permission));
   });
-  session.setPermissionCheckHandler((_webContents, permission) =>
-    ALLOWED_PERMISSIONS.has(permission),
-  );
+  session.setPermissionCheckHandler((_webContents, permission, _origin, details) => {
+    if (permission === 'media') {
+      const mediaType = (details as { mediaType?: 'audio' | 'video' | 'unknown' } | undefined)?.mediaType;
+      return isAudioCaptureEnabled() && mediaType !== 'video';
+    }
+    return ALLOWED_PERMISSIONS.has(permission);
+  });
 }

--- a/apps/desktop/src/main/services/featureFlags/FeatureFlagService.test.ts
+++ b/apps/desktop/src/main/services/featureFlags/FeatureFlagService.test.ts
@@ -9,12 +9,14 @@ const DEV_FLAGS: AppFeatureFlags = {
   switchboardRelay: true,
   byoLlm: false,
   chamberCopilot: true,
+  azureSpeech: false,
 };
 
 const REMOTE_FLAGS: AppFeatureFlags = {
   switchboardRelay: true,
   byoLlm: true,
   chamberCopilot: false,
+  azureSpeech: false,
 };
 
 describe('FeatureFlagService', () => {
@@ -114,6 +116,7 @@ describe('FeatureFlagService', () => {
       switchboardRelay: true,
       byoLlm: true,
       chamberCopilot: true,
+      azureSpeech: true,
     });
     expect(fetched).toBe(false);
   });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -69,6 +69,14 @@ const electronAPI: ElectronAPI = {
     restartAgents: () => ipcRenderer.invoke(IPC.BYO_LLM.RESTART_AGENTS),
     onChanged: (callback) => createIpcListener(ipcRenderer, IPC.BYO_LLM.CHANGED, callback),
   },
+  azureSpeech: {
+    get: () => ipcRenderer.invoke(IPC.AZURE_SPEECH.GET),
+    save: (config) => ipcRenderer.invoke(IPC.AZURE_SPEECH.SAVE, config),
+    disable: () => ipcRenderer.invoke(IPC.AZURE_SPEECH.DISABLE),
+    test: (config) => ipcRenderer.invoke(IPC.AZURE_SPEECH.TEST, config),
+    mintToken: () => ipcRenderer.invoke(IPC.AZURE_SPEECH.MINT_TOKEN),
+    onChanged: (callback) => createIpcListener(ipcRenderer, IPC.AZURE_SPEECH.CHANGED, callback),
+  },
   genesis: {
     getDefaultPath: () => ipcRenderer.invoke(IPC.GENESIS.GET_DEFAULT_PATH),
     pickPath: () => ipcRenderer.invoke(IPC.GENESIS.PICK_PATH),

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -249,6 +249,14 @@ export function installBrowserApi(): void {
       restartAgents: async () => ({ success: false, restartedCount: 0, error: 'Agent restart is desktop-only in browser mode.' }),
       onChanged: () => noopUnsubscribe,
     },
+    azureSpeech: {
+      get: async () => null,
+      save: async () => ({ success: false, error: 'Voice is desktop-only in browser mode.' }),
+      disable: async () => ({ success: false, error: 'Voice is desktop-only in browser mode.' }),
+      test: async () => ({ ok: false, error: 'Voice testing is desktop-only in browser mode.' }),
+      mintToken: async () => null,
+      onChanged: () => noopUnsubscribe,
+    },
     genesis: {
       getDefaultPath: async () => '',
       pickPath: async () => null,

--- a/apps/web/src/renderer/components/layout/ActivityBar.test.tsx
+++ b/apps/web/src/renderer/components/layout/ActivityBar.test.tsx
@@ -37,12 +37,12 @@ describe('ActivityBar', () => {
   });
 
   it('hides the A2A Relay button when the Switchboard Relay flag is disabled', () => {
-    renderActivityBar({ featureFlags: { switchboardRelay: false, byoLlm: false, chamberCopilot: false } });
+    renderActivityBar({ featureFlags: { switchboardRelay: false, byoLlm: false, chamberCopilot: false, azureSpeech: false } });
     expect(screen.queryByLabelText('A2A Relay')).toBeNull();
   });
 
   it('renders the A2A Relay button above settings when the Switchboard Relay flag is enabled', () => {
-    renderActivityBar({ featureFlags: { switchboardRelay: true, byoLlm: false, chamberCopilot: false } });
+    renderActivityBar({ featureFlags: { switchboardRelay: true, byoLlm: false, chamberCopilot: false, azureSpeech: false } });
     const relayButton = screen.getByLabelText('A2A Relay');
     const settingsButton = screen.getByLabelText('Settings');
     const footer = relayButton.closest('[data-testid="activity-bar-footer"]');

--- a/apps/web/src/renderer/components/settings/AzureSpeechSettingsSection.tsx
+++ b/apps/web/src/renderer/components/settings/AzureSpeechSettingsSection.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useState } from 'react';
+import { Check } from 'lucide-react';
+import type { AzureSpeechConfig } from '@chamber/shared/types';
+import { cn } from '../../lib/utils';
+
+interface TestState {
+  status: 'idle' | 'testing' | 'success' | 'error';
+  error?: string;
+}
+
+const EMPTY_FORM: AzureSpeechConfig = {
+  enabled: false,
+  region: '',
+  sttLanguage: '',
+  ttsVoice: '',
+  apiKey: '',
+};
+
+/**
+ * Settings -> "Voice" section.
+ *
+ * Configures Azure AI Speech for dictation (speech-to-text) and spoken
+ * replies (text-to-speech). The subscription key is stored in the OS keychain
+ * by the main process; the renderer only ever sees a masked value and
+ * short-lived authorization tokens minted on demand.
+ */
+export function AzureSpeechSettingsSection() {
+  const [savedConfig, setSavedConfig] = useState<AzureSpeechConfig | null>(null);
+  const [form, setForm] = useState<AzureSpeechConfig>(EMPTY_FORM);
+  const [test, setTest] = useState<TestState>({ status: 'idle' });
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.electronAPI.azureSpeech.get().then((config) => {
+      if (cancelled) return;
+      if (config) {
+        setSavedConfig(config);
+        setForm({ ...EMPTY_FORM, ...config });
+      }
+    });
+    const unsub = window.electronAPI.azureSpeech.onChanged((config) => {
+      setSavedConfig(config ?? null);
+      if (config) {
+        setForm({ ...EMPTY_FORM, ...config });
+      } else {
+        setForm(EMPTY_FORM);
+        setTest({ status: 'idle' });
+      }
+    });
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
+
+  const isEnabled = savedConfig?.enabled === true;
+
+  const updateForm = <K extends keyof AzureSpeechConfig>(key: K, value: AzureSpeechConfig[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (test.status !== 'idle') setTest({ status: 'idle' });
+  };
+
+  const handleTest = async () => {
+    setTest({ status: 'testing' });
+    setStatusMessage(null);
+    const result = await window.electronAPI.azureSpeech.test(form);
+    if (result.ok) {
+      setTest({ status: 'success' });
+    } else {
+      setTest({ status: 'error', error: result.error });
+    }
+  };
+
+  const handleApply = async () => {
+    setApplying(true);
+    setStatusMessage(null);
+    try {
+      if (form.enabled) {
+        if (!form.region.trim()) {
+          setStatusMessage('Region is required to enable voice.');
+          return;
+        }
+        const result = await window.electronAPI.azureSpeech.save(form);
+        setStatusMessage(result.success ? 'Voice settings applied.' : (result.error ?? 'Failed to save voice settings.'));
+      } else {
+        const result = await window.electronAPI.azureSpeech.disable();
+        setStatusMessage(result.success ? 'Voice disabled.' : (result.error ?? 'Failed to disable voice.'));
+      }
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const showActions = form.enabled || isEnabled;
+  const canApply = form.enabled ? Boolean(form.region.trim()) : isEnabled;
+
+  return (
+    <section>
+      <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">
+        Voice
+      </h2>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Use Azure AI Speech for dictation (speech-to-text) and spoken replies (text-to-speech).
+          Provide your Speech resource region and subscription key. Your key is stored securely in the
+          OS keychain and never leaves your machine except to authenticate directly with Azure.
+        </p>
+
+        {isEnabled ? (
+          <p role="status" className="text-sm text-foreground">
+            Active in region <span className="font-mono">{savedConfig?.region}</span>
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">Currently disabled.</p>
+        )}
+
+        <div className="flex items-center justify-between gap-4 rounded-lg border border-border bg-background/40 p-3">
+          <div>
+            <p className="text-sm font-medium text-foreground">Enable voice</p>
+            <p className="text-xs text-muted-foreground">
+              Turn this on to reveal Azure Speech settings and add the microphone to chat.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={form.enabled}
+            aria-label="Enable voice"
+            aria-controls="azure-speech-config-fields"
+            onClick={() => updateForm('enabled', !form.enabled)}
+            className={cn(
+              'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-border transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background',
+              form.enabled ? 'bg-primary' : 'bg-muted',
+            )}
+          >
+            <span
+              className={cn(
+                'inline-block h-5 w-5 rounded-full bg-background shadow transition-transform',
+                form.enabled ? 'translate-x-5' : 'translate-x-0.5',
+              )}
+            />
+          </button>
+        </div>
+
+        {form.enabled ? (
+          <div id="azure-speech-config-fields" className="space-y-3">
+            <label className="block">
+              <span className="text-xs font-medium text-muted-foreground">Region</span>
+              <input
+                type="text"
+                value={form.region}
+                onChange={(e) => updateForm('region', e.target.value)}
+                placeholder="e.g. eastus"
+                aria-label="Region"
+                className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono outline-none focus:border-muted-foreground"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-medium text-muted-foreground">Subscription key</span>
+              <input
+                type="password"
+                value={form.apiKey ?? ''}
+                onChange={(e) => updateForm('apiKey', e.target.value)}
+                placeholder="Azure Speech subscription key"
+                aria-label="Subscription key"
+                className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono outline-none focus:border-muted-foreground"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-medium text-muted-foreground">Recognition language (optional)</span>
+              <input
+                type="text"
+                value={form.sttLanguage ?? ''}
+                onChange={(e) => updateForm('sttLanguage', e.target.value)}
+                placeholder="e.g. en-US"
+                aria-label="Recognition language"
+                className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono outline-none focus:border-muted-foreground"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-medium text-muted-foreground">Voice (optional)</span>
+              <input
+                type="text"
+                value={form.ttsVoice ?? ''}
+                onChange={(e) => updateForm('ttsVoice', e.target.value)}
+                placeholder="e.g. en-US-AvaNeural"
+                aria-label="Voice"
+                className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono outline-none focus:border-muted-foreground"
+              />
+            </label>
+          </div>
+        ) : (
+          <div id="azure-speech-config-fields" className="rounded-lg border border-dashed border-border bg-background/30 p-3 text-sm text-muted-foreground">
+            Voice fields are hidden while the toggle is off.
+          </div>
+        )}
+
+        {showActions ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {form.enabled ? (
+              <button
+                type="button"
+                onClick={() => { void handleTest(); }}
+                disabled={!form.region.trim() || test.status === 'testing'}
+                className="rounded-lg border border-border px-3 py-2 text-sm hover:bg-accent transition-colors disabled:opacity-50"
+              >
+                {test.status === 'testing' ? 'Testing…' : 'Test connection'}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => { void handleApply(); }}
+              disabled={!canApply || applying}
+              className="rounded-lg border border-border bg-primary text-primary-foreground px-3 py-2 text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {applying ? 'Applying…' : 'Apply'}
+            </button>
+          </div>
+        ) : null}
+
+        {test.status === 'success' ? (
+          <p role="status" className="flex items-center gap-1.5 text-sm text-genesis">
+            <Check className="h-4 w-4" />
+            Connection succeeded
+          </p>
+        ) : null}
+        {test.status === 'error' ? (
+          <p role="alert" className="text-sm text-destructive">{test.error ?? 'Connection failed.'}</p>
+        ) : null}
+        {statusMessage ? (
+          <p role="status" className="text-sm text-muted-foreground">{statusMessage}</p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/renderer/components/settings/SettingsView.test.tsx
+++ b/apps/web/src/renderer/components/settings/SettingsView.test.tsx
@@ -79,7 +79,7 @@ describe('SettingsView', () => {
 
   it('shows Local & Custom LLM settings when BYO LLM is feature-flagged on', async () => {
     render(
-      <AppStateProvider testInitialState={{ featureFlags: { switchboardRelay: false, byoLlm: true, chamberCopilot: false } }}>
+      <AppStateProvider testInitialState={{ featureFlags: { switchboardRelay: false, byoLlm: true, chamberCopilot: false, azureSpeech: false } }}>
         <SettingsView />
       </AppStateProvider>,
     );

--- a/apps/web/src/renderer/components/voice/VoiceModeController.test.tsx
+++ b/apps/web/src/renderer/components/voice/VoiceModeController.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { VoiceModeController } from './VoiceModeController';
+import type { VoiceRecognizer, VoiceRecognizerCallbacks, VoiceRecognizerFactory } from '../../hooks/useVoiceInput';
+import type { VoiceSynthesizer, VoiceSynthesizerCallbacks, VoiceSynthesizerFactory } from '../../hooks/useVoiceConversation';
+import type { AzureSpeechToken } from '@chamber/shared/types';
+
+function makeFakeRecognizer() {
+  const start = vi.fn<() => Promise<void>>(() => Promise.resolve());
+  const stop = vi.fn<() => Promise<void>>(() => Promise.resolve());
+  const dispose = vi.fn<() => void>();
+  const recognizer: VoiceRecognizer = { start, stop, dispose };
+  let captured: VoiceRecognizerCallbacks | undefined;
+  const factory: VoiceRecognizerFactory = (_t, _r, _l, cb) => {
+    captured = cb;
+    return recognizer;
+  };
+  return { start, stop, dispose, recognizer, factory, get callbacks() { return captured!; } };
+}
+
+function makeFakeSynthesizer() {
+  const spoken: string[] = [];
+  const speak = vi.fn<(text: string) => Promise<void>>((text) => {
+    spoken.push(text);
+    return Promise.resolve();
+  });
+  const stop = vi.fn<() => void>();
+  const dispose = vi.fn<() => void>();
+  const synthesizer: VoiceSynthesizer = { speak, stop, dispose };
+  let captured: VoiceSynthesizerCallbacks | undefined;
+  const factory: VoiceSynthesizerFactory = (_t, _r, _v, cb) => {
+    captured = cb;
+    return synthesizer;
+  };
+  return { speak, stop, dispose, synthesizer, factory, spoken, get callbacks() { return captured!; } };
+}
+
+const token: AzureSpeechToken = { token: 'tok', region: 'eastus', expiresAt: Date.now() + 600_000 };
+
+function setup(overrides: { onUtterance?: (t: string) => void; onClose?: () => void } = {}) {
+  const recognizer = makeFakeRecognizer();
+  const synthesizer = makeFakeSynthesizer();
+  const onUtterance = overrides.onUtterance ?? vi.fn();
+  const onClose = overrides.onClose ?? vi.fn();
+  const mintToken = vi.fn<() => Promise<AzureSpeechToken | null>>(() => Promise.resolve(token));
+  const view = render(
+    <VoiceModeController
+      onUtterance={onUtterance}
+      reply={null}
+      onClose={onClose}
+      mintToken={mintToken}
+      createRecognizer={recognizer.factory}
+      createSynthesizer={synthesizer.factory}
+    />,
+  );
+  return { recognizer, synthesizer, onUtterance, onClose, mintToken, view };
+}
+
+describe('VoiceModeController', () => {
+  it('starts a session and shows the listening status', async () => {
+    setup();
+    expect(await screen.findByText('Listening')).toBeTruthy();
+  });
+
+  it('forwards a finalized utterance and switches to thinking', async () => {
+    const onUtterance = vi.fn();
+    const { recognizer } = setup({ onUtterance });
+    await screen.findByText('Listening');
+    act(() => recognizer.callbacks.onFinal('what is the weather'));
+    expect(onUtterance).toHaveBeenCalledWith('what is the weather');
+    expect(await screen.findByText('Thinking')).toBeTruthy();
+  });
+
+  it('speaks a reply that streams in while the session is active', async () => {
+    const { recognizer, synthesizer, view } = setup();
+    await screen.findByText('Listening');
+    act(() => recognizer.callbacks.onFinal('hello'));
+
+    await act(async () => {
+      view.rerender(
+        <VoiceModeController
+          onUtterance={vi.fn()}
+          reply={{ id: 'r1', text: 'Hi there. ', streaming: true }}
+          onClose={vi.fn()}
+          mintToken={vi.fn(() => Promise.resolve(token))}
+          createRecognizer={recognizer.factory}
+          createSynthesizer={synthesizer.factory}
+        />,
+      );
+    });
+
+    await waitFor(() => expect(synthesizer.spoken).toContain('Hi there.'));
+  });
+
+  it('does not replay a reply that completed before the session opened', async () => {
+    const recognizer = makeFakeRecognizer();
+    const synthesizer = makeFakeSynthesizer();
+    render(
+      <VoiceModeController
+        onUtterance={vi.fn()}
+        reply={{ id: 'old', text: 'old reply.', streaming: false }}
+        onClose={vi.fn()}
+        mintToken={vi.fn(() => Promise.resolve(token))}
+        createRecognizer={recognizer.factory}
+        createSynthesizer={synthesizer.factory}
+      />,
+    );
+    await screen.findByText('Listening');
+    expect(synthesizer.spoken).toHaveLength(0);
+  });
+
+  it('invokes onClose from the overlay', async () => {
+    const onClose = vi.fn();
+    setup({ onClose });
+    await screen.findByText('Listening');
+    fireEvent.click(screen.getByLabelText('Close voice mode'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/renderer/components/voice/VoiceModeController.tsx
+++ b/apps/web/src/renderer/components/voice/VoiceModeController.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  useVoiceConversation,
+  type VoiceSynthesizerFactory,
+} from '../../hooks/useVoiceConversation';
+import type { VoiceRecognizerFactory } from '../../hooks/useVoiceInput';
+import type { AzureSpeechToken } from '@chamber/shared/types';
+import { VoiceModeOverlay } from './VoiceModeOverlay';
+
+/** The current assistant reply being streamed back, or null when none. */
+export interface VoiceReplySource {
+  id: string;
+  text: string;
+  streaming: boolean;
+}
+
+interface Props {
+  /** Send a finalized user utterance to the model. */
+  onUtterance: (text: string) => void;
+  /** The latest assistant reply, fed to TTS as it streams. */
+  reply: VoiceReplySource | null;
+  /** Conversation partner name, shown in the overlay. */
+  mindName?: string;
+  /** Close the overlay and tear down the session. */
+  onClose: () => void;
+  // --- Test seams (omit in production) ---
+  mintToken?: () => Promise<AzureSpeechToken | null>;
+  createRecognizer?: VoiceRecognizerFactory;
+  createSynthesizer?: VoiceSynthesizerFactory;
+  /** When DI is supplied, these are used directly instead of loading config. */
+  language?: string;
+  voice?: string;
+}
+
+/**
+ * Owns a hands-free voice conversation session and renders its overlay.
+ *
+ * Loads the configured STT language and TTS voice, starts the
+ * {@link useVoiceConversation} session on mount, bridges the streaming
+ * assistant reply into TTS, and tears everything down when closed. Replies
+ * that began before the session opened are never spoken: only a reply whose
+ * streaming starts while the session is active is read back.
+ */
+export function VoiceModeController({
+  onUtterance,
+  reply,
+  mindName,
+  onClose,
+  mintToken,
+  createRecognizer,
+  createSynthesizer,
+  language: languageProp,
+  voice: voiceProp,
+}: Props) {
+  const usingTestSeams = Boolean(mintToken);
+  const [language, setLanguage] = useState<string | undefined>(languageProp);
+  const [voice, setVoice] = useState<string | undefined>(voiceProp);
+  const [configReady, setConfigReady] = useState(usingTestSeams);
+
+  // Load the configured language/voice before starting so the session is
+  // created with the right locale and neural voice.
+  useEffect(() => {
+    if (usingTestSeams) return;
+    let cancelled = false;
+    window.electronAPI.azureSpeech.get().then((config) => {
+      if (cancelled) return;
+      setLanguage(config?.sttLanguage || undefined);
+      setVoice(config?.ttsVoice || undefined);
+      setConfigReady(true);
+    }).catch(() => {
+      if (!cancelled) setConfigReady(true);
+    });
+    return () => { cancelled = true; };
+  }, [usingTestSeams]);
+
+  const conversation = useVoiceConversation({
+    onUtterance,
+    language,
+    voice,
+    mintToken,
+    createRecognizer,
+    createSynthesizer,
+  });
+
+  // Start once config is ready; stop on unmount. Refs keep the start/stop
+  // identities current without re-running the mount effect.
+  const startRef = useRef(conversation.start);
+  startRef.current = conversation.start;
+  const stopRef = useRef(conversation.stop);
+  stopRef.current = conversation.stop;
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!configReady || startedRef.current) return;
+    startedRef.current = true;
+    void startRef.current();
+    return () => { void stopRef.current(); };
+  }, [configReady]);
+
+  // Bridge the streaming reply into TTS. Only a reply that begins streaming
+  // while the session is active is spoken, and each reply is ended once.
+  const spokenIdRef = useRef<string | null>(null);
+  const endedIdRef = useRef<string | null>(null);
+  const { isActive, updateReply, endReply } = conversation;
+
+  useEffect(() => {
+    if (!isActive || !reply) return;
+    if (reply.streaming && spokenIdRef.current !== reply.id && endedIdRef.current !== reply.id) {
+      spokenIdRef.current = reply.id;
+    }
+    if (spokenIdRef.current !== reply.id) return;
+    updateReply(reply.text);
+    if (!reply.streaming) {
+      endReply();
+      endedIdRef.current = reply.id;
+      spokenIdRef.current = null;
+    }
+  }, [isActive, reply, updateReply, endReply]);
+
+  return (
+    <VoiceModeOverlay
+      status={conversation.status}
+      partialText={conversation.partialText}
+      error={conversation.error}
+      mindName={mindName}
+      onClose={onClose}
+    />
+  );
+}

--- a/apps/web/src/renderer/components/voice/VoiceModeOverlay.test.tsx
+++ b/apps/web/src/renderer/components/voice/VoiceModeOverlay.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VoiceModeOverlay } from './VoiceModeOverlay';
+
+describe('VoiceModeOverlay', () => {
+  it('renders the listening status label', () => {
+    render(<VoiceModeOverlay status="listening" partialText="" error={null} onClose={() => {}} />);
+    expect(screen.getByText('Listening')).toBeTruthy();
+  });
+
+  it('shows the live partial transcript', () => {
+    render(<VoiceModeOverlay status="listening" partialText="hello there" error={null} onClose={() => {}} />);
+    expect(screen.getByText('hello there')).toBeTruthy();
+  });
+
+  it('renders the error message in the error state', () => {
+    render(<VoiceModeOverlay status="error" partialText="" error="no key configured" onClose={() => {}} />);
+    expect(screen.getByText('Voice error')).toBeTruthy();
+    expect(screen.getByText('no key configured')).toBeTruthy();
+  });
+
+  it('shows the conversation partner name', () => {
+    render(<VoiceModeOverlay status="speaking" partialText="" error={null} mindName="Ava" onClose={() => {}} />);
+    expect(screen.getByText('with Ava')).toBeTruthy();
+  });
+
+  it('invokes onClose from the close button', () => {
+    const onClose = vi.fn();
+    render(<VoiceModeOverlay status="listening" partialText="" error={null} onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText('Close voice mode'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onClose from the end-conversation button', () => {
+    const onClose = vi.fn();
+    render(<VoiceModeOverlay status="listening" partialText="" error={null} onClose={onClose} />);
+    fireEvent.click(screen.getByText('End conversation'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(<VoiceModeOverlay status="listening" partialText="" error={null} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves focus to the close button on open', () => {
+    render(<VoiceModeOverlay status="listening" partialText="" error={null} onClose={() => {}} />);
+    expect(document.activeElement).toBe(screen.getByLabelText('Close voice mode'));
+  });
+
+  it('exposes the error message as an alert without the white-on-white token', () => {
+    render(<VoiceModeOverlay status="error" partialText="" error="no key configured" onClose={() => {}} />);
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toBe('no key configured');
+    expect(alert.className).toContain('text-destructive');
+    expect(alert.className).not.toContain('text-destructive-foreground');
+  });
+
+  it('tells the user the mic is paused while the assistant responds', () => {
+    render(<VoiceModeOverlay status="speaking" partialText="" error={null} onClose={() => {}} />);
+    expect(screen.getByText('Mic paused while the assistant responds')).toBeTruthy();
+  });
+
+  it('does not show the mic-paused hint while listening', () => {
+    render(<VoiceModeOverlay status="listening" partialText="" error={null} onClose={() => {}} />);
+    expect(screen.queryByText('Mic paused while the assistant responds')).toBeNull();
+  });
+});

--- a/apps/web/src/renderer/components/voice/VoiceModeOverlay.tsx
+++ b/apps/web/src/renderer/components/voice/VoiceModeOverlay.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { AudioLines, Loader2, Mic, MicOff, TriangleAlert, X } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import type { VoiceConversationStatus } from '../../hooks/useVoiceConversation';
+
+interface Props {
+  status: VoiceConversationStatus;
+  partialText: string;
+  error: string | null;
+  /** Mind name shown as the conversation partner, when known. */
+  mindName?: string;
+  onClose: () => void;
+}
+
+interface StatusVisual {
+  label: string;
+  icon: typeof Mic;
+  orbClass: string;
+  iconClass: string;
+}
+
+function statusVisual(status: VoiceConversationStatus): StatusVisual {
+  switch (status) {
+    case 'listening':
+      return { label: 'Listening', icon: Mic, orbClass: 'bg-genesis/15 ring-genesis/40 voice-orb-breathe', iconClass: 'text-genesis' };
+    case 'thinking':
+      return { label: 'Thinking', icon: Loader2, orbClass: 'bg-muted ring-border', iconClass: 'text-muted-foreground animate-spin' };
+    case 'speaking':
+      return { label: 'Speaking', icon: AudioLines, orbClass: 'bg-primary/15 ring-primary/40 animate-pulse', iconClass: 'text-primary' };
+    case 'error':
+      return { label: 'Voice error', icon: TriangleAlert, orbClass: 'bg-destructive/15 ring-destructive/40', iconClass: 'text-destructive' };
+    default:
+      return { label: 'Connecting', icon: Loader2, orbClass: 'bg-muted ring-border', iconClass: 'text-muted-foreground animate-spin' };
+  }
+}
+
+const CLOSE_BUTTON_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
+/**
+ * Full-surface overlay for a hands-free voice conversation. Purely
+ * presentational: it reflects the {@link useVoiceConversation} status and live
+ * partial transcript, and exposes a single close affordance. The owning
+ * controller drives state and tears the session down on close.
+ *
+ * Behaves as a real modal: focus moves to the close control on open, Tab is
+ * trapped within the dialog, Escape dismisses it, and focus is restored to the
+ * previously focused element on unmount.
+ */
+export function VoiceModeOverlay({ status, partialText, error, mindName, onClose }: Props) {
+  const visual = statusVisual(status);
+  const Icon = visual.icon;
+  const micPaused = status === 'thinking' || status === 'speaking';
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    closeButtonRef.current?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => !el.hasAttribute('disabled'));
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey) {
+        if (active === first || !dialog.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !dialog.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
+  return createPortal(
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Voice conversation"
+      className="fixed inset-0 z-[100] flex flex-col items-center justify-center bg-background/95 backdrop-blur-sm"
+    >
+      <button
+        ref={closeButtonRef}
+        type="button"
+        aria-label="Close voice mode"
+        onClick={onClose}
+        className={cn(
+          'absolute right-4 top-4 h-9 w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-accent flex items-center justify-center',
+          CLOSE_BUTTON_RING,
+        )}
+      >
+        <X className="h-5 w-5" />
+      </button>
+
+      <div
+        className={cn(
+          'flex h-40 w-40 items-center justify-center rounded-full ring-4 transition-colors',
+          visual.orbClass,
+        )}
+      >
+        <Icon className={cn('h-16 w-16', visual.iconClass)} />
+      </div>
+
+      <p className="mt-8 text-lg font-medium text-foreground" aria-live="polite">
+        {visual.label}
+      </p>
+      {mindName ? (
+        <p className="mt-1 text-sm text-muted-foreground">with {mindName}</p>
+      ) : null}
+
+      {status === 'error' && error ? (
+        <p role="alert" className="mt-4 max-w-md px-6 text-center text-sm text-destructive">{error}</p>
+      ) : (
+        <p className="mt-4 min-h-[1.5rem] max-w-md px-6 text-center text-sm text-muted-foreground">
+          {partialText}
+        </p>
+      )}
+
+      {micPaused ? (
+        <p className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <MicOff className="h-3.5 w-3.5" />
+          Mic paused while the assistant responds
+        </p>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={onClose}
+        className={cn(
+          'mt-10 rounded-full bg-muted px-6 py-2 text-sm font-medium text-foreground hover:bg-accent',
+          CLOSE_BUTTON_RING,
+        )}
+      >
+        End conversation
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/renderer/hooks/useVoiceConversation.test.tsx
+++ b/apps/web/src/renderer/hooks/useVoiceConversation.test.tsx
@@ -1,0 +1,286 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useVoiceConversation } from './useVoiceConversation';
+import type {
+  VoiceSynthesizer,
+  VoiceSynthesizerCallbacks,
+  VoiceSynthesizerFactory,
+} from './useVoiceConversation';
+import type {
+  VoiceRecognizer,
+  VoiceRecognizerCallbacks,
+  VoiceRecognizerFactory,
+} from './useVoiceInput';
+import type { AzureSpeechToken } from '@chamber/shared/types';
+
+function makeToken(): AzureSpeechToken {
+  return { token: 'tok', region: 'eastus', expiresAt: Date.now() + 600_000 };
+}
+
+function makeFakeRecognizer() {
+  const start = vi.fn<() => Promise<void>>(() => Promise.resolve());
+  const stop = vi.fn<() => Promise<void>>(() => Promise.resolve());
+  const dispose = vi.fn<() => void>();
+  const setAuthToken = vi.fn<(token: string) => void>();
+  const recognizer: VoiceRecognizer = { start, stop, dispose, setAuthToken };
+  let captured: VoiceRecognizerCallbacks | undefined;
+  const factory: VoiceRecognizerFactory = (_token, _region, _lang, callbacks) => {
+    captured = callbacks;
+    return recognizer;
+  };
+  return {
+    start,
+    stop,
+    dispose,
+    setAuthToken,
+    recognizer,
+    factory,
+    get callbacks(): VoiceRecognizerCallbacks {
+      if (!captured) throw new Error('recognizer not created yet');
+      return captured;
+    },
+  };
+}
+
+function makeFakeSynthesizer(options: { manual?: boolean } = {}) {
+  const spoken: string[] = [];
+  const resolvers: Array<() => void> = [];
+  const speak = vi.fn<(text: string) => Promise<void>>((text) => {
+    spoken.push(text);
+    if (options.manual) {
+      return new Promise<void>((resolve) => resolvers.push(resolve));
+    }
+    return Promise.resolve();
+  });
+  const stop = vi.fn<() => void>();
+  const dispose = vi.fn<() => void>();
+  const setAuthToken = vi.fn<(token: string) => void>();
+  const synthesizer: VoiceSynthesizer = { speak, stop, dispose, setAuthToken };
+  let captured: VoiceSynthesizerCallbacks | undefined;
+  const factory: VoiceSynthesizerFactory = (_token, _region, _voice, callbacks) => {
+    captured = callbacks;
+    return synthesizer;
+  };
+  const resolveNext = async () => {
+    const next = resolvers.shift();
+    if (next) next();
+    await Promise.resolve();
+  };
+  return {
+    speak,
+    stop,
+    dispose,
+    setAuthToken,
+    synthesizer,
+    factory,
+    spoken,
+    resolveNext,
+    get callbacks(): VoiceSynthesizerCallbacks {
+      if (!captured) throw new Error('synthesizer not created yet');
+      return captured;
+    },
+  };
+}
+
+function setup(overrides: { manual?: boolean } = {}) {
+  const recognizer = makeFakeRecognizer();
+  const synthesizer = makeFakeSynthesizer({ manual: overrides.manual });
+  const mintToken = vi.fn<() => Promise<AzureSpeechToken | null>>(() => Promise.resolve(makeToken()));
+  const onUtterance = vi.fn<(text: string) => void>();
+  const rendered = renderHook(() => useVoiceConversation({
+    onUtterance,
+    mintToken,
+    createRecognizer: recognizer.factory,
+    createSynthesizer: synthesizer.factory,
+  }));
+  return { recognizer, synthesizer, mintToken, onUtterance, ...rendered };
+}
+
+describe('useVoiceConversation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts listening after minting a token and opening recognizer + synthesizer', async () => {
+    const { result, recognizer, synthesizer, mintToken } = setup();
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(mintToken).toHaveBeenCalledOnce();
+    expect(recognizer.start).toHaveBeenCalledOnce();
+    expect(result.current.status).toBe('listening');
+    expect(result.current.isActive).toBe(true);
+    // synthesizer created but not yet asked to speak
+    expect(synthesizer.speak).not.toHaveBeenCalled();
+  });
+
+  it('forwards a finalized utterance and moves to thinking', async () => {
+    const { result, recognizer, onUtterance } = setup();
+    await act(async () => {
+      await result.current.start();
+    });
+
+    await act(async () => {
+      recognizer.callbacks.onFinal('what is the weather');
+    });
+
+    expect(onUtterance).toHaveBeenCalledWith('what is the weather');
+    expect(result.current.status).toBe('thinking');
+    expect(result.current.partialText).toBe('');
+  });
+
+  it('ignores utterances captured while not listening', async () => {
+    const { result, recognizer, onUtterance } = setup();
+    await act(async () => {
+      await result.current.start();
+    });
+
+    await act(async () => {
+      recognizer.callbacks.onFinal('first');
+    });
+    // status is now 'thinking'; a second final should be dropped
+    await act(async () => {
+      recognizer.callbacks.onFinal('echo of the reply');
+    });
+
+    expect(onUtterance).toHaveBeenCalledTimes(1);
+    expect(onUtterance).toHaveBeenCalledWith('first');
+  });
+
+  it('speaks completed sentences from the streaming reply', async () => {
+    const { result, synthesizer } = setup();
+    await act(async () => {
+      await result.current.start();
+    });
+
+    await act(async () => {
+      result.current.updateReply('Hello there. How are you');
+    });
+
+    expect(synthesizer.spoken).toEqual(['Hello there.']);
+  });
+
+  it('flushes the trailing fragment and resumes listening on endReply', async () => {
+    const { result, synthesizer } = setup();
+    await act(async () => {
+      await result.current.start();
+    });
+
+    await act(async () => {
+      result.current.updateReply('A complete sentence. Tail without terminator');
+    });
+    expect(synthesizer.spoken).toEqual(['A complete sentence.']);
+
+    await act(async () => {
+      result.current.endReply();
+    });
+
+    expect(synthesizer.spoken).toEqual(['A complete sentence.', 'Tail without terminator']);
+    await waitFor(() => expect(result.current.status).toBe('listening'));
+  });
+
+  it('holds speaking between chunks while the reply is still streaming', async () => {
+    const { result, synthesizer } = setup({ manual: true });
+    await act(async () => {
+      await result.current.start();
+    });
+
+    await act(async () => {
+      result.current.updateReply('Speaking now. ');
+    });
+    expect(result.current.status).toBe('speaking');
+
+    await act(async () => {
+      await synthesizer.resolveNext();
+    });
+    // The reply has not ended, so more sentences may still arrive. Status must
+    // stay 'speaking' rather than strobing to 'thinking' between chunks.
+    expect(result.current.status).toBe('speaking');
+  });
+
+  it('errors when no token is configured', async () => {
+    const recognizer = makeFakeRecognizer();
+    const synthesizer = makeFakeSynthesizer();
+    const { result } = renderHook(() => useVoiceConversation({
+      onUtterance: vi.fn(),
+      mintToken: () => Promise.resolve(null),
+      createRecognizer: recognizer.factory,
+      createSynthesizer: synthesizer.factory,
+    }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toMatch(/not configured/i);
+    expect(recognizer.start).not.toHaveBeenCalled();
+  });
+
+  it('tears down recognizer and synthesizer on stop', async () => {
+    const { result, recognizer, synthesizer } = setup();
+    await act(async () => {
+      await result.current.start();
+    });
+    await act(async () => {
+      await result.current.stop();
+    });
+
+    expect(recognizer.stop).toHaveBeenCalled();
+    expect(recognizer.dispose).toHaveBeenCalled();
+    expect(synthesizer.dispose).toHaveBeenCalled();
+    expect(result.current.status).toBe('idle');
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('surfaces a recognizer error and stops the session', async () => {
+    const { result, recognizer, synthesizer } = setup();
+    await act(async () => {
+      await result.current.start();
+    });
+
+    await act(async () => {
+      recognizer.callbacks.onError('mic failure');
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('mic failure');
+    expect(synthesizer.dispose).toHaveBeenCalled();
+  });
+
+  it('refreshes the recognizer and synthesizer tokens before expiry', async () => {
+    vi.useFakeTimers();
+    try {
+      const recognizer = makeFakeRecognizer();
+      const synthesizer = makeFakeSynthesizer();
+      const first: AzureSpeechToken = { token: 'tok-1', region: 'eastus', expiresAt: Date.now() + 9 * 60_000 };
+      const second: AzureSpeechToken = { token: 'tok-2', region: 'eastus', expiresAt: Date.now() + 18 * 60_000 };
+      const mintToken = vi.fn<() => Promise<AzureSpeechToken | null>>()
+        .mockResolvedValueOnce(first)
+        .mockResolvedValueOnce(second);
+      const { result } = renderHook(() => useVoiceConversation({
+        onUtterance: vi.fn(),
+        mintToken,
+        createRecognizer: recognizer.factory,
+        createSynthesizer: synthesizer.factory,
+      }));
+
+      await act(async () => {
+        await result.current.start();
+      });
+      expect(mintToken).toHaveBeenCalledOnce();
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(9 * 60_000 - 60_000); });
+
+      expect(mintToken).toHaveBeenCalledTimes(2);
+      expect(recognizer.setAuthToken).toHaveBeenCalledWith('tok-2');
+      expect(synthesizer.setAuthToken).toHaveBeenCalledWith('tok-2');
+      expect(result.current.status).toBe('listening');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/renderer/hooks/useVoiceConversation.ts
+++ b/apps/web/src/renderer/hooks/useVoiceConversation.ts
@@ -1,0 +1,345 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import type { AzureSpeechToken } from '@chamber/shared/types';
+import type {
+  VoiceRecognizer,
+  VoiceRecognizerCallbacks,
+  VoiceRecognizerFactory,
+} from './useVoiceInput';
+import { splitIntoSentences, stripSpeechMarkup } from '../lib/sentenceChunker';
+
+export type VoiceConversationStatus =
+  | 'idle'
+  | 'listening'
+  | 'thinking'
+  | 'speaking'
+  | 'error';
+
+/**
+ * Re-mint the authorization token this many milliseconds before it expires.
+ * Azure Speech tokens live ~9 minutes; refreshing early keeps a long
+ * conversation alive without a gap.
+ */
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+/** Retry delay after a failed refresh while the session is still live. */
+const TOKEN_REFRESH_RETRY_MS = 10_000;
+
+/** A live neural TTS session. Returned by a {@link VoiceSynthesizerFactory}. */
+export interface VoiceSynthesizer {
+  /** Synthesize and play a chunk of text; resolves when playback completes. */
+  speak(text: string): Promise<void>;
+  /** Halt current playback and release the synthesizer. */
+  stop(): void;
+  dispose(): void;
+  /** Rotate the authorization token on a live session before the old one expires. */
+  setAuthToken?(token: string): void;
+}
+
+export interface VoiceSynthesizerCallbacks {
+  onError(message: string): void;
+}
+
+export type VoiceSynthesizerFactory = (
+  token: string,
+  region: string,
+  voice: string | undefined,
+  callbacks: VoiceSynthesizerCallbacks,
+) => VoiceSynthesizer | Promise<VoiceSynthesizer>;
+
+export interface UseVoiceConversationOptions {
+  /** Called with each finalized user utterance so the caller can send it. */
+  onUtterance: (text: string) => void;
+  /** STT language tag (e.g. en-US). */
+  language?: string;
+  /** Neural TTS voice (e.g. en-US-AvaNeural). */
+  voice?: string;
+  /** Overridable for tests. Defaults to the preload Azure Speech bridge. */
+  mintToken?: () => Promise<AzureSpeechToken | null>;
+  /** Overridable for tests. Defaults to the SDK-backed recognizer. */
+  createRecognizer?: VoiceRecognizerFactory;
+  /** Overridable for tests. Defaults to the SDK-backed synthesizer. */
+  createSynthesizer?: VoiceSynthesizerFactory;
+}
+
+export interface UseVoiceConversationResult {
+  status: VoiceConversationStatus;
+  /** In-flight STT partial transcript. */
+  partialText: string;
+  error: string | null;
+  /** True while a session is running (not idle and not errored out). */
+  isActive: boolean;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  /** Feed the latest cumulative assistant reply text so TTS can speak it. */
+  updateReply: (fullText: string) => void;
+  /** Mark the current reply complete: flush the tail and resume listening. */
+  endReply: () => void;
+}
+
+/**
+ * Hands-free voice conversation backed by Azure Speech.
+ *
+ * Runs continuous recognition; each finalized utterance is handed to
+ * {@link UseVoiceConversationOptions.onUtterance} (the caller sends it to the
+ * model). The caller streams the assistant reply back via {@link updateReply}
+ * and signals completion via {@link endReply}; the hook sentence-chunks the
+ * reply and speaks it through a sequential neural-TTS queue, then returns to
+ * listening. Utterances arriving while thinking or speaking are ignored
+ * (barge-in is a later phase), which also stops the spoken reply from being
+ * recognized as a new turn.
+ */
+export function useVoiceConversation(options: UseVoiceConversationOptions): UseVoiceConversationResult {
+  const [status, setStatusState] = useState<VoiceConversationStatus>('idle');
+  const [partialText, setPartialText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const statusRef = useRef<VoiceConversationStatus>('idle');
+  const activeRef = useRef(false);
+  const recognizerRef = useRef<VoiceRecognizer | null>(null);
+  const synthesizerRef = useRef<VoiceSynthesizer | null>(null);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // TTS queue + streaming-reply chunker state.
+  const queueRef = useRef<string[]>([]);
+  const drainingRef = useRef(false);
+  const replyEndedRef = useRef(false);
+  const bufferRef = useRef('');
+  const lastReplyLenRef = useRef(0);
+
+  const applyStatus = useCallback((next: VoiceConversationStatus) => {
+    statusRef.current = next;
+    setStatusState(next);
+  }, []);
+
+  const clearRefreshTimer = useCallback(() => {
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+  }, []);
+
+  // Re-mint the auth token shortly before it expires and push it onto the live
+  // recognizer and synthesizer so a long conversation never drops mid-session.
+  const scheduleTokenRefresh = useCallback((expiresAt: number) => {
+    clearRefreshTimer();
+    const delay = Math.max(0, expiresAt - Date.now() - TOKEN_REFRESH_SKEW_MS);
+    refreshTimerRef.current = setTimeout(() => {
+      void (async () => {
+        if (!activeRef.current) return;
+        const { mintToken } = optionsRef.current;
+        const mint = mintToken ?? (() => window.electronAPI.azureSpeech.mintToken());
+        let next: AzureSpeechToken | null;
+        try {
+          next = await mint();
+        } catch {
+          next = null;
+        }
+        if (!activeRef.current) return;
+        if (next) {
+          recognizerRef.current?.setAuthToken?.(next.token);
+          synthesizerRef.current?.setAuthToken?.(next.token);
+          scheduleTokenRefresh(next.expiresAt);
+        } else {
+          // Transient failure: retry while the session is still live.
+          scheduleTokenRefresh(Date.now() + TOKEN_REFRESH_RETRY_MS);
+        }
+      })();
+    }, delay);
+  }, [clearRefreshTimer]);
+
+  const drainQueue = useCallback(async () => {
+    if (drainingRef.current) return;
+    drainingRef.current = true;
+    try {
+      while (queueRef.current.length > 0) {
+        const synth = synthesizerRef.current;
+        if (!synth) break;
+        applyStatus('speaking');
+        const text = queueRef.current.shift() as string;
+        try {
+          await synth.speak(text);
+        } catch {
+          // onError already surfaced the failure; abandon the queue.
+          queueRef.current = [];
+          break;
+        }
+      }
+    } finally {
+      drainingRef.current = false;
+      if (queueRef.current.length === 0 && activeRef.current) {
+        if (replyEndedRef.current) {
+          replyEndedRef.current = false;
+          applyStatus(recognizerRef.current ? 'listening' : 'idle');
+        }
+        // Otherwise the reply is still streaming and more sentences are coming.
+        // Hold 'speaking' rather than strobing to 'thinking' between chunks.
+      }
+    }
+  }, [applyStatus]);
+
+  const enqueueSentence = useCallback((text: string) => {
+    const speakable = stripSpeechMarkup(text);
+    if (!speakable) return;
+    queueRef.current.push(speakable);
+    void drainQueue();
+  }, [drainQueue]);
+
+  const updateReply = useCallback((fullText: string) => {
+    if (!activeRef.current) return;
+    // A shorter buffer than last time means a new reply has started.
+    if (fullText.length < lastReplyLenRef.current) {
+      bufferRef.current = '';
+      lastReplyLenRef.current = 0;
+    }
+    const delta = fullText.slice(lastReplyLenRef.current);
+    lastReplyLenRef.current = fullText.length;
+    if (!delta) return;
+    bufferRef.current += delta;
+    const { sentences, rest } = splitIntoSentences(bufferRef.current);
+    bufferRef.current = rest;
+    for (const sentence of sentences) enqueueSentence(sentence);
+  }, [enqueueSentence]);
+
+  const endReply = useCallback(() => {
+    if (!activeRef.current) return;
+    const tail = bufferRef.current;
+    bufferRef.current = '';
+    lastReplyLenRef.current = 0;
+    replyEndedRef.current = true;
+    if (tail.trim()) enqueueSentence(tail);
+    else void drainQueue();
+  }, [enqueueSentence, drainQueue]);
+
+  const teardown = useCallback(() => {
+    clearRefreshTimer();
+    const recognizer = recognizerRef.current;
+    const synthesizer = synthesizerRef.current;
+    recognizerRef.current = null;
+    synthesizerRef.current = null;
+    queueRef.current = [];
+    drainingRef.current = false;
+    replyEndedRef.current = false;
+    bufferRef.current = '';
+    lastReplyLenRef.current = 0;
+    setPartialText('');
+    if (recognizer) {
+      void Promise.resolve(recognizer.stop()).catch(() => undefined);
+      recognizer.dispose();
+    }
+    if (synthesizer) synthesizer.dispose();
+  }, [clearRefreshTimer]);
+
+  const stop = useCallback(async () => {
+    activeRef.current = false;
+    teardown();
+    applyStatus('idle');
+  }, [teardown, applyStatus]);
+
+  const start = useCallback(async () => {
+    if (recognizerRef.current) return;
+    setError(null);
+    setPartialText('');
+
+    const { mintToken, createRecognizer, createSynthesizer, language, voice } = optionsRef.current;
+    const mint = mintToken ?? (() => window.electronAPI.azureSpeech.mintToken());
+
+    let tokenInfo: AzureSpeechToken | null;
+    try {
+      tokenInfo = await mint();
+    } catch (err) {
+      applyStatus('error');
+      setError(getErrorMessage(err));
+      return;
+    }
+    if (!tokenInfo) {
+      applyStatus('error');
+      setError('Voice conversation is not configured. Add an Azure Speech key in Settings.');
+      return;
+    }
+
+    const recognizerFactory: VoiceRecognizerFactory = createRecognizer
+      ?? (async (token, region, lang, callbacks) => {
+        const { createAzureSpeechRecognizer } = await import('../lib/azureSpeechRecognizer');
+        return createAzureSpeechRecognizer(token, region, lang, callbacks);
+      });
+    const synthesizerFactory: VoiceSynthesizerFactory = createSynthesizer
+      ?? (async (token, region, v, callbacks) => {
+        const { createAzureSpeechSynthesizer } = await import('../lib/azureSpeechSynthesizer');
+        return createAzureSpeechSynthesizer(token, region, v, callbacks);
+      });
+
+    const recognizerCallbacks: VoiceRecognizerCallbacks = {
+      onPartial: (text) => {
+        if (statusRef.current === 'listening') setPartialText(text);
+      },
+      onFinal: (text) => {
+        // Ignore anything captured while the assistant is thinking or speaking.
+        if (statusRef.current !== 'listening') return;
+        setPartialText('');
+        applyStatus('thinking');
+        optionsRef.current.onUtterance(text);
+      },
+      onError: (message) => {
+        activeRef.current = false;
+        teardown();
+        setError(message);
+        applyStatus('error');
+      },
+    };
+
+    let synthesizer: VoiceSynthesizer;
+    let recognizer: VoiceRecognizer;
+    try {
+      synthesizer = await synthesizerFactory(tokenInfo.token, tokenInfo.region, voice, {
+        onError: (message) => setError(message),
+      });
+      recognizer = await recognizerFactory(tokenInfo.token, tokenInfo.region, language, recognizerCallbacks);
+      await recognizer.start();
+    } catch (err) {
+      if (synthesizer!) synthesizer!.dispose();
+      if (recognizer!) recognizer!.dispose();
+      recognizerRef.current = null;
+      synthesizerRef.current = null;
+      applyStatus('error');
+      setError(getErrorMessage(err));
+      return;
+    }
+
+    synthesizerRef.current = synthesizer;
+    recognizerRef.current = recognizer;
+    activeRef.current = true;
+    applyStatus('listening');
+    scheduleTokenRefresh(tokenInfo.expiresAt);
+  }, [teardown, applyStatus, scheduleTokenRefresh]);
+
+  useEffect(() => () => {
+    activeRef.current = false;
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+    const recognizer = recognizerRef.current;
+    const synthesizer = synthesizerRef.current;
+    recognizerRef.current = null;
+    synthesizerRef.current = null;
+    if (recognizer) {
+      void Promise.resolve(recognizer.stop()).catch(() => undefined);
+      recognizer.dispose();
+    }
+    if (synthesizer) synthesizer.dispose();
+  }, []);
+
+  return {
+    status,
+    partialText,
+    error,
+    isActive: status !== 'idle' && status !== 'error',
+    start,
+    stop,
+    updateReply,
+    endReply,
+  };
+}

--- a/apps/web/src/renderer/hooks/useVoiceInput.test.tsx
+++ b/apps/web/src/renderer/hooks/useVoiceInput.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { AzureSpeechToken } from '@chamber/shared/types';
+import {
+  useVoiceInput,
+  type VoiceRecognizer,
+  type VoiceRecognizerCallbacks,
+} from './useVoiceInput';
+
+const TOKEN: AzureSpeechToken = { token: 'tok', region: 'eastus', expiresAt: Date.now() + 60_000 };
+
+function makeFakeRecognizer() {
+  const callbacks: { current: VoiceRecognizerCallbacks | null } = { current: null };
+  const start = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const stop = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const dispose = vi.fn<() => void>();
+  const setAuthToken = vi.fn<(token: string) => void>();
+  const recognizer: VoiceRecognizer = { start, stop, dispose, setAuthToken };
+  const factory = vi.fn(
+    (_token: string, _region: string, _language: string | undefined, cb: VoiceRecognizerCallbacks) => {
+      callbacks.current = cb;
+      return recognizer;
+    },
+  );
+  return { start, stop, dispose, setAuthToken, factory, callbacks };
+}
+
+describe('useVoiceInput', () => {
+  it('mints a token and starts listening', async () => {
+    const { start, factory } = makeFakeRecognizer();
+    const mintToken = vi.fn().mockResolvedValue(TOKEN);
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript: vi.fn(),
+      language: 'en-US',
+      mintToken,
+      createRecognizer: factory,
+    }));
+
+    await act(async () => { await result.current.start(); });
+
+    expect(mintToken).toHaveBeenCalledOnce();
+    expect(factory).toHaveBeenCalledWith('tok', 'eastus', 'en-US', expect.any(Object));
+    expect(start).toHaveBeenCalledOnce();
+    expect(result.current.isListening).toBe(true);
+    expect(result.current.status).toBe('listening');
+  });
+
+  it('surfaces partial transcripts and clears them on final', async () => {
+    const onFinalTranscript = vi.fn();
+    const fake = makeFakeRecognizer();
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript,
+      mintToken: vi.fn().mockResolvedValue(TOKEN),
+      createRecognizer: fake.factory,
+    }));
+
+    await act(async () => { await result.current.start(); });
+
+    act(() => { fake.callbacks.current!.onPartial('hello wor'); });
+    expect(result.current.partialText).toBe('hello wor');
+
+    act(() => { fake.callbacks.current!.onFinal('hello world'); });
+    expect(result.current.partialText).toBe('');
+    expect(onFinalTranscript).toHaveBeenCalledWith('hello world');
+  });
+
+  it('stops and disposes the recognizer', async () => {
+    const { stop, dispose, factory } = makeFakeRecognizer();
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript: vi.fn(),
+      mintToken: vi.fn().mockResolvedValue(TOKEN),
+      createRecognizer: factory,
+    }));
+
+    await act(async () => { await result.current.start(); });
+    await act(async () => { await result.current.stop(); });
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(result.current.isListening).toBe(false);
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('reports an error when the token cannot be minted', async () => {
+    const { factory } = makeFakeRecognizer();
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript: vi.fn(),
+      mintToken: vi.fn().mockResolvedValue(null),
+      createRecognizer: factory,
+    }));
+
+    await act(async () => { await result.current.start(); });
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toMatch(/not configured/i);
+  });
+
+  it('reports recognizer errors and stops listening', async () => {
+    const fake = makeFakeRecognizer();
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript: vi.fn(),
+      mintToken: vi.fn().mockResolvedValue(TOKEN),
+      createRecognizer: fake.factory,
+    }));
+
+    await act(async () => { await result.current.start(); });
+    act(() => { fake.callbacks.current!.onError('mic exploded'); });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error).toBe('mic exploded');
+    expect(result.current.isListening).toBe(false);
+    expect(fake.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('toggle starts then stops', async () => {
+    const { stop, factory } = makeFakeRecognizer();
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript: vi.fn(),
+      mintToken: vi.fn().mockResolvedValue(TOKEN),
+      createRecognizer: factory,
+    }));
+
+    await act(async () => { result.current.toggle(); });
+    await waitFor(() => expect(result.current.isListening).toBe(true));
+
+    await act(async () => { result.current.toggle(); });
+    await waitFor(() => expect(result.current.isListening).toBe(false));
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it('reports a starting status while the token is being minted', async () => {
+    const { factory } = makeFakeRecognizer();
+    let resolveMint!: (token: AzureSpeechToken) => void;
+    const mintToken = vi.fn(() => new Promise<AzureSpeechToken>((resolve) => { resolveMint = resolve; }));
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript: vi.fn(),
+      mintToken,
+      createRecognizer: factory,
+    }));
+
+    let startPromise!: Promise<void>;
+    act(() => { startPromise = result.current.start(); });
+    expect(result.current.status).toBe('starting');
+    expect(result.current.isListening).toBe(false);
+
+    await act(async () => { resolveMint(TOKEN); await startPromise; });
+    expect(result.current.status).toBe('listening');
+  });
+
+  it('refreshes the auth token before it expires and pushes it to the live recognizer', async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = makeFakeRecognizer();
+      const first: AzureSpeechToken = { token: 'tok-1', region: 'eastus', expiresAt: Date.now() + 9 * 60_000 };
+      const second: AzureSpeechToken = { token: 'tok-2', region: 'eastus', expiresAt: Date.now() + 18 * 60_000 };
+      const mintToken = vi.fn<() => Promise<AzureSpeechToken | null>>()
+        .mockResolvedValueOnce(first)
+        .mockResolvedValueOnce(second);
+      const { result } = renderHook(() => useVoiceInput({
+        onFinalTranscript: vi.fn(),
+        mintToken,
+        createRecognizer: fake.factory,
+      }));
+
+      await act(async () => { await result.current.start(); });
+      expect(mintToken).toHaveBeenCalledOnce();
+
+      // Advance to the scheduled refresh (expiry minus the 60s skew).
+      await act(async () => { await vi.advanceTimersByTimeAsync(9 * 60_000 - 60_000); });
+
+      expect(mintToken).toHaveBeenCalledTimes(2);
+      expect(fake.setAuthToken).toHaveBeenCalledWith('tok-2');
+      expect(result.current.status).toBe('listening');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops refreshing the token after stop', async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = makeFakeRecognizer();
+      const token: AzureSpeechToken = { token: 'tok', region: 'eastus', expiresAt: Date.now() + 9 * 60_000 };
+      const mintToken = vi.fn<() => Promise<AzureSpeechToken | null>>().mockResolvedValue(token);
+      const { result } = renderHook(() => useVoiceInput({
+        onFinalTranscript: vi.fn(),
+        mintToken,
+        createRecognizer: fake.factory,
+      }));
+
+      await act(async () => { await result.current.start(); });
+      await act(async () => { await result.current.stop(); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(20 * 60_000); });
+
+      expect(mintToken).toHaveBeenCalledOnce();
+      expect(fake.setAuthToken).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores a toggle while a start is already in flight', async () => {
+    const { factory } = makeFakeRecognizer();
+    let resolveMint!: (token: AzureSpeechToken) => void;
+    const mintToken = vi.fn(() => new Promise<AzureSpeechToken>((resolve) => { resolveMint = resolve; }));
+    const { result } = renderHook(() => useVoiceInput({
+      onFinalTranscript: vi.fn(),
+      mintToken,
+      createRecognizer: factory,
+    }));
+
+    let startPromise!: Promise<void>;
+    act(() => { startPromise = result.current.start(); });
+    expect(result.current.status).toBe('starting');
+
+    act(() => { result.current.toggle(); });
+
+    await act(async () => { resolveMint(TOKEN); await startPromise; });
+    expect(mintToken).toHaveBeenCalledOnce();
+    expect(factory).toHaveBeenCalledOnce();
+    expect(result.current.status).toBe('listening');
+  });
+});

--- a/apps/web/src/renderer/hooks/useVoiceInput.ts
+++ b/apps/web/src/renderer/hooks/useVoiceInput.ts
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import type { AzureSpeechToken } from '@chamber/shared/types';
+
+export type VoiceInputStatus = 'idle' | 'starting' | 'listening' | 'error';
+
+/**
+ * Re-mint the authorization token this many milliseconds before it expires.
+ * Azure Speech tokens live ~9 minutes; refreshing early keeps a long dictation
+ * session alive without a gap.
+ */
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+/** Retry delay after a failed refresh while the session is still live. */
+const TOKEN_REFRESH_RETRY_MS = 10_000;
+
+/** A live recognition session. Returned by a {@link VoiceRecognizerFactory}. */
+export interface VoiceRecognizer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  dispose(): void;
+  /** Rotate the authorization token on a live session before the old one expires. */
+  setAuthToken?(token: string): void;
+}
+
+export interface VoiceRecognizerCallbacks {
+  onPartial(text: string): void;
+  onFinal(text: string): void;
+  onError(message: string): void;
+}
+
+export type VoiceRecognizerFactory = (
+  token: string,
+  region: string,
+  language: string | undefined,
+  callbacks: VoiceRecognizerCallbacks,
+) => VoiceRecognizer | Promise<VoiceRecognizer>;
+
+export interface UseVoiceInputOptions {
+  /** Called with each finalized utterance so the caller can append it. */
+  onFinalTranscript: (text: string) => void;
+  /** STT language tag (e.g. en-US). Optional: defaults to the service default. */
+  language?: string;
+  /** Overridable for tests. Defaults to the preload Azure Speech bridge. */
+  mintToken?: () => Promise<AzureSpeechToken | null>;
+  /** Overridable for tests. Defaults to the SDK-backed recognizer. */
+  createRecognizer?: VoiceRecognizerFactory;
+}
+
+export interface UseVoiceInputResult {
+  status: VoiceInputStatus;
+  partialText: string;
+  error: string | null;
+  isListening: boolean;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  toggle: () => void;
+}
+
+/**
+ * Microphone dictation backed by Azure Speech continuous recognition.
+ *
+ * Mints a short-lived authorization token from the main process (the
+ * subscription key never reaches the renderer), opens a recognizer, and
+ * forwards finalized utterances to {@link UseVoiceInputOptions.onFinalTranscript}
+ * while surfacing the in-flight partial transcript for live display.
+ */
+export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResult {
+  const [status, setStatus] = useState<VoiceInputStatus>('idle');
+  const [partialText, setPartialText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const recognizerRef = useRef<VoiceRecognizer | null>(null);
+  // True between the moment start() is invoked and the recognizer going live or
+  // failing. Guards double-start while the token is still being minted.
+  const startingRef = useRef(false);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep the latest options without re-creating the start/stop callbacks.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const clearRefreshTimer = useCallback(() => {
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+  }, []);
+
+  // Re-mint the auth token shortly before it expires and push it onto the live
+  // recognizer so a long dictation session never drops on token expiry.
+  const scheduleTokenRefresh = useCallback((expiresAt: number) => {
+    clearRefreshTimer();
+    const delay = Math.max(0, expiresAt - Date.now() - TOKEN_REFRESH_SKEW_MS);
+    refreshTimerRef.current = setTimeout(() => {
+      void (async () => {
+        if (!recognizerRef.current) return;
+        const { mintToken } = optionsRef.current;
+        const mint = mintToken ?? (() => window.electronAPI.azureSpeech.mintToken());
+        let next: AzureSpeechToken | null;
+        try {
+          next = await mint();
+        } catch {
+          next = null;
+        }
+        if (!recognizerRef.current) return;
+        if (next) {
+          recognizerRef.current.setAuthToken?.(next.token);
+          scheduleTokenRefresh(next.expiresAt);
+        } else {
+          // Transient failure: retry while we still have a live session.
+          scheduleTokenRefresh(Date.now() + TOKEN_REFRESH_RETRY_MS);
+        }
+      })();
+    }, delay);
+  }, [clearRefreshTimer]);
+
+  const teardown = useCallback(() => {
+    clearRefreshTimer();
+    const recognizer = recognizerRef.current;
+    recognizerRef.current = null;
+    setPartialText('');
+    if (recognizer) {
+      void Promise.resolve(recognizer.stop()).catch(() => undefined);
+      recognizer.dispose();
+    }
+  }, [clearRefreshTimer]);
+
+  const stop = useCallback(async () => {
+    startingRef.current = false;
+    teardown();
+    setStatus('idle');
+  }, [teardown]);
+
+  const start = useCallback(async () => {
+    if (recognizerRef.current || startingRef.current) return;
+    startingRef.current = true;
+    setError(null);
+    setPartialText('');
+    setStatus('starting');
+
+    const { mintToken, createRecognizer, language } = optionsRef.current;
+    const mint = mintToken ?? (() => window.electronAPI.azureSpeech.mintToken());
+
+    let tokenInfo: AzureSpeechToken | null;
+    try {
+      tokenInfo = await mint();
+    } catch (err) {
+      startingRef.current = false;
+      setStatus('error');
+      setError(getErrorMessage(err));
+      return;
+    }
+    if (!tokenInfo) {
+      startingRef.current = false;
+      setStatus('error');
+      setError('Voice input is not configured. Add an Azure Speech key in Settings.');
+      return;
+    }
+
+    const factory: VoiceRecognizerFactory = createRecognizer
+      ?? (async (token, region, lang, callbacks) => {
+        const { createAzureSpeechRecognizer } = await import('../lib/azureSpeechRecognizer');
+        return createAzureSpeechRecognizer(token, region, lang, callbacks);
+      });
+
+    let recognizer: VoiceRecognizer;
+    try {
+      recognizer = await factory(tokenInfo.token, tokenInfo.region, language, {
+        onPartial: (text) => setPartialText(text),
+        onFinal: (text) => {
+          setPartialText('');
+          optionsRef.current.onFinalTranscript(text);
+        },
+        onError: (message) => {
+          teardown();
+          setError(message);
+          setStatus('error');
+        },
+      });
+      await recognizer.start();
+    } catch (err) {
+      if (recognizer!) recognizer!.dispose();
+      recognizerRef.current = null;
+      startingRef.current = false;
+      setStatus('error');
+      setError(getErrorMessage(err));
+      return;
+    }
+
+    recognizerRef.current = recognizer;
+    startingRef.current = false;
+    setStatus('listening');
+    scheduleTokenRefresh(tokenInfo.expiresAt);
+  }, [teardown, scheduleTokenRefresh]);
+
+  const toggle = useCallback(() => {
+    if (recognizerRef.current) {
+      void stop();
+      return;
+    }
+    if (startingRef.current) return;
+    void start();
+  }, [start, stop]);
+
+  useEffect(() => () => {
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+    const recognizer = recognizerRef.current;
+    recognizerRef.current = null;
+    if (recognizer) {
+      void Promise.resolve(recognizer.stop()).catch(() => undefined);
+      recognizer.dispose();
+    }
+  }, []);
+
+  return {
+    status,
+    partialText,
+    error,
+    isListening: status === 'listening',
+    start,
+    stop,
+    toggle,
+  };
+}

--- a/apps/web/src/renderer/lib/azureSpeechRecognizer.ts
+++ b/apps/web/src/renderer/lib/azureSpeechRecognizer.ts
@@ -1,0 +1,47 @@
+// Azure Speech recognizer factory (renderer).
+//
+// Isolated from useVoiceInput so the hook's unit tests never import the Speech
+// SDK (which touches browser-only globals). The hook lazy-imports this module
+// only when it actually starts a real recognition session.
+
+import * as SpeechSDK from 'microsoft-cognitiveservices-speech-sdk';
+import type { VoiceRecognizer, VoiceRecognizerCallbacks } from '../hooks/useVoiceInput';
+
+export function createAzureSpeechRecognizer(
+  token: string,
+  region: string,
+  language: string | undefined,
+  callbacks: VoiceRecognizerCallbacks,
+): VoiceRecognizer {
+  const speechConfig = SpeechSDK.SpeechConfig.fromAuthorizationToken(token, region);
+  if (language && language.trim()) {
+    speechConfig.speechRecognitionLanguage = language.trim();
+  }
+  const audioConfig = SpeechSDK.AudioConfig.fromDefaultMicrophoneInput();
+  const recognizer = new SpeechSDK.SpeechRecognizer(speechConfig, audioConfig);
+
+  recognizer.recognizing = (_sender, event) => {
+    if (event.result.text) callbacks.onPartial(event.result.text);
+  };
+  recognizer.recognized = (_sender, event) => {
+    if (event.result.reason === SpeechSDK.ResultReason.RecognizedSpeech && event.result.text) {
+      callbacks.onFinal(event.result.text);
+    }
+  };
+  recognizer.canceled = (_sender, event) => {
+    callbacks.onError(event.errorDetails || 'Speech recognition was canceled.');
+  };
+
+  return {
+    start: () => new Promise<void>((resolve, reject) => {
+      recognizer.startContinuousRecognitionAsync(() => resolve(), (err) => reject(new Error(err)));
+    }),
+    stop: () => new Promise<void>((resolve, reject) => {
+      recognizer.stopContinuousRecognitionAsync(() => resolve(), (err) => reject(new Error(err)));
+    }),
+    setAuthToken: (next) => {
+      recognizer.authorizationToken = next;
+    },
+    dispose: () => recognizer.close(),
+  };
+}

--- a/apps/web/src/renderer/lib/azureSpeechSynthesizer.ts
+++ b/apps/web/src/renderer/lib/azureSpeechSynthesizer.ts
@@ -1,0 +1,65 @@
+// Azure Speech synthesizer factory (renderer).
+//
+// Isolated from useVoiceConversation so the hook's unit tests never import the
+// Speech SDK (which touches browser-only globals). The hook lazy-imports this
+// module only when it actually starts a real conversation session.
+
+import * as SpeechSDK from 'microsoft-cognitiveservices-speech-sdk';
+import type { VoiceSynthesizer, VoiceSynthesizerCallbacks } from '../hooks/useVoiceConversation';
+
+export function createAzureSpeechSynthesizer(
+  token: string,
+  region: string,
+  voice: string | undefined,
+  callbacks: VoiceSynthesizerCallbacks,
+): VoiceSynthesizer {
+  const speechConfig = SpeechSDK.SpeechConfig.fromAuthorizationToken(token, region);
+  if (voice && voice.trim()) {
+    speechConfig.speechSynthesisVoiceName = voice.trim();
+  }
+  // No AudioConfig argument: the SDK plays through the default speaker output.
+  let synthesizer: SpeechSDK.SpeechSynthesizer | null = new SpeechSDK.SpeechSynthesizer(speechConfig);
+
+  return {
+    speak: (text) => new Promise<void>((resolve, reject) => {
+      const active = synthesizer;
+      if (!active) {
+        resolve();
+        return;
+      }
+      active.speakTextAsync(
+        text,
+        (result) => {
+          if (result.reason === SpeechSDK.ResultReason.SynthesizingAudioCompleted) {
+            resolve();
+          } else {
+            const message = result.errorDetails || 'Speech synthesis failed.';
+            callbacks.onError(message);
+            reject(new Error(message));
+          }
+        },
+        (err) => {
+          callbacks.onError(err);
+          reject(new Error(err));
+        },
+      );
+    }),
+    stop: () => {
+      if (synthesizer) {
+        synthesizer.close();
+        synthesizer = null;
+      }
+    },
+    setAuthToken: (next) => {
+      if (synthesizer) {
+        synthesizer.authorizationToken = next;
+      }
+    },
+    dispose: () => {
+      if (synthesizer) {
+        synthesizer.close();
+        synthesizer = null;
+      }
+    },
+  };
+}

--- a/apps/web/src/renderer/lib/sentenceChunker.test.ts
+++ b/apps/web/src/renderer/lib/sentenceChunker.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { splitIntoSentences, stripSpeechMarkup } from './sentenceChunker';
+
+describe('splitIntoSentences', () => {
+  it('returns no sentences for an unterminated fragment', () => {
+    const result = splitIntoSentences('Hello there');
+    expect(result.sentences).toEqual([]);
+    expect(result.rest).toBe('Hello there');
+  });
+
+  it('extracts a single completed sentence and buffers the rest', () => {
+    const result = splitIntoSentences('Hello there. How are');
+    expect(result.sentences).toEqual(['Hello there.']);
+    expect(result.rest).toBe('How are');
+  });
+
+  it('extracts multiple sentences across punctuation kinds', () => {
+    const result = splitIntoSentences('One. Two! Three? Four');
+    expect(result.sentences).toEqual(['One.', 'Two!', 'Three?']);
+    expect(result.rest).toBe('Four');
+  });
+
+  it('keeps a terminator at the very end buffered (no trailing whitespace)', () => {
+    const result = splitIntoSentences('The value is 3.14');
+    expect(result.sentences).toEqual([]);
+    expect(result.rest).toBe('The value is 3.14');
+  });
+
+  it('does not split a decimal mid-number', () => {
+    const result = splitIntoSentences('Pi is 3.14 and that matters. Next');
+    expect(result.sentences).toEqual(['Pi is 3.14 and that matters.']);
+    expect(result.rest).toBe('Next');
+  });
+
+  it('treats newlines as a boundary', () => {
+    const result = splitIntoSentences('First line\nSecond line\nthird');
+    expect(result.sentences).toEqual(['First line', 'Second line']);
+    expect(result.rest).toBe('third');
+  });
+
+  it('includes a trailing closing quote with the sentence', () => {
+    const result = splitIntoSentences('She said "go." Then left');
+    expect(result.sentences).toEqual(['She said "go."']);
+    expect(result.rest).toBe('Then left');
+  });
+
+  it('handles an ellipsis terminator', () => {
+    const result = splitIntoSentences('Wait… really');
+    expect(result.sentences).toEqual(['Wait…']);
+    expect(result.rest).toBe('really');
+  });
+
+  it('collapses consecutive newlines into a single boundary', () => {
+    const result = splitIntoSentences('Para one\n\nPara two\n\n');
+    expect(result.sentences).toEqual(['Para one', 'Para two']);
+    expect(result.rest).toBe('');
+  });
+
+  it('drops whitespace-only segments between boundaries', () => {
+    const result = splitIntoSentences('Done.   \nNext one. tail');
+    expect(result.sentences).toEqual(['Done.', 'Next one.']);
+    expect(result.rest).toBe('tail');
+  });
+});
+
+describe('stripSpeechMarkup', () => {
+  it('removes emphasis and heading markers', () => {
+    expect(stripSpeechMarkup('# Title with **bold** and _italic_')).toBe('Title with bold and italic');
+  });
+
+  it('unwraps inline code and link text', () => {
+    expect(stripSpeechMarkup('Run `npm test` then see [the docs](https://x.y)')).toBe('Run npm test then see the docs');
+  });
+
+  it('strips fenced code blocks and collapses whitespace', () => {
+    expect(stripSpeechMarkup('Before\n```\ncode here\n```\nafter')).toBe('Before after');
+  });
+
+  it('drops image syntax', () => {
+    expect(stripSpeechMarkup('Look ![alt](img.png) here')).toBe('Look here');
+  });
+});

--- a/apps/web/src/renderer/lib/sentenceChunker.ts
+++ b/apps/web/src/renderer/lib/sentenceChunker.ts
@@ -1,0 +1,59 @@
+// Streaming sentence chunker for text-to-speech.
+//
+// As an assistant reply streams in, we want to start speaking complete
+// sentences before the whole message finishes. This splits an accumulating
+// buffer into speakable sentences, keeping any trailing incomplete fragment
+// buffered until the next delta (or a final flush) completes it.
+
+export interface SentenceSplit {
+  /** Complete, trimmed sentences ready to synthesize. */
+  sentences: string[];
+  /** Trailing text not yet terminated by punctuation or a newline. */
+  rest: string;
+}
+
+// A boundary is either sentence-ending punctuation (optionally followed by a
+// closing quote/bracket) trailed by whitespace, or one-or-more newlines. The
+// trailing whitespace requirement means a terminator at the very end of the
+// buffer (e.g. the "." in "3.14" mid-stream) stays buffered until we know what
+// follows it.
+const BOUNDARY = /[.!?…]['")\]]*\s|\n+/;
+
+/**
+ * Extract complete sentences from an accumulating text buffer.
+ *
+ * Punctuation-or-newline terminated runs become {@link SentenceSplit.sentences};
+ * the unterminated tail is returned as {@link SentenceSplit.rest} for the caller
+ * to carry forward and re-feed once more text arrives.
+ */
+export function splitIntoSentences(buffer: string): SentenceSplit {
+  const sentences: string[] = [];
+  let working = buffer;
+
+  for (;;) {
+    const match = BOUNDARY.exec(working);
+    if (!match) break;
+    const end = match.index + match[0].length;
+    const sentence = working.slice(0, end).trim();
+    if (sentence) sentences.push(sentence);
+    working = working.slice(end);
+  }
+
+  return { sentences, rest: working };
+}
+
+/**
+ * Strip Markdown markup that reads badly when spoken aloud (code fences,
+ * emphasis markers, link/image syntax) and collapse whitespace. Returns plain
+ * prose suitable for a neural TTS voice.
+ */
+export function stripSpeechMarkup(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, ' ')          // fenced code blocks
+    .replace(/`([^`]+)`/g, '$1')              // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')    // images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')  // links -> link text
+    .replace(/[*_~#>]/g, '')                  // emphasis / heading / quote markers
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -750,7 +750,7 @@ describe('appReducer', () => {
   it('SET_FEATURE_FLAGS updates feature flags', () => {
     const state = appReducer(initialState, {
       type: 'SET_FEATURE_FLAGS',
-      payload: { switchboardRelay: true, byoLlm: true, chamberCopilot: true },
+      payload: { switchboardRelay: true, byoLlm: true, chamberCopilot: true, azureSpeech: false },
     });
     expect(state.featureFlags.switchboardRelay).toBe(true);
     expect(state.featureFlags.byoLlm).toBe(true);

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -209,6 +209,14 @@ export function mockElectronAPI(): ElectronAPI {
       restartAgents: vi.fn().mockResolvedValue({ success: true, restartedCount: 0 }),
       onChanged: vi.fn().mockReturnValue(vi.fn()),
     },
+    azureSpeech: {
+      get: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue({ success: true }),
+      disable: vi.fn().mockResolvedValue({ success: true }),
+      test: vi.fn().mockResolvedValue({ ok: true }),
+      mintToken: vi.fn().mockResolvedValue(null),
+      onChanged: vi.fn().mockReturnValue(vi.fn()),
+    },
     genesis: {
       getDefaultPath: vi.fn().mockResolvedValue('C:\\Users\\test\\agents'),
       pickPath: vi.fn().mockResolvedValue(null),
@@ -344,7 +352,7 @@ export function mockElectronAPI(): ElectronAPI {
       close: vi.fn(),
     },
     app: {
-      getFeatureFlags: vi.fn().mockResolvedValue({ switchboardRelay: false, byoLlm: false, chamberCopilot: false }),
+      getFeatureFlags: vi.fn().mockResolvedValue({ switchboardRelay: false, byoLlm: false, chamberCopilot: false, azureSpeech: false }),
       onStartupProgress: vi.fn().mockReturnValue(vi.fn()),
     },
   };

--- a/docs/flags/v1/flags.json
+++ b/docs/flags/v1/flags.json
@@ -5,12 +5,14 @@
     "stable": {
       "switchboardRelay": false,
       "byoLlm": false,
-      "chamberCopilot": false
+      "chamberCopilot": false,
+      "azureSpeech": false
     },
     "insiders": {
       "switchboardRelay": true,
       "byoLlm": true,
-      "chamberCopilot": true
+      "chamberCopilot": true,
+      "azureSpeech": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "hono": "^4.12.15",
         "keytar": "^7.9.0",
         "lucide-react": "^1.9.0",
+        "microsoft-cognitiveservices-speech-sdk": "1.50.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -168,6 +169,46 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@azure/msal-common": {
       "version": "16.6.0",
@@ -5615,6 +5656,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/webrtc": {
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.37.tgz",
+      "integrity": "sha512-JGAJC/ZZDhcrrmepU4sPLQLIOIAgs5oIK+Ieq90K8fdaNMhfdfqmYatJdgif1NDQtvrSlTOGJDUYHIDunuufOg==",
+      "license": "MIT"
+    },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
@@ -5913,6 +5960,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -6589,7 +6650,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -7214,6 +7274,29 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/bent": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/bent/-/bent-7.3.12.tgz",
+      "integrity": "sha512-T3yrKnVGB63zRuoco/7Ybl7BwwGZR0lceoVG5XmQyMIH9s19SV5m+a8qam4if0zQuAmOQTyPTPmsQBdAorGK3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bytesish": "^0.4.1",
+        "caseless": "~0.12.0",
+        "is-stream": "^2.0.0"
+      }
+    },
+    "node_modules/bent/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/better-sqlite3": {
       "version": "12.10.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
@@ -7434,6 +7517,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/bytesish": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/bytesish/-/bytesish-0.4.4.tgz",
+      "integrity": "sha512-i4uu6M4zuMUiyfZN4RU2+i9+peJh//pXhd9x1oSe1LBkZ3LEbCoygu8W0bXTukU1Jme2txKuotpCZRaC3FLxcQ==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
     "node_modules/cac": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
@@ -7507,6 +7596,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -10651,7 +10746,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -10679,7 +10773,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -13319,6 +13412,55 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/microsoft-cognitiveservices-speech-sdk": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.50.0.tgz",
+      "integrity": "sha512-h2OE1YYokwwM0mrBSmOp7NxNr6LlzsT7hISocKxWgwogfJ5TI6SjFKI5Na1gETeJPcuLxnw2tmExB/E/0tCZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@types/webrtc": "^0.0.37",
+        "agent-base": "^6.0.1",
+        "bent": "^7.3.12",
+        "https-proxy-agent": "^4.0.0",
+        "uuid": "^9.0.0",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/mime": {
@@ -16959,6 +17101,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "hono": "^4.12.15",
     "keytar": "^7.9.0",
     "lucide-react": "^1.9.0",
+    "microsoft-cognitiveservices-speech-sdk": "1.50.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/packages/services/src/azure-speech/AzureSpeechStore.test.ts
+++ b/packages/services/src/azure-speech/AzureSpeechStore.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  AZURE_SPEECH_CREDENTIAL_ACCOUNT,
+  AZURE_SPEECH_CREDENTIAL_SERVICE,
+  AzureSpeechStore,
+  type FetchLike,
+} from './AzureSpeechStore';
+import type { AzureSpeechConfig } from '@chamber/shared/types';
+import type { CredentialStore } from '../ports';
+
+function createCredentialStore(): CredentialStore {
+  const entries = new Map<string, string>();
+  const key = (service: string, account: string) => `${service}\0${account}`;
+  return {
+    findCredentials: vi.fn(async (service: string) => Array.from(entries.entries())
+      .filter(([entryKey]) => entryKey.startsWith(`${service}\0`))
+      .map(([entryKey, password]) => ({ account: entryKey.slice(service.length + 1), password }))),
+    setPassword: vi.fn(async (service: string, account: string, password: string) => {
+      entries.set(key(service, account), password);
+    }),
+    deletePassword: vi.fn(async (service: string, account: string) => entries.delete(key(service, account))),
+  };
+}
+
+async function readStoredKey(credentials: CredentialStore): Promise<string | null> {
+  const entry = (await credentials.findCredentials(AZURE_SPEECH_CREDENTIAL_SERVICE))
+    .find((credential) => credential.account === AZURE_SPEECH_CREDENTIAL_ACCOUNT);
+  return entry ? entry.password : null;
+}
+
+describe('AzureSpeechStore', () => {
+  let tempDir: string;
+  let credentials: CredentialStore;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'azure-speech-store-'));
+    credentials = createCredentialStore();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
+  });
+
+  function makeStore(fetchImpl?: FetchLike, now?: () => number): AzureSpeechStore {
+    return new AzureSpeechStore({ storeDir: tempDir, credentials, fetchImpl, now });
+  }
+
+  it('returns null when the config file does not exist', async () => {
+    expect(await makeStore().load()).toBeNull();
+  });
+
+  it('returns null on corrupt JSON', async () => {
+    const store = makeStore();
+    fs.writeFileSync(store.getFilePath(), '{ not valid json', 'utf-8');
+    expect(await store.load()).toBeNull();
+  });
+
+  it('returns null when required fields are missing', async () => {
+    const store = makeStore();
+    fs.writeFileSync(store.getFilePath(), JSON.stringify({ enabled: true }), 'utf-8');
+    expect(await store.load()).toBeNull();
+  });
+
+  it('round-trips config and keeps the key out of the JSON file', async () => {
+    const store = makeStore();
+    const config: AzureSpeechConfig = {
+      enabled: true,
+      region: 'eastus',
+      sttLanguage: 'en-US',
+      ttsVoice: 'en-US-AvaNeural',
+      apiKey: 'super-secret-key',
+    };
+    await store.save(config);
+    const loaded = await store.load();
+    expect(loaded).toEqual(config);
+
+    const file = fs.readFileSync(store.getFilePath(), 'utf-8');
+    expect(file).not.toContain('super-secret-key');
+    await expect(readStoredKey(credentials)).resolves.toBe('super-secret-key');
+  });
+
+  it('clear removes both the file and the stored key', async () => {
+    const store = makeStore();
+    await store.save({ enabled: true, region: 'eastus', apiKey: 'k' });
+    await store.clear();
+    expect(fs.existsSync(store.getFilePath())).toBe(false);
+    await expect(readStoredKey(credentials)).resolves.toBeNull();
+    expect(await store.load()).toBeNull();
+  });
+
+  it('mintToken exchanges the stored key for a short-lived token', async () => {
+    const fetchImpl = vi.fn<FetchLike>(async (url, init) => {
+      expect(url).toBe('https://eastus.api.cognitive.microsoft.com/sts/v1.0/issueToken');
+      expect(init?.method).toBe('POST');
+      expect(init?.headers?.['Ocp-Apim-Subscription-Key']).toBe('the-key');
+      return { ok: true, status: 200, text: async () => 'issued-token' };
+    });
+    const store = makeStore(fetchImpl, () => 1_000);
+    await store.save({ enabled: true, region: 'eastus', apiKey: 'the-key' });
+
+    const token = await store.mintToken();
+    expect(token).toEqual({ token: 'issued-token', region: 'eastus', expiresAt: 1_000 + 9 * 60 * 1000 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('mintToken throws when not configured', async () => {
+    await expect(makeStore().mintToken()).rejects.toThrow('not configured');
+  });
+
+  it('rejects a region that is not a simple token (SSRF guard)', async () => {
+    const fetchImpl = vi.fn<FetchLike>(async () => ({ ok: true, status: 200, text: async () => 'x' }));
+    const store = makeStore(fetchImpl);
+    await store.save({ enabled: true, region: 'eastus', apiKey: 'k' });
+    // Tamper the on-disk region with a malicious host.
+    fs.writeFileSync(
+      store.getFilePath(),
+      JSON.stringify({ enabled: true, region: 'evil.example.com/x?' }),
+      'utf-8',
+    );
+    await expect(store.mintToken()).rejects.toThrow('Invalid Azure region');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('testConnection reports ok on a successful token mint', async () => {
+    const fetchImpl = vi.fn<FetchLike>(async () => ({ ok: true, status: 200, text: async () => 'tok' }));
+    const store = makeStore(fetchImpl);
+    await expect(store.testConnection({ region: 'westus2', apiKey: 'k' })).resolves.toEqual({ ok: true });
+  });
+
+  it('testConnection reports failure on an HTTP error', async () => {
+    const fetchImpl = vi.fn<FetchLike>(async () => ({ ok: false, status: 401, text: async () => '' }));
+    const store = makeStore(fetchImpl);
+    const result = await store.testConnection({ region: 'westus2', apiKey: 'bad' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('401');
+  });
+
+  it('testConnection falls back to stored credentials when not supplied', async () => {
+    const fetchImpl = vi.fn<FetchLike>(async (_url, init) => {
+      expect(init?.headers?.['Ocp-Apim-Subscription-Key']).toBe('stored-key');
+      return { ok: true, status: 200, text: async () => 'tok' };
+    });
+    const store = makeStore(fetchImpl);
+    await store.save({ enabled: true, region: 'eastus', apiKey: 'stored-key' });
+    await expect(store.testConnection()).resolves.toEqual({ ok: true });
+  });
+});

--- a/packages/services/src/azure-speech/AzureSpeechStore.ts
+++ b/packages/services/src/azure-speech/AzureSpeechStore.ts
@@ -1,0 +1,228 @@
+// AzureSpeechStore — atomic file-backed persistence for the user's Azure
+// Speech (voice) configuration.
+//
+// File: <storeDir>/azure-speech.json (defaults to ~/.chamber/azure-speech.json)
+//
+// Atomic write strategy: write to a sibling .tmp file, fsync, rename over the
+// real file. Mirrors ByoLlmStore.
+//
+// The subscription key is stored through the injected OS credential store. The
+// JSON file stores only non-secret connection metadata (region, language,
+// voice). The renderer never receives the key — it authenticates with
+// short-lived tokens minted here via mintToken().
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type {
+  AzureSpeechConfig,
+  AzureSpeechToken,
+  AzureSpeechTestResult,
+} from '@chamber/shared/types';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import { Logger } from '../logger';
+import type { CredentialStore } from '../ports';
+
+const log = Logger.create('AzureSpeechStore');
+const FILE_NAME = 'azure-speech.json';
+export const AZURE_SPEECH_CREDENTIAL_SERVICE = 'chamber-azure-speech';
+export const AZURE_SPEECH_CREDENTIAL_ACCOUNT = 'default';
+
+/** Authorization tokens issued by Azure Speech are valid for ~10 minutes. We
+ * treat them as valid for a slightly shorter window so callers refresh early. */
+const TOKEN_TTL_MS = 9 * 60 * 1000;
+
+/** Region tokens are lowercase alphanumeric with hyphens (e.g. 'eastus',
+ * 'westus2'). Validating here prevents a crafted region from rewriting the
+ * issueToken URL host (SSRF defense-in-depth). */
+const REGION_RE = /^[a-z0-9-]+$/;
+
+export type FetchLike = (
+  input: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+
+export interface AzureSpeechStoreOptions {
+  storeDir?: string;
+  credentials?: CredentialStore;
+  /** Injected for tests; defaults to the global fetch. */
+  fetchImpl?: FetchLike;
+  /** Injected for tests; defaults to Date.now. */
+  now?: () => number;
+}
+
+export class AzureSpeechStore {
+  private readonly storeDir: string;
+  private readonly filePath: string;
+  private readonly credentials?: CredentialStore;
+  private readonly fetchImpl: FetchLike;
+  private readonly now: () => number;
+
+  constructor(options: AzureSpeechStoreOptions = {}) {
+    this.storeDir = options.storeDir ?? path.join(os.homedir(), '.chamber');
+    this.filePath = path.join(this.storeDir, FILE_NAME);
+    this.credentials = options.credentials;
+    this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  async load(): Promise<AzureSpeechConfig | null> {
+    let config: AzureSpeechConfig | null = null;
+    try {
+      const raw = await fs.promises.readFile(this.filePath, 'utf-8');
+      config = this.coerce(JSON.parse(raw) as unknown);
+      if (!config) {
+        log.warn(`Stored Azure Speech config at ${this.filePath} is invalid; ignoring.`);
+        return null;
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === 'ENOENT') return null;
+      log.warn(`Failed to read Azure Speech config from ${this.filePath}: ${getErrorMessage(err)}`);
+      return null;
+    }
+    const apiKey = await this.loadKey();
+    return apiKey ? { ...config, apiKey } : config;
+  }
+
+  async save(config: AzureSpeechConfig): Promise<void> {
+    const sanitized = this.coerce(config);
+    if (!sanitized) {
+      throw new Error('Refusing to save invalid Azure Speech config');
+    }
+    if (config.apiKey && config.apiKey.length > 0) {
+      await this.saveKey(config.apiKey);
+    }
+    await this.writeConfig(sanitized);
+    log.info(`Saved Azure Speech config (region=${sanitized.region}, enabled=${sanitized.enabled})`);
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await fs.promises.unlink(this.filePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT') throw err;
+    }
+    await this.clearKey();
+    log.info('Cleared Azure Speech config');
+  }
+
+  /**
+   * Exchanges the stored subscription key for a short-lived Azure Speech
+   * authorization token. The renderer's Speech SDK authenticates with this
+   * token; the key never leaves the main process.
+   */
+  async mintToken(): Promise<AzureSpeechToken> {
+    const config = await this.load();
+    if (!config) throw new Error('Azure Speech is not configured');
+    if (!config.apiKey) throw new Error('Azure Speech subscription key is missing');
+    return this.issueToken(config.region, config.apiKey);
+  }
+
+  /**
+   * Validates a region + key pair by attempting to mint a token. When called
+   * without a key (e.g. the renderer sent a masked value), falls back to the
+   * stored key.
+   */
+  async testConnection(input?: { region?: string; apiKey?: string }): Promise<AzureSpeechTestResult> {
+    let region = input?.region;
+    let apiKey = input?.apiKey;
+    if (!region || !apiKey) {
+      const stored = await this.load();
+      region = region ?? stored?.region;
+      apiKey = apiKey ?? stored?.apiKey;
+    }
+    if (!region) return { ok: false, error: 'Region is required' };
+    if (!apiKey) return { ok: false, error: 'Subscription key is required' };
+    try {
+      await this.issueToken(region, apiKey);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: getErrorMessage(err) };
+    }
+  }
+
+  private async issueToken(region: string, apiKey: string): Promise<AzureSpeechToken> {
+    if (!REGION_RE.test(region)) {
+      throw new Error(`Invalid Azure region: ${region}`);
+    }
+    const url = `https://${region}.api.cognitive.microsoft.com/sts/v1.0/issueToken`;
+    const res = await this.fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Ocp-Apim-Subscription-Key': apiKey,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': '0',
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`Token request failed with status ${res.status}`);
+    }
+    const token = await res.text();
+    if (!token) throw new Error('Token request returned an empty token');
+    return { token, region, expiresAt: this.now() + TOKEN_TTL_MS };
+  }
+
+  private async writeConfig(config: AzureSpeechConfig): Promise<void> {
+    await fs.promises.mkdir(this.storeDir, { recursive: true });
+    const tempPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
+    const data = JSON.stringify(stripKey(config), null, 2);
+    const fh = await fs.promises.open(tempPath, 'w');
+    try {
+      await fh.writeFile(data, 'utf-8');
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
+    await fs.promises.rename(tempPath, this.filePath);
+  }
+
+  private async loadKey(): Promise<string | undefined> {
+    if (!this.credentials) return undefined;
+    try {
+      const credential = (await this.credentials.findCredentials(AZURE_SPEECH_CREDENTIAL_SERVICE))
+        .find((entry) => entry.account === AZURE_SPEECH_CREDENTIAL_ACCOUNT);
+      return credential?.password && credential.password.length > 0 ? credential.password : undefined;
+    } catch (err) {
+      throw new Error(`Failed to read Azure Speech key from credential store: ${getErrorMessage(err)}`, { cause: err });
+    }
+  }
+
+  private async saveKey(apiKey: string): Promise<void> {
+    if (!this.credentials) {
+      throw new Error('Cannot save Azure Speech key without an OS credential store');
+    }
+    await this.credentials.setPassword(AZURE_SPEECH_CREDENTIAL_SERVICE, AZURE_SPEECH_CREDENTIAL_ACCOUNT, apiKey);
+  }
+
+  private async clearKey(): Promise<void> {
+    if (!this.credentials) return;
+    await this.credentials.deletePassword(AZURE_SPEECH_CREDENTIAL_SERVICE, AZURE_SPEECH_CREDENTIAL_ACCOUNT);
+  }
+
+  /** Validate, normalize, and strip unknown fields. Returns null if not coercible. */
+  private coerce(input: unknown): AzureSpeechConfig | null {
+    if (!input || typeof input !== 'object') return null;
+    const raw = input as Record<string, unknown>;
+    if (typeof raw.enabled !== 'boolean') return null;
+    if (typeof raw.region !== 'string' || raw.region.length === 0) return null;
+    const out: AzureSpeechConfig = {
+      enabled: raw.enabled,
+      region: raw.region,
+    };
+    if (typeof raw.sttLanguage === 'string' && raw.sttLanguage.length > 0) out.sttLanguage = raw.sttLanguage;
+    if (typeof raw.ttsVoice === 'string' && raw.ttsVoice.length > 0) out.ttsVoice = raw.ttsVoice;
+    return out;
+  }
+}
+
+function stripKey(config: AzureSpeechConfig): AzureSpeechConfig {
+  const nonSecret = { ...config };
+  delete nonSecret.apiKey;
+  return nonSecret;
+}

--- a/packages/services/src/azure-speech/index.ts
+++ b/packages/services/src/azure-speech/index.ts
@@ -1,0 +1,7 @@
+export {
+  AzureSpeechStore,
+  AZURE_SPEECH_CREDENTIAL_SERVICE,
+  AZURE_SPEECH_CREDENTIAL_ACCOUNT,
+  type AzureSpeechStoreOptions,
+  type FetchLike,
+} from './AzureSpeechStore';

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -2,6 +2,7 @@ export * from './logger';
 export * from './a2a';
 export * from './auth';
 export * from './byo-llm';
+export * from './azure-speech';
 export * from './canvas';
 export * from './chamberTools';
 export * from './chamberCopilot';

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -28,6 +28,10 @@ import type {
   AgentProfileAvatarSaveRequest,
   AgentProfileSaveRequest,
   AgentProfileSaveResult,
+  AzureSpeechConfig,
+  AzureSpeechSaveResult,
+  AzureSpeechTestResult,
+  AzureSpeechToken,
   ByoLlmConfig,
   ByoLlmProbeResult,
   ByoLlmSaveResult,
@@ -173,6 +177,14 @@ export interface ElectronAPI {
     probe: (config: ByoLlmConfig) => Promise<ByoLlmProbeResult>;
     restartAgents: () => Promise<{ success: boolean; restartedCount: number; error?: string }>;
     onChanged: (callback: (config: ByoLlmConfig | null) => void) => () => void;
+  };
+  azureSpeech: {
+    get: () => Promise<AzureSpeechConfig | null>;
+    save: (config: AzureSpeechConfig) => Promise<AzureSpeechSaveResult>;
+    disable: () => Promise<AzureSpeechSaveResult>;
+    test: (config: AzureSpeechConfig) => Promise<AzureSpeechTestResult>;
+    mintToken: () => Promise<AzureSpeechToken | null>;
+    onChanged: (callback: (config: AzureSpeechConfig | null) => void) => () => void;
   };
   window: {
     minimize: () => void;

--- a/packages/shared/src/feature-flags.test.ts
+++ b/packages/shared/src/feature-flags.test.ts
@@ -21,6 +21,7 @@ describe('feature flags', () => {
       switchboardRelay: true,
       byoLlm: true,
       chamberCopilot: true,
+      azureSpeech: true,
     });
   });
 
@@ -33,6 +34,7 @@ describe('feature flags', () => {
       switchboardRelay: true,
       byoLlm: true,
       chamberCopilot: true,
+      azureSpeech: true,
     });
   });
 
@@ -43,11 +45,13 @@ describe('feature flags', () => {
         switchboardRelay: false,
         byoLlm: true,
         chamberCopilot: false,
+        azureSpeech: false,
       },
     })).toEqual({
       switchboardRelay: false,
       byoLlm: true,
       chamberCopilot: false,
+      azureSpeech: false,
     });
   });
 
@@ -67,6 +71,7 @@ describe('feature flags', () => {
       switchboardRelay: true,
       byoLlm: false,
       chamberCopilot: false,
+      azureSpeech: false,
     });
   });
 
@@ -76,15 +81,15 @@ describe('feature flags', () => {
       updatedAt: '2026-05-17T21:00:00Z',
       ignored: true,
       channels: {
-        stable: { switchboardRelay: false, byoLlm: false, chamberCopilot: false },
-        insiders: { switchboardRelay: true, byoLlm: true, chamberCopilot: true, futureFlag: true },
+        stable: { switchboardRelay: false, byoLlm: false, chamberCopilot: false, azureSpeech: false },
+        insiders: { switchboardRelay: true, byoLlm: true, chamberCopilot: true, azureSpeech: true, futureFlag: true },
       },
     })).toEqual({
       version: 1,
       updatedAt: '2026-05-17T21:00:00Z',
       channels: {
         stable: DEFAULT_APP_FEATURE_FLAGS,
-        insiders: { switchboardRelay: true, byoLlm: true, chamberCopilot: true },
+        insiders: { switchboardRelay: true, byoLlm: true, chamberCopilot: true, azureSpeech: true },
       },
     });
   });
@@ -104,7 +109,7 @@ describe('feature flags', () => {
       updatedAt: '2026-05-17T21:00:00Z',
       channels: {
         stable: DEFAULT_APP_FEATURE_FLAGS,
-        insiders: { switchboardRelay: true, byoLlm: true, chamberCopilot: true },
+        insiders: { switchboardRelay: true, byoLlm: true, chamberCopilot: true, azureSpeech: true },
       },
     });
   });

--- a/packages/shared/src/feature-flags.ts
+++ b/packages/shared/src/feature-flags.ts
@@ -2,6 +2,7 @@ export interface AppFeatureFlags {
   readonly switchboardRelay: boolean;
   readonly byoLlm: boolean;
   readonly chamberCopilot: boolean;
+  readonly azureSpeech: boolean;
 }
 
 export type FeatureFlagChannel = 'stable' | 'insiders';
@@ -16,6 +17,7 @@ export const DEFAULT_APP_FEATURE_FLAGS: AppFeatureFlags = {
   switchboardRelay: false,
   byoLlm: false,
   chamberCopilot: false,
+  azureSpeech: false,
 };
 
 export function getAppFeatureFlags(options: {
@@ -29,6 +31,7 @@ export function getAppFeatureFlags(options: {
     switchboardRelay: insiders,
     byoLlm: insiders,
     chamberCopilot: insiders,
+    azureSpeech: insiders,
   };
 }
 
@@ -60,6 +63,7 @@ export function parseFeatureFlags(value: unknown): AppFeatureFlags | null {
     switchboardRelay: value.switchboardRelay === true,
     byoLlm: value.byoLlm === true,
     chamberCopilot: value.chamberCopilot === true,
+    azureSpeech: value.azureSpeech === true,
   };
 }
 
@@ -68,7 +72,8 @@ export function parseCompleteFeatureFlags(value: unknown): AppFeatureFlags | nul
   if (
     typeof value.switchboardRelay !== 'boolean' ||
     typeof value.byoLlm !== 'boolean' ||
-    typeof value.chamberCopilot !== 'boolean'
+    typeof value.chamberCopilot !== 'boolean' ||
+    typeof value.azureSpeech !== 'boolean'
   ) {
     return null;
   }
@@ -76,6 +81,7 @@ export function parseCompleteFeatureFlags(value: unknown): AppFeatureFlags | nul
     switchboardRelay: value.switchboardRelay,
     byoLlm: value.byoLlm,
     chamberCopilot: value.chamberCopilot,
+    azureSpeech: value.azureSpeech,
   };
 }
 

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -96,6 +96,14 @@ export const IPC = {
     RESTART_AGENTS: 'byoLlm:restartAgents',
     CHANGED: 'byoLlm:changed',
   },
+  AZURE_SPEECH: {
+    GET: 'azureSpeech:get',
+    SAVE: 'azureSpeech:save',
+    DISABLE: 'azureSpeech:disable',
+    TEST: 'azureSpeech:test',
+    MINT_TOKEN: 'azureSpeech:mintToken',
+    CHANGED: 'azureSpeech:changed',
+  },
   CHATROOM: {
     SEND: 'chatroom:send',
     HISTORY: 'chatroom:history',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -519,6 +519,49 @@ export interface ByoLlmSaveResult {
   error?: string;
 }
 
+// Azure Speech (voice) — speech-to-text + text-to-speech configuration.
+// The subscription key is stored in the OS keychain; only non-secret metadata
+// is persisted to disk. The renderer authenticates with short-lived tokens
+// minted by the main process, never the key itself.
+// ---------------------------------------------------------------------------
+export interface AzureSpeechConfig {
+  enabled: boolean;
+  /** Azure region of the Speech resource, e.g. 'eastus'. */
+  region: string;
+  /** STT recognition language BCP-47 tag, e.g. 'en-US'. */
+  sttLanguage?: string;
+  /** Default neural TTS voice, e.g. 'en-US-AvaNeural'. */
+  ttsVoice?: string;
+  /** Subscription key — secret. Present only on the save round-trip from the
+   * renderer; never returned to the renderer (redacted/masked). */
+  apiKey?: string;
+}
+
+/** Short-lived authorization token the renderer Speech SDK uses to connect. */
+export interface AzureSpeechToken {
+  token: string;
+  region: string;
+  /** Epoch milliseconds at which the token expires. */
+  expiresAt: number;
+}
+
+export interface AzureSpeechTestSuccess {
+  ok: true;
+}
+
+export interface AzureSpeechTestFailure {
+  ok: false;
+  error: string;
+  status?: number;
+}
+
+export type AzureSpeechTestResult = AzureSpeechTestSuccess | AzureSpeechTestFailure;
+
+export interface AzureSpeechSaveResult {
+  success: boolean;
+  error?: string;
+}
+
 /**
  * Per-step progress event broadcast from the main process to all renderer
  * windows while the app boots. Drives the boot-screen activity log (#56) so

--- a/tests/invariants/security-boundaries.invariant.test.ts
+++ b/tests/invariants/security-boundaries.invariant.test.ts
@@ -73,6 +73,12 @@ describe('security boundary invariants', () => {
       path.join(repoRoot, 'apps', 'server', 'src', 'privileged-protocol.ts'),
       path.join(repoRoot, 'packages', 'services', 'src', 'auth', 'AuthService.ts'),
       path.join(repoRoot, 'packages', 'services', 'src', 'byo-llm', 'ByoLlmStore.ts'),
+      // AzureSpeechStore writes the Azure Speech subscription key only through the
+      // keytar-backed CredentialStore port. Its JSON config is key-stripped
+      // (stripKey + coerce never persist apiKey) and the renderer receives only
+      // short-lived issued tokens, never the key. Reviewed 2026-06-22 as a
+      // compliant credential writer, same boundary contract as ByoLlmStore.
+      path.join(repoRoot, 'packages', 'services', 'src', 'azure-speech', 'AzureSpeechStore.ts'),
       path.join(repoRoot, 'packages', 'services', 'src', 'ports.ts'),
     ]);
     const violations = productionFiles.flatMap((filePath) => {


### PR DESCRIPTION
## Summary

Adds an optional **Azure Speech voice subsystem**, behind a feature flag (off by default):

- Microphone dictation into the composer (speech-to-text).
- Hands-free conversation mode (STT in, TTS out).

This is a standalone **cloud** voice alternative to the local Foundry dictation in #385. They are different architectures (cloud Azure vs on-device); shipping this does not preclude later converging Azure STT under #385's `TranscriptionProvider` contract.

## Security posture (please review)

- The subscription **key is stored only via the keytar `CredentialStore` port**. `AzureSpeechStore` throws rather than falling back if no OS keychain is available.
- The JSON config file holds **non-secret metadata only**: `writeConfig` runs `stripKey`, and `coerce` never emits `apiKey`. The key never reaches disk in plaintext.
- The **renderer never receives the key**. It authenticates with short-lived (~9 min) tokens minted in the main process via `mintToken` / `issueToken`.
- **SSRF defense:** the region is validated against `^[a-z0-9-]+$` before building the `issueToken` URL host.
- The Electron session security boundary (`sessionSecurity.ts`) is extended to scope the Azure Speech endpoints and mic permission.
- `AzureSpeechStore.ts` is registered in the credential-write security invariant allowlist (`security-boundaries.invariant.test.ts`) with the review documented inline, same boundary contract as `ByoLlmStore`.

## Branch shape (off the current master tip, 0 behind)

- `bb8b482` refactor(ui): extract shared UI foundation off master
- `6b40ed8` feat(voice): Azure Speech voice subsystem (STT/TTS) + security boundary
- `080bfa3` test(security): register AzureSpeechStore in credential-write allowlist + changelog

54 files.

## Test evidence

- `npm run lint`: green (tsc + eslint + dependency-cruiser 537 modules / 0 violations + yaml + markdown).
- Security invariant `security-boundaries.invariant.test.ts`: **12/12 pass** after the reviewed allowlist registration.
- Full `npm test` before the fix was 2078 pass / 2 fail, where the two failures were exactly (a) this credential-boundary invariant and (b) `MindProfileService > rejects symlinked profile files`. The invariant now passes; the only remaining failure is the symlink test, a Windows `fs.symlinkSync` EPERM (Developer Mode) limitation that is unrelated and green in CI on Linux.

## Notes

- Feature-flagged off by default.
- No linked issue.

