### PR TITLE
feat(update): theme-aware update banner + indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Add chamber:a2a ttasks runtime support** — Adds a chamber:a2a custom task type, production A2A bridge wiring, durable ttasks persistence, and invariants for the runtime contract.
+- **Add theme-aware update chrome** — Adds a dismissible ready-to-install banner and update-status indicator with accessible light and dark theme colors.
 
 ### Refactor
 

--- a/apps/web/src/renderer/components/layout/UpdateBanner.test.tsx
+++ b/apps/web/src/renderer/components/layout/UpdateBanner.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { DesktopUpdateState } from '@chamber/shared/types';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import { TooltipProvider } from '../ui/tooltip';
+import { UpdateBanner } from './UpdateBanner';
+
+const SESSION_KEY = 'chamber:update-banner-dismissed-version';
+
+function renderBanner() {
+  return render(
+    <TooltipProvider>
+      <UpdateBanner />
+    </TooltipProvider>,
+  );
+}
+
+function makeState(overrides: Partial<DesktopUpdateState> = {}): DesktopUpdateState {
+  return {
+    enabled: true,
+    status: 'downloaded',
+    currentVersion: '0.64.1',
+    downloadedVersion: '0.65.0',
+    downloadPercent: 100,
+    message: null,
+    canRetry: false,
+    ...overrides,
+  };
+}
+
+describe('UpdateBanner', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    api = installElectronAPI();
+  });
+
+  afterEach(() => {
+    cleanup();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when updater is disabled', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState({ enabled: false }));
+    renderBanner();
+    await act(async () => {});
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('renders nothing for non-downloaded states', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState({ status: 'up-to-date' }));
+    renderBanner();
+    await act(async () => {});
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('shows a restart-now CTA naming the downloaded version', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState());
+    renderBanner();
+    await act(async () => {});
+
+    const banner = await screen.findByRole('status');
+    expect(banner.textContent).toContain('Chamber 0.65.0 is ready to install');
+    expect(screen.getByRole('button', { name: 'Restart now' })).toBeTruthy();
+  });
+
+  it('calls installAndRestart when the user clicks Restart now', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState());
+    renderBanner();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart now' }));
+    expect(api.updater.installAndRestart).toHaveBeenCalledOnce();
+  });
+
+  it('dismissing hides the banner for that version only', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState());
+    renderBanner();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss update reminder' }));
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe('0.65.0');
+
+    cleanup();
+
+    // A newer downloaded version should re-surface the banner.
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState({ downloadedVersion: '0.65.1' }));
+    renderBanner();
+    await act(async () => {});
+    expect(await screen.findByRole('status')).toBeTruthy();
+  });
+});

--- a/apps/web/src/renderer/components/layout/UpdateBanner.tsx
+++ b/apps/web/src/renderer/components/layout/UpdateBanner.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { RefreshCw, X } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import { useDesktopUpdater } from '../../hooks/useDesktopUpdater';
+import { TooltipFor } from '../ui/tooltip';
+
+const DISMISSED_STORAGE_KEY = 'chamber:update-banner-dismissed-version';
+
+/**
+ * Top-of-shell banner shown when an update has been downloaded and is waiting
+ * for the user to restart. Surfaces the destructive nature of restart (loses
+ * in-flight streaming responses) instead of hiding it behind a 40x40 rail icon.
+ *
+ * Dismissable per downloaded version: dismissing v0.65.0 won't suppress the
+ * banner for v0.65.1.
+ */
+export function UpdateBanner() {
+  const { state, installAndRestart } = useDesktopUpdater();
+  const [dismissed, setDismissed] = useState<string | null>(
+    () => sessionStorage.getItem(DISMISSED_STORAGE_KEY),
+  );
+
+  if (!state?.enabled) return null;
+  if (state.status !== 'downloaded') return null;
+
+  const version = state.downloadedVersion ?? 'a new version';
+  if (dismissed && dismissed === version) return null;
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(DISMISSED_STORAGE_KEY, version);
+    setDismissed(version);
+  };
+
+  const handleRestart = () => {
+    void installAndRestart();
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'flex items-center justify-between gap-3 px-4 py-2 text-sm',
+        'border-b border-warning/40 bg-warning/10 text-foreground',
+      )}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <RefreshCw size={16} className="shrink-0" aria-hidden />
+        <span className="truncate">
+          Chamber {version} is ready to install. Restart to apply.
+        </span>
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <button
+          type="button"
+          onClick={handleRestart}
+          className="rounded-md bg-warning px-3 py-1 text-xs font-medium text-warning-foreground hover:bg-warning/90 transition-colors"
+        >
+          Restart now
+        </button>
+        <TooltipFor label="Dismiss until next launch">
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss update reminder"
+            className="rounded-md p-1 text-foreground/70 hover:text-foreground hover:bg-warning/10 transition-colors"
+          >
+            <X size={16} aria-hidden />
+          </button>
+        </TooltipFor>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/layout/UpdateIndicator.test.tsx
+++ b/apps/web/src/renderer/components/layout/UpdateIndicator.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { DesktopUpdateState } from '@chamber/shared/types';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import { TooltipProvider } from '../ui/tooltip';
+import { UpdateIndicator } from './UpdateIndicator';
+
+type StateCallback = (state: DesktopUpdateState) => void;
+
+function renderIndicator() {
+  return render(
+    <TooltipProvider>
+      <UpdateIndicator />
+    </TooltipProvider>,
+  );
+}
+
+function makeState(overrides: Partial<DesktopUpdateState> = {}): DesktopUpdateState {
+  return {
+    enabled: true,
+    status: 'up-to-date',
+    currentVersion: '0.64.1',
+    downloadPercent: null,
+    message: null,
+    canRetry: false,
+    ...overrides,
+  };
+}
+
+describe('UpdateIndicator', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+  let stateCallback: StateCallback | null;
+
+  beforeEach(() => {
+    api = installElectronAPI();
+    stateCallback = null;
+    (api.updater.onStateChanged as ReturnType<typeof vi.fn>).mockImplementation((cb: StateCallback) => {
+      stateCallback = cb;
+      return () => { stateCallback = null; };
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when updater is disabled', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState({ enabled: false }));
+    renderIndicator();
+    await act(async () => {});
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('shows download percent under the icon while downloading', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState({
+      status: 'downloading',
+      downloadPercent: 47,
+    }));
+    renderIndicator();
+    const btn = await screen.findByRole('button');
+    expect(btn.textContent).toContain('47%');
+  });
+
+  it('flashes "You\'re up to date" feedback after a user-initiated check resolves with up-to-date', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState({ status: 'up-to-date' }));
+    (api.updater.check as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+
+    renderIndicator();
+    const btn = await screen.findByRole('button', { name: 'Check for updates' });
+
+    // Click triggers a user-initiated check; simulate the backend flipping to
+    // 'checking' then back to 'up-to-date'. The indicator must surface a
+    // transient confirmation so the click doesn't feel like a no-op.
+    fireEvent.click(btn);
+    expect(api.updater.check).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      stateCallback?.(makeState({ status: 'checking' }));
+    });
+    await act(async () => {
+      stateCallback?.(makeState({ status: 'up-to-date' }));
+    });
+
+    expect(screen.getByRole('button', { name: "You're up to date" })).toBeTruthy();
+  });
+
+  it('does not flash feedback when the state arrives without a user-initiated check', async () => {
+    (api.updater.getState as ReturnType<typeof vi.fn>).mockResolvedValue(makeState({ status: 'up-to-date' }));
+    renderIndicator();
+    await screen.findByRole('button', { name: 'Check for updates' });
+
+    // Background state-change event (e.g. periodic poll) should not flash feedback.
+    await act(async () => {
+      stateCallback?.(makeState({ status: 'up-to-date' }));
+    });
+
+    expect(screen.getByRole('button', { name: 'Check for updates' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: "You're up to date" })).toBeNull();
+  });
+});

--- a/apps/web/src/renderer/components/layout/UpdateIndicator.tsx
+++ b/apps/web/src/renderer/components/layout/UpdateIndicator.tsx
@@ -1,11 +1,39 @@
-import React from 'react';
-import { Download, RefreshCw, Rocket, RotateCw } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { Check, Download, RefreshCw, Rocket, RotateCw } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { cn } from '../../lib/utils';
 import { useDesktopUpdater } from '../../hooks/useDesktopUpdater';
 
+// How long to surface "Just checked - up to date" feedback after a user-
+// initiated check resolves with no available update.
+const JUST_CHECKED_MS = 3000;
+
 export function UpdateIndicator() {
   const { state, check, download, installAndRestart } = useDesktopUpdater();
+  const [justChecked, setJustChecked] = useState(false);
+  const userCheckPendingRef = useRef(false);
+  const justCheckedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // When a user-initiated check resolves with up-to-date, show transient
+  // confirmation so the click doesn't feel like a no-op.
+  useEffect(() => {
+    if (!state) return;
+    if (!userCheckPendingRef.current) return;
+    if (state.status === 'checking') return;
+
+    userCheckPendingRef.current = false;
+    if (state.status === 'up-to-date') {
+      setJustChecked(true);
+      if (justCheckedTimerRef.current) clearTimeout(justCheckedTimerRef.current);
+      justCheckedTimerRef.current = setTimeout(() => setJustChecked(false), JUST_CHECKED_MS);
+    }
+  }, [state]);
+
+  useEffect(() => {
+    return () => {
+      if (justCheckedTimerRef.current) clearTimeout(justCheckedTimerRef.current);
+    };
+  }, []);
 
   if (!state?.enabled) return null;
 
@@ -27,26 +55,32 @@ export function UpdateIndicator() {
       void installAndRestart();
       return;
     }
+    userCheckPendingRef.current = true;
+    setJustChecked(false);
     void check();
   };
 
-  const Icon = state.status === 'available'
-    ? Download
-    : state.status === 'downloaded'
-      ? Rocket
-      : state.status === 'error'
-        ? RotateCw
-        : RefreshCw;
+  const Icon = justChecked
+    ? Check
+    : state.status === 'available'
+      ? Download
+      : state.status === 'downloaded'
+        ? Rocket
+        : state.status === 'error'
+          ? RotateCw
+          : RefreshCw;
 
-  const label = state.status === 'available'
-    ? `Download Chamber ${state.availableVersion}`
-    : state.status === 'downloaded'
-      ? `Restart to install Chamber ${state.downloadedVersion}`
-      : state.status === 'downloading'
-        ? `Downloading update${percent === null ? '' : ` ${percent}%`}`
-        : state.status === 'up-to-date'
-          ? 'Check for updates'
-          : state.message ?? 'Check for updates';
+  const label = justChecked
+    ? "You're up to date"
+    : state.status === 'available'
+      ? `Download Chamber ${state.availableVersion}`
+      : state.status === 'downloaded'
+        ? `Restart to install Chamber ${state.downloadedVersion}`
+        : state.status === 'downloading'
+          ? `Downloading update${percent === null ? '' : ` ${percent}%`}`
+          : state.status === 'up-to-date'
+            ? 'Check for updates'
+            : state.message ?? 'Check for updates';
 
   return (
     <Tooltip delayDuration={300}>
@@ -57,18 +91,25 @@ export function UpdateIndicator() {
           onClick={handleClick}
           disabled={!canAct}
           className={cn(
-            'relative w-10 h-10 rounded-lg flex items-center justify-center transition-colors',
-            state.status === 'available' || state.status === 'downloaded'
-              ? 'text-yellow-300 hover:text-yellow-200 hover:bg-yellow-400/10'
-              : state.status === 'error'
-                ? 'text-destructive hover:bg-destructive/10'
-                : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
+            'relative w-10 h-10 rounded-lg flex flex-col items-center justify-center transition-colors',
+            justChecked
+              ? 'text-green-400 hover:text-green-300 hover:bg-green-400/10'
+              : state.status === 'available' || state.status === 'downloaded'
+                ? 'text-yellow-300 hover:text-yellow-200 hover:bg-yellow-400/10'
+                : state.status === 'error'
+                  ? 'text-destructive hover:bg-destructive/10'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
             isBusy && 'opacity-70 cursor-wait',
-            state.status === 'up-to-date' && 'opacity-50',
+            state.status === 'up-to-date' && !justChecked && 'opacity-50',
           )}
         >
-          <Icon size={20} className={isBusy ? 'animate-spin' : undefined} />
-          {(state.status === 'available' || state.status === 'downloaded') && (
+          <Icon size={20} className={isBusy && !percent ? 'animate-spin' : undefined} />
+          {state.status === 'downloading' && percent !== null && (
+            <span className="absolute bottom-0.5 left-0 right-0 text-[9px] font-medium tabular-nums leading-none text-center">
+              {percent}%
+            </span>
+          )}
+          {!isBusy && (state.status === 'available' || state.status === 'downloaded') && (
             <span className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-yellow-300" />
           )}
         </button>


### PR DESCRIPTION
## What

Theme-aware auto-updater chrome, split off `feat/webgl-ambient-background` onto the `refactor/ui-foundation` base (#389).

## Contents (4 files, +347/-27)

- Update banner + indicator restyled to the new theme tokens (light/dark aware).

## Stack

Sibling on `refactor/ui-foundation` (#389). Note: the `UpdateBanner` mount in `AppShell` is part of the final integration PR.

## Validation

- `npm run lint` -- green (tsc, eslint, dependency-cruiser, yaml, md).
- Slice's own tests pass.
