### PR TITLE
feat(chat): polish message rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Establish shared renderer UI foundations** — Adds shared design tokens, light and dark palettes, Inter typography, reusable tabs and skeletons, and responsive, resizable, clipboard, delay, and theme hooks.
 
+### Changed
+
+- **Polish chat message rendering** — Improves streaming, scrolling, tool and reasoning groups, agent colors, copy actions, composer affordances, and welcome states.
+
+
 
 
 

--- a/apps/web/src/renderer/components/chat/AgentWelcome.test.tsx
+++ b/apps/web/src/renderer/components/chat/AgentWelcome.test.tsx
@@ -1,0 +1,46 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AgentWelcome } from './AgentWelcome';
+import { AppStateProvider } from '../../lib/store';
+import { installElectronAPI } from '../../../test/helpers';
+import type { MindContext } from '@chamber/shared/types';
+
+const mind: MindContext = {
+  mindId: 'mind-1',
+  mindPath: 'C:\\agents\\moneypenny',
+  identity: { name: 'Moneypenny', systemMessage: '# Moneypenny' },
+  status: 'ready',
+};
+
+function renderWelcome(onPickPrompt = vi.fn()) {
+  render(
+    <AppStateProvider>
+      <AgentWelcome mind={mind} onPickPrompt={onPickPrompt} />
+    </AppStateProvider>,
+  );
+  return onPickPrompt;
+}
+
+describe('AgentWelcome', () => {
+  beforeEach(() => {
+    installElectronAPI();
+  });
+
+  it('greets with the agent name and the help prompt', () => {
+    renderWelcome();
+    expect(screen.getByText('Moneypenny')).toBeTruthy();
+    expect(screen.getByText('How can I help you today?')).toBeTruthy();
+  });
+
+  it('renders exactly three starter prompts', () => {
+    renderWelcome();
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+  });
+
+  it('stages a starter prompt via onPickPrompt instead of sending', () => {
+    const onPickPrompt = renderWelcome();
+    fireEvent.click(screen.getByText('Daily briefing'));
+    expect(onPickPrompt).toHaveBeenCalledWith('Give me my daily report');
+  });
+});

--- a/apps/web/src/renderer/components/chat/AgentWelcome.tsx
+++ b/apps/web/src/renderer/components/chat/AgentWelcome.tsx
@@ -1,0 +1,60 @@
+import type { MindContext } from '@chamber/shared/types';
+import { useAppState } from '../../lib/store';
+import { useMindProfiles } from '../../hooks/useMindProfiles';
+import { AgentAvatar } from '../profile/AgentAvatar';
+
+const STARTER_PROMPTS = [
+  { label: 'Daily briefing', prompt: 'Give me my daily report' },
+  { label: 'What can you do?', prompt: 'What skills and capabilities do you have? How can you help me?' },
+  { label: 'Explore the mind', prompt: 'What do you know about? List your domains and expertise areas.' },
+];
+
+interface Props {
+  mind: MindContext;
+  onPickPrompt: (prompt: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * AgentWelcome — chat empty state for an active agent. Mirrors the simple
+ * centered layout from the product shot: the agent's avatar, its name, a
+ * greeting, and a short strip of starter prompts. Deeper detail (lens views,
+ * tools, skills) lives in the agent profile modal, not here.
+ */
+export function AgentWelcome({ mind, onPickPrompt, disabled = false }: Props) {
+  const { minds } = useAppState();
+  const profileByMindId = useMindProfiles(minds);
+  const profile = profileByMindId[mind.mindId];
+  const name = profile?.displayName ?? mind.identity.name;
+
+  return (
+    <div className="chamber-fade-in flex-1 flex flex-col items-center justify-center px-4">
+      <div className="max-w-lg text-center">
+        <AgentAvatar
+          name={name}
+          avatarDataUrl={profile?.avatarDataUrl}
+          className="glow-genesis w-16 h-16 rounded-2xl mx-auto mb-6 flex items-center justify-center text-2xl font-bold text-primary-foreground"
+          fallbackClassName="bg-gradient-to-br from-genesis to-[oklch(0.46_0.14_165)]"
+          fallback={name.charAt(0).toUpperCase()}
+        />
+
+        <h2 className="text-2xl font-semibold mb-2 tracking-tight">{name}</h2>
+        <p className="text-muted-foreground mb-6">How can I help you today?</p>
+
+        <div className="grid grid-cols-3 gap-3 max-w-xl">
+          {STARTER_PROMPTS.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              disabled={disabled}
+              onClick={() => onPickPrompt(item.prompt)}
+              className="surface-card surface-card-hover text-left p-3 rounded-xl border border-border bg-card group disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="text-sm font-medium group-hover:text-foreground">{item.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.test.tsx
@@ -125,6 +125,40 @@ describe('ChatInput', () => {
     expect(screen.getByRole('combobox').hasAttribute('data-disabled')).toBe(true);
   });
 
+  it('exposes an aria-label on the textarea so screen readers have a name after the placeholder clears', () => {
+    render(<ChatInput {...defaultProps} />);
+    expect(screen.getByRole('textbox').getAttribute('aria-label')).toBe('Message your agent');
+  });
+
+  it('Send button is actually disabled when the textarea is empty (not just visually muted)', () => {
+    render(<ChatInput {...defaultProps} />);
+    const sendBtn = screen.getByLabelText('Send message');
+    expect(sendBtn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('Send button enables once the textarea has content', () => {
+    render(<ChatInput {...defaultProps} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hi' } });
+    expect(screen.getByLabelText('Send message').hasAttribute('disabled')).toBe(false);
+  });
+
+  it('Stop button stays enabled while streaming, regardless of textarea contents', () => {
+    render(<ChatInput {...defaultProps} isStreaming={true} />);
+    const stopBtn = screen.getByLabelText('Stop streaming (Escape)');
+    expect(stopBtn.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('shows an Enter/Shift+Enter keyboard hint when idle', () => {
+    render(<ChatInput {...defaultProps} />);
+    expect(screen.getByText('Enter to send · Shift+Enter for newline')).toBeTruthy();
+  });
+
+  it('swaps the keyboard hint to "Esc to stop" while streaming', () => {
+    render(<ChatInput {...defaultProps} isStreaming={true} />);
+    expect(screen.getByText('Esc to stop')).toBeTruthy();
+    expect(screen.queryByText('Enter to send · Shift+Enter for newline')).toBeNull();
+  });
+
   describe('emoji picker', () => {
     it('renders an emoji trigger button with aria-label', () => {
       render(<ChatInput {...defaultProps} />);

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -15,6 +15,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '../ui/popover';
+import { TooltipFor } from '../ui/tooltip';
+import { Smile } from 'lucide-react';
 import {
   Command,
   CommandList,
@@ -424,7 +426,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   return (
     <div className="border-t border-border px-4 py-3">
       <div className="max-w-3xl mx-auto">
-        <div className="relative flex flex-col bg-secondary rounded-xl px-4 py-3 gap-2">
+        <div className="focus-halo relative flex flex-col bg-secondary rounded-xl px-4 py-3 gap-2 border border-border transition-[border-color,box-shadow] duration-200">
           <textarea
             ref={textareaRef}
             value={input}
@@ -441,6 +443,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
               isComposingRef.current = false;
             }}
             placeholder={placeholder ?? (disabled ? 'Select a mind directory to start…' : 'Message your agent… (paste an image to attach)')}
+            aria-label="Message your agent"
             disabled={disabled}
             rows={1}
             className="w-full bg-transparent text-sm resize-none outline-none placeholder:text-muted-foreground disabled:opacity-50 overflow-y-auto"
@@ -462,9 +465,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
                       e.preventDefault();
                     }}
                     onClick={() => setEmojiOpen((v) => !v)}
-                    className="h-6 w-6 shrink-0 rounded-md text-base text-muted-foreground hover:text-foreground hover:bg-accent disabled:opacity-50 disabled:hover:bg-transparent flex items-center justify-center"
+                    className="h-6 w-6 shrink-0 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent disabled:opacity-50 disabled:hover:bg-transparent flex items-center justify-center"
                   >
-                    😀
+                    <Smile className="w-4 h-4" />
                   </button>
                 </PopoverTrigger>
                 <PopoverContent
@@ -491,13 +494,13 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
                   <SelectTrigger className="h-6 w-auto gap-1.5 border-none bg-transparent px-0 text-xs text-muted-foreground shadow-none hover:text-foreground focus:ring-0">
                     <SelectValue placeholder="Select model" />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent position="popper" side="top" sideOffset={8} align="start" collisionPadding={12}>
                     {availableModels.map((model) => {
                       const key = modelSelectionKeyFromModel(model);
                       return (
                         <SelectItem key={key} value={key} className="text-xs">
                           {model.name}
-                          {model.provider === 'byo' ? <span className="ml-2 rounded bg-emerald-700/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-emerald-300">Local</span> : null}
+                          {model.provider === 'byo' ? <span className="ml-2 rounded bg-genesis/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-genesis">Local</span> : null}
                         </SelectItem>
                       );
                     })}
@@ -510,34 +513,43 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
               )}
             </div>
 
-            <button
-              onClick={isStreaming ? onStop : handleSubmit}
-              disabled={disabled && !isStreaming}
-              aria-label={isStreaming ? 'Stop streaming (Escape)' : 'Send message'}
-              className={cn(
-                'shrink-0 w-8 h-8 rounded-lg flex items-center justify-center transition-colors',
-                isStreaming
-                  ? 'bg-destructive-foreground text-background hover:opacity-80'
-                  : canSubmit
-                    ? 'bg-primary text-primary-foreground hover:opacity-80'
-                    : 'bg-muted text-muted-foreground'
-              )}
-            >
-              {isStreaming ? (
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
-                  <rect x="2" y="2" width="10" height="10" rx="1" />
-                </svg>
-              ) : (
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="7" y1="12" x2="7" y2="2" />
-                  <polyline points="3,6 7,2 11,6" />
-                </svg>
-              )}
-            </button>
+            <TooltipFor label={isStreaming ? 'Stop streaming (Esc)' : (canSubmit ? 'Send message (Enter)' : 'Type a message to send')}>
+              <button
+                onClick={isStreaming ? onStop : handleSubmit}
+                disabled={isStreaming ? false : !canSubmit}
+                aria-label={isStreaming ? 'Stop streaming (Escape)' : 'Send message'}
+                className={cn(
+                  'shrink-0 w-8 h-8 rounded-lg flex items-center justify-center',
+                  'transition-[background-color,color,transform,box-shadow] duration-150',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-secondary',
+                  'active:scale-95',
+                  isStreaming
+                    ? 'bg-destructive text-destructive-foreground hover:opacity-80'
+                    : canSubmit
+                      ? 'bg-genesis text-genesis-foreground hover:bg-genesis hover:scale-[1.06] hover:shadow-[0_2px_8px_oklch(0.55_0.16_160/0.35)]'
+                      : 'bg-muted text-muted-foreground cursor-not-allowed'
+                )}
+              >
+                {isStreaming ? (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+                    <rect x="2" y="2" width="10" height="10" rx="1" />
+                  </svg>
+                ) : (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="7" y1="12" x2="7" y2="2" />
+                    <polyline points="3,6 7,2 11,6" />
+                  </svg>
+                )}
+              </button>
+            </TooltipFor>
           </div>
         </div>
 
         <p className="text-xs text-muted-foreground text-center mt-2">
+          <span className="opacity-70">
+            {isStreaming ? 'Esc to stop' : 'Enter to send · Shift+Enter for newline'}
+          </span>
+          <span className="mx-2 opacity-30">·</span>
           AI agents can make mistakes. Verify important information.
         </p>
       </div>

--- a/apps/web/src/renderer/components/chat/ChatPanel.tsx
+++ b/apps/web/src/renderer/components/chat/ChatPanel.tsx
@@ -1,17 +1,37 @@
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { useChatStreaming } from '../../hooks/useChatStreaming';
+import { useDelayedFlag } from '../../hooks/useDelayedFlag';
 import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
 import { WelcomeScreen } from './WelcomeScreen';
+import { AgentWelcome } from './AgentWelcome';
 import { Logger } from '../../lib/logger';
+import { Skeleton } from '../ui/skeleton';
+import { cn } from '../../lib/utils';
 
 const log = Logger.create('ChatPanel');
 
 export function ChatPanel() {
-  const { messagesByMind, activeMindId, minds, availableModels, selectedModel, conversationViewByMind, composeDraftByMind } = useAppState();
+  const { messagesByMind, activeMindId, minds, availableModels, selectedModel, conversationViewByMind, conversationHistoryByMind, composeDraftByMind } = useAppState();
   const messages = activeMindId ? (messagesByMind[activeMindId] ?? []) : [];
   const conversationView = activeMindId ? conversationViewByMind[activeMindId] : undefined;
   const isConversationHydrating = conversationView?.status === 'hydrating';
+  // The conversation hasn't settled until its saved-history list has loaded
+  // and any active session has been hydrated into messages. Before that we
+  // hold a loading state instead of flashing the welcome/about panel for a
+  // frame and then jumping to the transcript.
+  const conversationHistory = activeMindId ? conversationHistoryByMind[activeMindId] : undefined;
+  const conversationStatus = conversationView?.status;
+  const isConversationSettled = conversationStatus === 'ready' || conversationStatus === 'idle';
+  const isConversationSettling =
+    Boolean(activeMindId) &&
+    messages.length === 0 &&
+    !isConversationHydrating &&
+    (conversationHistory === undefined || (conversationHistory.length > 0 && !isConversationSettled));
+  const isLoadingConversation = isConversationHydrating || isConversationSettling;
+  // Only paint the skeleton once loading outlasts a short grace window, so
+  // instant (cached) loads don't flash a single-frame pulse.
+  const showHydratingSkeleton = useDelayedFlag(isLoadingConversation);
   const isModelSwitching = Boolean(conversationView?.modelSwitching);
   const connected = minds.length > 0;
   const dispatch = useAppDispatch();
@@ -44,34 +64,74 @@ export function ChatPanel() {
       });
   };
 
+  const activeMind = activeMindId ? minds.find((m) => m.mindId === activeMindId) : undefined;
+  const showAboutPanel = messages.length === 0 && !isLoadingConversation && activeMind;
+
   return (
     <div className="flex-1 flex flex-col min-h-0">
-      {isConversationHydrating ? (
-        <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
-          Loading conversation…
-        </div>
-      ) : messages.length === 0 ? (
-        <WelcomeScreen
-          onSendMessage={sendMessage}
-          connected={connected}
-          disabled={isModelSwitching}
-        />
+      {isLoadingConversation ? (
+        showHydratingSkeleton ? <ConversationHydratingSkeleton /> : null
       ) : (
-        <MessageList />
-      )}
+        <>
+          {showAboutPanel ? (
+            <AgentWelcome
+              mind={activeMind}
+              onPickPrompt={handleDraftChange}
+              disabled={isModelSwitching}
+            />
+          ) : messages.length === 0 ? (
+            <WelcomeScreen
+              onPickPrompt={handleDraftChange}
+              connected={connected}
+              disabled={isModelSwitching}
+            />
+          ) : (
+            <MessageList />
+          )}
 
-      <ChatInput
-        onSend={sendMessage}
-        onStop={stopStreaming}
-        isStreaming={isStreaming}
-        disabled={!connected || isModelSwitching}
-        availableModels={availableModels}
-        selectedModel={selectedModel}
-        onModelChange={handleModelChange}
-        placeholder={isModelSwitching ? 'Switching model…' : undefined}
-        value={draft}
-        onValueChange={handleDraftChange}
-      />
+          <ChatInput
+            onSend={sendMessage}
+            onStop={stopStreaming}
+            isStreaming={isStreaming}
+            disabled={!connected || isModelSwitching}
+            availableModels={availableModels}
+            selectedModel={selectedModel}
+            onModelChange={handleModelChange}
+            placeholder={isModelSwitching ? 'Switching model…' : undefined}
+            value={draft}
+            onValueChange={handleDraftChange}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Placeholder shown while a conversation rehydrates from disk. Mirrors the
+ * alternating message-bubble rhythm of the real transcript so the pane keeps
+ * a stable shape instead of flashing a single centered "Loading" line that
+ * then jumps to the message list.
+ */
+function ConversationHydratingSkeleton() {
+  return (
+    <div className="flex-1 overflow-y-auto" aria-busy="true" data-testid="conversation-hydrating-skeleton">
+      <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+        {[
+          { mine: false, lines: 2 },
+          { mine: true, lines: 1 },
+          { mine: false, lines: 3 },
+        ].map((row, i) => (
+          <div key={i} className={cn('flex flex-col gap-2', row.mine ? 'items-end' : 'items-start')}>
+            <Skeleton className="h-3 w-20" />
+            <div className={cn('w-full max-w-[80%] space-y-2 rounded-2xl border border-border bg-card p-4', row.mine && 'ml-auto')}>
+              {Array.from({ length: row.lines }).map((_, line) => (
+                <Skeleton key={line} className={cn('h-3', line === row.lines - 1 ? 'w-[60%]' : 'w-full')} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/renderer/components/chat/MessageActions.tsx
+++ b/apps/web/src/renderer/components/chat/MessageActions.tsx
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+
+/**
+ * Hover-revealed action row for a completed assistant turn. Mirrors the
+ * M365/Anthropic pattern: actions stay out of the way until the row is
+ * hovered (or the button is focused for keyboard users), then offer a quick
+ * copy of the message's plain-text content. Shared by single-agent chat and
+ * the chatroom transcript.
+ */
+export function MessageActions({ content }: { content: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  const handleCopy = useCallback(() => copy(content), [copy, content]);
+
+  return (
+    <div className="mt-1.5 flex items-center opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? 'Copied' : 'Copy message'}
+        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/chat/MessageList.test.tsx
+++ b/apps/web/src/renderer/components/chat/MessageList.test.tsx
@@ -1,8 +1,8 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { AppStateProvider } from '../../lib/store';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AppStateProvider, useAppDispatch } from '../../lib/store';
 import { MessageList } from './MessageList';
 import type { ChatMessage, MindContext } from '@chamber/shared/types';
 import { installElectronAPI } from '../../../test/helpers';
@@ -70,6 +70,23 @@ describe('MessageList', () => {
     expect(screen.getByText('Hello directly.')).toBeTruthy();
   });
 
+  it('collapses an SDK skill-context injection into a chip instead of dumping the block', () => {
+    renderMessages([
+      {
+        id: 'skill-1',
+        role: 'user',
+        blocks: [{ type: 'text', content: '<skill-context name="lens">\n# Lens\nlong documentation body\n</skill-context>' }],
+        timestamp: 1000,
+      },
+    ]);
+
+    expect(screen.getByText('Loaded skill: lens')).toBeTruthy();
+    expect(screen.queryByText(/long documentation body/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Loaded skill: lens/ }));
+    expect(screen.getByText(/long documentation body/)).toBeTruthy();
+  });
+
   it('renders the saved user profile avatar for directly authored messages', async () => {
     const api = installElectronAPI();
     (api.userProfile.get as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -121,6 +138,7 @@ describe('MessageList', () => {
       displayName: 'Moneypenny',
       folderName: 'moneypenny',
       avatarDataUrl: 'data:image/png;base64,bW9uZXlwZW5ueQ==',
+      accentColor: null,
       soul: { kind: 'soul', label: 'SOUL.md', relativePath: 'SOUL.md', content: '', exists: true, mtimeMs: 1 },
       agentFiles: [],
       needsRestart: false,
@@ -139,5 +157,115 @@ describe('MessageList', () => {
       expect(screen.getByAltText('Moneypenny avatar')).toHaveProperty('src', 'data:image/png;base64,bW9uZXlwZW5ueQ==');
     });
     expect(screen.getByText('Moneypenny')).toBeTruthy();
+  });
+
+  it('snaps to bottom when a user message arrives even after the user scrolled up', () => {
+    // Use useAppDispatch to mutate state from inside the same Provider so the
+    // MessageList instance (and its scroller ref) survives the change.
+    const Harness = () => {
+      const dispatch = useAppDispatch();
+      return (
+        <>
+          <button onClick={() => dispatch({
+            type: 'ADD_USER_MESSAGE',
+            payload: { id: 'user-new', content: 'Just sent this', timestamp: 9999 },
+          })}>send</button>
+          <MessageList />
+        </>
+      );
+    };
+
+    const initial: ChatMessage[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `asst-${i}`,
+      role: 'assistant' as const,
+      blocks: [{ type: 'text', content: `Reply ${i} `.repeat(40) }],
+      timestamp: 1000 + i,
+    }));
+
+    const { container } = render(
+      <AppStateProvider
+        testInitialState={{
+          activeMindId: MONEYPENNY.mindId,
+          minds: [Q, MONEYPENNY],
+          messagesByMind: { [MONEYPENNY.mindId]: initial },
+        }}
+      >
+        <Harness />
+      </AppStateProvider>,
+    );
+
+    const scroller = container.querySelector('.overflow-y-auto') as HTMLDivElement;
+    expect(scroller).toBeTruthy();
+    // Simulate the scroller geometry + a user scrolled up.
+    Object.defineProperty(scroller, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(scroller, 'clientHeight', { value: 400, configurable: true });
+    scroller.scrollTop = 100;
+    scroller.dispatchEvent(new Event('scroll'));
+    expect(scroller.scrollTop).toBe(100);
+
+    // User clicks send. Even though they're scrolled away from the bottom,
+    // the new user message must snap them back so they see what they wrote.
+    act(() => {
+      fireEvent.click(screen.getByText('send'));
+    });
+    expect(scroller.scrollTop).toBe(2000);
+  });
+
+  it('surfaces a "New messages" pill when an assistant message arrives while the user is scrolled up', () => {
+    const Harness = () => {
+      const dispatch = useAppDispatch();
+      return (
+        <>
+          <button onClick={() => dispatch({
+            type: 'ADD_ASSISTANT_MESSAGE',
+            payload: { id: 'asst-new', timestamp: 9999 },
+          })}>add-assistant</button>
+          <MessageList />
+        </>
+      );
+    };
+
+    const initial: ChatMessage[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `asst-${i}`,
+      role: 'assistant' as const,
+      blocks: [{ type: 'text', content: `Reply ${i}` }],
+      timestamp: 1000 + i,
+    }));
+
+    const { container } = render(
+      <AppStateProvider
+        testInitialState={{
+          activeMindId: MONEYPENNY.mindId,
+          minds: [Q, MONEYPENNY],
+          messagesByMind: { [MONEYPENNY.mindId]: initial },
+        }}
+      >
+        <Harness />
+      </AppStateProvider>,
+    );
+
+    const scroller = container.querySelector('.overflow-y-auto') as HTMLDivElement;
+    expect(scroller).toBeTruthy();
+    Object.defineProperty(scroller, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(scroller, 'clientHeight', { value: 400, configurable: true });
+    scroller.scrollTop = 100;
+    scroller.dispatchEvent(new Event('scroll'));
+
+    // No pill before a new message arrives.
+    expect(screen.queryByLabelText('Jump to latest message')).toBeNull();
+
+    act(() => {
+      fireEvent.click(screen.getByText('add-assistant'));
+    });
+
+    const pill = screen.getByLabelText('Jump to latest message');
+    expect(pill).toBeTruthy();
+
+    // Clicking the pill snaps to the bottom and the pill disappears.
+    act(() => {
+      fireEvent.click(pill);
+    });
+    expect(scroller.scrollTop).toBe(2000);
+    expect(screen.queryByLabelText('Jump to latest message')).toBeNull();
   });
 });

--- a/apps/web/src/renderer/components/chat/MessageList.tsx
+++ b/apps/web/src/renderer/components/chat/MessageList.tsx
@@ -1,13 +1,15 @@
-import React, { useEffect, useRef } from 'react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowDown, ChevronDown, ChevronRight, Sparkles } from 'lucide-react';
+import { MessageActions } from './MessageActions';
 import { useAppState, getPlainContent } from '../../lib/store';
 import { StreamingMessage } from './StreamingMessage';
-import { cn, formatTime } from '../../lib/utils';
+import { cn, formatTime, parseSkillContextInjection } from '../../lib/utils';
 import type { ChatMessage, MindContext } from '@chamber/shared/types';
 import type { AgentProfileSummary } from '../../lib/store/state';
 import { AgentAvatar } from '../profile/AgentAvatar';
 import { useMindProfiles } from '../../hooks/useMindProfiles';
 import { useUserProfile } from '../../hooks/useUserProfile';
-import { agentColor } from './agentColors';
+import { agentColor, readableTextColor } from './agentColors';
 
 function displayName(name: string, fallback: string): string {
   const trimmed = name.trim();
@@ -41,7 +43,7 @@ function messagePresenter(
     return {
       name,
       initial: name.charAt(0).toUpperCase(),
-      color: agentColor(minds, message.sender.mindId),
+      color: agentColor(minds, message.sender.mindId, profileByMindId),
       isAgentSender: true,
       avatarDataUrl: profile?.avatarDataUrl,
     };
@@ -66,92 +68,220 @@ export function MessageList() {
   const agentName = activeMind ? profileName(activeProfile, activeMind.identity.name) : 'Agent';
   const scrollRef = useRef<HTMLDivElement>(null);
   const isAutoScrolling = useRef(true);
+  const lastMessageIdRef = useRef<string | null>(null);
+  const [hasNewBelow, setHasNewBelow] = useState(false);
+  const lastMessageCountRef = useRef(messages.length);
+
+  const scrollToBottom = useCallback(() => {
+    if (!scrollRef.current) return;
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    isAutoScrolling.current = true;
+    setHasNewBelow(false);
+  }, []);
 
   useEffect(() => {
-    if (isAutoScrolling.current && scrollRef.current) {
+    if (!scrollRef.current) return;
+
+    // User-just-sent: when the newest message is a user message and the id has
+    // changed since last render, override auto-scroll and snap to bottom. User
+    // intent is unambiguous on Send -- they want to see what they wrote land.
+    const latest = messages[messages.length - 1];
+    const isNewUserMessage = latest?.role === 'user' && latest.id !== lastMessageIdRef.current;
+    const grewByOne = messages.length > lastMessageCountRef.current;
+
+    if (isNewUserMessage) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      isAutoScrolling.current = true;
+      setHasNewBelow(false);
+    } else if (isAutoScrolling.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      setHasNewBelow(false);
+    } else if (grewByOne) {
+      // New assistant message arrived while the user was scrolled up. Surface
+      // the floating "New messages" pill instead of silently appending.
+      setHasNewBelow(true);
     }
+
+    lastMessageIdRef.current = latest?.id ?? null;
+    lastMessageCountRef.current = messages.length;
   }, [messages]);
 
   const handleScroll = () => {
     if (!scrollRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
     // Auto-scroll if within 100px of bottom
-    isAutoScrolling.current = scrollHeight - scrollTop - clientHeight < 100;
+    const nearBottom = scrollHeight - scrollTop - clientHeight < 100;
+    isAutoScrolling.current = nearBottom;
+    if (nearBottom && hasNewBelow) setHasNewBelow(false);
   };
 
   return (
-    <div
-      ref={scrollRef}
-      onScroll={handleScroll}
-      className="flex-1 overflow-y-auto px-4 py-4"
-    >
-      <div className="max-w-3xl mx-auto space-y-6">
-        {messages.map((message) => {
-          const presenter = messagePresenter(message, agentName, minds, profileByMindId);
-          const avatarDataUrl = message.role === 'assistant'
-            ? activeProfile?.avatarDataUrl
-            : presenter.isAgentSender
-              ? presenter.avatarDataUrl
-              : userProfile?.avatarDataUrl;
+    <div className="chamber-fade-in relative flex-1 min-h-0 flex flex-col">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto px-4 py-4"
+      >
+        <div className="max-w-3xl mx-auto space-y-6">
+          {messages.map((message) => {
+            const presenter = messagePresenter(message, agentName, minds, profileByMindId);
+            const avatarDataUrl = message.role === 'assistant'
+              ? activeProfile?.avatarDataUrl
+              : presenter.isAgentSender
+                ? presenter.avatarDataUrl
+                : userProfile?.avatarDataUrl;
 
-          return (
-            <div key={message.id} className="flex gap-3">
-              {/* Avatar */}
-              <AgentAvatar
-                name={presenter.name}
+            return (
+              <MessageRow
+                key={message.id}
+                message={message}
+                presenter={presenter}
                 avatarDataUrl={avatarDataUrl}
-                className="w-[42px] h-[42px] rounded-full flex items-center justify-center text-sm font-medium shrink-0 -mt-2.5"
-                fallbackClassName={cn(
-                  message.role === 'assistant' ? 'bg-genesis text-primary-foreground' : 'bg-secondary text-secondary-foreground',
-                )}
-                style={presenter.isAgentSender ? { backgroundColor: presenter.color, color: '#fff' } : undefined}
-                fallback={presenter.initial}
+                animate={message.id === messages[messages.length - 1]?.id}
+                launch={message.id === messages[messages.length - 1]?.id && message.role === 'user'}
               />
-
-              {/* Content */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <span
-                    className="text-sm font-medium"
-                    style={presenter.isAgentSender ? { color: presenter.color } : undefined}
-                  >
-                    {presenter.name}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {formatTime(message.timestamp)}
-                  </span>
-                </div>
-
-                {message.role === 'assistant' ? (
-                  <StreamingMessage
-                    blocks={message.blocks}
-                    isStreaming={message.isStreaming}
-                  />
-                ) : (
-                  <div className="space-y-2">
-                    {message.blocks
-                      .filter((b): b is Extract<typeof b, { type: 'image' }> => b.type === 'image')
-                      .map((img, idx) => (
-                        <img
-                          key={`${img.name}-${idx}`}
-                          src={img.dataUrl}
-                          alt={img.name}
-                          className="max-w-sm max-h-80 rounded-lg border border-border object-contain"
-                        />
-                      ))}
-                    {getPlainContent(message) && (
-                      <p className="text-sm leading-relaxed whitespace-pre-wrap">
-                        {getPlainContent(message)}
-                      </p>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
+      {hasNewBelow && (
+        <button
+          type="button"
+          onClick={scrollToBottom}
+          aria-label="Jump to latest message"
+          className="absolute bottom-3 right-4 z-10 flex items-center gap-1.5 rounded-full border border-border bg-popover px-3 py-1.5 text-xs font-medium text-popover-foreground shadow-md hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowDown size={13} aria-hidden />
+          New messages
+        </button>
+      )}
     </div>
   );
 }
+
+interface MessagePresenter {
+  name: string;
+  initial: string;
+  color: string | undefined;
+  isAgentSender: boolean;
+  avatarDataUrl: string | null | undefined;
+}
+
+interface MessageRowProps {
+  message: ChatMessage;
+  presenter: MessagePresenter;
+  avatarDataUrl: string | null | undefined;
+  // Only the newest row plays the entry fade. Replaying it on every row when a
+  // saved conversation loads reads as a laggy bulk fade.
+  animate: boolean;
+  // The newest row when it is the user's just-sent message: plays the launch
+  // entrance instead of the generic fade.
+  launch: boolean;
+}
+
+// Memoized so an inbound message at the end of a long transcript doesn't force
+// every prior message subtree (markdown + rehype-highlight + work-group cells)
+// to re-render. content-visibility hint lets the browser skip layout/paint
+// work for off-screen rows.
+const MessageRow = memo(function MessageRow({ message, presenter, avatarDataUrl, animate, launch }: MessageRowProps) {
+  return (
+    <div
+      className={cn('group flex gap-3', launch ? 'chamber-launch' : animate && 'chamber-fade-in')}
+      style={{ contentVisibility: 'auto', containIntrinsicSize: '140px' } as React.CSSProperties}
+    >
+      <AgentAvatar
+        name={presenter.name}
+        avatarDataUrl={avatarDataUrl}
+        className="w-[42px] h-[42px] rounded-full flex items-center justify-center text-sm font-medium shrink-0"
+        fallbackClassName={cn(
+          message.role === 'assistant' ? 'bg-genesis text-primary-foreground' : 'bg-secondary text-secondary-foreground',
+        )}
+        style={presenter.isAgentSender ? { backgroundColor: presenter.color, color: readableTextColor(presenter.color) } : undefined}
+        fallback={presenter.initial}
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span
+            className="text-sm font-medium"
+            style={presenter.isAgentSender ? { color: presenter.color } : undefined}
+          >
+            {presenter.name}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {formatTime(message.timestamp)}
+          </span>
+        </div>
+
+        {message.role === 'assistant' ? (
+          <>
+            <StreamingMessage
+              blocks={message.blocks}
+              isStreaming={message.isStreaming}
+            />
+            {!message.isStreaming && getPlainContent(message).trim() && (
+              <MessageActions content={getPlainContent(message)} />
+            )}
+          </>
+        ) : (
+          <div className="space-y-2">
+            {message.blocks
+              .filter((b): b is Extract<typeof b, { type: 'image' }> => b.type === 'image')
+              .map((img, idx) => (
+                <img
+                  key={`${img.name}-${idx}`}
+                  src={img.dataUrl}
+                  alt={img.name}
+                  className="max-w-sm max-h-80 rounded-lg border border-border object-contain"
+                />
+              ))}
+            {(() => {
+              const plain = getPlainContent(message);
+              if (!plain) return null;
+              const skillContext = parseSkillContextInjection(plain);
+              if (skillContext) {
+                return <SkillContextChip name={skillContext.name} body={skillContext.body} />;
+              }
+              return (
+                <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                  {plain}
+                </p>
+              );
+            })()}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Collapsed marker for a Copilot SDK skill-context injection. The SDK injects
+ * a loaded skill (e.g. `lens`) into the conversation as a synthetic user turn;
+ * rather than dumping the whole SKILL.md into the transcript, we show a compact
+ * chip that expands on demand.
+ */
+function SkillContextChip({ name, body }: { name: string; body: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/40">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg"
+      >
+        {expanded ? <ChevronDown size={12} aria-hidden /> : <ChevronRight size={12} aria-hidden />}
+        <Sparkles size={12} aria-hidden />
+        <span>Loaded skill: {name}</span>
+      </button>
+      {expanded && (
+        <pre className="max-h-80 overflow-auto border-t border-border px-2.5 py-2 text-[11px] leading-relaxed whitespace-pre-wrap text-muted-foreground">
+          {body}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+

--- a/apps/web/src/renderer/components/chat/StreamingMessage.render.test.tsx
+++ b/apps/web/src/renderer/components/chat/StreamingMessage.render.test.tsx
@@ -1,0 +1,42 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StreamingMessage } from './StreamingMessage';
+import { makeTextBlock } from '@/test/helpers';
+
+// Companion file to StreamingMessage.test.tsx that does NOT stub react-markdown,
+// so we can assert the actual rendered DOM for fenced code blocks and GFM tables.
+
+describe('StreamingMessage markdown chrome', () => {
+  it('renders fenced code blocks with language label and copy button', () => {
+    const md = '```json\n{"hello":"world"}\n```';
+    render(<StreamingMessage blocks={[makeTextBlock(md)]} />);
+
+    // Language label.
+    expect(screen.getByText('json')).toBeTruthy();
+    // Copy button is keyboard-accessible.
+    const copyBtn = screen.getByRole('button', { name: 'Copy code' });
+    expect(copyBtn).toBeTruthy();
+    // Code content survives the chrome.
+    expect(screen.getByText(/"hello"/)).toBeTruthy();
+  });
+
+  it('wraps GFM tables in a horizontally scrollable container with zebra rows', () => {
+    const md = [
+      '| col a | col b |',
+      '| --- | --- |',
+      '| 1 | 2 |',
+      '| 3 | 4 |',
+    ].join('\n');
+
+    const { container } = render(<StreamingMessage blocks={[makeTextBlock(md)]} />);
+    const table = container.querySelector('table');
+    expect(table).toBeTruthy();
+    expect(table?.parentElement?.className).toContain('overflow-x-auto');
+    // Zebra striping is applied to <tr>s via even:bg-muted/20.
+    const rows = container.querySelectorAll('tr');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(Array.from(rows).some((r) => r.className.includes('even:bg-muted'))).toBe(true);
+  });
+});

--- a/apps/web/src/renderer/components/chat/StreamingMessage.test.tsx
+++ b/apps/web/src/renderer/components/chat/StreamingMessage.test.tsx
@@ -30,6 +30,7 @@ describe('StreamingMessage', () => {
     const block = makeToolCallBlock({ toolName: 'read_file', status: 'running' });
     render(<StreamingMessage blocks={[block]} />);
     expect(screen.getByText(/Tool calls \(1\)/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Tool calls \(1\)/ }));
     expect(screen.getByText('read_file')).toBeTruthy();
   });
 
@@ -38,6 +39,7 @@ describe('StreamingMessage', () => {
     render(<StreamingMessage blocks={[block]} />);
     expect(screen.getByText(/Work log \(1\)/)).toBeTruthy();
     expect(screen.queryByText(/detail-only-line/)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Work log \(1\)/ }));
     fireEvent.click(screen.getByRole('button', { name: /Thought/ }));
     expect(screen.getByText(/detail-only-line/)).toBeTruthy();
   });

--- a/apps/web/src/renderer/components/chat/StreamingMessage.tsx
+++ b/apps/web/src/renderer/components/chat/StreamingMessage.tsx
@@ -1,18 +1,123 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
+import { Check, Copy } from 'lucide-react';
 import type { PluggableList } from 'unified';
 import type { Components } from 'react-markdown';
 import { cn } from '../../lib/utils';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { WorkGroup, hasRunningTool } from './WorkGroup';
 import { groupBlocksIntoChunks } from './WorkGroup.logic';
 import type { ContentBlock, TextBlock } from '@chamber/shared/types';
 
 const REMARK_PLUGINS: PluggableList = [remarkGfm];
 const REHYPE_PLUGINS: PluggableList = [[rehypeHighlight, { detect: true, ignoreMissing: true }]];
+// While a chunk is still streaming we skip syntax highlighting entirely: it
+// would re-tokenize the growing code block on every incoming token. Highlight
+// once, after the chunk settles (streaming === false).
+const REHYPE_PLUGINS_STREAMING: PluggableList = [];
+
+// Extract a language hint from rehype-highlight's `hljs language-<lang>` class.
+function extractLanguage(className: string | undefined): string | null {
+  if (!className) return null;
+  const langMatch = /language-(\S+)/.exec(className);
+  return langMatch ? langMatch[1] : null;
+}
+
+// react-markdown injects a `node` prop on every renderer; strip it before
+// spreading onto the DOM element to avoid React's unknown-prop warning.
+function stripNode<T extends { node?: unknown }>(props: T): Omit<T, 'node'> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { node, ...rest } = props;
+  return rest;
+}
+
+function CodeBlock({ children, className }: { children: React.ReactNode; className?: string }) {
+  const language = extractLanguage(className);
+  const { copied, copy } = useCopyToClipboard();
+
+  const handleCopy = useCallback(() => {
+    // children is the highlighted <code> tree; pull plain text from it.
+    const text = typeof children === 'string'
+      ? children
+      : (() => {
+          let acc = '';
+          const walk = (node: React.ReactNode): void => {
+            if (node == null || node === false) return;
+            if (typeof node === 'string' || typeof node === 'number') {
+              acc += String(node);
+              return;
+            }
+            if (Array.isArray(node)) {
+              node.forEach(walk);
+              return;
+            }
+            if (React.isValidElement(node)) {
+              walk((node.props as { children?: React.ReactNode }).children);
+            }
+          };
+          walk(children);
+          return acc;
+        })();
+
+    copy(text);
+  }, [children, copy]);
+
+  return (
+    <div className="not-prose my-3 overflow-hidden rounded-md border border-border bg-muted/40">
+      <div className="flex items-center justify-between border-b border-border bg-muted/60 px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        <span>{language ?? 'code'}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={copied ? 'Copied' : 'Copy code'}
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {copied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="overflow-x-auto p-3 text-[12px] leading-relaxed">
+        <code className={className}>{children}</code>
+      </pre>
+    </div>
+  );
+}
+
 const MARKDOWN_COMPONENTS: Components = {
   a: (props) => <a {...props} target="_blank" rel="noopener noreferrer" />,
+  // Wrap GFM tables in a horizontal-scroll container with zebra rows + cell
+  // borders so they read as tables instead of bare data.
+  table: (props) => (
+    <div className="not-prose my-3 overflow-x-auto rounded-md border border-border">
+      <table {...stripNode(props)} className="w-full border-collapse text-xs" />
+    </div>
+  ),
+  thead: (props) => <thead {...stripNode(props)} className="bg-muted/60" />,
+  th: (props) => (
+    <th {...stripNode(props)} className="border-b border-border px-2.5 py-1.5 text-left font-medium" />
+  ),
+  td: (props) => (
+    <td {...stripNode(props)} className="border-b border-border/50 px-2.5 py-1.5 align-top" />
+  ),
+  tr: (props) => (
+    <tr {...stripNode(props)} className="even:bg-muted/20 hover:bg-accent/40 transition-colors" />
+  ),
+  // Detect fenced code blocks (the parent is <pre>); render via CodeBlock chrome.
+  // Inline code keeps its prose styling.
+  pre: ({ children }) => <>{children}</>,
+  code: ({ className, children, ...rest }) => {
+    const isFenced = typeof className === 'string' && /language-/.test(className);
+    if (isFenced) {
+      return <CodeBlock className={className}>{children}</CodeBlock>;
+    }
+    return (
+      <code {...rest} className={cn(className, 'whitespace-nowrap')}>
+        {children}
+      </code>
+    );
+  },
 };
 
 interface Props {
@@ -23,6 +128,10 @@ interface Props {
 export function StreamingMessage({ blocks, isStreaming }: Props) {
   if (blocks.length === 0 && isStreaming) {
     return <ThinkingDots label="Thinking…" />;
+  }
+
+  if (blocks.length === 0) {
+    return <p className="text-sm italic text-muted-foreground/60">No response.</p>;
   }
 
   const chunks = groupBlocksIntoChunks(blocks);
@@ -40,7 +149,7 @@ export function StreamingMessage({ blocks, isStreaming }: Props) {
     (!lastChunk || lastChunk.kind !== 'text');
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col" aria-live="polite" aria-busy={Boolean(isStreaming)}>
       {chunks.map((chunk, i) => {
         const isLast = i === chunks.length - 1;
         if (chunk.kind === 'text') {
@@ -61,12 +170,8 @@ export function StreamingMessage({ blocks, isStreaming }: Props) {
         );
       })}
       {showTrailingIndicator && (
-        <div className="mt-2 flex items-center gap-1.5 text-muted-foreground">
-          <div className="flex gap-1">
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:0ms]" />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:150ms]" />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:300ms]" />
-          </div>
+        <div className="chamber-fade-in mt-2 flex items-center gap-1.5 text-muted-foreground">
+          <BounceDots />
         </div>
       )}
     </div>
@@ -77,19 +182,22 @@ const TextChunk = memo(function TextChunk({ block, streaming }: { block: TextBlo
   return (
     <div
       className={cn(
-        'prose prose-sm prose-invert max-w-none text-sm leading-relaxed',
-        streaming && 'streaming',
+        'prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed',
+        // Long unbroken tokens (Windows paths, URLs) must wrap inside the
+        // message column instead of forcing a horizontal scrollbar on the
+        // whole chat surface. `anywhere` keeps regular prose flowing.
+        '[overflow-wrap:anywhere]',
       )}
     >
       <Markdown
         remarkPlugins={REMARK_PLUGINS}
-        rehypePlugins={REHYPE_PLUGINS}
+        rehypePlugins={streaming ? REHYPE_PLUGINS_STREAMING : REHYPE_PLUGINS}
         components={MARKDOWN_COMPONENTS}
       >
         {block.content}
       </Markdown>
       {streaming && (
-        <span className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-genesis align-text-bottom" />
+        <span className="ml-0.5 inline-block h-4 w-[3px] rounded-full bg-genesis align-text-bottom chamber-caret" />
       )}
     </div>
   );
@@ -97,13 +205,19 @@ const TextChunk = memo(function TextChunk({ block, streaming }: { block: TextBlo
 
 function ThinkingDots({ label }: { label: string }) {
   return (
-    <div className="flex items-center gap-1.5 text-muted-foreground">
-      <div className="flex gap-1">
-        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:0ms]" />
-        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:150ms]" />
-        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:300ms]" />
-      </div>
+    <div className="chamber-fade-in flex items-center gap-1.5 text-muted-foreground">
+      <BounceDots />
       <span className="text-xs">{label}</span>
+    </div>
+  );
+}
+
+function BounceDots() {
+  return (
+    <div className="flex gap-1">
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:0ms]" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:150ms]" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-genesis [animation-delay:300ms]" />
     </div>
   );
 }

--- a/apps/web/src/renderer/components/chat/WelcomeScreen.test.tsx
+++ b/apps/web/src/renderer/components/chat/WelcomeScreen.test.tsx
@@ -5,30 +5,30 @@ import { WelcomeScreen } from './WelcomeScreen';
 
 describe('WelcomeScreen', () => {
   it('renders "How can I help you today?" when connected', () => {
-    render(<WelcomeScreen onSendMessage={vi.fn()} connected={true} />);
+    render(<WelcomeScreen onPickPrompt={vi.fn()} connected={true} />);
     expect(screen.getByText('How can I help you today?')).toBeTruthy();
   });
 
   it('renders prompt buttons when connected (6 buttons)', () => {
-    render(<WelcomeScreen onSendMessage={vi.fn()} connected={true} />);
+    render(<WelcomeScreen onPickPrompt={vi.fn()} connected={true} />);
     const buttons = screen.getAllByRole('button');
     expect(buttons).toHaveLength(6);
   });
 
-  it('clicking a starter prompt calls onSendMessage with the prompt text', () => {
-    const onSendMessage = vi.fn();
-    render(<WelcomeScreen onSendMessage={onSendMessage} connected={true} />);
+  it('clicking a starter prompt stages it via onPickPrompt instead of sending', () => {
+    const onPickPrompt = vi.fn();
+    render(<WelcomeScreen onPickPrompt={onPickPrompt} connected={true} />);
     fireEvent.click(screen.getByText('Daily briefing'));
-    expect(onSendMessage).toHaveBeenCalledWith('Give me my daily report');
+    expect(onPickPrompt).toHaveBeenCalledWith('Give me my daily report');
   });
 
   it('renders "Select a mind directory" when not connected', () => {
-    render(<WelcomeScreen onSendMessage={vi.fn()} connected={false} />);
+    render(<WelcomeScreen onPickPrompt={vi.fn()} connected={false} />);
     expect(screen.getByText(/Select a mind directory/)).toBeTruthy();
   });
 
   it('does not render prompt buttons when not connected', () => {
-    render(<WelcomeScreen onSendMessage={vi.fn()} connected={false} />);
+    render(<WelcomeScreen onPickPrompt={vi.fn()} connected={false} />);
     expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 });

--- a/apps/web/src/renderer/components/chat/WelcomeScreen.tsx
+++ b/apps/web/src/renderer/components/chat/WelcomeScreen.tsx
@@ -1,53 +1,62 @@
 import React from 'react';
+import { FileText, Compass, ListChecks, Sparkles, Lightbulb, Megaphone, type LucideIcon } from 'lucide-react';
 
-const STARTER_PROMPTS = [
-  { emoji: '📋', label: 'Daily briefing', prompt: 'Give me my daily report' },
-  { emoji: '🔍', label: 'Explore the mind', prompt: 'What do you know about? List your domains and expertise areas.' },
-  { emoji: '📝', label: 'Check initiatives', prompt: 'What active initiatives are you tracking? Give me a status update.' },
-  { emoji: '🔮', label: 'Create a Lens', prompt: 'Create a new Lens view for me. What data would you like to visualize? Suggest some options based on what you know about this mind.' },
-  { emoji: '💡', label: 'What can you do?', prompt: 'What skills and capabilities do you have? How can you help me?' },
-  { emoji: '🆕', label: 'What\'s new?', prompt: 'Tell me about the Lens view framework. What view types are available? How do I create a new view? What can I do with the action bar on each view?' },
+const STARTER_PROMPTS: { icon: LucideIcon; label: string; prompt: string }[] = [
+  { icon: FileText, label: 'Daily briefing', prompt: 'Give me my daily report' },
+  { icon: Compass, label: 'Explore the mind', prompt: 'What do you know about? List your domains and expertise areas.' },
+  { icon: ListChecks, label: 'Check initiatives', prompt: 'What active initiatives are you tracking? Give me a status update.' },
+  { icon: Sparkles, label: 'Create a Lens', prompt: 'Create a new Lens view for me. What data would you like to visualize? Suggest some options based on what you know about this mind.' },
+  { icon: Lightbulb, label: 'What can you do?', prompt: 'What skills and capabilities do you have? How can you help me?' },
+  { icon: Megaphone, label: 'What\'s new?', prompt: 'Tell me about the Lens view framework. What view types are available? How do I create a new view? What can I do with the action bar on each view?' },
 ];
 
 interface Props {
-  onSendMessage: (message: string) => void;
+  onPickPrompt: (prompt: string) => void;
   connected: boolean;
   disabled?: boolean;
 }
 
-export function WelcomeScreen({ onSendMessage, connected, disabled = false }: Props) {
+export function WelcomeScreen({ onPickPrompt, connected, disabled = false }: Props) {
   return (
-    <div className="flex-1 flex flex-col items-center justify-center px-4">
+    <div className="chamber-fade-in flex-1 flex flex-col items-center justify-center px-4">
       <div className="max-w-lg text-center">
         {/* Chamber logo */}
-        <div className="w-16 h-16 rounded-2xl bg-genesis flex items-center justify-center text-2xl font-bold text-primary-foreground mx-auto mb-6">
+        <div className="glow-genesis w-16 h-16 rounded-2xl bg-gradient-to-br from-genesis to-[oklch(0.46_0.14_165)] flex items-center justify-center text-2xl font-bold text-primary-foreground mx-auto mb-6">
           C
         </div>
 
-        <h2 className="text-2xl font-semibold mb-2">Chamber</h2>
-        <p className="text-muted-foreground mb-8">
+        <h2 className="text-2xl font-semibold mb-2 tracking-tight">Chamber</h2>
+        <p className="text-muted-foreground mb-2">
           {connected
             ? 'How can I help you today?'
             : 'Select a mind directory from the sidebar to get started.'}
         </p>
 
         {connected && (
-          <div className="grid grid-cols-3 gap-3 max-w-xl">
-            {STARTER_PROMPTS.map((item) => (
-              <button
-                key={item.label}
-                type="button"
-                disabled={disabled}
-                onClick={() => onSendMessage(item.prompt)}
-                className="text-left p-3 rounded-xl border border-border hover:bg-accent transition-colors group disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
-              >
-                <span className="text-lg mb-1 block">{item.emoji}</span>
-                <span className="text-sm font-medium group-hover:text-foreground">
-                  {item.label}
-                </span>
-              </button>
-            ))}
-          </div>
+          <>
+            <p className="text-xs text-foreground/50 mb-6">
+              Click a starter to stage the prompt in the composer below. Edit it before sending.
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 max-w-xl">
+              {STARTER_PROMPTS.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <button
+                    key={item.label}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => onPickPrompt(item.prompt)}
+                    className="surface-card surface-card-hover text-left p-3 rounded-xl border border-border bg-card group transition-transform duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0"
+                  >
+                    <Icon className="w-5 h-5 mb-2 text-muted-foreground group-hover:text-foreground transition-colors" />
+                    <span className="text-sm font-medium group-hover:text-foreground">
+                      {item.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/apps/web/src/renderer/components/chat/WorkEntryRow.tsx
+++ b/apps/web/src/renderer/components/chat/WorkEntryRow.tsx
@@ -31,6 +31,7 @@ export function WorkEntryRow({ entry, autoExpand = false }: Props) {
   const { Icon, iconClass } = iconAndTone(entry);
   const heading = headingFor(entry);
   const preview = entry.preview;
+  const isReasoning = entry.kind === 'reasoning';
 
   return (
     <div className="rounded-md">
@@ -53,9 +54,21 @@ export function WorkEntryRow({ entry, autoExpand = false }: Props) {
           )}
         />
         <Icon className={cn('h-3.5 w-3.5 shrink-0', iconClass)} />
-        <span className="shrink-0 font-mono font-medium text-foreground/90">{heading}</span>
+        <span
+          className={cn(
+            'shrink-0 font-medium',
+            isReasoning ? 'italic text-muted-foreground/80' : 'font-mono text-foreground/90',
+          )}
+        >
+          {heading}
+        </span>
         {preview && (
-          <span className="ml-1 min-w-0 flex-1 truncate font-mono text-muted-foreground/70">
+          <span
+            className={cn(
+              'ml-1 min-w-0 flex-1 truncate text-muted-foreground/70',
+              isReasoning ? 'italic' : 'font-mono',
+            )}
+          >
             {preview}
           </span>
         )}
@@ -112,7 +125,7 @@ function iconAndTone(entry: WorkEntry): { Icon: ReturnType<typeof iconForToolNam
   const Icon = iconForToolName(entry.toolName);
   const iconClass =
     entry.status === 'error'
-      ? 'text-destructive-foreground'
+      ? 'text-destructive'
       : entry.status === 'running'
         ? 'text-genesis'
         : 'text-foreground/80';
@@ -125,7 +138,7 @@ function StatusGlyph({ status }: { status: 'running' | 'done' | 'error' }) {
   }
   if (status === 'error') {
     return (
-      <X className="h-3 w-3 shrink-0 text-destructive-foreground" aria-label="error" />
+      <X className="h-3 w-3 shrink-0 text-destructive" aria-label="error" />
     );
   }
   return <Check className="h-3 w-3 shrink-0 text-emerald-400/80" aria-label="done" />;
@@ -163,9 +176,9 @@ function permissionOutcomeLabel(outcome: PermissionOutcome): string {
 function EntryDetail({ entry }: { entry: WorkEntry }) {
   if (entry.kind === 'reasoning') {
     return (
-      <pre className="whitespace-pre-wrap break-words border-l-2 border-border px-3 py-1.5 text-[11px] leading-relaxed font-mono text-muted-foreground/70">
+      <div className="whitespace-pre-wrap break-words border-l-2 border-border/70 pl-3 py-0.5 text-[12px] italic leading-relaxed text-muted-foreground/75">
         {entry.block.content}
-      </pre>
+      </div>
     );
   }
   if (entry.kind === 'permission') {
@@ -189,7 +202,7 @@ function EntryDetail({ entry }: { entry: WorkEntry }) {
         </pre>
       )}
       {entry.block.error && (
-        <p className="px-3 py-2 text-xs text-destructive-foreground">{entry.block.error}</p>
+        <p className="px-3 py-2 text-xs text-destructive">{entry.block.error}</p>
       )}
     </div>
   );

--- a/apps/web/src/renderer/components/chat/WorkGroup.test.tsx
+++ b/apps/web/src/renderer/components/chat/WorkGroup.test.tsx
@@ -22,6 +22,11 @@ function entriesFromBlocks(blocks: ContentBlock[]): WorkEntry[] {
   return chunk.entries as WorkEntry[];
 }
 
+/** Expand a collapsed work log by clicking its header toggle. */
+function expandWorkLog(label: RegExp): void {
+  fireEvent.click(screen.getByRole('button', { name: label }));
+}
+
 describe('WorkGroup', () => {
   it('renders all entries with an entry count label', () => {
     const entries = entriesFromBlocks([
@@ -31,6 +36,7 @@ describe('WorkGroup', () => {
     ]);
     render(<WorkGroup entries={entries} />);
     expect(screen.getByText(/Tool calls \(3\)/)).toBeTruthy();
+    expandWorkLog(/Tool calls \(3\)/);
     expect(screen.getByText('grep')).toBeTruthy();
     expect(screen.getByText('read_file')).toBeTruthy();
     expect(screen.getByText('bash')).toBeTruthy();
@@ -46,12 +52,30 @@ describe('WorkGroup', () => {
     expect(screen.getByText(/Work log \(2\)/)).toBeTruthy();
   });
 
+  it('is collapsed by default for a completed (inactive) group', () => {
+    const entries = entriesFromBlocks([
+      tool('tc-1', { toolName: 'grep' }),
+      tool('tc-2', { toolName: 'read_file' }),
+    ]);
+    render(<WorkGroup entries={entries} />);
+    expect(screen.queryByText('grep')).toBeNull();
+    expandWorkLog(/Tool calls \(2\)/);
+    expect(screen.getByText('grep')).toBeTruthy();
+  });
+
+  it('is expanded by default while the group is active', () => {
+    const entries = entriesFromBlocks([tool('tc-1', { toolName: 'grep' })]);
+    render(<WorkGroup entries={entries} isActive />);
+    expect(screen.getByText('grep')).toBeTruthy();
+  });
+
   it('truncates to last 6 entries with a show-more button', () => {
     const blocks: ContentBlock[] = Array.from({ length: 10 }, (_, i) =>
       tool(`tc-${i}`, { toolName: `tool_${i}` }),
     );
     const entries = entriesFromBlocks(blocks);
     render(<WorkGroup entries={entries} />);
+    expandWorkLog(/Tool calls \(10\)/);
     // Newest 6 visible.
     expect(screen.queryByText('tool_0')).toBeNull();
     expect(screen.queryByText('tool_3')).toBeNull();
@@ -68,6 +92,7 @@ describe('WorkGroup', () => {
       tool('tc-1', { toolName: 'grep', output: 'first-line\nsecond-detail-line' }),
     ]);
     render(<WorkGroup entries={entries} />);
+    expandWorkLog(/Tool calls \(1\)/);
     // Detail-only line hidden initially.
     expect(screen.queryByText(/second-detail-line/)).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /grep/ }));
@@ -103,6 +128,7 @@ describe('WorkGroup', () => {
       tool('tc-1', { toolName: 'grep', status: 'done' }),
     ]);
     render(<WorkGroup entries={entries} />);
+    expandWorkLog(/Tool calls \(1\)/);
     const button = screen.getByRole('button', { name: /grep/ });
     expect(button).toHaveProperty('disabled', true);
   });

--- a/apps/web/src/renderer/components/chat/WorkGroup.tsx
+++ b/apps/web/src/renderer/components/chat/WorkGroup.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { WorkEntryRow } from './WorkEntryRow';
 import {
@@ -18,6 +19,11 @@ interface Props {
 }
 
 export function WorkGroup({ entries, isActive = false }: Props) {
+  // Match the common chatbot pattern: the work log is expanded while the mind
+  // is actively working (so progress is visible) and collapses to a one-line
+  // summary once the turn is done. Read isActive once on mount so a group the
+  // user has manually toggled is never yanked open or shut by a later restream.
+  const [collapsed, setCollapsed] = useState(!isActive);
   const [isExpanded, setIsExpanded] = useState(false);
   const { visible, hiddenCount } = truncateWorkEntries(entries, isExpanded);
   const label = workGroupLabel(entries);
@@ -27,14 +33,39 @@ export function WorkGroup({ entries, isActive = false }: Props) {
   // output is streaming in before the next block arrives, should still show
   // live output.
   const lastRunningToolId = findLastRunningToolId(entries);
+  const running = hasRunningTool(entries);
 
   return (
-    <div className="my-2 rounded-xl border border-border/50 bg-card/30 px-2 py-1.5">
-      <div className="mb-1 flex items-center justify-between gap-2 px-1">
-        <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground/60">
-          {label} ({entries.length})
-        </p>
-        {hasOverflow && (
+    <div
+      className={cn(
+        'my-2 rounded-xl border px-2 py-1.5 transition-colors',
+        running ? 'border-genesis/40 bg-genesis/5' : 'border-border bg-card/50',
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 px-1">
+        <button
+          type="button"
+          onClick={() => setCollapsed((v) => !v)}
+          aria-expanded={!collapsed}
+          className={cn(
+            'flex items-center gap-1.5 rounded text-[11px] uppercase tracking-[0.14em]',
+            running ? 'text-genesis' : 'text-muted-foreground',
+            'hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          )}
+        >
+          {collapsed ? (
+            <ChevronRight size={11} aria-hidden />
+          ) : (
+            <ChevronDown size={11} aria-hidden />
+          )}
+          {running && (
+            <Loader2 size={11} className="animate-spin text-genesis" aria-hidden />
+          )}
+          <span>
+            {label} ({entries.length})
+          </span>
+        </button>
+        {!collapsed && hasOverflow && (
           <button
             type="button"
             onClick={() => setIsExpanded((v) => !v)}
@@ -47,15 +78,17 @@ export function WorkGroup({ entries, isActive = false }: Props) {
           </button>
         )}
       </div>
-      <div className="space-y-0.5">
-        {visible.map((entry) => (
-          <WorkEntryRow
-            key={entry.id}
-            entry={entry}
-            autoExpand={isActive && entry.id === lastRunningToolId}
-          />
-        ))}
-      </div>
+      {!collapsed && (
+        <div className="mt-1 space-y-0.5">
+          {visible.map((entry) => (
+            <WorkEntryRow
+              key={entry.id}
+              entry={entry}
+              autoExpand={isActive && entry.id === lastRunningToolId}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/renderer/components/chat/agentColors.ts
+++ b/apps/web/src/renderer/components/chat/agentColors.ts
@@ -2,7 +2,36 @@ import type { MindContext } from '@chamber/shared/types';
 
 export const AGENT_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
 
-export function agentColor(minds: MindContext[], mindId: string): string {
+/**
+ * Resolves an agent's display color. A user-chosen accent (surfaced via the
+ * profile summary map) wins; otherwise the agent falls back to a stable
+ * position in {@link AGENT_COLORS} keyed by its index in `minds`.
+ */
+export function agentColor(
+  minds: MindContext[],
+  mindId: string,
+  accentByMindId?: Record<string, { accentColor?: string | null } | undefined>,
+): string {
+  const accent = accentByMindId?.[mindId]?.accentColor;
+  if (accent) return accent;
   const idx = minds.findIndex(m => m.mindId === mindId);
   return AGENT_COLORS[(idx >= 0 ? idx : 0) % AGENT_COLORS.length];
+}
+
+/**
+ * Picks black or white text for legibility on a solid hex background, using
+ * the WCAG-style relative luminance of the background. Light agent colors
+ * (e.g. amber) get black text; dark ones get white. Falls back to white for
+ * an unknown/malformed color.
+ */
+export function readableTextColor(hex?: string): string {
+  if (!hex) return '#fff';
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return '#fff';
+  const int = parseInt(match[1], 16);
+  const r = (int >> 16) & 0xff;
+  const g = (int >> 8) & 0xff;
+  const b = int & 0xff;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6 ? '#000' : '#fff';
 }

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -9,6 +9,7 @@ export interface AgentProfileSummary {
   mindId: string;
   displayName: string;
   avatarDataUrl: string | null;
+  accentColor?: string | null;
 }
 
 // Per-mind conversation view state machine:


### PR DESCRIPTION
## What

Chat message-rendering polish, split off `feat/webgl-ambient-background` onto the `refactor/ui-foundation` base (#389). Sibling of voice (#387), ambient (#386), chrome (#390). Base of the chatroom-sessions slice, which stacks on this.

## Contents (18 files, +974/-206)

- `MessageList`, `StreamingMessage`: memoized rows, streaming caret, scroll-to-bottom behavior, render polish.
- `ChatInput`: composer affordances.
- `WelcomeScreen`, `AgentWelcome`: empty-state polish.
- `WorkGroup`, `WorkEntryRow`, `MessageActions`, `agentColors`: tool-call grouping + per-agent color tokens.
- Voice-specific rendering intentionally deferred to the voice branch (#387).

## Stack

```
master
 └─ refactor/ui-foundation #389
     |- voice #387 . ambient #386 . app-chrome #390
     `- chat-polish (this) <- chatroom-sessions stacks on this
```

## Validation

- `npm run lint` -- green (tsc, eslint, dependency-cruiser, yaml, md).
- Tests -- 125 passed (9 chat component test files).
