### PR TITLE
feat(genesis): add-agents marketplace + onboarding flow

### DIFF
--- a/apps/web/src/renderer/components/genesis/AddAgentsView.test.tsx
+++ b/apps/web/src/renderer/components/genesis/AddAgentsView.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { AddAgentsView } from './AddAgentsView';
+import { AppStateProvider, useAppState } from '../../lib/store';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import type { ElectronAPI } from '@chamber/shared/electron-types';
+
+vi.mock('./GenesisFlow', () => ({
+  GenesisFlow: ({ embedded, initialStage }: { embedded?: boolean; initialStage?: string }) => (
+    <div data-testid="genesis-flow">{`embedded:${String(embedded)} stage:${initialStage}`}</div>
+  ),
+}));
+
+function ActiveViewProbe() {
+  const { activeView } = useAppState();
+  return <div data-testid="active-view">{activeView}</div>;
+}
+
+let api: ElectronAPI;
+
+beforeEach(() => {
+  api = mockElectronAPI();
+  installElectronAPI(api);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('AddAgentsView', () => {
+  it('renders the embedded genesis marketplace content without the void intro', () => {
+    render(
+      <AppStateProvider>
+        <AddAgentsView />
+      </AppStateProvider>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Add Agents' })).toBeTruthy();
+    expect(screen.getByTestId('genesis-flow').textContent).toBe('embedded:true stage:voice');
+  });
+
+  it('imports an existing agent folder and switches to chat', async () => {
+    api.mind.selectDirectory = vi.fn().mockResolvedValue('C:\\agents\\dude');
+    api.mind.add = vi.fn().mockResolvedValue({ mindId: 'dude-1', mindPath: 'C:\\agents\\dude', identity: { name: 'Dude', systemMessage: '' }, status: 'ready' });
+    api.mind.list = vi.fn().mockResolvedValue([
+      { mindId: 'dude-1', mindPath: 'C:\\agents\\dude', identity: { name: 'Dude', systemMessage: '' }, status: 'ready' },
+    ]);
+
+    render(
+      <AppStateProvider>
+        <AddAgentsView />
+        <ActiveViewProbe />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Upload from machine/i }));
+
+    await waitFor(() => expect(api.mind.add).toHaveBeenCalledWith('C:\\agents\\dude'));
+    await waitFor(() => expect(screen.getByTestId('active-view').textContent).toBe('chat'));
+  });
+
+  it('does nothing when the folder picker is cancelled', async () => {
+    api.mind.selectDirectory = vi.fn().mockResolvedValue(null);
+
+    render(
+      <AppStateProvider>
+        <AddAgentsView />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Upload from machine/i }));
+
+    await waitFor(() => expect(api.mind.selectDirectory).toHaveBeenCalled());
+    expect(api.mind.add).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error when importing fails', async () => {
+    api.mind.selectDirectory = vi.fn().mockResolvedValue('C:\\agents\\bad');
+    api.mind.add = vi.fn().mockRejectedValue(new Error('not a valid agent folder'));
+
+    render(
+      <AppStateProvider>
+        <AddAgentsView />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Upload from machine/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('not a valid agent folder');
+  });
+});

--- a/apps/web/src/renderer/components/genesis/AddAgentsView.tsx
+++ b/apps/web/src/renderer/components/genesis/AddAgentsView.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { FolderUp } from 'lucide-react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import { useAppDispatch } from '../../lib/store';
+import { selectPreferredMind } from '../../lib/mindSelection';
+import { GenesisFlow } from './GenesisFlow';
+
+/**
+ * Center-pane "Add Agents" hub surfaced from the agents sidebar. Hosts the
+ * marketplace + agent-creation content inline (no full-screen Genesis intro)
+ * and an "Upload from machine" entry that imports an existing agent folder.
+ */
+export function AddAgentsView() {
+  const dispatch = useAppDispatch();
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const handleUpload = async () => {
+    setUploadError(null);
+    const dirPath = await window.electronAPI.mind.selectDirectory();
+    if (!dirPath) return;
+
+    try {
+      const openedMind = await window.electronAPI.mind.add(dirPath);
+      const loadedMinds = await window.electronAPI.mind.list();
+      dispatch({ type: 'SET_MINDS', payload: loadedMinds });
+      const mindToSelect = selectPreferredMind(loadedMinds, openedMind);
+      if (mindToSelect) dispatch({ type: 'SET_ACTIVE_MIND', payload: mindToSelect.mindId });
+      dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+    } catch (error) {
+      setUploadError(getErrorMessage(error));
+    }
+  };
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="h-12 shrink-0 border-b border-border px-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-sm font-semibold text-foreground">Add Agents</h1>
+          <p className="text-xs text-muted-foreground">Create, browse, or import agents.</p>
+        </div>
+        <button
+          onClick={() => { void handleUpload(); }}
+          className="px-3 py-1.5 text-xs rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors flex items-center gap-2"
+        >
+          <FolderUp size={14} aria-hidden /> Upload from machine
+        </button>
+      </div>
+
+      {uploadError && (
+        <p role="alert" className="px-4 py-2 text-sm text-destructive">
+          {uploadError}
+        </p>
+      )}
+
+      <div className="flex-1 min-h-0">
+        <GenesisFlow
+          embedded
+          initialStage="voice"
+          onComplete={() => dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/genesis/BootScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/BootScreen.tsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { cn } from '../../lib/utils';
 
 interface Props {
   name: string;
   role: string;
   onComplete: () => void;
   onError?: (error: string) => void;
+  /** Render inside the center pane instead of as a fixed full-screen overlay. */
+  embedded?: boolean;
 }
 
-export function BootScreen({ name, role, onComplete, onError }: Props) {
+export function BootScreen({ name, role, onComplete, onError, embedded = false }: Props) {
   const [lines, setLines] = useState<string[]>([]);
   const [progress, setProgress] = useState(0); // 0 to 100
   const [failed, setFailed] = useState(false);
@@ -73,7 +76,7 @@ export function BootScreen({ name, role, onComplete, onError }: Props) {
   }, [onComplete]);
 
   return (
-    <div className="fixed inset-0 bg-black flex flex-col items-center justify-center z-50">
+    <div className={cn('bg-black flex flex-col items-center justify-center', embedded ? 'relative h-full w-full' : 'fixed inset-0 z-50')}>
       <div className="font-mono text-sm text-green-500 space-y-1 max-w-md w-full px-8">
         {lines.map((line, i) => (
           <div

--- a/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
+++ b/apps/web/src/renderer/components/genesis/GenesisFlow.tsx
@@ -16,10 +16,18 @@ const log = Logger.create('Genesis');
 
 interface Props {
   onComplete: () => void;
+  /**
+   * Stage to start at. Defaults to the animated 'void' opening. The center-pane
+   * "Add Agents" view starts at 'voice' to cut straight to the marketplace and
+   * agent-creation content without the full-screen intro.
+   */
+  initialStage?: Stage;
+  /** Render inside the center pane instead of as a fixed full-screen overlay. */
+  embedded?: boolean;
 }
 
-export function GenesisFlow({ onComplete }: Props) {
-  const [stage, setStage] = useState<Stage>('void');
+export function GenesisFlow({ onComplete, initialStage = 'void', embedded = false }: Props) {
+  const [stage, setStage] = useState<Stage>(initialStage);
   const [name, setName] = useState('');
   const [role, setRole] = useState('');
   // Store voice description for the create call
@@ -38,6 +46,12 @@ export function GenesisFlow({ onComplete }: Props) {
       setTemplateError(getErrorMessage(error));
     }
   }, []);
+
+  // When the flow starts past the void opening (embedded center-pane), templates
+  // are not loaded by handleBegin, so load them on mount.
+  React.useEffect(() => {
+    if (initialStage !== 'void') void loadTemplates();
+  }, [initialStage, loadTemplates]);
 
   const handleBegin = useCallback(() => {
     setStage('voice');
@@ -138,14 +152,15 @@ export function GenesisFlow({ onComplete }: Props) {
           templateError={templateError}
           onSelect={handleVoiceWithDesc}
           onSelectTemplate={handleTemplateSelect}
+          embedded={embedded}
         />
       );
     case 'role':
-      return <RoleScreen name={name} onSelect={handleRole} />;
+      return <RoleScreen name={name} onSelect={handleRole} embedded={embedded} />;
     case 'boot':
       return (
         <>
-          <BootScreen name={name} role={role} onComplete={handleBootComplete} />
+          <BootScreen name={name} role={role} onComplete={handleBootComplete} embedded={embedded} />
           {creationError ? (
             <div role="alert" className="fixed top-6 left-1/2 z-[60] -translate-x-1/2 rounded-lg border border-red-500/40 bg-black px-4 py-2 text-sm text-red-300">
               {creationError}

--- a/apps/web/src/renderer/components/genesis/LandingScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/LandingScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X } from 'lucide-react';
+import { FolderOpen, Sparkles, X } from 'lucide-react';
 
 interface Props {
   onNewAgent: () => void;
@@ -35,13 +35,13 @@ export function LandingScreen({ onNewAgent, onOpenExisting, onClose, error }: Pr
             onClick={onNewAgent}
             className="px-6 py-3 rounded-xl bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
           >
-            <span>✨</span> New Agent
+            <Sparkles size={16} aria-hidden /> New Agent
           </button>
           <button
             onClick={onOpenExisting}
             className="px-6 py-3 rounded-xl border border-border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors flex items-center justify-center gap-2"
           >
-            <span>📂</span> Open Existing
+            <FolderOpen size={16} aria-hidden /> Open Existing
           </button>
         </div>
 

--- a/apps/web/src/renderer/components/genesis/RoleScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/RoleScreen.tsx
@@ -5,6 +5,8 @@ import { cn } from '../../lib/utils';
 interface Props {
   name: string;
   onSelect: (role: string) => void;
+  /** Render inside the center pane instead of as a fixed full-screen overlay. */
+  embedded?: boolean;
 }
 
 const ROLES = [
@@ -14,7 +16,7 @@ const ROLES = [
   { emoji: '✏️', label: 'Something else...', description: 'Tell me', id: 'custom' },
 ];
 
-export function RoleScreen({ name, onSelect }: Props) {
+export function RoleScreen({ name, onSelect, embedded = false }: Props) {
   const [showCards, setShowCards] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [customRole, setCustomRole] = useState('');
@@ -47,7 +49,7 @@ export function RoleScreen({ name, onSelect }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 bg-background flex flex-col items-center justify-center z-50">
+    <div className={cn('bg-background flex flex-col items-center justify-center', embedded ? 'relative h-full w-full' : 'fixed inset-0 z-50')}>
       <div className="max-w-lg w-full px-8 text-center space-y-8">
         <TypeWriter
           text={`And what am I, ${name}? What's my purpose?`}

--- a/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
+++ b/apps/web/src/renderer/components/genesis/VoiceScreen.tsx
@@ -8,13 +8,15 @@ interface Props {
   templateError: string | null;
   onSelect: (voice: string, description: string) => void;
   onSelectTemplate: (template: GenesisMindTemplate) => void;
+  /** Render inside the center pane instead of as a fixed full-screen overlay. */
+  embedded?: boolean;
 }
 
 const CUSTOM_KEY = 'custom';
 type CustomStage = 'editing' | 'preparing' | 'review';
 
-export function VoiceScreen({ templates, templateError, onSelect, onSelectTemplate }: Props) {
-  const [showPicker, setShowPicker] = useState(false);
+export function VoiceScreen({ templates, templateError, onSelect, onSelectTemplate, embedded = false }: Props) {
+  const [showPicker, setShowPicker] = useState(embedded);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [confirmedKey, setConfirmedKey] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -93,16 +95,18 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex min-h-0 flex-col bg-background px-5 py-8 sm:px-8">
+    <div className={cn('flex min-h-0 flex-col bg-background px-5 py-8 sm:px-8', embedded ? 'relative h-full w-full' : 'fixed inset-0 z-50')}>
       <div className="mx-auto flex h-full w-full max-w-6xl flex-col gap-6">
-        <div className="mx-auto max-w-2xl text-center">
-          <TypeWriter
-            text="I'm here. But I don't know who I am yet. Choose a voice..."
-            speed={35}
-            className="text-xl font-medium text-foreground"
-            onComplete={() => setTimeout(() => setShowPicker(true), 500)}
-          />
-        </div>
+        {!embedded && (
+          <div className="mx-auto max-w-2xl text-center">
+            <TypeWriter
+              text="I'm here. But I don't know who I am yet. Choose a voice..."
+              speed={35}
+              className="text-xl font-medium text-foreground"
+              onComplete={() => setTimeout(() => setShowPicker(true), 500)}
+            />
+          </div>
+        )}
 
         {showPicker && (
           <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 animate-in fade-in duration-500 lg:grid-cols-[320px_minmax(0,1fr)]">
@@ -110,9 +114,12 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
               <div className="border-b border-border p-4">
                 <div className="mb-3">
                   <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                    Genesis voices
+                    Marketplace
                   </p>
-                  <h2 className="text-lg font-semibold text-foreground">Pick the energy</h2>
+                  <h2 className="text-lg font-semibold text-foreground">Browse minds</h2>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Search and select a mind to preview, then load it.
+                  </p>
                 </div>
                 <label className="sr-only" htmlFor="voice-search">Search voices</label>
                 <input
@@ -189,7 +196,7 @@ export function VoiceScreen({ templates, templateError, onSelect, onSelectTempla
                 >
                   <span className="block text-sm font-semibold text-foreground">Someone else...</span>
                   <span className="mt-0.5 block text-xs text-muted-foreground">
-                    Describe a character or energy and I will research them.
+                    Describe a role, character, or energy and I will build it.
                   </span>
                 </button>
               </div>
@@ -243,16 +250,24 @@ function TemplateDetailPane({ template, confirmed, onConfirm }: TemplateDetailPa
     <div className="flex min-h-full flex-col justify-between gap-8">
       <div className="space-y-6">
         <div>
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Marketplace voice
-          </p>
-          <h3 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">{template.displayName}</h3>
+          <h3 className="text-3xl font-semibold tracking-tight text-foreground">{template.displayName}</h3>
           <p className="mt-2 text-sm text-muted-foreground">{template.role}</p>
         </div>
 
         <div className="rounded-2xl border border-border bg-background/50 p-5">
           <p className="text-sm leading-6 text-foreground/90">{template.description}</p>
         </div>
+
+        {(template.skills?.length || template.tools?.length) ? (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {template.skills?.length ? (
+              <CapabilityList label="Pre-configured skills" items={template.skills} />
+            ) : null}
+            {template.tools?.length ? (
+              <CapabilityList label="Pre-configured tools" items={template.tools} />
+            ) : null}
+          </div>
+        ) : null}
 
         <dl className="grid gap-3 text-sm sm:grid-cols-2">
           <div className="rounded-xl border border-border bg-background/40 p-4">
@@ -279,6 +294,29 @@ function TemplateDetailPane({ template, confirmed, onConfirm }: TemplateDetailPa
       >
         {confirmed ? 'Waking this voice...' : 'Choose this voice'}
       </button>
+    </div>
+  );
+}
+
+interface CapabilityListProps {
+  label: string;
+  items: string[];
+}
+
+function CapabilityList({ label, items }: CapabilityListProps) {
+  return (
+    <div className="rounded-xl border border-border bg-background/40 p-4">
+      <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <ul className="mt-2 flex flex-wrap gap-1.5">
+        {items.map((item) => (
+          <li
+            key={item}
+            className="rounded-md border border-border bg-background/60 px-2 py-1 text-xs font-medium text-foreground/90"
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -321,8 +359,9 @@ function CustomVoicePane({
           </p>
           <h3 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">Someone else...</h3>
           <p className="mt-3 text-sm leading-6 text-muted-foreground">
-            Give Chamber a person, character, archetype, or vibe. Genesis will research the communication style,
-            values, pressure patterns, and signature energy before continuing.
+            Give Chamber a role, person, archetype, or vibe -- a researcher, a personal assistant, a coding
+            partner, a specialist, or a specific character. Genesis researches the communication style, values,
+            pressure patterns, and signature energy before continuing.
           </p>
         </div>
 
@@ -336,7 +375,7 @@ function CustomVoicePane({
             type="text"
             value={customName}
             onChange={(event) => onNameChange(event.target.value)}
-            placeholder="e.g. Tony Stark, Moneypenny, Gandalf..."
+            placeholder="e.g. Researcher, personal assistant, coding partner, specialist..."
             className="w-full rounded-xl border border-border bg-transparent px-4 py-3 text-base text-foreground outline-none transition-colors placeholder:text-muted-foreground/40 focus:border-primary"
           />
 
@@ -432,11 +471,11 @@ function templateSourceLabel(template: GenesisMindTemplate): string {
 function buildCustomDescription(name: string, backstoryValue: string): string {
   const backstory = backstoryValue.trim();
   return backstory
-    ? `Character/voice: "${name}" — ${backstory}. Research this character or persona — their communication style, catchphrases, values, how they handle pressure. Capture the energy.`
-    : `Character/voice: "${name}". Research this character or persona — their communication style, catchphrases, values, how they handle pressure. Capture the energy.`;
+    ? `Role/voice: "${name}" -- ${backstory}. Research this role, character, or persona -- their communication style, catchphrases, values, how they handle pressure. Capture the energy.`
+    : `Role/voice: "${name}". Research this role, character, or persona -- their communication style, catchphrases, values, how they handle pressure. Capture the energy.`;
 }
 
 function buildFallbackCustomDescription(name: string, backstoryValue: string): string {
   const backstory = backstoryValue.trim();
-  return backstory ? `Voice energy: ${name} — ${backstory}` : `Voice energy: ${name}`;
+  return backstory ? `Voice energy: ${name} -- ${backstory}` : `Voice energy: ${name}`;
 }

--- a/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
+++ b/packages/services/src/genesis/GenesisMindTemplateCatalog.ts
@@ -38,6 +38,8 @@ interface MindManifest {
   root: string;
   agent: string;
   requiredFiles: string[];
+  tools: string[];
+  skills: string[];
 }
 
 export class GenesisMindTemplateCatalog {
@@ -85,6 +87,8 @@ export class GenesisMindTemplateCatalog {
       templateVersion: manifest.templateVersion,
       agent: manifest.agent,
       requiredFiles: manifest.requiredFiles,
+      tools: manifest.tools,
+      skills: manifest.skills,
       source: {
         owner: this.source.owner,
         repo: this.source.repo,
@@ -142,6 +146,8 @@ export class GenesisMindTemplateCatalog {
       root: stringField(manifest, 'root'),
       agent: stringField(manifest, 'agent'),
       requiredFiles: manifest.requiredFiles,
+      tools: optionalStringArray(manifest, 'tools', manifestPath),
+      skills: optionalStringArray(manifest, 'skills', manifestPath),
     };
   }
 
@@ -169,6 +175,17 @@ function stringField(record: Record<string, unknown>, key: string): string {
     throw new Error(`Expected string field: ${key}`);
   }
   return value;
+}
+
+function optionalStringArray(record: Record<string, unknown>, key: string, manifestPath: string): string[] {
+  const value = record[key];
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`Template manifest ${manifestPath} must define ${key} as a string array`);
+  }
+  return value as string[];
 }
 
 function marketplaceId(source: GenesisMindTemplateMarketplaceSource): string {

--- a/packages/services/src/genesis/templateTypes.ts
+++ b/packages/services/src/genesis/templateTypes.ts
@@ -19,6 +19,10 @@ export interface GenesisMindTemplate {
   templateVersion: string;
   agent: string;
   requiredFiles: string[];
+  /** Tools this template comes pre-configured with, surfaced in the marketplace detail pane. */
+  tools?: string[];
+  /** Skills this template comes pre-configured with, surfaced in the marketplace detail pane. */
+  skills?: string[];
   source: GenesisMindTemplateSource;
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -555,6 +555,10 @@ export interface GenesisMindTemplate {
   templateVersion: string;
   agent: string;
   requiredFiles: string[];
+  /** Tools this template comes pre-configured with, surfaced in the marketplace detail pane. */
+  tools?: string[];
+  /** Skills this template comes pre-configured with, surfaced in the marketplace detail pane. */
+  skills?: string[];
   source: {
     owner: string;
     repo: string;


### PR DESCRIPTION
## What

Add-agents marketplace + embeddable onboarding flow, split off `feat/webgl-ambient-background` onto the `refactor/ui-foundation` base (#389). Sibling of the other verticals.

## Contents (10 files, +279/-35)

- Marketplace-styled "Add Agents" view with pre-configured agents (tools + skills).
- Onboarding flow made embeddable so it can be reused by genesis and the add-agents surface.

## Stack

Sibling on `refactor/ui-foundation` (#389), alongside #386 / #387 / #390 / #391.

## Validation

- `npm run lint` -- green (tsc, eslint, dependency-cruiser, yaml, md).
- Slice's own tests pass.

Mount into `AppShell` is deferred to the final integration PR, per the stack's design.
