### PR TITLE
Fix Copilot CLI auth popups after Chamber sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Restore legacy conversation resume fallback** — Conversation resume now falls back from Chamber's current SDK session-state root to the legacy default Copilot session-state root before recreating a missing session, so pre-move chat history hydrates instead of opening empty.
 - **Refresh packaged Copilot runtime pin** — Aligns the committed @github/copilot runtime pin with the launcher-resolved 1.0.58 build so package smoke validates the bundled CLI.
+- **Stop Copilot CLI auth popups after sign-in** — Pass Chamber's stored GitHub OAuth token into SDK-created CLI clients and disable CLI auto-login so device-flow browser prompts only occur from Chamber's explicit sign-in flow.
 
 ### Tests
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -37,6 +37,7 @@ import {
   AuthService,
   CanvasService,
   ChamberCopilotService,
+  listStoredGitHubCredentials,
   ChatroomService,
   ChatService,
   ConfigService,
@@ -276,7 +277,17 @@ async function initializeRuntime(): Promise<void> {
   }).initialize();
 
   const chamberToolsBinDir = getChamberToolsBinDir();
-  const clientFactory = new CopilotClientFactory({ toolsBinDir: chamberToolsBinDir });
+  const clientFactory = new CopilotClientFactory({
+    toolsBinDir: chamberToolsBinDir,
+    getGitHubToken: async () => {
+      const stored = await listStoredGitHubCredentials(credentialStore);
+      const active = configService.load().activeLogin;
+      const entry = active
+        ? stored.find((c) => c.login === active)
+        : stored[0];
+      return entry?.password ?? null;
+    },
+  });
   void clientFactory.preloadSdk().catch((err: unknown) => {
     log.warn('SDK preload failed (non-fatal — first createClient will retry):', err);
   });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -311,7 +311,7 @@ async function initializeRuntime(): Promise<void> {
     saveActiveLogin,
     userAgent,
   );
-  scaffold = new MindScaffold();
+  scaffold = new MindScaffold(githubRegistryClient, clientFactory);
   genesisTemplateCatalog = new GenesisMindTemplateMarketplaceCatalog(githubRegistryClient, getGenesisMarketplaceSources);
   genesisTemplateInstaller = new GenesisMindTemplateInstaller(githubRegistryClient, clientFactory, getGenesisMarketplaceSources);
   marketplaceRegistryService = new MarketplaceRegistryService(configService, githubRegistryClient);
@@ -851,7 +851,9 @@ app.on('ready', async () => {
       return mindPath ? createTaskLedger(mindPath) : undefined;
     },
   });
-  setupAuthIPC(authService, mindManager);
+  setupAuthIPC(authService, mindManager, async () => {
+    await chamberCopilotService?.resetAuthState();
+  });
   setupByoLlmIPC(byoLlmStore, mindManager, {
     featureEnabled: appFeatureFlags.byoLlm,
     onConfigChanged: (config) => { cachedByoLlmConfig = appFeatureFlags.byoLlm ? config : null; },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -235,6 +235,15 @@ let cronService: CronService;
 let automationBridgeStop: (() => Promise<void>) | null = null;
 let authService: AuthService;
 let chamberCopilotService: ChamberCopilotService | null = null;
+
+async function getActiveGitHubToken(): Promise<string | null> {
+  const stored = await listStoredGitHubCredentials(credentialStore);
+  const active = configService.load().activeLogin;
+  const entry = active
+    ? stored.find((c) => c.login === active)
+    : stored[0];
+  return entry?.password ?? null;
+}
 let updaterService: UpdaterService;
 const taskLedgersByMindPath = new Map<string, TaskLedger>();
 const ttasksStoresByMindPath = new Map<string, SqliteStore>();
@@ -279,14 +288,7 @@ async function initializeRuntime(): Promise<void> {
   const chamberToolsBinDir = getChamberToolsBinDir();
   const clientFactory = new CopilotClientFactory({
     toolsBinDir: chamberToolsBinDir,
-    getGitHubToken: async () => {
-      const stored = await listStoredGitHubCredentials(credentialStore);
-      const active = configService.load().activeLogin;
-      const entry = active
-        ? stored.find((c) => c.login === active)
-        : stored[0];
-      return entry?.password ?? null;
-    },
+    getGitHubToken: getActiveGitHubToken,
   });
   void clientFactory.preloadSdk().catch((err: unknown) => {
     log.warn('SDK preload failed (non-fatal — first createClient will retry):', err);
@@ -497,10 +499,17 @@ function createChamberCopilotService(
   const service = new ChamberCopilotService({
     connectionsByMode: {
       safe: () => new AcpConnection({
-        connectionFactory: defaultAcpConnectionFactory({
-          command: cliPath,
-          args: ['--acp', '--no-auto-update'],
-        }),
+        connectionFactory: async () => {
+          const gitHubToken = await getActiveGitHubToken();
+          const env = gitHubToken
+            ? { ...process.env, COPILOT_SDK_AUTH_TOKEN: gitHubToken }
+            : process.env;
+          return defaultAcpConnectionFactory({
+            command: cliPath,
+            args: ['--acp', '--no-auto-update', '--no-auto-login', '--auth-token-env', 'COPILOT_SDK_AUTH_TOKEN'],
+            env,
+          })();
+        },
       }),
     },
     // Keep value-level chamber-copilot imports out of ChamberCopilotService.ts;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -501,12 +501,18 @@ function createChamberCopilotService(
       safe: () => new AcpConnection({
         connectionFactory: async () => {
           const gitHubToken = await getActiveGitHubToken();
-          const env = gitHubToken
-            ? { ...process.env, COPILOT_SDK_AUTH_TOKEN: gitHubToken }
-            : process.env;
+          const env = { ...process.env };
+          const authArgs = gitHubToken
+            ? ['--auth-token-env', 'COPILOT_SDK_AUTH_TOKEN']
+            : [];
+          if (gitHubToken) {
+            env.COPILOT_SDK_AUTH_TOKEN = gitHubToken;
+          } else {
+            delete env.COPILOT_SDK_AUTH_TOKEN;
+          }
           return defaultAcpConnectionFactory({
             command: cliPath,
-            args: ['--acp', '--no-auto-update', '--no-auto-login', '--auth-token-env', 'COPILOT_SDK_AUTH_TOKEN'],
+            args: ['--acp', '--no-auto-update', '--no-auto-login', ...authArgs],
             env,
           })();
         },

--- a/apps/desktop/src/main/ipc/auth.test.ts
+++ b/apps/desktop/src/main/ipc/auth.test.ts
@@ -56,16 +56,18 @@ describe('setupAuthIPC', () => {
     const fakeAuth = createFakeAuth();
     const fakeMindManager = createFakeMindManager();
     fakeAuth.listAccounts = vi.fn().mockResolvedValue([{ login: 'alice' }, { login: 'bob' }]);
+    const onAuthStateChanged = vi.fn().mockResolvedValue(undefined);
 
     const mockSend = vi.fn();
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([{ webContents: { send: mockSend } }] as never);
 
-    setupAuthIPC(fakeAuth, fakeMindManager);
+    setupAuthIPC(fakeAuth, fakeMindManager, onAuthStateChanged);
 
     const switchCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:switchAccount');
     await switchCall![1]({} as never, 'bob');
 
     expect(fakeAuth.setActiveLogin).toHaveBeenCalledWith('bob');
+    expect(onAuthStateChanged).toHaveBeenCalled();
     expect(fakeMindManager.reloadAllMinds).toHaveBeenCalled();
     expect(mockSend).toHaveBeenNthCalledWith(1, 'auth:accountSwitchStarted', { login: 'bob' });
     expect(mockSend).toHaveBeenNthCalledWith(2, 'auth:accountSwitched', { login: 'bob' });
@@ -85,17 +87,19 @@ describe('setupAuthIPC', () => {
     const fakeAuth = createFakeAuth();
     const fakeMindManager = createFakeMindManager();
     fakeAuth.startLogin = vi.fn().mockResolvedValue({ success: true, login: 'alice' });
+    const onAuthStateChanged = vi.fn().mockResolvedValue(undefined);
 
     const mockSend = vi.fn();
     vi.mocked(BrowserWindow.fromWebContents).mockReturnValue({ webContents: { send: mockSend } } as never);
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([{ webContents: { send: mockSend } }] as never);
 
-    setupAuthIPC(fakeAuth, fakeMindManager);
+    setupAuthIPC(fakeAuth, fakeMindManager, onAuthStateChanged);
 
     const startLoginCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:startLogin');
     await expect(startLoginCall![1]({ sender: {} } as never, ...([] as unknown[]))).resolves.toEqual({ success: true, login: 'alice' });
 
     expect(fakeAuth.setActiveLogin).toHaveBeenCalledWith('alice');
+    expect(onAuthStateChanged).toHaveBeenCalled();
     expect(fakeMindManager.reloadAllMinds).toHaveBeenCalled();
     expect(mockSend).toHaveBeenNthCalledWith(1, 'auth:accountSwitchStarted', { login: 'alice' });
     expect(mockSend).toHaveBeenNthCalledWith(2, 'auth:accountSwitched', { login: 'alice' });
@@ -106,16 +110,18 @@ describe('setupAuthIPC', () => {
     const fakeMindManager = createFakeMindManager();
     fakeMindManager.reloadAllMinds = vi.fn().mockRejectedValue(new Error('disk failure')) as never;
     fakeAuth.listAccounts = vi.fn().mockResolvedValue([{ login: 'alice' }]);
+    const onAuthStateChanged = vi.fn().mockResolvedValue(undefined);
 
     const mockSend = vi.fn();
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([{ webContents: { send: mockSend } }] as never);
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
-    setupAuthIPC(fakeAuth, fakeMindManager);
+    setupAuthIPC(fakeAuth, fakeMindManager, onAuthStateChanged);
 
     const switchCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:switchAccount');
     await switchCall![1]({} as never, 'alice');
 
+    expect(onAuthStateChanged).toHaveBeenCalled();
     expect(mockSend).toHaveBeenCalledWith('auth:accountSwitched', { login: 'alice' });
     consoleSpy.mockRestore();
   });
@@ -123,6 +129,7 @@ describe('setupAuthIPC', () => {
   it('auth:logout handler calls authService.logout, reloads minds, and broadcasts to all windows', async () => {
     const fakeAuth = createFakeAuth();
     const fakeMindManager = createFakeMindManager();
+    const onAuthStateChanged = vi.fn().mockResolvedValue(undefined);
     const mockSend = vi.fn();
     const mockWindows = [
       { webContents: { send: mockSend } },
@@ -130,7 +137,7 @@ describe('setupAuthIPC', () => {
     ];
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(mockWindows as never);
 
-    setupAuthIPC(fakeAuth, fakeMindManager);
+    setupAuthIPC(fakeAuth, fakeMindManager, onAuthStateChanged);
 
     // Find and invoke the auth:logout handler
     const logoutCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:logout');
@@ -138,6 +145,7 @@ describe('setupAuthIPC', () => {
     await logoutCall![1]({} as never, ...([] as unknown[]));
 
     expect(fakeAuth.logout).toHaveBeenCalled();
+    expect(onAuthStateChanged).toHaveBeenCalled();
     expect(fakeMindManager.reloadAllMinds).toHaveBeenCalled();
     expect(mockSend).toHaveBeenCalledWith('auth:loggedOut');
     expect(mockSend).toHaveBeenCalledTimes(2);

--- a/apps/desktop/src/main/ipc/auth.test.ts
+++ b/apps/desktop/src/main/ipc/auth.test.ts
@@ -120,8 +120,9 @@ describe('setupAuthIPC', () => {
     consoleSpy.mockRestore();
   });
 
-  it('auth:logout handler calls authService.logout and broadcasts to all windows', async () => {
+  it('auth:logout handler calls authService.logout, reloads minds, and broadcasts to all windows', async () => {
     const fakeAuth = createFakeAuth();
+    const fakeMindManager = createFakeMindManager();
     const mockSend = vi.fn();
     const mockWindows = [
       { webContents: { send: mockSend } },
@@ -129,7 +130,7 @@ describe('setupAuthIPC', () => {
     ];
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(mockWindows as never);
 
-    setupAuthIPC(fakeAuth, createFakeMindManager());
+    setupAuthIPC(fakeAuth, fakeMindManager);
 
     // Find and invoke the auth:logout handler
     const logoutCall = vi.mocked(ipcMain.handle).mock.calls.find(c => c[0] === 'auth:logout');
@@ -137,6 +138,7 @@ describe('setupAuthIPC', () => {
     await logoutCall![1]({} as never, ...([] as unknown[]));
 
     expect(fakeAuth.logout).toHaveBeenCalled();
+    expect(fakeMindManager.reloadAllMinds).toHaveBeenCalled();
     expect(mockSend).toHaveBeenCalledWith('auth:loggedOut');
     expect(mockSend).toHaveBeenCalledTimes(2);
   });

--- a/apps/desktop/src/main/ipc/auth.ts
+++ b/apps/desktop/src/main/ipc/auth.ts
@@ -141,6 +141,11 @@ export function setupAuthIPC(
 
   ipcMain.handle(IPC.AUTH.LOGOUT, async () => {
     await authService.logout();
+    try {
+      await mindManager.reloadAllMinds();
+    } catch (err) {
+      log.error('Failed to reload minds after logout:', err);
+    }
     broadcast(IPC.AUTH.LOGGED_OUT);
   });
 

--- a/apps/desktop/src/main/ipc/auth.ts
+++ b/apps/desktop/src/main/ipc/auth.ts
@@ -29,6 +29,7 @@ function broadcast(
 export function setupAuthIPC(
   authService: AuthService,
   mindManager: MindManager,
+  onAuthStateChanged: () => Promise<void> = async () => undefined,
 ): void {
 
   ipcMain.handle(IPC.AUTH.GET_STATUS, async () => {
@@ -52,6 +53,19 @@ export function setupAuthIPC(
   // a network roundtrip or external browser launch.
   let e2eStartLoginResolver: ((value: { success: boolean; login?: string }) => void) | null = null;
 
+  const reloadMindsAfterAuthChange = async (context: string): Promise<void> => {
+    try {
+      await onAuthStateChanged();
+    } catch (err) {
+      log.error(`Failed to refresh auth-bound services after ${context}:`, err);
+    }
+    try {
+      await mindManager.reloadAllMinds();
+    } catch (err) {
+      log.error(`Failed to reload minds after ${context}:`, err);
+    }
+  };
+
   ipcMain.handle(IPC.AUTH.START_LOGIN, async (event) => {
     if (E2E_ENABLED) {
       // Resolve any prior pending stub before starting a new one.
@@ -65,11 +79,7 @@ export function setupAuthIPC(
       if (result.success && result.login) {
         authService.setActiveLogin(result.login);
         broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login: result.login });
-        try {
-          await mindManager.reloadAllMinds();
-        } catch (err) {
-          log.error('Failed to reload minds after e2e login:', err);
-        }
+        await reloadMindsAfterAuthChange('e2e login');
         broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login: result.login });
       }
       return result;
@@ -94,11 +104,7 @@ export function setupAuthIPC(
       if (result.success && result.login) {
         authService.setActiveLogin(result.login);
         broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login: result.login });
-        try {
-          await mindManager.reloadAllMinds();
-        } catch (err) {
-          log.error('Failed to reload minds after login:', err);
-        }
+        await reloadMindsAfterAuthChange('login');
         broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login: result.login });
       }
 
@@ -131,21 +137,13 @@ export function setupAuthIPC(
 
     authService.setActiveLogin(login);
     broadcast(IPC.AUTH.ACCOUNT_SWITCH_STARTED, { login });
-    try {
-      await mindManager.reloadAllMinds();
-    } catch (err) {
-      log.error('Failed to reload minds after account switch:', err);
-    }
+    await reloadMindsAfterAuthChange('account switch');
     broadcast(IPC.AUTH.ACCOUNT_SWITCHED, { login });
   });
 
   ipcMain.handle(IPC.AUTH.LOGOUT, async () => {
     await authService.logout();
-    try {
-      await mindManager.reloadAllMinds();
-    } catch (err) {
-      log.error('Failed to reload minds after logout:', err);
-    }
+    await reloadMindsAfterAuthChange('logout');
     broadcast(IPC.AUTH.LOGGED_OUT);
   });
 

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -14,6 +14,7 @@ import {
   CopilotClientFactory,
   getChamberToolsBinDir,
   IdentityLoader,
+  listStoredGitHubCredentials,
   MessageRouter,
   MindManager,
   TaskManager,
@@ -52,13 +53,24 @@ const saveActiveLogin = (login: string | null) => {
   configService.save({ ...config, activeLogin: login });
 };
 const authService = new AuthService(credentialStore, () => configService.load().activeLogin, saveActiveLogin);
+async function getActiveGitHubToken(): Promise<string | null> {
+  const stored = await listStoredGitHubCredentials(credentialStore);
+  const active = configService.load().activeLogin;
+  const entry = active
+    ? stored.find((credential) => credential.login === active)
+    : stored[0];
+  return entry?.password ?? null;
+}
 const viewDiscovery = new ViewDiscovery();
 const a2aEventBus = new EventEmitter();
 const agentCardRegistry = new AgentCardRegistry();
 const activeA2AResolver = new ActiveA2AResolver(agentCardRegistry);
 const a2aRelayModeService = new A2ARelayModeService(agentCardRegistry, activeA2AResolver);
 const mindManager = new MindManager(
-  new CopilotClientFactory({ toolsBinDir: getChamberToolsBinDir() }),
+  new CopilotClientFactory({
+    toolsBinDir: getChamberToolsBinDir(),
+    getGitHubToken: getActiveGitHubToken,
+  }),
   new IdentityLoader(() => configService.load().installedTools ?? []),
   configService,
   viewDiscovery,

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -61,6 +61,13 @@ async function getActiveGitHubToken(): Promise<string | null> {
     : stored[0];
   return entry?.password ?? null;
 }
+async function reloadMindsAfterAuthChange(context: string): Promise<void> {
+  try {
+    await mindManager.reloadAllMinds();
+  } catch (error) {
+    log.error(`Failed to reload minds after ${context}:`, error);
+  }
+}
 const viewDiscovery = new ViewDiscovery();
 const a2aEventBus = new EventEmitter();
 const agentCardRegistry = new AgentCardRegistry();
@@ -135,6 +142,7 @@ const productionContext: ChamberCtx = createServerContext({
     const result = await authService.startLogin({ onProgress });
     if (result.success && result.login) {
       authService.setActiveLogin(result.login);
+      await reloadMindsAfterAuthChange('login');
     }
     return result;
   },
@@ -144,8 +152,12 @@ const productionContext: ChamberCtx = createServerContext({
       throw new Error(`Account ${login} is not available`);
     }
     authService.setActiveLogin(login);
+    await reloadMindsAfterAuthChange('account switch');
   },
-  logoutAuth: () => authService.logout(),
+  logoutAuth: async () => {
+    await authService.logout();
+    await reloadMindsAfterAuthChange('logout');
+  },
   listChamberTools: () => configService.load().installedTools ?? [],
   saveAttachment: notImplemented('saveAttachment'),
   sendChat: ({ mindId, message, messageId, model, attachments }) =>

--- a/packages/services/src/chamberCopilot/ChamberCopilotService.test.ts
+++ b/packages/services/src/chamberCopilot/ChamberCopilotService.test.ts
@@ -514,6 +514,47 @@ describe('ChamberCopilotService', () => {
       expect(jobStoreFactoryCalls[0].yolo).toBeUndefined();
     });
 
+    it('does not let an old yolo-start failure assign stale safe-only connections after reset', async () => {
+      const staleSafe = new FakeAcpConnection();
+      const staleYolo = new FakeAcpConnection();
+      let rejectStaleYolo: ((error: Error) => void) | undefined;
+      staleYolo.start = vi.fn(() => new Promise<void>((_resolve, reject) => {
+        rejectStaleYolo = reject;
+      }));
+      const freshSafe = new FakeAcpConnection();
+      const freshYolo = new FakeAcpConnection();
+      const safeFactory = vi.fn()
+        .mockReturnValueOnce(staleSafe as unknown as AcpConnection)
+        .mockReturnValueOnce(freshSafe as unknown as AcpConnection);
+      const yoloFactory = vi.fn()
+        .mockReturnValueOnce(staleYolo as unknown as AcpConnection)
+        .mockReturnValueOnce(freshYolo as unknown as AcpConnection);
+      const jobStoreFactoryCalls: Array<{ readonly safe: AcpConnection; readonly yolo?: AcpConnection }> = [];
+      const service = new ChamberCopilotService({
+        connectionsByMode: { safe: safeFactory, yolo: yoloFactory },
+        jobStoreFactory: (connections) => {
+          jobStoreFactoryCalls.push(connections);
+          return new FakeJobStore() as unknown as JobStore;
+        },
+        toolFactory: () => [],
+      });
+
+      const prewarm = service.prewarm();
+      await Promise.resolve();
+      const reset = service.resetAuthState();
+      await Promise.resolve();
+      rejectStaleYolo?.(new Error('old yolo failed after auth reset'));
+
+      await Promise.all([prewarm, reset]);
+
+      expect(staleSafe.stop).toHaveBeenCalledOnce();
+      expect(freshSafe.start).toHaveBeenCalledOnce();
+      expect(freshYolo.start).toHaveBeenCalledOnce();
+      expect(jobStoreFactoryCalls).toHaveLength(1);
+      expect(jobStoreFactoryCalls[0].safe).toBe(freshSafe as unknown as AcpConnection);
+      expect(jobStoreFactoryCalls[0].yolo).toBe(freshYolo as unknown as AcpConnection);
+    });
+
     it('treats a safe-start failure as fatal (no yolo factory call attempted)', async () => {
       const failingSafe = new FakeAcpConnection();
       failingSafe.start = vi.fn(async () => {

--- a/packages/services/src/chamberCopilot/ChamberCopilotService.test.ts
+++ b/packages/services/src/chamberCopilot/ChamberCopilotService.test.ts
@@ -378,6 +378,54 @@ describe('ChamberCopilotService', () => {
     expect(failingConnection.stop).not.toHaveBeenCalled();
   });
 
+  it('resetAuthState keeps a fresh prewarmed store available through a mind reload', async () => {
+    const { service, connection } = buildHarness();
+
+    await service.activateMind('mind-1', '/tmp/mind-1');
+    await service.resetAuthState();
+    await service.releaseMind('mind-1');
+
+    expect(connection.stop).toHaveBeenCalledOnce();
+    expect(service.getToolsForMind('mind-2', '/tmp/mind-2').map((tool) => tool.name)).toContain('cli_delegate');
+
+    await service.activateMind('mind-2', '/tmp/mind-2');
+    await service.releaseMind('mind-2');
+
+    expect(connection.stop).toHaveBeenCalledTimes(2);
+  });
+
+  it('resetAuthState invalidates an in-flight prewarm so stale auth cannot win the race', async () => {
+    const staleConnection = new FakeAcpConnection();
+    let resolveStaleStart: (() => void) | undefined;
+    staleConnection.start = vi.fn(() => new Promise<void>((resolve) => {
+      resolveStaleStart = () => {
+        staleConnection.isStarted = true;
+        resolve();
+      };
+    }));
+    const freshConnection = new FakeAcpConnection();
+    const connectionFactory = vi.fn()
+      .mockReturnValueOnce(staleConnection as unknown as AcpConnection)
+      .mockReturnValueOnce(freshConnection as unknown as AcpConnection);
+    const service = new ChamberCopilotService({
+      connectionFactory,
+      jobStoreFactory: () => new FakeJobStore() as unknown as JobStore,
+      toolFactory: () => [makeStubTool('cli_delegate')],
+    });
+
+    const prewarm = service.prewarm();
+    await Promise.resolve();
+    const reset = service.resetAuthState();
+    await Promise.resolve();
+    resolveStaleStart?.();
+
+    await Promise.all([prewarm, reset]);
+
+    expect(staleConnection.stop).toHaveBeenCalledOnce();
+    expect(freshConnection.start).toHaveBeenCalledOnce();
+    expect(service.getToolsForMind('mind-1', '/tmp/mind-1').map((tool) => tool.name)).toEqual(['cli_delegate']);
+  });
+
   describe('connectionsByMode (yolo posture)', () => {
     it('rejects passing both connectionFactory and connectionsByMode at the same time', () => {
       const safe = vi.fn(() => new FakeAcpConnection() as unknown as AcpConnection);

--- a/packages/services/src/chamberCopilot/ChamberCopilotService.ts
+++ b/packages/services/src/chamberCopilot/ChamberCopilotService.ts
@@ -152,6 +152,13 @@ export class ChamberCopilotService implements ChamberToolProvider {
     }
   }
 
+  async resetAuthState(): Promise<void> {
+    await this.shutdown();
+    if (this.activeMinds.size > 0) {
+      await this.ensureStarted();
+    }
+  }
+
   private getOrCreateScopedStore(mindId: string, mindPath = this.mindPaths.get(mindId)): MindScopedJobs {
     let scoped = this.scopedStores.get(mindId);
     if (!scoped) {

--- a/packages/services/src/chamberCopilot/ChamberCopilotService.ts
+++ b/packages/services/src/chamberCopilot/ChamberCopilotService.ts
@@ -233,6 +233,10 @@ export class ChamberCopilotService implements ChamberToolProvider {
         );
       }
     }
+    if (epoch !== this.startEpoch) {
+      await this.stopOne(safe, 'safe');
+      return;
+    }
 
     this.connections = yolo ? { safe, yolo } : { safe };
     this.store = this.jobStoreFactory(this.connections);

--- a/packages/services/src/chamberCopilot/ChamberCopilotService.ts
+++ b/packages/services/src/chamberCopilot/ChamberCopilotService.ts
@@ -76,6 +76,8 @@ export class ChamberCopilotService implements ChamberToolProvider {
   private connections: StartedConnections | null = null;
   private store: JobStore | null = null;
   private startPromise: Promise<void> | null = null;
+  private startEpoch = 0;
+  private retainStartedWhileIdle = false;
 
   constructor(options: ChamberCopilotServiceOptions) {
     this.connectionFactories = resolveFactories(options);
@@ -110,6 +112,7 @@ export class ChamberCopilotService implements ChamberToolProvider {
       return;
     }
     this.activeMinds.add(mindId);
+    this.retainStartedWhileIdle = false;
     this.mindPaths.set(mindId, mindPath);
     // Eagerly create the per-mind scoped store so that a getToolsForMind
     // call before activation returns [], and after activation always
@@ -147,16 +150,17 @@ export class ChamberCopilotService implements ChamberToolProvider {
     if (scoped) {
       await scoped.releaseAll();
     }
-    if (this.activeMinds.size === 0) {
+    if (this.activeMinds.size === 0 && !this.retainStartedWhileIdle) {
       await this.shutdown();
     }
   }
 
   async resetAuthState(): Promise<void> {
+    this.startEpoch += 1;
+    this.startPromise = null;
+    this.retainStartedWhileIdle = true;
     await this.shutdown();
-    if (this.activeMinds.size > 0) {
-      await this.ensureStarted();
-    }
+    await this.ensureStarted();
   }
 
   private getOrCreateScopedStore(mindId: string, mindPath = this.mindPaths.get(mindId)): MindScopedJobs {
@@ -181,7 +185,8 @@ export class ChamberCopilotService implements ChamberToolProvider {
     if (this.startPromise) {
       return this.startPromise;
     }
-    this.startPromise = this.startInternal();
+    const epoch = this.startEpoch;
+    this.startPromise = this.startInternal(epoch);
     try {
       await this.startPromise;
     } finally {
@@ -189,7 +194,7 @@ export class ChamberCopilotService implements ChamberToolProvider {
     }
   }
 
-  private async startInternal(): Promise<void> {
+  private async startInternal(epoch: number): Promise<void> {
     // Safe MUST start successfully. A safe-start failure is fatal for the
     // service: without the safe connection chamber-copilot cannot serve
     // any delegated jobs (yolo alone is rejected at JobStore construction).
@@ -199,6 +204,10 @@ export class ChamberCopilotService implements ChamberToolProvider {
     } catch (error) {
       log.error('Failed to start chamber-copilot safe AcpConnection', error);
       throw error;
+    }
+    if (epoch !== this.startEpoch) {
+      await this.stopOne(safe, 'safe');
+      return;
     }
 
     // Yolo is best-effort. If wiring it fails (CLI permission denied,
@@ -212,6 +221,11 @@ export class ChamberCopilotService implements ChamberToolProvider {
         const yoloCandidate = this.connectionFactories.yolo();
         await yoloCandidate.start();
         yolo = yoloCandidate;
+        if (epoch !== this.startEpoch) {
+          await this.stopOne(safe, 'safe');
+          await this.stopOne(yolo, 'yolo');
+          return;
+        }
       } catch (error) {
         log.error(
           'chamber-copilot yolo AcpConnection failed to start; running in safe-only mode',

--- a/packages/services/src/sdk/CopilotClientFactory.test.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.test.ts
@@ -165,6 +165,34 @@ describe('CopilotClientFactory', () => {
       expect(env.Path).toBe(`${toolsBinDir}${path.delimiter}${existing}`);
     });
 
+    it('passes useLoggedInUser: false to suppress CLI-driven device flow browser windows', async () => {
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      expect(client.options.useLoggedInUser).toBe(false);
+    });
+
+    it('passes gitHubToken from getGitHubToken callback when a token is available', async () => {
+      factory = new CopilotClientFactory({
+        getGitHubToken: async () => 'ghu_test_token',
+      });
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      expect(client.options.gitHubToken).toBe('ghu_test_token');
+      expect(client.options.useLoggedInUser).toBe(false);
+    });
+
+    it('passes gitHubToken as undefined (not the string "undefined") when callback returns null', async () => {
+      factory = new CopilotClientFactory({
+        getGitHubToken: async () => null,
+      });
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      expect(client.options.gitHubToken).toBeUndefined();
+      expect(client.options.useLoggedInUser).toBe(false);
+    });
+
+    it('omits gitHubToken entirely when no getGitHubToken callback is configured', async () => {
+      const client = await factory.createClient('C:\\agents\\q') as unknown as FakeCopilotClient;
+      expect(client.options.gitHubToken).toBeUndefined();
+    });
+
     it('creates separate clients for different mind paths', async () => {
       const client1 = await factory.createClient('C:\\agents\\q');
       const client2 = await factory.createClient('C:\\agents\\fox');

--- a/packages/services/src/sdk/CopilotClientFactory.ts
+++ b/packages/services/src/sdk/CopilotClientFactory.ts
@@ -14,6 +14,19 @@ export interface CopilotClientFactoryOptions {
   toolsBinDir?: string;
   env?: Record<string, string | undefined>;
   stopTimeoutMs?: number;
+  /**
+   * Returns the active GitHub OAuth token from the keychain. When provided,
+   * the token is forwarded to the CLI via the SDK's `gitHubToken` option
+   * (injected as COPILOT_SDK_AUTH_TOKEN) and `useLoggedInUser` is set to
+   * false, which adds `--no-auto-login` to the CLI args. This prevents the
+   * CLI from ever launching its own device-flow browser window — Chamber
+   * owns auth entirely.
+   *
+   * If the callback returns `null` (no stored credential), the client is
+   * still created with `useLoggedInUser: false`; the CLI will fail any
+   * operation that requires auth rather than prompting in the browser.
+   */
+  getGitHubToken?: () => Promise<string | null>;
 }
 
 // Side-effect tool kinds Chamber auto-approves at the CLI layer. The list
@@ -117,11 +130,22 @@ export class CopilotClientFactory {
       ? { ...withTools, ...createOptions.extraEnv }
       : withTools;
 
+    // Retrieve the active OAuth token so we can hand it to the SDK explicitly.
+    // This causes the SDK to inject it via COPILOT_SDK_AUTH_TOKEN and to add
+    // --no-auto-login, which prevents the bundled CLI from ever launching its
+    // own device-flow browser window. Chamber is the sole auth authority.
+    const gitHubToken = this.options.getGitHubToken ? (await this.options.getGitHubToken() ?? undefined) : undefined;
+
     const client = new sdk.CopilotClient({
       connection: sdk.RuntimeConnection.forStdio({ path: cliPath, args: cliArgs }),
       workingDirectory: mindPath,
       logLevel: 'all',
       env: finalEnv,
+      gitHubToken,
+      // Explicitly disable auto-login even when no token is available so the CLI
+      // never opens a browser on its own. If there is no token the CLI will return
+      // auth errors which Chamber surfaces in the chat UI.
+      useLoggedInUser: false,
     });
 
     await client.start();


### PR DESCRIPTION
## Summary

Stops bundled Copilot CLI auth prompts from appearing after Chamber has already authenticated the user.

## Notable changes

- Passes Chamber's active keytar-backed GitHub OAuth token into SDK-created Copilot clients via `gitHubToken` and forces `useLoggedInUser: false` so the SDK adds `--no-auto-login`.
- Applies the same no-auto-login posture to desktop, loopback server, Genesis custom mind creation, and chamber-copilot ACP workers.
- Reloads/reset auth-bound runtimes on login, account switch, and logout so stale child CLI processes cannot retain old token state.
- Hardens ACP reset behavior against in-flight startup races and ambient `COPILOT_SDK_AUTH_TOKEN` fallback.
- Adds changelog and regression coverage for SDK auth forwarding, auth lifecycle reset, and ACP stale-start/tool-availability behavior.

## Issue

No tracking issue.

## Validation

- `npm run lint`
- `npm test` — 194 files / 2004 tests passed
- `npm run smoke:sdk`
- Manual soak: Chamber left running for several hours with no repeated browser auth popups

## Skipped smoke

- Packaging smoke skipped: no packaging config, runtime pin, installer, or first-launch packaging path changed.