### PR TITLE
refactor(ui): shared UI foundation (tokens, theming, Inter, primitives)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Add chamber:a2a ttasks runtime support** — Adds a chamber:a2a custom task type, production A2A bridge wiring, durable ttasks persistence, and invariants for the runtime contract.
 
+### Refactor
+
+- **Establish shared renderer UI foundations** — Adds shared design tokens, light and dark palettes, Inter typography, reusable tabs and skeletons, and responsive, resizable, clipboard, delay, and theme hooks.
+
+
 
 
 

--- a/apps/web/src/renderer.tsx
+++ b/apps/web/src/renderer.tsx
@@ -1,3 +1,4 @@
+import '@fontsource-variable/inter';
 import './renderer/index.css';
 import React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/apps/web/src/renderer/components/ui/dialog.tsx
+++ b/apps/web/src/renderer/components/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           'fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4',
-          'rounded-lg border border-border bg-card p-6 shadow-lg outline-none',
+          'rounded-lg border border-border bg-card text-card-foreground p-6 shadow-lg outline-none',
           'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           className,
@@ -118,7 +118,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      className={cn('text-lg font-semibold leading-none tracking-tight text-foreground', className)}
       {...props}
     />
   );

--- a/apps/web/src/renderer/components/ui/skeleton.tsx
+++ b/apps/web/src/renderer/components/ui/skeleton.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/renderer/lib/utils"
+
+// Placeholder box for content that is still loading. Reserves layout space so
+// panels don't jump when real data arrives. Uses `bg-foreground/10` (not
+// `bg-muted`) because Chamber maps `--color-muted` to the solid foreground
+// color; a low-opacity foreground tint reads as a subtle gray in both light
+// and dark mode. The pulse is disabled automatically under
+// prefers-reduced-motion via the global rule in index.css.
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-md bg-foreground/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/apps/web/src/renderer/components/ui/tabs.tsx
+++ b/apps/web/src/renderer/components/ui/tabs.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Tabs as TabsPrimitive } from 'radix-ui';
+
+import { cn } from '@/renderer/lib/utils';
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        'inline-flex h-9 w-fit items-center justify-center rounded-lg border border-border bg-card/60 p-1 text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium text-muted-foreground transition-colors',
+        'hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'disabled:pointer-events-none disabled:opacity-50',
+        'data-[state=active]:bg-secondary data-[state=active]:text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn('outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/web/src/renderer/components/ui/tooltip.tsx
+++ b/apps/web/src/renderer/components/ui/tooltip.tsx
@@ -40,7 +40,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs font-medium text-background shadow-md has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -53,3 +53,36 @@ function TooltipContent({
 }
 
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }
+
+/**
+ * Convenience wrapper: takes any element + a label and wires up the Radix
+ * tooltip primitives. Removes the boilerplate of three nested components
+ * at every icon button site and keeps tooltip styling on-brand instead
+ * of falling back to the native OS [title] chrome.
+ *
+ * Self-providing: wraps with TooltipProvider so the helper works in
+ * isolated test renders or component trees that don't already sit under
+ * a global provider. Nested providers are harmless.
+ */
+export function TooltipFor({
+  label,
+  side = 'top',
+  sideOffset = 6,
+  delayDuration = 300,
+  children,
+}: {
+  label: React.ReactNode;
+  side?: React.ComponentProps<typeof TooltipPrimitive.Content>['side'];
+  sideOffset?: number;
+  delayDuration?: number;
+  children: React.ReactElement;
+}) {
+  return (
+    <TooltipProvider delayDuration={delayDuration}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} sideOffset={sideOffset}>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/renderer/env.d.ts
+++ b/apps/web/src/renderer/env.d.ts
@@ -2,6 +2,7 @@
 // Vite handles these at build time; TS needs the module shapes to type-check.
 
 declare module '*.css';
+declare module '@fontsource-variable/inter';
 
 interface Window {
   desktop?: {
@@ -9,5 +10,6 @@ interface Window {
     openMindWindow: (mindId: string) => Promise<void>;
     getAppBranding?: () => Promise<{ name: string; version: string }>;
     confirm?: (message: string) => Promise<boolean>;
+    setTheme?: (theme: 'light' | 'dark') => Promise<void>;
   };
 }

--- a/apps/web/src/renderer/hooks/index.ts
+++ b/apps/web/src/renderer/hooks/index.ts
@@ -1,3 +1,7 @@
 export { useAgentStatus } from './useAgentStatus';
 export { useAppSubscriptions } from './useAppSubscriptions';
 export { useChatStreaming } from './useChatStreaming';
+export { useResponsiveLayout } from './useResponsiveLayout';
+export type { ResponsiveLayout } from './useResponsiveLayout';
+export { useTheme } from './useTheme';
+export type { Theme } from './useTheme';

--- a/apps/web/src/renderer/hooks/useCopyToClipboard.ts
+++ b/apps/web/src/renderer/hooks/useCopyToClipboard.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Clipboard-copy state machine shared by every copy affordance. Returns the
+ * transient `copied` flag (true for `resetMs` after a successful copy) and a
+ * `copy` callback. The clipboard may be unavailable (e.g. tests); failures
+ * silently no-op.
+ */
+export function useCopyToClipboard(resetMs = 1500): { copied: boolean; copy: (text: string) => void } {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback((text: string) => {
+    void navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), resetMs);
+    }).catch(() => {
+      // Clipboard may be unavailable (e.g. tests). Silently no-op.
+    });
+  }, [resetMs]);
+
+  return { copied, copy };
+}

--- a/apps/web/src/renderer/hooks/useDelayedFlag.ts
+++ b/apps/web/src/renderer/hooks/useDelayedFlag.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns `true` only after `active` has stayed `true` continuously for
+ * `delayMs`. When `active` flips back to `false`, the result drops to `false`
+ * immediately.
+ *
+ * Used to gate loading skeletons: near-instant hydrations (cached/already
+ * resident data) resolve inside the grace window, so the skeleton never
+ * mounts and the user doesn't see a single-frame pulse flash. Genuinely slow
+ * loads still get the skeleton once they cross the threshold.
+ */
+export function useDelayedFlag(active: boolean, delayMs = 120): boolean {
+  const [shown, setShown] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setShown(false);
+      return;
+    }
+    const id = window.setTimeout(() => setShown(true), delayMs);
+    return () => window.clearTimeout(id);
+  }, [active, delayMs]);
+  return shown;
+}

--- a/apps/web/src/renderer/hooks/useResizableWidth.test.ts
+++ b/apps/web/src/renderer/hooks/useResizableWidth.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type * as React from 'react';
+import { useResizableWidth } from './useResizableWidth';
+
+const baseOptions = { storageKey: 'test:resizable-width', defaultWidth: 240, min: 140, max: 400 };
+
+function keyEvent(key: string) {
+  const preventDefault = vi.fn();
+  const event = { key, preventDefault } as unknown as React.KeyboardEvent<HTMLDivElement>;
+  return { event, preventDefault };
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('useResizableWidth', () => {
+  it('exposes accessible separator props on the grip', () => {
+    const { result } = renderHook(() => useResizableWidth(baseOptions));
+    const props = result.current.handleProps;
+    expect(props.role).toBe('separator');
+    expect(props.tabIndex).toBe(0);
+    expect(props['aria-orientation']).toBe('vertical');
+    expect(props['aria-valuenow']).toBe(240);
+    expect(props['aria-valuemin']).toBe(140);
+    expect(props['aria-valuemax']).toBe(400);
+    expect(typeof props.onKeyDown).toBe('function');
+  });
+
+  it('widens on ArrowRight and narrows on ArrowLeft by a fixed 16px step', () => {
+    const { result } = renderHook(() => useResizableWidth(baseOptions));
+
+    const right = keyEvent('ArrowRight');
+    act(() => {
+      result.current.handleProps.onKeyDown(right.event);
+    });
+    expect(right.preventDefault).toHaveBeenCalled();
+    expect(result.current.width).toBe(256);
+
+    const left = keyEvent('ArrowLeft');
+    act(() => {
+      result.current.handleProps.onKeyDown(left.event);
+    });
+    expect(result.current.width).toBe(240);
+  });
+
+  it('clamps keyboard resizing to the configured max', () => {
+    const { result } = renderHook(() => useResizableWidth({ ...baseOptions, defaultWidth: 396 }));
+    act(() => {
+      result.current.handleProps.onKeyDown(keyEvent('ArrowRight').event);
+    });
+    expect(result.current.width).toBe(400);
+  });
+
+  it('ignores keys other than the horizontal arrows', () => {
+    const { result } = renderHook(() => useResizableWidth(baseOptions));
+    act(() => {
+      result.current.handleProps.onKeyDown(keyEvent('ArrowUp').event);
+    });
+    expect(result.current.width).toBe(240);
+  });
+});

--- a/apps/web/src/renderer/hooks/useResizableWidth.ts
+++ b/apps/web/src/renderer/hooks/useResizableWidth.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface Options {
+  storageKey: string;
+  defaultWidth: number;
+  min: number;
+  max: number;
+  /** Drag from the left edge of the panel (true) or the right edge (false). */
+  edge?: 'left' | 'right';
+}
+
+/**
+ * Persistent, pointer-drag panel-width hook. Returns the current width plus a
+ * `handleProps` bundle to spread on a 4px-wide grip element. The grip should
+ * be absolutely positioned along the chosen edge.
+ *
+ * Width is saved to localStorage so the layout survives reloads. On pointer
+ * down the grip captures the pointer (`setPointerCapture`), so subsequent
+ * `onPointerMove` events keep firing on the grip even when the cursor leaves
+ * it, and the drag only ends on `onPointerUp`.
+ *
+ * The grip is also keyboard-operable: `handleProps` makes it focusable and
+ * exposes `aria-value*` plus an `onKeyDown` that resizes by 16px on Arrow
+ * Left/Right, so the separator works without a pointer.
+ */
+export function useResizableWidth({ storageKey, defaultWidth, min, max, edge = 'left' }: Options) {
+  const [width, setWidth] = useState<number>(() => {
+    if (typeof window === 'undefined') return defaultWidth;
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return defaultWidth;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return defaultWidth;
+    return Math.min(max, Math.max(min, n));
+  });
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(width);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(storageKey, String(width));
+    } catch {
+      /* storage unavailable */
+    }
+  }, [storageKey, width]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    dragging.current = true;
+    startX.current = e.clientX;
+    startWidth.current = width;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, [width]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragging.current) return;
+    const delta = e.clientX - startX.current;
+    // Dragging the left edge expands when the pointer moves left.
+    const signed = edge === 'left' ? -delta : delta;
+    const next = Math.min(max, Math.max(min, startWidth.current + signed));
+    setWidth(next);
+  }, [edge, max, min]);
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    dragging.current = false;
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* capture may already be gone */
+    }
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  }, []);
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const STEP = 16;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      setWidth((w) => Math.max(min, w - STEP));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      setWidth((w) => Math.min(max, w + STEP));
+    }
+  }, [min, max]);
+
+  const reset = useCallback(() => setWidth(defaultWidth), [defaultWidth]);
+
+  return {
+    width,
+    setWidth,
+    reset,
+    handleProps: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onKeyDown,
+      tabIndex: 0,
+      role: 'separator' as const,
+      'aria-orientation': 'vertical' as const,
+      'aria-valuenow': width,
+      'aria-valuemin': min,
+      'aria-valuemax': max,
+    },
+  };
+}

--- a/apps/web/src/renderer/hooks/useResponsiveLayout.test.ts
+++ b/apps/web/src/renderer/hooks/useResponsiveLayout.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useResponsiveLayout } from './useResponsiveLayout';
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', { value: width, configurable: true, writable: true });
+  window.dispatchEvent(new Event('resize'));
+}
+
+describe('useResponsiveLayout', () => {
+  const originalWidth = window.innerWidth;
+
+  beforeEach(() => {
+    setViewportWidth(1440);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: originalWidth, configurable: true, writable: true });
+  });
+
+  it('reports a wide viewport as no-clamp and no-auto-collapse', () => {
+    setViewportWidth(1440);
+    const { result } = renderHook(() => useResponsiveLayout());
+    expect(result.current.shouldAutoCollapseHistory).toBe(false);
+    expect(result.current.shouldClampMindSidebar).toBe(false);
+  });
+
+  it('auto-collapses history below the lg breakpoint (1024px)', () => {
+    setViewportWidth(900);
+    const { result } = renderHook(() => useResponsiveLayout());
+    expect(result.current.shouldAutoCollapseHistory).toBe(true);
+    expect(result.current.shouldClampMindSidebar).toBe(false);
+  });
+
+  it('clamps the mind sidebar below the md breakpoint (768px)', () => {
+    setViewportWidth(700);
+    const { result } = renderHook(() => useResponsiveLayout());
+    expect(result.current.shouldAutoCollapseHistory).toBe(true);
+    expect(result.current.shouldClampMindSidebar).toBe(true);
+  });
+
+  it('responds to window resize events', () => {
+    setViewportWidth(1440);
+    const { result } = renderHook(() => useResponsiveLayout());
+    expect(result.current.shouldAutoCollapseHistory).toBe(false);
+
+    act(() => setViewportWidth(900));
+    expect(result.current.shouldAutoCollapseHistory).toBe(true);
+
+    act(() => setViewportWidth(1440));
+    expect(result.current.shouldAutoCollapseHistory).toBe(false);
+  });
+});

--- a/apps/web/src/renderer/hooks/useResponsiveLayout.ts
+++ b/apps/web/src/renderer/hooks/useResponsiveLayout.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+// Tailwind default breakpoints we care about for shell layout.
+const MD_BREAKPOINT = 768;
+const LG_BREAKPOINT = 1024;
+
+export interface ResponsiveLayout {
+  /** True when viewport is below `lg` (1024px). History panel should auto-collapse. */
+  shouldAutoCollapseHistory: boolean;
+  /** True when viewport is below `md` (768px). Agents column should clamp to min width. */
+  shouldClampMindSidebar: boolean;
+}
+
+function readLayout(): ResponsiveLayout {
+  if (typeof window === 'undefined') {
+    return { shouldAutoCollapseHistory: false, shouldClampMindSidebar: false };
+  }
+  const w = window.innerWidth;
+  return {
+    shouldAutoCollapseHistory: w < LG_BREAKPOINT,
+    shouldClampMindSidebar: w < MD_BREAKPOINT,
+  };
+}
+
+export function useResponsiveLayout(): ResponsiveLayout {
+  const [layout, setLayout] = useState<ResponsiveLayout>(() => readLayout());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onResize = () => setLayout(readLayout());
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return layout;
+}

--- a/apps/web/src/renderer/hooks/useTheme.ts
+++ b/apps/web/src/renderer/hooks/useTheme.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'chamber.theme';
+
+function readInitialTheme(): Theme {
+  if (typeof document === 'undefined') return 'dark';
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme): void {
+  const root = document.documentElement;
+  // Mark the document as "mid-swap" so the global color transition kicks
+  // in just for this paint. We clear the class after the transition ends
+  // so it doesn't interfere with per-component hover transitions.
+  root.classList.add('theme-switching');
+  root.classList.toggle('dark', theme === 'dark');
+  root.dataset.theme = theme;
+  // Keep this aligned with THEME_MS (ambientScene.ts) and the 450ms CSS
+  // color transition in index.css so the class clears as the crossfade ends.
+  window.setTimeout(() => {
+    root.classList.remove('theme-switching');
+  }, 450);
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    /* storage may be unavailable */
+  }
+  // Repaint the native Windows titleBarOverlay so the OS chrome stays
+  // legible against the new app background.
+  try {
+    void window.desktop?.setTheme?.(theme);
+  } catch {
+    /* desktop bridge may not be present in browser smoke tests */
+  }
+}
+
+export function useTheme(): { theme: Theme; setTheme: (t: Theme) => void; toggle: () => void } {
+  const [theme, setThemeState] = useState<Theme>(readInitialTheme);
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY && (e.newValue === 'light' || e.newValue === 'dark')) {
+        setThemeState(e.newValue);
+        applyTheme(e.newValue);
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    applyTheme(next);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setThemeState((current) => {
+      const next: Theme = current === 'dark' ? 'light' : 'dark';
+      applyTheme(next);
+      return next;
+    });
+  }, []);
+
+  return { theme, setTheme, toggle };
+}

--- a/apps/web/src/renderer/index.css
+++ b/apps/web/src/renderer/index.css
@@ -7,38 +7,164 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --color-background: oklch(0.145 0.008 260);
-  --color-foreground: oklch(0.985 0 0);
-  --color-card: oklch(0.195 0.015 260);
-  --color-card-foreground: oklch(0.985 0 0);
-  --color-popover: oklch(0.145 0 0);
-  --color-popover-foreground: oklch(0.985 0 0);
-  --color-primary: oklch(0.985 0 0);
-  --color-primary-foreground: oklch(0.205 0 0);
-  --color-secondary: oklch(0.255 0.015 260);
-  --color-secondary-foreground: oklch(0.985 0 0);
-  --color-muted: oklch(0.255 0.015 260);
-  --color-muted-foreground: oklch(0.708 0.01 260);
-  --color-accent: oklch(0.255 0.015 260);
-  --color-accent-foreground: oklch(0.985 0 0);
-  --color-destructive: oklch(0.396 0.141 25.723);
-  --color-destructive-foreground: oklch(0.637 0.237 25.331);
-  --color-border: oklch(0.25 0.012 260);
-  --color-input: oklch(0.255 0.015 260);
-  --color-ring: oklch(0.556 0 0);
-  --color-genesis: oklch(0.72 0.15 160);
-  --color-genesis-foreground: oklch(0.985 0 0);
+  /* Default (light) palette. Dark theme overrides via the .dark variant
+   * below. The palette is monochrome with one reserved brand accent
+   * (genesis). Secondary text uses a genuinely muted foreground so the
+   * secondary tier (timestamps, placeholders, helper text) recedes from
+   * primary body copy. Reserve pure foreground for primary content. */
+  --color-background: oklch(1 0 0);
+  --color-foreground: oklch(0.15 0 0);
+  /* Cards sit slightly off-white so they read against the pure-white app
+   * background; the border picks up just enough warmth to be visible
+   * without looking like a hard line. */
+  --color-card: oklch(0.985 0.003 260);
+  --color-card-foreground: oklch(0.15 0 0);
+  --color-popover: oklch(1 0 0);
+  --color-popover-foreground: oklch(0.15 0 0);
+  --color-primary: oklch(0.15 0 0);
+  --color-primary-foreground: oklch(1 0 0);
+  --color-secondary: oklch(0.95 0.005 260);
+  --color-secondary-foreground: oklch(0.15 0 0);
+  --color-muted: oklch(0.95 0.005 260);
+  --color-muted-foreground: oklch(0.46 0.01 260);
+  --color-accent: oklch(0.92 0.008 260);
+  --color-accent-foreground: oklch(0.15 0 0);
+  /* Interaction surfaces. `hover` is a neutral wash that stays perceivable
+   * against both the card and the app background; `selected` is a slightly
+   * stronger neutral wash so the current item reads as "chosen" rather than
+   * merely hovered. Pairing selected fills with a genesis left-bar gives a
+   * Fluent / Linear-grade selection language that is legible in both themes. */
+  --color-hover: oklch(0.945 0.006 260);
+  --color-selected: oklch(0.92 0.008 260);
+  --color-selected-foreground: oklch(0.15 0 0);
+  --color-destructive: oklch(0.55 0.2 25);
+  --color-destructive-foreground: oklch(1 0 0);
+  /* Borders need to be visible against both the card and the background.
+   * Previously oklch(0.9) which disappeared on white. */
+  --color-border: oklch(0.82 0.008 260);
+  --color-input: oklch(0.95 0.005 260);
+  --color-ring: oklch(0.5 0 0);
+  --color-genesis: oklch(0.55 0.16 160);
+  --color-genesis-foreground: oklch(1 0 0);
+  /* Warning is the one amber reserved for "busy / running" status. Pair with
+   * genesis (ready/online) and destructive (error) for the full status set. */
+  --color-warning: oklch(0.72 0.15 75);
+  --color-warning-foreground: oklch(0.2 0.03 75);
   --radius-sm: 0.25rem;
   --radius-md: 0.375rem;
   --radius-lg: 0.5rem;
   --radius-xl: 0.75rem;
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  /* Material-grade elevation, light theme. Layered soft shadows read as
+   * clean lifted surfaces against the white app background. These power
+   * `shadow-xs|sm|md|lg` utilities and the `.bg-card` elevation below.
+   * Dark theme zeroes these out (contrasting card color carries depth). */
+  --shadow-xs: 0 1px 2px 0 oklch(0.15 0 0 / 0.06);
+  --shadow-sm: 0 1px 2px 0 oklch(0.15 0 0 / 0.06), 0 1px 3px 0 oklch(0.15 0 0 / 0.08);
+  --shadow-md: 0 2px 4px -1px oklch(0.15 0 0 / 0.07), 0 4px 10px -2px oklch(0.15 0 0 / 0.09);
+  --shadow-lg: 0 4px 6px -2px oklch(0.15 0 0 / 0.06), 0 12px 24px -4px oklch(0.15 0 0 / 0.12);
+  --font-sans: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
+}
+
+:where(.dark) {
+  /* Deep night: dark, but light enough that the blue ambient aurora
+   * (.app-ambient) reads through as a faint glow rather than crushing to flat
+   * black. A touch of blue chroma in the base reinforces the tint. This is
+   * the base color the radial-gradient auroras layer over. */
+  --color-background: oklch(0.11 0.013 260);
+  --color-foreground: oklch(1 0 0);
+  --color-card: oklch(0.195 0.015 260);
+  --color-card-foreground: oklch(1 0 0);
+  --color-popover: oklch(0.145 0 0);
+  --color-popover-foreground: oklch(1 0 0);
+  --color-primary: oklch(1 0 0);
+  --color-primary-foreground: oklch(0.205 0 0);
+  --color-secondary: oklch(0.255 0.015 260);
+  --color-secondary-foreground: oklch(1 0 0);
+  --color-muted: oklch(0.255 0.015 260);
+  --color-muted-foreground: oklch(0.68 0.012 260);
+  --color-accent: oklch(0.255 0.015 260);
+  --color-accent-foreground: oklch(1 0 0);
+  --color-hover: oklch(0.275 0.016 260);
+  --color-selected: oklch(0.30 0.012 260);
+  --color-selected-foreground: oklch(1 0 0);
+  /* Mirror light mode: destructive is the readable red used for text, icons,
+   * borders, and solid-button backgrounds; its foreground is white. A bright
+   * red (not the old L=0.396 surface red) keeps `text-destructive` legible on
+   * the dark card and avoids red-on-red on solid destructive buttons. */
+  --color-destructive: oklch(0.637 0.237 25.331);
+  --color-destructive-foreground: oklch(1 0 0);
+  --color-border: oklch(0.205 0.012 260);
+  --color-input: oklch(0.255 0.015 260);
+  --color-ring: oklch(0.556 0 0);
+  --color-genesis: oklch(0.72 0.15 160);
+  --color-genesis-foreground: oklch(1 0 0);
+  --color-warning: oklch(0.78 0.14 75);
+  --color-warning-foreground: oklch(0.18 0.03 75);
+  /* Dark surfaces lean on contrasting card color, not cast shadows. */
+  --shadow-xs: none;
+  --shadow-sm: none;
+  --shadow-md: 0 4px 12px -2px oklch(0 0 0 / 0.5);
+  --shadow-lg: 0 12px 28px -6px oklch(0 0 0 / 0.6);
 }
 
 body {
   font-family: var(--font-sans);
   overflow: hidden;
+  /* Crisper glyph edges (matters most on 1x displays and macOS). */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  /* Inter's single-story a/g (cv11) + stylistic set read better at UI sizes;
+   * tabular figures keep counts, timestamps, and stat numbers from shifting. */
+  font-feature-settings: "cv11", "ss01";
+  font-variant-numeric: tabular-nums;
+  text-rendering: optimizeLegibility;
+}
+
+/* Typesetting niceties (Chromium-supported in Electron 41). `balance`
+ * evens out multi-line headings so titles don't leave a lone trailing
+ * word; `pretty` prevents orphans/widows in running paragraphs. */
+h1, h2, h3, h4, h5, h6 {
+  text-wrap: balance;
+}
+p {
+  text-wrap: pretty;
+}
+
+/* Smooth day/night swap. The `.theme-switching` class is added by the
+ * useTheme hook for 450ms when toggling (matching THEME_MS), so the color
+ * crossfade only happens during the swap itself and doesn't slow down hovers
+ * the rest of the time. */
+html.theme-switching,
+html.theme-switching body,
+html.theme-switching *,
+html.theme-switching *::before,
+html.theme-switching *::after {
+  /* box-shadow is deliberately NOT animated here: it isn't GPU-composited, so
+   * crossfading it on every element repaints each frame across all panels and
+   * starves the canvas requestAnimationFrame, which reads as stutter. The few
+   * elements whose shadow change is actually noticeable (surface panels/cards)
+   * opt back into a box-shadow crossfade in the scoped rule below. */
+  transition-property: background-color, border-color, color, fill, stroke !important;
+  transition-duration: 450ms !important;
+  /* easeInOutCubic -- the cubic-bezier equivalent of the canvas `easeInOut`
+   * (ambientScene.ts) so the WebGL background and the CSS surfaces advance
+   * along the exact same curve and never appear to lag one another. */
+  transition-timing-function: cubic-bezier(0.65, 0, 0.35, 1) !important;
+}
+
+/* box-shadow is intentionally excluded from the universal rule above (it isn't
+ * GPU-composited, so crossfading it on *every* element starves the canvas rAF).
+ * But the surface panels/cards carry a heavy layered drop shadow in light mode
+ * and an inset-only shadow in dark, so snapping that shadow while the colors
+ * crossfade reads as jarring. Crossfade box-shadow on just this bounded set of
+ * elements -- on the same curve/duration -- so the depth fades in lockstep with
+ * the color swap without the per-frame repaint cost of doing it everywhere. */
+html.theme-switching .surface-panel,
+html.theme-switching .surface-card {
+  transition-property: background-color, border-color, color, fill, stroke, box-shadow !important;
+  transition-duration: 450ms !important;
+  transition-timing-function: cubic-bezier(0.65, 0, 0.35, 1) !important;
 }
 
 .titlebar-drag {
@@ -49,24 +175,256 @@ body {
 }
 
 ::-webkit-scrollbar {
-  width: 6px;
+  width: 10px;
+  height: 10px;
 }
 ::-webkit-scrollbar-track {
+  background: oklch(0.55 0.005 260 / 0.06);
+  border-radius: 10px;
+}
+.dark ::-webkit-scrollbar-track {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: oklch(0.35 0 0);
-  border-radius: 3px;
+  background: oklch(0.5 0.005 260 / 0.55);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  border-radius: 10px;
+  transition: background-color 160ms ease;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: oklch(0.45 0 0);
+  background: oklch(0.35 0.005 260 / 0.75);
+  background-clip: padding-box;
+}
+.dark ::-webkit-scrollbar-thumb {
+  background: oklch(0.45 0.01 260 / 0.45);
+  background-clip: padding-box;
+}
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.65 0.012 260 / 0.85);
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* In light mode, plain borders on cards still feel flat. Lift cards with a
+ * soft layered shadow so they read as clean elevated surfaces. Dark mode
+ * skips this -- the contrasting card color carries the elevation. */
+.bg-card {
+  box-shadow: var(--shadow-sm);
+}
+.dark .bg-card {
+  box-shadow: none;
+}
+
+/* ----------------------------------------------------------------------
+ * Ambient depth + lit surfaces
+ *
+ * The flat single-tone background reads as an admin tool. These primitives
+ * add the "lit from above" depth that premium AI products (Linear, Vercel,
+ * Raycast) use: a faint aurora behind the whole window plus a top sheen +
+ * hairline highlight on every panel. Tuned to stay subtle and legible in
+ * both themes.
+ * ------------------------------------------------------------------- */
+
+/* Fixed, non-interactive aurora behind the whole app. Shows through the
+ * gaps between shell panels and as a soft halo at the window's top edge. */
+.app-ambient {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(1100px 520px at 12% -8%, oklch(0.55 0.16 260 / 0.05), transparent 60%),
+    radial-gradient(1000px 640px at 105% -6%, oklch(0.6 0.13 255 / 0.045), transparent 58%);
+}
+.dark .app-ambient {
+  background:
+    radial-gradient(1100px 540px at 10% -10%, oklch(0.72 0.15 260 / 0.16), transparent 60%),
+    radial-gradient(1000px 720px at 112% -12%, oklch(0.62 0.13 260 / 0.11), transparent 58%);
+}
+
+/* Premium panel surface: a soft top-down sheen plus an inset hairline
+ * highlight along the top edge, so the card looks lit rather than printed.
+ * Layer this on top of `bg-card` / `bg-background` panels. */
+.surface-panel {
+  background-image: linear-gradient(to bottom, oklch(1 0 0 / 0.025), transparent 96px);
+  /* Light mode: card and page are both near-white, so a 1px token shadow
+   * vanishes. Use a soft layered lift with enough spread + opacity to read
+   * against the light background. */
+  box-shadow:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.04),
+    0 2px 5px 0 oklch(0.2 0.02 260 / 0.12),
+    0 16px 42px -9px oklch(0.2 0.02 260 / 0.24);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.dark .surface-panel {
+  background-image: linear-gradient(to bottom, oklch(1 0 0 / 0.025), transparent 120px);
+  /* Floating glass: the showcase lifts its panels with a large soft drop
+   * shadow (0 20px 60px rgba(0,0,0,0.45)) so they read as hovering over the
+   * ambient background rather than printed on it. The inset hairline keeps
+   * the lit top edge. Opacity/blur of the panel itself is unchanged. */
+  box-shadow:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.045),
+    0 20px 60px oklch(0 0 0 / 0.45);
+}
+
+/* Interactive premium card: same lit surface, with a neutral lift on
+ * hover. Use for stat cards, starter prompts, and other clickable tiles. */
+.surface-card {
+  background-image: linear-gradient(to bottom, oklch(1 0 0 / 0.02), transparent 80px);
+  /* In light mode the lit inset alone reads flat and the card sits on a
+   * near-white page, so pair it with a soft layered drop shadow that has
+   * enough spread + opacity to be visible. Dark mode keeps inset-only since
+   * the contrasting card color carries the depth. */
+  box-shadow:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.04),
+    0 1px 3px 0 oklch(0.2 0.02 260 / 0.10),
+    0 11px 29px -8px oklch(0.2 0.02 260 / 0.19);
+  transition: border-color 160ms ease, box-shadow 200ms ease, transform 160ms ease, background-color 160ms ease;
+}
+.dark .surface-card {
+  background-image: linear-gradient(to bottom, oklch(1 0 0 / 0.03), transparent 80px);
+  box-shadow: inset 0 1px 0 0 oklch(1 0 0 / 0.05);
+}
+.surface-card-hover:hover {
+  border-color: oklch(0.55 0.02 260 / 0.45);
+  box-shadow:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.06),
+    0 6px 20px -8px oklch(0.55 0.02 260 / 0.35);
+}
+.dark .surface-card-hover:hover {
+  border-color: oklch(0.72 0.02 260 / 0.5);
+  box-shadow:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.08),
+    0 8px 28px -10px oklch(0.72 0.02 260 / 0.4);
+}
+
+/* Soft genesis glow ring -- avatars and accent marks. */
+.glow-genesis {
+  box-shadow:
+    0 0 0 1px oklch(0.55 0.16 160 / 0.25),
+    0 4px 16px -2px oklch(0.55 0.16 160 / 0.4);
+}
+.dark .glow-genesis {
+  box-shadow:
+    0 0 0 1px oklch(0.72 0.15 160 / 0.3),
+    0 6px 22px -4px oklch(0.72 0.15 160 / 0.5);
+}
+
+/* Composer focus halo: a calm neutral ring + outer glow when the input is
+ * active, so the primary action surface feels alive. */
+.focus-halo:focus-within {
+  border-color: oklch(0.55 0.02 260 / 0.6) !important;
+  box-shadow:
+    0 0 0 1px oklch(0.55 0.02 260 / 0.35),
+    0 8px 30px -10px oklch(0.55 0.02 260 / 0.4);
+}
+.dark .focus-halo:focus-within {
+  border-color: oklch(0.72 0.02 260 / 0.55) !important;
+  box-shadow:
+    0 0 0 1px oklch(0.72 0.02 260 / 0.4),
+    0 10px 36px -12px oklch(0.72 0.02 260 / 0.45);
+}
+
+/* Selection color is a neutral wash so highlights don't look like
+ * raw OS chrome bleeding into the app. */
+::selection {
+  background: oklch(0.72 0.02 260 / 0.35);
+  color: var(--color-foreground);
+}
+
+/* Message + panel entry animation. Kept short + subtle so nothing feels
+ * laggy; respects prefers-reduced-motion. */
+@keyframes chamber-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.chamber-fade-in {
+  animation: chamber-fade-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* View transition: keyed remount on the ViewRouter wrapper restarts this
+ * animation when the user switches activity-bar destinations. Slightly
+ * snappier than message fade-ins so the swap doesn't feel laggy. */
+@keyframes view-enter {
+  from { opacity: 0; transform: translateY(2px) scale(0.995); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.view-enter {
+  animation: view-enter 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* Send "launch": the message the user just sent rises into the transcript
+ * from just above the composer, so pressing Send feels like it propels the
+ * message into place. One-shot, slightly longer than the generic fade so the
+ * travel reads. Neutralized under prefers-reduced-motion below. */
+@keyframes chamber-launch {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.chamber-launch {
+  animation: chamber-launch 260ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* Streaming caret: a crisp typing cursor that blinks while tokens arrive,
+ * rather than a soft opacity pulse that reads as a fade. steps() gives a hard
+ * on/off blink. Settles solid under prefers-reduced-motion because the element's
+ * default opacity is 1 and the global rule below zeroes the animation. */
+@keyframes chamber-caret {
+  0%, 45% { opacity: 1; }
+  50%, 95% { opacity: 0.18; }
+  100% { opacity: 1; }
+}
+.chamber-caret {
+  animation: chamber-caret 1s steps(1, end) infinite;
+}
+
+/* Orchestration topology: a small glow segment travels along an active
+ * connector to show the direction of collaboration (fan-out, pipeline,
+ * hand-off, etc.). The track stays static; only this segment moves.
+ * Neutralized under prefers-reduced-motion by the global rule below. */
+@keyframes chamber-travel-y {
+  from { transform: translateY(-120%); }
+  to { transform: translateY(120%); }
+}
+@keyframes chamber-travel-x {
+  from { transform: translateX(-120%); }
+  to { transform: translateX(120%); }
+}
+.chamber-travel-y { animation: chamber-travel-y 1100ms linear infinite; }
+.chamber-travel-x { animation: chamber-travel-x 1100ms linear infinite; }
+
+/* Voice listening orb: a slow, calm breath that is visually distinct from the
+ * faster `animate-pulse` used for the speaking state. Settles solid under
+ * prefers-reduced-motion via the global rule below. */
+@keyframes voice-orb-breathe {
+  0%, 100% { transform: scale(1); opacity: 0.85; }
+  50% { transform: scale(1.06); opacity: 1; }
+}
+.voice-orb-breathe { animation: voice-orb-breathe 2400ms ease-in-out infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .chamber-fade-in,
+  .chamber-launch,
+  .voice-orb-breathe,
+  .view-enter { animation: none; }
+  *, *::before, *::after {
+    transition-duration: 0ms !important;
+    animation-duration: 0ms !important;
+  }
 }
 
 .prose pre {
-  background: oklch(0.205 0 0);
+  background: oklch(0.95 0.005 260);
   border-radius: var(--radius-md);
   padding: 0.75rem 1rem;
   overflow-x: auto;
+}
+.dark .prose pre {
+  background: oklch(0.205 0 0);
 }
 .prose pre code {
   background: transparent;
@@ -82,10 +440,13 @@ body {
 .prose :not(pre) > code {
   font-family: var(--font-mono);
   font-size: 0.875em;
-  background: oklch(0.205 0 0);
+  background: oklch(0.95 0.005 260);
   padding: 0.125rem 0.375rem;
   border-radius: var(--radius-sm);
   font-weight: inherit;
+}
+.dark .prose :not(pre) > code {
+  background: oklch(0.205 0 0);
 }
 .prose :not(pre) > code::before,
 .prose :not(pre) > code::after {

--- a/apps/web/src/renderer/lib/utils.test.ts
+++ b/apps/web/src/renderer/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cn, generateId, formatTime } from './utils';
+import { cn, generateId, formatTime, formatDisplayValue, parseSkillContextInjection } from './utils';
 
 describe('cn', () => {
   it('merges class names', () => {
@@ -50,5 +50,60 @@ describe('formatTime', () => {
     // Should contain hour and minute separated by colon
     expect(result).toMatch(/\d{1,2}:\d{2}/);
     expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe('formatDisplayValue', () => {
+  it('joins arrays with commas', () => {
+    expect(formatDisplayValue(['a', 'b', 'c'])).toBe('a, b, c');
+  });
+
+  it('stringifies plain objects', () => {
+    expect(formatDisplayValue({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it('renders a dash for null and undefined', () => {
+    expect(formatDisplayValue(null)).toBe('--');
+    expect(formatDisplayValue(undefined)).toBe('--');
+  });
+
+  it('humanizes an ISO datetime string with a timezone offset', () => {
+    const result = formatDisplayValue('2026-06-04T09:00:24.110-04:00');
+    expect(result).not.toContain('T');
+    expect(result).not.toContain('-04:00');
+    expect(result).toMatch(/2026/);
+    expect(result).toMatch(/Jun/);
+  });
+
+  it('humanizes a UTC ISO datetime string', () => {
+    const result = formatDisplayValue('2026-01-15T14:30:00Z');
+    expect(result).not.toContain('T');
+    expect(result).toMatch(/2026/);
+    expect(result).toMatch(/Jan/);
+  });
+
+  it('leaves non-date strings untouched', () => {
+    expect(formatDisplayValue('3 active')).toBe('3 active');
+    expect(formatDisplayValue('America/New_York')).toBe('America/New_York');
+  });
+});
+
+describe('parseSkillContextInjection', () => {
+  it('extracts the name and trimmed body of a skill-context block', () => {
+    const result = parseSkillContextInjection('<skill-context name="lens">\n# Lens\nbody text\n</skill-context>');
+    expect(result).toEqual({ name: 'lens', body: '# Lens\nbody text' });
+  });
+
+  it('tolerates leading and trailing whitespace around the block', () => {
+    const result = parseSkillContextInjection('  \n<skill-context name="cron">do things</skill-context>\n  ');
+    expect(result).toEqual({ name: 'cron', body: 'do things' });
+  });
+
+  it('returns null for a genuine user message that merely mentions the tag', () => {
+    expect(parseSkillContextInjection('How does <skill-context> work?')).toBeNull();
+  });
+
+  it('returns null for ordinary text', () => {
+    expect(parseSkillContextInjection('Generate a morning briefing')).toBeNull();
   });
 });

--- a/apps/web/src/renderer/lib/utils.ts
+++ b/apps/web/src/renderer/lib/utils.ts
@@ -17,14 +17,70 @@ export function formatTime(timestamp: number): string {
   });
 }
 
+/** Humanize an ISO/parsable timestamp as a compact relative age ("just now", "5m ago", "3h ago", "2d ago"). */
+export function formatRelativeTime(value: string): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return value;
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
 /** Convert a snake_case key to Title Case (e.g. "inbox_count" → "Inbox Count") */
 export function formatTitle(key: string): string {
   return key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
-/** Format an unknown value for display — arrays joined, objects stringified, nulls → dash */
+/** Matches an ISO 8601 datetime string, e.g. "2026-06-04T09:00:24.110-04:00". */
+const ISO_DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/;
+
+/** Format an ISO datetime string into a readable local date and time. */
+function formatIsoDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/** Format an unknown value for display: arrays joined, objects stringified, ISO dates humanized, nulls -> dash */
 export function formatDisplayValue(value: unknown): string {
   if (Array.isArray(value)) return value.join(', ');
   if (typeof value === 'object' && value !== null) return JSON.stringify(value);
-  return String(value ?? '—');
+  if (typeof value === 'string' && ISO_DATETIME_PATTERN.test(value)) return formatIsoDateTime(value);
+  return value == null ? '--' : String(value);
+}
+
+export interface SkillContextInjection {
+  /** The skill name from the `<skill-context name="...">` wrapper. */
+  name: string;
+  /** The injected skill body, trimmed of the wrapper. */
+  body: string;
+}
+
+/**
+ * Matches a turn whose entire content is a Copilot SDK skill-context injection,
+ * e.g. `<skill-context name="lens">...</skill-context>`. The SDK injects loaded
+ * skills as synthetic user-role turns; Chamber should not surface them as
+ * authored user messages.
+ */
+const SKILL_CONTEXT_PATTERN = /^\s*<skill-context\s+name="([^"]+)">([\s\S]*?)<\/skill-context>\s*$/;
+
+/**
+ * Parse an SDK skill-context injection out of a message's plain content.
+ * Returns null unless the content is, in its entirety, a single skill-context
+ * block — so genuine user messages that merely mention the tag are untouched.
+ */
+export function parseSkillContextInjection(content: string): SkillContextInjection | null {
+  const match = content.match(SKILL_CONTEXT_PATTERN);
+  if (!match) return null;
+  return { name: match[1], body: match[2].trim() };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "dependencies": {
         "@azure/msal-node": "^5.2.0",
         "@azure/msal-node-extensions": "^5.2.0",
+        "@fontsource-variable/inter": "^5.2.8",
         "better-sqlite3": "12.10.0",
         "chamber-copilot": "0.5.11",
         "class-variance-authority": "^0.7.1",
@@ -1563,6 +1564,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@github/copilot": {
       "version": "1.0.58",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   "dependencies": {
     "@azure/msal-node": "^5.2.0",
     "@azure/msal-node-extensions": "^5.2.0",
+    "@fontsource-variable/inter": "^5.2.8",
     "better-sqlite3": "12.10.0",
     "chamber-copilot": "0.5.11",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## What

Extracts the shared UI foundation off `master` as a clean, standalone base so the UX verticals (voice, ambient, chatroom sessions, settings, agent profile, chat polish) can each branch off it instead of one 50-commit kitchen-sink branch.

This is commit `bb8b482`, already validated as the base of the voice PR #387. Promoting it to its own PR lets the rest of the work stack cleanly off a small, reviewable base.

## Contents (19 files, +1021)

**Design system / tokens** (`index.css`)
- Light-default + `.dark` palette (monochrome with one reserved `genesis` accent), elevation shadows, lit surfaces (`.surface-panel` / `.surface-card`), restyled scrollbars, day/night crossfade, `prefers-reduced-motion`, entry animations.

**Theming**
- `useTheme.ts` -- day/night state, persistence, and `setTheme` bridge.
- `env.d.ts` -- `@fontsource-variable/inter` module decl + `setTheme` on `window.desktop`.

**Typography**
- Inter (`@fontsource-variable/inter`) wired in `renderer.tsx`; optical legibility + tabular figures.

**Primitives**
- New: `ui/skeleton.tsx`, `ui/tabs.tsx`. Token adoption: `ui/dialog.tsx`, `ui/tooltip.tsx`.

**Foundation hooks**
- `useResizableWidth`, `useResponsiveLayout`, `useCopyToClipboard`, `useDelayedFlag` (+ `lib/utils`).

## Stack

```
master
 └─ refactor/ui-foundation   <- this PR (base)
     |- #387 voice           re-points base here (bb8b482 is its first commit; no force-push)
     |- #386 ambient         rebases here (resolves the .app-ambient / env.d.ts overlap)
     `- chatroom / settings / agent-profile / chat-polish (stack on top)
```

## Validation

- `npm run lint` -- green: `tsc --noEmit`, eslint, dependency-cruiser (520 modules, 0 violations), yaml, md.
- Foundation unit tests -- 27 passed (`useResizableWidth`, `useResponsiveLayout`, `utils`).

No behavior beyond the shared base; each vertical adopts these tokens in its own PR.
