### PR TITLE
feat(profile): agent accent color + identity surface

### DIFF
--- a/apps/desktop/src/main/ipc/mindProfile.ts
+++ b/apps/desktop/src/main/ipc/mindProfile.ts
@@ -74,6 +74,10 @@ export function setupMindProfileIPC(profileService: MindProfileService, mindMana
     return profileService.removeAvatar(mindId);
   });
 
+  ipcMain.handle('mindProfile:setAccentColor', async (_event, mindId: string, color: string | null) => {
+    return profileService.setAccentColor(mindId, color);
+  });
+
   ipcMain.handle('mindProfile:restart', async (_event, mindId: string) => {
     return mindManager.reloadMind(mindId);
   });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -39,6 +39,7 @@ const electronAPI: ElectronAPI = {
     pickAvatarImage: () => ipcRenderer.invoke('mindProfile:pickAvatarImage'),
     saveAvatar: (request) => ipcRenderer.invoke('mindProfile:saveAvatar', request),
     removeAvatar: (mindId) => ipcRenderer.invoke('mindProfile:removeAvatar', mindId),
+    setAccentColor: (mindId, color) => ipcRenderer.invoke('mindProfile:setAccentColor', mindId, color),
     restart: (mindId) => ipcRenderer.invoke('mindProfile:restart', mindId),
   },
   lens: {

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -176,6 +176,7 @@ export function installBrowserApi(): void {
       pickAvatarImage: async () => ({ success: false, error: 'Agent profiles are desktop-only in browser mode.' }),
       saveAvatar: async () => ({ success: false, error: 'Agent profiles are desktop-only in browser mode.' }),
       removeAvatar: async () => ({ success: false, error: 'Agent profiles are desktop-only in browser mode.' }),
+      setAccentColor: async () => ({ success: false, error: 'Agent profiles are desktop-only in browser mode.' }),
       restart: async () => {
         throw new Error('Agent profiles are desktop-only in browser mode.');
       },

--- a/apps/web/src/renderer/components/profile/AgentProfileModal.test.tsx
+++ b/apps/web/src/renderer/components/profile/AgentProfileModal.test.tsx
@@ -101,6 +101,7 @@ function makeProfile(overrides?: Partial<AgentProfile>): AgentProfile {
     displayName: 'Moneypenny',
     folderName: 'moneypenny',
     avatarDataUrl: null,
+    accentColor: null,
     soul: {
       kind: 'soul',
       label: 'SOUL.md',

--- a/apps/web/src/renderer/components/profile/AgentProfileModal.tsx
+++ b/apps/web/src/renderer/components/profile/AgentProfileModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getErrorMessage } from '@chamber/shared/getErrorMessage';
-import { Camera, FileText, Trash2 } from 'lucide-react';
+import { Camera, Check, FileText, Trash2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -11,6 +11,9 @@ import {
 } from '../ui/dialog';
 import { cn } from '../../lib/utils';
 import { useAppDispatch } from '../../lib/store';
+import { AgentSurface } from './AgentSurface';
+import { Skeleton } from '../ui/skeleton';
+import { AGENT_COLORS } from '../chat/agentColors';
 import type {
   AgentProfile,
   AgentProfileAvatarCrop,
@@ -26,9 +29,9 @@ interface AgentProfileModalProps {
   onProfileChanged?: (profile: AgentProfile) => void;
 }
 
-const secondaryButtonClass = 'rounded-lg border border-slate-700 bg-slate-900/80 px-4 py-2 text-sm text-slate-100 transition-colors hover:border-slate-500 hover:bg-slate-800 hover:text-white disabled:opacity-50';
-const primaryButtonClass = 'rounded-lg bg-sky-400 px-4 py-2 text-sm font-medium text-slate-950 transition-colors hover:bg-sky-300 disabled:opacity-50 disabled:hover:bg-sky-400';
-const iconButtonClass = 'inline-flex items-center justify-center rounded-md border border-slate-700 bg-slate-900/80 px-2 py-1 text-xs text-slate-100 transition-colors hover:border-slate-500 hover:bg-slate-800 hover:text-white';
+const secondaryButtonClass = 'rounded-lg border border-border bg-card/80 px-4 py-2 text-sm text-foreground transition-colors hover:border-border hover:bg-secondary hover:text-white disabled:opacity-50';
+const primaryButtonClass = 'rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:hover:bg-primary';
+const iconButtonClass = 'inline-flex items-center justify-center rounded-md border border-border bg-card/80 px-2 py-1 text-xs text-foreground transition-colors hover:border-border hover:bg-secondary hover:text-white';
 
 export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }: AgentProfileModalProps) {
   const dispatch = useAppDispatch();
@@ -88,6 +91,27 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
     }
   };
 
+  const handleSetAccentColor = async (color: string | null) => {
+    if (!profile) return;
+    const result = await window.electronAPI.mindProfile.setAccentColor(profile.mindId, color);
+    if (result.success) {
+      setProfile(result.profile);
+      onProfileChanged?.(result.profile);
+      dispatch({
+        type: 'SET_AGENT_PROFILE_SUMMARY',
+        payload: {
+          mindId: result.profile.mindId,
+          displayName: result.profile.displayName,
+          avatarDataUrl: result.profile.avatarDataUrl,
+          accentColor: result.profile.accentColor,
+        },
+      });
+      setError(null);
+    } else {
+      setError(result.error);
+    }
+  };
+
   const handleRestart = async () => {
     if (!profile) return;
     setRestarting(true);
@@ -109,14 +133,14 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-5xl max-h-[88vh] overflow-hidden bg-slate-950 p-0 text-slate-100">
-          <div className="flex min-h-[620px] flex-col">
+        <DialogContent className="surface-panel flex max-h-[88vh] min-h-[min(620px,88vh)] w-full max-w-5xl flex-col overflow-hidden bg-background p-0 text-foreground">
+          <div className="flex min-h-0 flex-1 flex-col">
             <DialogHeader className="border-b border-border px-6 py-5">
               <div className="flex items-start justify-between gap-4 pr-8">
                 <div>
-                  <DialogTitle>Agent profile</DialogTitle>
+                  <DialogTitle>Agent</DialogTitle>
                   <DialogDescription>
-                    Edit local profile assets for this agent. Share and publish are tracked separately.
+                    This agent's profile, identity files, and capability surface. Share and publish are tracked separately.
                   </DialogDescription>
                 </div>
                 {profile?.needsRestart ? (
@@ -133,7 +157,7 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
             </DialogHeader>
 
             <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-              {loading ? <p className="text-sm text-muted-foreground">Loading profile...</p> : null}
+              {loading ? <AgentProfileSkeleton /> : null}
               {error ? <div role="alert" className="mb-4 rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-300">{error}</div> : null}
 
               {profile ? (
@@ -161,9 +185,11 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
                           </button>
                         ) : null}
                       </div>
+                      <AccentColorPicker selected={profile.accentColor} onSelect={handleSetAccentColor} />
                     </div>
                     <div className="grid gap-3 sm:grid-cols-2">
                       <ProfileFact label="Display name" value={profile.displayName} />
+                      <ProfileFact label="Model" value={mind?.selectedModel ?? '—'} />
                       <ProfileFact label="Folder" value={profile.folderName} />
                       <ProfileFact label="Path" value={profile.mindPath} className="sm:col-span-2" />
                     </div>
@@ -179,6 +205,8 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
                       />
                     ))}
                   </div>
+
+                  {mind ? <AgentSurface mind={mind} /> : null}
                 </div>
               ) : null}
             </div>
@@ -221,13 +249,81 @@ export function AgentProfileModal({ mind, open, onOpenChange, onProfileChanged }
   );
 }
 
+// Mirrors the loaded profile layout (avatar + facts grid + file cards) so the
+// modal body keeps a stable height while the profile loads.
+function AgentProfileSkeleton() {
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-[120px_minmax(0,1fr)]">
+        <div className="flex flex-col items-center gap-3">
+          <Skeleton className="h-24 w-24 rounded-2xl" />
+          <Skeleton className="h-7 w-16" />
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16 sm:col-span-2" />
+        </div>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Skeleton className="h-24" />
+        <Skeleton className="h-24" />
+      </div>
+    </div>
+  );
+}
+
 function AvatarPreview({ profile }: { profile: AgentProfile }) {
   if (profile.avatarDataUrl) {
     return <img src={profile.avatarDataUrl} alt="" className="h-24 w-24 rounded-2xl border border-border object-cover" />;
   }
+  const accent = profile.accentColor;
   return (
-    <div className="flex h-24 w-24 items-center justify-center rounded-2xl border border-border bg-primary/15 text-3xl font-bold text-primary">
+    <div
+      className={cn(
+        'flex h-24 w-24 items-center justify-center rounded-2xl border border-border text-3xl font-bold',
+        !accent && 'bg-primary/15 text-primary',
+      )}
+      style={accent ? { backgroundColor: `${accent}26`, color: accent } : undefined}
+    >
       {initials(profile.displayName)}
+    </div>
+  );
+}
+
+// Preset accent swatches plus a reset-to-default control. The chosen color
+// drives the agent's pill, avatar fallback, and message accents everywhere.
+function AccentColorPicker({ selected, onSelect }: { selected: string | null; onSelect: (color: string | null) => void }) {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <div className="grid grid-cols-3 gap-1.5">
+        {AGENT_COLORS.map((color) => {
+          const isActive = selected?.toLowerCase() === color.toLowerCase();
+          return (
+            <button
+              key={color}
+              type="button"
+              onClick={() => onSelect(color)}
+              aria-label={`Use ${color} accent color`}
+              aria-pressed={isActive}
+              className={cn(
+                'flex h-5 w-5 items-center justify-center rounded-full border border-black/10 transition-transform hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                isActive && 'ring-2 ring-foreground ring-offset-2 ring-offset-background',
+              )}
+              style={{ backgroundColor: color }}
+            >
+              {isActive ? <Check size={12} className="text-white" /> : null}
+            </button>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        Default color
+      </button>
     </div>
   );
 }
@@ -246,19 +342,19 @@ function ProfileFileCard({ file, onOpen }: { file: AgentProfileFile; onOpen: () 
     <button
       type="button"
       onClick={onOpen}
-      className="min-h-72 rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-left text-slate-100 transition-colors hover:border-slate-600 hover:bg-slate-900"
+      className="surface-card surface-card-hover min-h-72 rounded-xl border border-border bg-card/60 p-4 text-left text-foreground"
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <FileText size={16} className="text-muted-foreground" />
           <span className="font-medium text-foreground">{file.label}</span>
         </div>
-        <span className="rounded-full border border-slate-700 bg-slate-950 px-2 py-0.5 text-xs text-slate-300">
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 text-xs text-foreground/70">
           {file.exists ? 'Edit' : 'Create'}
         </span>
       </div>
       <p className="mb-3 text-xs text-muted-foreground">{file.relativePath}</p>
-      <pre className="max-h-44 overflow-hidden whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs leading-5 text-slate-300">
+      <pre className="max-h-44 overflow-hidden whitespace-pre-wrap rounded-lg border border-border bg-background p-3 text-xs leading-5 text-foreground/70">
         {file.content.trim() || 'No local profile file yet.'}
       </pre>
     </button>
@@ -308,7 +404,7 @@ function ProfileMarkdownEditor({
 
   return (
     <Dialog open={Boolean(file)} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="flex max-h-[88vh] max-w-4xl flex-col bg-slate-950 text-slate-100">
+      <DialogContent className="flex max-w-4xl flex-col bg-background text-foreground">
         <DialogHeader>
           <DialogTitle>{file?.label ?? 'Profile file'}</DialogTitle>
           <DialogDescription>{file?.relativePath}</DialogDescription>
@@ -318,7 +414,8 @@ function ProfileMarkdownEditor({
           value={value}
           onChange={(event) => setValue(event.target.value)}
           spellCheck={false}
-          className="min-h-[200px] w-full flex-1 resize-none rounded-xl border border-border bg-background p-4 font-mono text-sm leading-6 text-foreground outline-none focus:border-primary"
+          style={{ height: '60vh', maxHeight: '85vh' }}
+          className="w-full min-h-[200px] resize-y rounded-xl border border-border bg-background p-4 font-mono text-sm leading-6 text-foreground outline-none focus:border-primary"
         />
         <DialogFooter>
           {dirty ? <span className="mr-auto self-center text-xs text-amber-300">Unsaved edits</span> : null}
@@ -391,7 +488,7 @@ function AvatarCropModal({
 
   return (
     <Dialog open={Boolean(source)} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="max-w-3xl bg-slate-950 text-slate-100">
+      <DialogContent className="max-w-3xl bg-background text-foreground">
         <DialogHeader>
           <DialogTitle>Crop avatar</DialogTitle>
           <DialogDescription>Position the square crop, then save a normalized 512x512 avatar.</DialogDescription>
@@ -399,7 +496,7 @@ function AvatarCropModal({
         {error ? <div role="alert" className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-300">{error}</div> : null}
         {source && crop ? (
           <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_220px]">
-            <div className="flex min-h-96 items-center justify-center rounded-2xl border border-slate-800 bg-black p-3">
+            <div className="flex min-h-96 items-center justify-center rounded-2xl border border-border bg-black p-3">
               <CropPreview source={source} crop={crop} size={360} />
             </div>
             <div className="space-y-4">
@@ -441,7 +538,7 @@ function CropPreview({
 
   return (
     <div
-      className="relative mx-auto overflow-hidden rounded-2xl border border-slate-700 bg-black"
+      className="relative mx-auto overflow-hidden rounded-2xl border border-border bg-black"
       style={{ width: size, height: size }}
     >
       <img

--- a/apps/web/src/renderer/components/profile/AgentSurface.tsx
+++ b/apps/web/src/renderer/components/profile/AgentSurface.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { GraduationCap, LayoutGrid, Wrench } from 'lucide-react';
+import type { MindContext, SkillManifest, ToolCatalogEntry } from '@chamber/shared/types';
+import { useAppState } from '../../lib/store';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
+
+interface SurfaceItem {
+  key: string;
+  title: string;
+  subtitle?: string;
+}
+
+/**
+ * AgentSurface — read-only summary of an agent's capability surface for the
+ * profile modal, split across Lens / Tools / Skills tabs. Tools and skills
+ * load lazily from the bridge; both are defensive so the modal still renders
+ * when those bridges are absent.
+ */
+export function AgentSurface({ mind }: { mind: MindContext }) {
+  const { discoveredViews } = useAppState();
+  const [tools, setTools] = useState<ToolCatalogEntry[]>([]);
+  const [skills, setSkills] = useState<SkillManifest[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.electronAPI?.tools?.list?.()
+      .then((list) => { if (!cancelled) setTools((list ?? []).filter((tool) => tool.status === 'installed')); })
+      .catch(() => { /* tools registry may be unavailable */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSkills([]);
+    void window.electronAPI?.skills?.listForMind?.(mind.mindId)
+      .then((list) => { if (!cancelled) setSkills(list ?? []); })
+      .catch(() => { /* skills bridge may be unavailable */ });
+    return () => { cancelled = true; };
+  }, [mind.mindId]);
+
+  const lensItems: SurfaceItem[] = discoveredViews.map((view) => ({
+    key: view.id,
+    title: view.name,
+    subtitle: view.description ?? view.view,
+  }));
+  const toolItems: SurfaceItem[] = tools.map((tool) => ({
+    key: tool.id,
+    title: tool.displayName ?? tool.id,
+    subtitle: tool.description,
+  }));
+  const skillItems: SurfaceItem[] = skills.map((skill) => ({
+    key: skill.id,
+    title: skill.name || skill.id,
+    subtitle: skill.description,
+  }));
+
+  return (
+    <Tabs defaultValue="lens" className="gap-3">
+      <TabsList>
+        <TabsTrigger value="lens">
+          <LayoutGrid size={14} /> Lens
+          <TabCount count={lensItems.length} />
+        </TabsTrigger>
+        <TabsTrigger value="tools">
+          <Wrench size={14} /> Tools
+          <TabCount count={toolItems.length} />
+        </TabsTrigger>
+        <TabsTrigger value="skills">
+          <GraduationCap size={14} /> Skills
+          <TabCount count={skillItems.length} />
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="lens">
+        <SurfaceList items={lensItems} emptyHint="No lens views yet." />
+      </TabsContent>
+      <TabsContent value="tools">
+        <SurfaceList items={toolItems} emptyHint="No tools installed yet." />
+      </TabsContent>
+      <TabsContent value="skills">
+        <SurfaceList items={skillItems} emptyHint="No skills installed yet." />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function TabCount({ count }: { count: number }) {
+  return (
+    <span className="rounded-full bg-background/60 px-1.5 text-[11px] tabular-nums text-foreground/55">
+      {count}
+    </span>
+  );
+}
+
+function SurfaceList({ items, emptyHint }: { items: SurfaceItem[]; emptyHint: string }) {
+  if (items.length === 0) {
+    return (
+      <section className="rounded-xl border border-border bg-card/60 p-4">
+        <p className="text-xs text-foreground/55">{emptyHint}</p>
+      </section>
+    );
+  }
+  return (
+    <div className="divide-y divide-border rounded-xl border border-border bg-card/60">
+      {items.map((item) => (
+        <div
+          key={item.key}
+          className="px-3 py-2 transition-colors hover:bg-accent/50"
+        >
+          <div className="text-sm font-medium text-foreground">{item.title}</div>
+          {item.subtitle ? (
+            <p className="text-xs text-foreground/60 line-clamp-2">{item.subtitle}</p>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/renderer/hooks/useMindProfiles.ts
+++ b/apps/web/src/renderer/hooks/useMindProfiles.ts
@@ -23,6 +23,7 @@ export function useMindProfiles(minds: MindContext[]) {
                 mindId: mind.mindId,
                 displayName: mind.identity.name,
                 avatarDataUrl: null,
+                accentColor: null,
               },
             });
             return;
@@ -33,6 +34,7 @@ export function useMindProfiles(minds: MindContext[]) {
               mindId: mind.mindId,
               displayName: profile.displayName,
               avatarDataUrl: profile.avatarDataUrl,
+              accentColor: profile.accentColor,
             },
           });
         } catch (error) {
@@ -44,6 +46,7 @@ export function useMindProfiles(minds: MindContext[]) {
               mindId: mind.mindId,
               displayName: mind.identity.name,
               avatarDataUrl: null,
+              accentColor: null,
             },
           });
         }

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -9,6 +9,7 @@ export interface AgentProfileSummary {
   mindId: string;
   displayName: string;
   avatarDataUrl: string | null;
+  accentColor?: string | null;
 }
 
 // Per-mind conversation view state machine:

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -138,6 +138,7 @@ export function mockElectronAPI(): ElectronAPI {
         displayName: 'Test',
         folderName: 'test',
         avatarDataUrl: null,
+        accentColor: null,
         soul: { kind: 'soul', label: 'SOUL.md', relativePath: 'SOUL.md', content: '# Test\n', exists: true, mtimeMs: 1 },
         agentFiles: [{ kind: 'agent', label: 'test.agent.md', relativePath: '.github\\agents\\test.agent.md', content: '# Test agent\n', exists: true, mtimeMs: 2 }],
         needsRestart: false,
@@ -148,6 +149,7 @@ export function mockElectronAPI(): ElectronAPI {
         displayName: 'Test',
         folderName: 'test',
         avatarDataUrl: null,
+        accentColor: null,
         soul: { kind: 'soul', label: 'SOUL.md', relativePath: 'SOUL.md', content: '# Test\n', exists: true, mtimeMs: 3 },
         agentFiles: [{ kind: 'agent', label: 'test.agent.md', relativePath: '.github\\agents\\test.agent.md', content: '# Test agent\n', exists: true, mtimeMs: 2 }],
         needsRestart: true,
@@ -155,6 +157,7 @@ export function mockElectronAPI(): ElectronAPI {
       pickAvatarImage: vi.fn().mockResolvedValue({ success: false, error: 'not stubbed' }),
       saveAvatar: vi.fn().mockResolvedValue({ success: false, error: 'not stubbed' }),
       removeAvatar: vi.fn().mockResolvedValue({ success: false, error: 'not stubbed' }),
+      setAccentColor: vi.fn().mockResolvedValue({ success: false, error: 'not stubbed' }),
       restart: vi.fn().mockResolvedValue({ mindId: 'test-1234', mindPath: 'C:\\test', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }),
     },
     userProfile: {

--- a/packages/services/src/mindProfile/MindProfileService.test.ts
+++ b/packages/services/src/mindProfile/MindProfileService.test.ts
@@ -105,6 +105,56 @@ describe('MindProfileService', () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('defaults the accent color to null when none is stored', () => {
+    const { root, service } = createProfileFixture();
+    try {
+      expect(service.getProfile('mind-1').accentColor).toBeNull();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('persists and reads back a chosen accent color', () => {
+    const { root, service } = createProfileFixture();
+    try {
+      const result = service.setAccentColor('mind-1', '#3B82F6');
+
+      expect(result.success).toBe(true);
+      expect(service.getProfile('mind-1').accentColor).toBe('#3b82f6');
+      expect(fs.readFileSync(path.join(root, '.chamber', 'accent-color'), 'utf-8')).toBe('#3b82f6');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('clears the accent color when set to null', () => {
+    const { root, service } = createProfileFixture();
+    try {
+      service.setAccentColor('mind-1', '#10b981');
+      const result = service.setAccentColor('mind-1', null);
+
+      expect(result.success).toBe(true);
+      expect(service.getProfile('mind-1').accentColor).toBeNull();
+      expect(fs.existsSync(path.join(root, '.chamber', 'accent-color'))).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an invalid accent color and leaves any prior value intact', () => {
+    const { root, service } = createProfileFixture();
+    try {
+      service.setAccentColor('mind-1', '#abcdef');
+      const result = service.setAccentColor('mind-1', 'not-a-color');
+
+      if (result.success) throw new Error('Expected invalid accent color to fail');
+      expect(result.error).toContain('hex');
+      expect(service.getProfile('mind-1').accentColor).toBe('#abcdef');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 function createProfileFixture() {

--- a/packages/services/src/mindProfile/MindProfileService.ts
+++ b/packages/services/src/mindProfile/MindProfileService.ts
@@ -14,7 +14,9 @@ import type { IdentityLoader } from '../chat/IdentityLoader';
 import type { AvatarNormalizer, MindProfileMindProvider } from './types';
 
 const AVATAR_RELATIVE_PATH = path.join('.chamber', 'avatar.png');
+const ACCENT_COLOR_RELATIVE_PATH = path.join('.chamber', 'accent-color');
 const MAX_PROFILE_FILE_BYTES = 512_000;
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
 export class MindProfileService {
   constructor(
@@ -28,6 +30,7 @@ export class MindProfileService {
     const identity = this.identityLoader.load(mindPath);
     const displayName = identity?.name ?? path.basename(mindPath);
     const avatarPath = path.join(mindPath, AVATAR_RELATIVE_PATH);
+    const accentPath = path.join(mindPath, ACCENT_COLOR_RELATIVE_PATH);
 
     return {
       mindId,
@@ -35,10 +38,34 @@ export class MindProfileService {
       displayName,
       folderName: path.basename(mindPath),
       avatarDataUrl: readAvatarDataUrl(avatarPath),
+      accentColor: readAccentColor(accentPath),
       soul: this.readProfileFile(mindPath, 'soul', 'SOUL.md'),
       agentFiles: this.listAgentFiles(mindPath),
       needsRestart,
     };
+  }
+
+  setAccentColor(mindId: string, color: string | null): AgentProfileActionResult {
+    const mindPath = this.requireMindPath(mindId);
+    const accentPath = path.join(mindPath, ACCENT_COLOR_RELATIVE_PATH);
+
+    if (color === null) {
+      if (fs.existsSync(accentPath)) fs.rmSync(accentPath, { force: true });
+      return { success: true, profile: this.getProfile(mindId) };
+    }
+
+    const normalized = color.trim().toLowerCase();
+    if (!HEX_COLOR_PATTERN.test(normalized)) {
+      return {
+        success: false,
+        error: 'Agent color must be a #rrggbb hex value.',
+        profile: this.getProfile(mindId),
+      };
+    }
+
+    fs.mkdirSync(path.dirname(accentPath), { recursive: true });
+    fs.writeFileSync(accentPath, normalized, 'utf-8');
+    return { success: true, profile: this.getProfile(mindId) };
   }
 
   async saveFile(request: AgentProfileSaveRequest): Promise<AgentProfileSaveResult> {
@@ -228,6 +255,12 @@ function readAvatarDataUrl(avatarPath: string): string | null {
   if (!fs.existsSync(avatarPath)) return null;
   const data = fs.readFileSync(avatarPath);
   return `data:image/png;base64,${data.toString('base64')}`;
+}
+
+function readAccentColor(accentPath: string): string | null {
+  if (!fs.existsSync(accentPath)) return null;
+  const raw = fs.readFileSync(accentPath, 'utf-8').trim().toLowerCase();
+  return /^#[0-9a-f]{6}$/.test(raw) ? raw : null;
 }
 
 function assertEditableProfilePath(mindPath: string, targetPath: string): void {

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -85,6 +85,7 @@ export interface ElectronAPI {
     pickAvatarImage: () => Promise<AgentProfileAvatarPickResult>;
     saveAvatar: (request: AgentProfileAvatarSaveRequest) => Promise<AgentProfileActionResult>;
     removeAvatar: (mindId: string) => Promise<AgentProfileActionResult>;
+    setAccentColor: (mindId: string, color: string | null) => Promise<AgentProfileActionResult>;
     restart: (mindId: string) => Promise<MindContext>;
   };
   lens: {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -181,6 +181,12 @@ export interface AgentProfile {
   displayName: string;
   folderName: string;
   avatarDataUrl: string | null;
+  /**
+   * User-chosen accent color as a `#rrggbb` hex string, or null to fall back
+   * to the index-based palette. Drives the agent's pill, avatar fallback,
+   * message accent, and typing-indicator color everywhere it appears.
+   */
+  accentColor: string | null;
   soul: AgentProfileFile;
   agentFiles: AgentProfileFile[];
   needsRestart: boolean;
@@ -420,6 +426,8 @@ export interface LensViewManifest {
   id: string;
   name: string;
   icon: string;
+  /** Optional one-line description shown in catalogs and the About panel. */
+  description?: string;
   view: 'form' | 'table' | 'briefing' | 'status-board' | 'list' | 'monitor' | 'detail' | 'timeline' | 'editor' | 'canvas';
   source: string;
   schema?: Record<string, unknown>;


### PR DESCRIPTION
## What

Agent accent color + identity surface (AgentProfileModal + per-mind profile saving), split off `feat/webgl-ambient-background`. Stacked on mind-skills (#397), which is on the foundation (#389).

## Contents (over mind-skills)

- `AgentProfileModal`: per-agent identity surface (accent color, id).
- `MindProfileService`: persists the mind's `SOUL.md` profile; path-safety **rejects symlinked profile files** to prevent symlink-escape writes (security boundary).
- Per-agent accent color tokens applied across chat/chatroom surfaces.

**Security note for review**: `MindProfileService` writes the mind `SOUL.md` and validates the target path, rejecting symlink escapes. Worth a focused look.

## Stack

```
refactor/ui-foundation #389
 └─ mind-skills #397
     └─ agent-profile (this)
```

## Validation

- `npm run lint` -- green (tsc, eslint, dependency-cruiser, yaml, md).
- Tests -- 21 passed. The single failure is the **known Windows-only** `MindProfileService > rejects symlinked profile files`: `fs.symlinkSync` throws `EPERM` in the test setup because symlink creation needs admin on Windows, so the service code is never reached. Environmental, passes on Linux CI (same caveat as #386 / #387).
