### PR TITLE
feat(skills): per-mind skill discovery + IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Polish Lens view presentation** — Adds view descriptions, Lucide icons, loading skeletons, refined empty states, and improved detail-view readability.
 
 
+
+
+
+
 ## [0.64.1] - 2026-06-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Add chamber:a2a ttasks runtime support** — Adds a chamber:a2a custom task type, production A2A bridge wiring, durable ttasks persistence, and invariants for the runtime contract.
 - **Add theme-aware update chrome** — Adds a dismissible ready-to-install banner and update-status indicator with accessible light and dark theme colors.
+- **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 
 ### Refactor
 
@@ -31,10 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Polish chat message rendering** — Improves streaming, scrolling, tool and reasoning groups, agent colors, copy actions, composer affordances, and welcome states.
 - **Refresh Settings navigation and layout** — Reorganizes Profile, Account, Marketplaces, and Local LLM settings into a clearer left-rail interface with updated panels and light-theme styling.
 - **Polish Lens view presentation** — Adds view descriptions, Lucide icons, loading skeletons, refined empty states, and improved detail-view readability.
-
-
-
-
 
 
 ## [0.64.1] - 2026-06-01

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -114,6 +114,7 @@ import { setupChatroomIPC } from './main/ipc/chatroom';
 import { setupConversationHistoryIPC } from './main/ipc/conversationHistory';
 import { setupUpdaterIPC } from './main/ipc/updater';
 import { setupUserProfileIPC } from './main/ipc/userProfile';
+import { setupSkillsIPC } from './main/ipc/skills';
 
 import { EventEmitter } from 'events';
 import { wireLifecycleEvents } from './main/wireLifecycleEvents';
@@ -824,6 +825,7 @@ app.on('ready', async () => {
   }
 
   // --- IPC adapters (thin, parameter-injected) ---
+  const skillDiscovery = new MindSkillDiscovery();
   setupChatIPC(chatService, mindManager);
   setupConversationHistoryIPC(chatService);
   setupMindIPC(mindManager, chatService, {
@@ -858,6 +860,10 @@ app.on('ready', async () => {
       return mindPath ? createTaskLedger(mindPath) : undefined;
     },
   });
+  setupSkillsIPC(
+    { getMindPath: (mindId) => mindManager.getMind(mindId)?.mindPath },
+    skillDiscovery,
+  );
   setupAuthIPC(authService, mindManager, async () => {
     await chamberCopilotService?.resetAuthState();
   });
@@ -886,13 +892,6 @@ app.on('ready', async () => {
   ipcMain.on(IPC.WINDOW.CLOSE, () => mainWindow?.close());
   ipcMain.handle(IPC.DESKTOP.GET_BRANDING, () => ({ name: app.getName(), version: app.getVersion() }));
   ipcMain.handle(IPC.APP.GET_FEATURE_FLAGS, () => appFeatureFlags);
-  const skillDiscovery = new MindSkillDiscovery();
-  ipcMain.handle(IPC.SKILLS.LIST_FOR_MIND, (_event, mindId: string) => {
-    if (typeof mindId !== 'string') return [];
-    const mind = mindManager.getMind(mindId);
-    if (!mind) return [];
-    return skillDiscovery.list(mind.mindPath);
-  });
   ipcMain.handle(IPC.DESKTOP.CONFIRM, (_event, message: string) => {
     const choice = mainWindow
       ? dialog.showMessageBoxSync(mainWindow, {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -61,6 +61,7 @@ import {
   MindManager,
   MindProfileService,
   MindScaffold,
+  MindSkillDiscovery,
   TaskManager,
   TaskLedger,
   ChildProcessRunner,
@@ -885,6 +886,13 @@ app.on('ready', async () => {
   ipcMain.on(IPC.WINDOW.CLOSE, () => mainWindow?.close());
   ipcMain.handle(IPC.DESKTOP.GET_BRANDING, () => ({ name: app.getName(), version: app.getVersion() }));
   ipcMain.handle(IPC.APP.GET_FEATURE_FLAGS, () => appFeatureFlags);
+  const skillDiscovery = new MindSkillDiscovery();
+  ipcMain.handle(IPC.SKILLS.LIST_FOR_MIND, (_event, mindId: string) => {
+    if (typeof mindId !== 'string') return [];
+    const mind = mindManager.getMind(mindId);
+    if (!mind) return [];
+    return skillDiscovery.list(mind.mindPath);
+  });
   ipcMain.handle(IPC.DESKTOP.CONFIRM, (_event, message: string) => {
     const choice = mainWindow
       ? dialog.showMessageBoxSync(mainWindow, {

--- a/apps/desktop/src/main/ipc/skills.test.ts
+++ b/apps/desktop/src/main/ipc/skills.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+import { ipcMain } from 'electron';
+import type { IpcMainInvokeEvent } from 'electron';
+import { IPC } from '@chamber/shared';
+import { setupSkillsIPC } from './skills';
+
+const EVT = {} as IpcMainInvokeEvent;
+type InvokeHandler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
+
+describe('Skills IPC', () => {
+  const getMindPath = vi.fn<(mindId: string) => string | undefined>();
+  const list = vi.fn<(mindPath: string) => Promise<Array<{ id: string; name: string }>>>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMindPath.mockReturnValue(undefined);
+    list.mockResolvedValue([]);
+    setupSkillsIPC({ getMindPath }, { list });
+  });
+
+  for (const [label, value] of [
+    ['null', null],
+    ['undefined', undefined],
+    ['number', 42],
+    ['object', { mindId: 'lucy' }],
+  ] as const) {
+    it(`rejects ${label} mindId without resolving a mind`, async () => {
+      await expect(getHandler(IPC.SKILLS.LIST_FOR_MIND)(EVT, value)).rejects.toThrow(TypeError);
+      expect(getMindPath).not.toHaveBeenCalled();
+      expect(list).not.toHaveBeenCalled();
+    });
+  }
+
+  it('rejects an empty mindId with a channel-labeled TypeError', async () => {
+    const handler = getHandler(IPC.SKILLS.LIST_FOR_MIND);
+    await expect(handler(EVT, '')).rejects.toThrow(TypeError);
+    await expect(handler(EVT, '')).rejects.toThrow(/skills:listForMind/);
+    expect(getMindPath).not.toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('returns [] for a stale unknown mindId', async () => {
+    await expect(getHandler(IPC.SKILLS.LIST_FOR_MIND)(EVT, 'stale-mind')).resolves.toEqual([]);
+    expect(getMindPath).toHaveBeenCalledWith('stale-mind');
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('lists skills only through the trusted resolved mind path', async () => {
+    getMindPath.mockReturnValue('C:\\minds\\lucy');
+    list.mockResolvedValue([{ id: 'lens', name: 'Lens' }]);
+
+    await expect(getHandler(IPC.SKILLS.LIST_FOR_MIND)(EVT, 'lucy')).resolves.toEqual([
+      { id: 'lens', name: 'Lens' },
+    ]);
+    expect(getMindPath).toHaveBeenCalledWith('lucy');
+    expect(list).toHaveBeenCalledWith('C:\\minds\\lucy');
+  });
+});
+
+function getHandler(channel: string): InvokeHandler {
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((item) => item[0] === channel);
+  if (!call) throw new Error(`no handler registered for ${channel}`);
+  return call[1] as InvokeHandler;
+}

--- a/apps/desktop/src/main/ipc/skills.ts
+++ b/apps/desktop/src/main/ipc/skills.ts
@@ -1,0 +1,26 @@
+import { ipcMain } from 'electron';
+import { z } from 'zod';
+import { IPC, parseIpcArgs } from '@chamber/shared';
+import type { SkillManifest } from '@chamber/shared';
+
+const mindIdSchema = z.string().min(1, 'must be a non-empty string');
+
+export interface SkillsIpcMindProvider {
+  getMindPath(mindId: string): string | undefined;
+}
+
+export interface MindSkillDiscoveryPort {
+  list(mindPath: string): Promise<SkillManifest[]>;
+}
+
+export function setupSkillsIPC(
+  mindProvider: SkillsIpcMindProvider,
+  discovery: MindSkillDiscoveryPort,
+): void {
+  ipcMain.handle(IPC.SKILLS.LIST_FOR_MIND, async (_event, rawMindId: unknown) => {
+    const mindId = parseIpcArgs(IPC.SKILLS.LIST_FOR_MIND, mindIdSchema, rawMindId);
+    const mindPath = mindProvider.getMindPath(mindId);
+    if (!mindPath) return [];
+    return discovery.list(mindPath);
+  });
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -142,6 +142,9 @@ const electronAPI: ElectronAPI = {
     getFeatureFlags: () => ipcRenderer.invoke(IPC.APP.GET_FEATURE_FLAGS),
     onStartupProgress: (callback) => createIpcListener(ipcRenderer, IPC.APP.STARTUP_PROGRESS, callback),
   },
+  skills: {
+    listForMind: (mindId: string) => ipcRenderer.invoke(IPC.SKILLS.LIST_FOR_MIND, mindId),
+  },
 };
 
 if (ipcRenderer.sendSync(IPC.E2E.IS_ENABLED) === true) {

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -373,6 +373,10 @@ export function installBrowserApi(): void {
       // can install/uninstall freely.
       onStartupProgress: () => noopUnsubscribe,
     },
+    skills: {
+      // Web host has no on-disk mind directory to scan.
+      listForMind: async () => [],
+    },
   };
   window.electronAPI = api;
   if (!window.desktop) {

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -347,6 +347,9 @@ export function mockElectronAPI(): ElectronAPI {
       getFeatureFlags: vi.fn().mockResolvedValue({ switchboardRelay: false, byoLlm: false, chamberCopilot: false }),
       onStartupProgress: vi.fn().mockReturnValue(vi.fn()),
     },
+    skills: {
+      listForMind: vi.fn().mockResolvedValue([]),
+    },
   };
 }
 

--- a/packages/services/src/skills/MindSkillDiscovery.test.ts
+++ b/packages/services/src/skills/MindSkillDiscovery.test.ts
@@ -1,23 +1,31 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { MindSkillDiscovery } from './MindSkillDiscovery';
+import {
+  MAX_SKILL_DIRECTORIES,
+  MAX_SKILL_MARKDOWN_BYTES,
+  MindSkillDiscovery,
+} from './MindSkillDiscovery';
 
 describe('MindSkillDiscovery', () => {
   let tmp: string;
+  let outsidePath: string;
   let mindPath: string;
   let skillsDir: string;
 
   beforeEach(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-skills-'));
+    outsidePath = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-skills-outside-'));
     mindPath = tmp;
     skillsDir = path.join(mindPath, '.github', 'skills');
     fs.mkdirSync(skillsDir, { recursive: true });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(outsidePath, { recursive: true, force: true });
   });
 
   function addSkill(name: string, frontmatter: string, body: string = '# Body\n'): void {
@@ -26,61 +34,197 @@ describe('MindSkillDiscovery', () => {
     fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${frontmatter}\n---\n${body}`);
   }
 
-  it('returns [] when no skills directory exists', () => {
+  it('returns [] when no skills directory exists', async () => {
     fs.rmSync(skillsDir, { recursive: true, force: true });
-    expect(new MindSkillDiscovery().list(mindPath)).toEqual([]);
+    await expect(new MindSkillDiscovery().list(mindPath)).resolves.toEqual([]);
   });
 
-  it('returns [] when the skills directory is empty', () => {
-    expect(new MindSkillDiscovery().list(mindPath)).toEqual([]);
+  it('returns [] when the skills directory is empty', async () => {
+    await expect(new MindSkillDiscovery().list(mindPath)).resolves.toEqual([]);
   });
 
-  it('reads name, version, and description from frontmatter', () => {
+  it('reads name, version, and description from frontmatter', async () => {
     addSkill('automation', 'name: automation\nversion: 2.3.0\ndescription: "Run cron jobs."');
-    const skills = new MindSkillDiscovery().list(mindPath);
+    const skills = await new MindSkillDiscovery().list(mindPath);
     expect(skills).toEqual([
       { id: 'automation', name: 'automation', version: '2.3.0', description: 'Run cron jobs.' },
     ]);
   });
 
-  it('returns a fallback manifest when SKILL.md is missing', () => {
+  it('returns a fallback manifest when SKILL.md is missing', async () => {
     fs.mkdirSync(path.join(skillsDir, 'orphan'), { recursive: true });
-    const skills = new MindSkillDiscovery().list(mindPath);
+    const skills = await new MindSkillDiscovery().list(mindPath);
     expect(skills).toEqual([{ id: 'orphan', name: 'orphan' }]);
   });
 
-  it('returns a fallback manifest when frontmatter is missing entirely', () => {
+  it('falls back to the directory id when frontmatter is missing entirely', async () => {
     const dir = path.join(skillsDir, 'plain');
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'SKILL.md'), '# Just a body\n');
-    const skills = new MindSkillDiscovery().list(mindPath);
-    expect(skills).toEqual([{ id: 'plain', name: '' }]);
+    const skills = await new MindSkillDiscovery().list(mindPath);
+    expect(skills).toEqual([{ id: 'plain', name: 'plain' }]);
   });
 
-  it('sorts skills alphabetically by name', () => {
-    addSkill('zebra', 'name: zebra');
-    addSkill('alpha', 'name: alpha');
-    addSkill('mango', 'name: mango');
-    const skills = new MindSkillDiscovery().list(mindPath);
-    expect(skills.map((s) => s.name)).toEqual(['alpha', 'mango', 'zebra']);
+  it('falls back to the directory id when the name field is blank', async () => {
+    addSkill('blank-name', 'name:   \nversion: 1.0.0');
+    const skills = await new MindSkillDiscovery().list(mindPath);
+    expect(skills).toEqual([{ id: 'blank-name', name: 'blank-name', version: '1.0.0' }]);
   });
 
-  it('ignores files at the top level of the skills directory', () => {
+  it('parses frontmatter after one UTF-8 BOM', async () => {
+    const dir = path.join(skillsDir, 'bom-skill');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      '\uFEFF---\nname: BOM Skill\nversion: 1.2.3\ndescription: "BOM metadata"\n---\n# Body\n',
+    );
+
+    const skills = await new MindSkillDiscovery().list(mindPath);
+
+    expect(skills).toEqual([
+      { id: 'bom-skill', name: 'BOM Skill', version: '1.2.3', description: 'BOM metadata' },
+    ]);
+  });
+
+  it('sorts skills by stable on-disk id', async () => {
+    addSkill('zebra', 'name: Alpha');
+    addSkill('alpha', 'name: Zebra');
+    addSkill('mango', 'name: Mango');
+    const skills = await new MindSkillDiscovery().list(mindPath);
+    expect(skills.map((skill) => skill.id)).toEqual(['alpha', 'mango', 'zebra']);
+  });
+
+  it('lists all skills at the direct-directory limit', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    for (let index = 0; index < MAX_SKILL_DIRECTORIES; index += 1) {
+      fs.mkdirSync(path.join(skillsDir, `skill-${String(index).padStart(3, '0')}`));
+    }
+
+    const skills = await new MindSkillDiscovery().list(mindPath);
+
+    expect(skills).toHaveLength(MAX_SKILL_DIRECTORIES);
+    expect(skills.at(-1)?.id).toBe('skill-255');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('deterministically truncates and logs when direct directories exceed the limit', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    for (let index = MAX_SKILL_DIRECTORIES; index >= 0; index -= 1) {
+      fs.mkdirSync(path.join(skillsDir, `skill-${String(index).padStart(3, '0')}`));
+    }
+
+    const skills = await new MindSkillDiscovery().list(mindPath);
+
+    expect(skills).toHaveLength(MAX_SKILL_DIRECTORIES);
+    expect(skills[0].id).toBe('skill-000');
+    expect(skills.at(-1)?.id).toBe('skill-255');
+    expect(skills.map((skill) => skill.id)).not.toContain('skill-256');
+    expect(warn).toHaveBeenCalledWith(
+      '[MindSkillDiscovery]',
+      expect.stringContaining('257 skill directories'),
+    );
+  });
+
+  it('returns fallback metadata and logs when SKILL.md exceeds the byte limit', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const prefix = '---\nname: unbounded\nversion: 9.9.9\n---\n';
+    const dir = path.join(skillsDir, 'oversized');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      prefix + 'x'.repeat(MAX_SKILL_MARKDOWN_BYTES + 1 - Buffer.byteLength(prefix)),
+    );
+
+    const skills = await new MindSkillDiscovery().list(mindPath);
+
+    expect(skills).toEqual([{ id: 'oversized', name: 'oversized' }]);
+    expect(warn).toHaveBeenCalledWith(
+      '[MindSkillDiscovery]',
+      expect.stringContaining(`exceeds the ${MAX_SKILL_MARKDOWN_BYTES} byte limit`),
+    );
+  });
+
+  it('reads metadata when SKILL.md is exactly at the byte limit', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const prefix = '---\nname: exact-limit\nversion: 1.0.0\n---\n';
+    const dir = path.join(skillsDir, 'exact-limit');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      prefix + 'x'.repeat(MAX_SKILL_MARKDOWN_BYTES - Buffer.byteLength(prefix)),
+    );
+
+    const skills = await new MindSkillDiscovery().list(mindPath);
+
+    expect(skills).toEqual([{ id: 'exact-limit', name: 'exact-limit', version: '1.0.0' }]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('returns fallback metadata and logs when SKILL.md is not a regular file', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const dir = path.join(skillsDir, 'unreadable');
+    fs.mkdirSync(path.join(dir, 'SKILL.md'), { recursive: true });
+
+    const skills = await new MindSkillDiscovery().list(mindPath);
+
+    expect(skills).toEqual([{ id: 'unreadable', name: 'unreadable' }]);
+    expect(warn).toHaveBeenCalledWith(
+      '[MindSkillDiscovery]',
+      expect.stringContaining('is not a regular file'),
+    );
+  });
+
+  it('ignores files at the top level of the skills directory', async () => {
     fs.writeFileSync(path.join(skillsDir, 'README.md'), '# notes');
     addSkill('real', 'name: real');
-    const skills = new MindSkillDiscovery().list(mindPath);
+    const skills = await new MindSkillDiscovery().list(mindPath);
     expect(skills.map((s) => s.id)).toEqual(['real']);
   });
 
-  it('folds continuation lines into a single description value', () => {
+  it.skipIf(process.platform === 'win32')('excludes POSIX directory symlinks', async () => {
+    addSkillAt(outsidePath, 'outside');
+    fs.symlinkSync(outsidePath, path.join(skillsDir, 'linked'), 'dir');
+
+    await expect(new MindSkillDiscovery().list(mindPath)).resolves.toEqual([]);
+  });
+
+  it.skipIf(process.platform !== 'win32')('excludes Windows directory junctions', async () => {
+    addSkillAt(outsidePath, 'outside');
+    fs.symlinkSync(outsidePath, path.join(skillsDir, 'linked'), 'junction');
+
+    await expect(new MindSkillDiscovery().list(mindPath)).resolves.toEqual([]);
+  });
+
+  it.skipIf(process.platform === 'win32')('does not read metadata through a symlinked SKILL.md', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const dir = path.join(skillsDir, 'linked-file');
+    const outsideSkill = path.join(outsidePath, 'SKILL.md');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(outsideSkill, '---\nname: outside\nversion: 9.9.9\n---\n');
+    fs.symlinkSync(outsideSkill, path.join(dir, 'SKILL.md'), 'file');
+
+    const skills = await new MindSkillDiscovery().list(mindPath);
+
+    expect(skills).toEqual([{ id: 'linked-file', name: 'linked-file' }]);
+    expect(warn).toHaveBeenCalledWith(
+      '[MindSkillDiscovery]',
+      expect.stringContaining('cannot be a symbolic link'),
+    );
+  });
+
+  it('folds continuation lines into a single description value', async () => {
     addSkill('multiline', 'name: multiline\ndescription: "first half\n  and a continuation"');
-    const skills = new MindSkillDiscovery().list(mindPath);
+    const skills = await new MindSkillDiscovery().list(mindPath);
     expect(skills[0].description).toBe('first half and a continuation');
   });
 
-  it('strips single quotes around scalar values', () => {
+  it('strips single quotes around scalar values', async () => {
     addSkill('quoted', "name: 'q-name'\ndescription: 'q-desc'");
-    const skills = new MindSkillDiscovery().list(mindPath);
+    const skills = await new MindSkillDiscovery().list(mindPath);
     expect(skills[0]).toEqual({ id: 'quoted', name: 'q-name', description: 'q-desc' });
   });
+
+  function addSkillAt(directory: string, name: string): void {
+    fs.writeFileSync(path.join(directory, 'SKILL.md'), `---\nname: ${name}\n---\n`);
+  }
 });

--- a/packages/services/src/skills/MindSkillDiscovery.test.ts
+++ b/packages/services/src/skills/MindSkillDiscovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MindSkillDiscovery } from './MindSkillDiscovery';
+
+describe('MindSkillDiscovery', () => {
+  let tmp: string;
+  let mindPath: string;
+  let skillsDir: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-skills-'));
+    mindPath = tmp;
+    skillsDir = path.join(mindPath, '.github', 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function addSkill(name: string, frontmatter: string, body: string = '# Body\n'): void {
+    const dir = path.join(skillsDir, name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${frontmatter}\n---\n${body}`);
+  }
+
+  it('returns [] when no skills directory exists', () => {
+    fs.rmSync(skillsDir, { recursive: true, force: true });
+    expect(new MindSkillDiscovery().list(mindPath)).toEqual([]);
+  });
+
+  it('returns [] when the skills directory is empty', () => {
+    expect(new MindSkillDiscovery().list(mindPath)).toEqual([]);
+  });
+
+  it('reads name, version, and description from frontmatter', () => {
+    addSkill('automation', 'name: automation\nversion: 2.3.0\ndescription: "Run cron jobs."');
+    const skills = new MindSkillDiscovery().list(mindPath);
+    expect(skills).toEqual([
+      { id: 'automation', name: 'automation', version: '2.3.0', description: 'Run cron jobs.' },
+    ]);
+  });
+
+  it('returns a fallback manifest when SKILL.md is missing', () => {
+    fs.mkdirSync(path.join(skillsDir, 'orphan'), { recursive: true });
+    const skills = new MindSkillDiscovery().list(mindPath);
+    expect(skills).toEqual([{ id: 'orphan', name: 'orphan' }]);
+  });
+
+  it('returns a fallback manifest when frontmatter is missing entirely', () => {
+    const dir = path.join(skillsDir, 'plain');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), '# Just a body\n');
+    const skills = new MindSkillDiscovery().list(mindPath);
+    expect(skills).toEqual([{ id: 'plain', name: '' }]);
+  });
+
+  it('sorts skills alphabetically by name', () => {
+    addSkill('zebra', 'name: zebra');
+    addSkill('alpha', 'name: alpha');
+    addSkill('mango', 'name: mango');
+    const skills = new MindSkillDiscovery().list(mindPath);
+    expect(skills.map((s) => s.name)).toEqual(['alpha', 'mango', 'zebra']);
+  });
+
+  it('ignores files at the top level of the skills directory', () => {
+    fs.writeFileSync(path.join(skillsDir, 'README.md'), '# notes');
+    addSkill('real', 'name: real');
+    const skills = new MindSkillDiscovery().list(mindPath);
+    expect(skills.map((s) => s.id)).toEqual(['real']);
+  });
+
+  it('folds continuation lines into a single description value', () => {
+    addSkill('multiline', 'name: multiline\ndescription: "first half\n  and a continuation"');
+    const skills = new MindSkillDiscovery().list(mindPath);
+    expect(skills[0].description).toBe('first half and a continuation');
+  });
+
+  it('strips single quotes around scalar values', () => {
+    addSkill('quoted', "name: 'q-name'\ndescription: 'q-desc'");
+    const skills = new MindSkillDiscovery().list(mindPath);
+    expect(skills[0]).toEqual({ id: 'quoted', name: 'q-name', description: 'q-desc' });
+  });
+});

--- a/packages/services/src/skills/MindSkillDiscovery.ts
+++ b/packages/services/src/skills/MindSkillDiscovery.ts
@@ -1,0 +1,129 @@
+// MindSkillDiscovery — reads the SKILL.md frontmatter under
+// <mindPath>/.github/skills/<name>/ for every skill installed on a mind.
+//
+// This is renderer-facing metadata only: it powers the "Skills" list on the
+// chat About panel so users can see what an agent can do without dropping
+// into the mind's filesystem. The actual skill-execution flow lives in the
+// SDK runtime; this file does not invoke skills, modify them, or replace
+// any of the existing skill-management services.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { SkillManifest } from '@chamber/shared/types';
+import { Logger } from '../logger';
+
+const log = Logger.create('MindSkillDiscovery');
+
+export class MindSkillDiscovery {
+  /**
+   * Scan `<mindPath>/.github/skills` and return one SkillManifest per
+   * subdirectory containing a SKILL.md. Skills missing the file (or with
+   * unreadable frontmatter) are returned with just the directory name.
+   * Returns an empty array if the skills directory does not exist.
+   */
+  list(mindPath: string): SkillManifest[] {
+    const skillsDir = path.join(mindPath, '.github', 'skills');
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT') {
+        log.warn(`Failed to read skills directory ${skillsDir}: ${(err as Error)?.message}`);
+      }
+      return [];
+    }
+
+    const skills: SkillManifest[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillMdPath = path.join(skillsDir, entry.name, 'SKILL.md');
+      const manifest = this.readSkillManifest(entry.name, skillMdPath);
+      if (manifest) skills.push(manifest);
+    }
+    // Stable alphabetical order so the UI doesn't shuffle between scans.
+    skills.sort((a, b) => a.name.localeCompare(b.name));
+    return skills;
+  }
+
+  private readSkillManifest(id: string, skillMdPath: string): SkillManifest {
+    let raw: string;
+    try {
+      // SKILL.md frontmatter sits in the first ~30 lines; reading the full
+      // file is fine because skills are small and called rarely.
+      raw = fs.readFileSync(skillMdPath, 'utf-8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT') {
+        log.warn(`Failed to read ${skillMdPath}: ${(err as Error)?.message}`);
+      }
+      return { id, name: id };
+    }
+    return { id, ...parseFrontmatter(raw) };
+  }
+}
+
+interface ParsedFrontmatter {
+  name: string;
+  version?: string;
+  description?: string;
+}
+
+/**
+ * Minimal YAML frontmatter parser tailored to the SKILL.md shape:
+ *   ---
+ *   name: foo
+ *   version: 1.2.3
+ *   description: "single-line summary"
+ *   ---
+ *
+ * We deliberately don't pull in a YAML library here -- skill frontmatter is
+ * deeply constrained by the lens/automation skill author guidelines, and the
+ * three fields we surface are always simple scalars. Multi-line values are
+ * folded into one line, surrounding quotes are stripped.
+ */
+function parseFrontmatter(raw: string): ParsedFrontmatter {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return { name: '' };
+
+  const fields = new Map<string, string>();
+  let currentKey: string | null = null;
+  for (const line of match[1].split(/\r?\n/)) {
+    // Continuation lines for folded scalars start with whitespace.
+    if (currentKey && /^\s+\S/.test(line)) {
+      fields.set(currentKey, `${fields.get(currentKey) ?? ''} ${line.trim()}`);
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z0-9_]+)\s*:\s*(.*)$/);
+    if (!kv) {
+      currentKey = null;
+      continue;
+    }
+    currentKey = kv[1];
+    fields.set(currentKey, kv[2].trim());
+  }
+
+  // Strip enclosing quote pair AFTER folding so multi-line "..." values
+  // come out clean.
+  for (const [k, v] of fields) fields.set(k, stripQuotes(v));
+
+  const name = fields.get('name') ?? '';
+  const version = fields.get('version');
+  const description = fields.get('description');
+  return {
+    name,
+    version: version && version.length > 0 ? version : undefined,
+    description: description && description.length > 0 ? description : undefined,
+  };
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}

--- a/packages/services/src/skills/MindSkillDiscovery.ts
+++ b/packages/services/src/skills/MindSkillDiscovery.ts
@@ -1,65 +1,59 @@
-// MindSkillDiscovery — reads the SKILL.md frontmatter under
-// <mindPath>/.github/skills/<name>/ for every skill installed on a mind.
-//
-// This is renderer-facing metadata only: it powers the "Skills" list on the
-// chat About panel so users can see what an agent can do without dropping
-// into the mind's filesystem. The actual skill-execution flow lives in the
-// SDK runtime; this file does not invoke skills, modify them, or replace
-// any of the existing skill-management services.
-
-import * as fs from 'fs';
-import * as path from 'path';
+import { constants as fsConstants, type Dirent } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { FileHandle } from 'node:fs/promises';
 import type { SkillManifest } from '@chamber/shared/types';
 import { Logger } from '../logger';
 
+export const MAX_SKILL_DIRECTORIES = 256;
+export const MAX_SKILL_MARKDOWN_BYTES = 512_000;
+
+const SKILL_MARKDOWN_FILENAME = 'SKILL.md';
+const OPEN_READ_NOFOLLOW_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 const log = Logger.create('MindSkillDiscovery');
 
+/**
+ * Reads self-declared display metadata from skill directories on disk.
+ *
+ * This service does not invoke skills, modify them, or establish managed-skill
+ * provenance, integrity, installation, or update state.
+ */
 export class MindSkillDiscovery {
   /**
-   * Scan `<mindPath>/.github/skills` and return one SkillManifest per
-   * subdirectory containing a SKILL.md. Skills missing the file (or with
-   * unreadable frontmatter) are returned with just the directory name.
-   * Returns an empty array if the skills directory does not exist.
+   * Lists at most 256 direct skill directories in stable directory-id order.
+   * Missing or unreadable SKILL.md files fall back to the directory id.
    */
-  list(mindPath: string): SkillManifest[] {
+  async list(mindPath: string): Promise<SkillManifest[]> {
     const skillsDir = path.join(mindPath, '.github', 'skills');
-    let entries: fs.Dirent[];
+    const resolvedSkillsDir = await resolveSkillsDirectory(mindPath, skillsDir);
+    if (!resolvedSkillsDir) return [];
+
+    let entries: Dirent[];
     try {
-      entries = fs.readdirSync(skillsDir, { withFileTypes: true });
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException)?.code;
-      if (code !== 'ENOENT') {
-        log.warn(`Failed to read skills directory ${skillsDir}: ${(err as Error)?.message}`);
-      }
+      entries = await fs.readdir(resolvedSkillsDir, { withFileTypes: true });
+    } catch (error) {
+      logReadFailure(`skills directory ${resolvedSkillsDir}`, error);
       return [];
     }
 
+    const directories = entries
+      .filter((entry) => entry.isDirectory())
+      .sort((left, right) => compareText(left.name, right.name));
+
+    if (directories.length > MAX_SKILL_DIRECTORIES) {
+      log.warn(
+        `Found ${directories.length} skill directories in ${resolvedSkillsDir}; `
+        + `listing the first ${MAX_SKILL_DIRECTORIES} in stable directory-id order. `
+        + 'The remaining directories were not inspected.',
+      );
+    }
+
     const skills: SkillManifest[] = [];
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const skillMdPath = path.join(skillsDir, entry.name, 'SKILL.md');
-      const manifest = this.readSkillManifest(entry.name, skillMdPath);
+    for (const entry of directories.slice(0, MAX_SKILL_DIRECTORIES)) {
+      const manifest = await readSkillManifest(resolvedSkillsDir, entry.name);
       if (manifest) skills.push(manifest);
     }
-    // Stable alphabetical order so the UI doesn't shuffle between scans.
-    skills.sort((a, b) => a.name.localeCompare(b.name));
     return skills;
-  }
-
-  private readSkillManifest(id: string, skillMdPath: string): SkillManifest {
-    let raw: string;
-    try {
-      // SKILL.md frontmatter sits in the first ~30 lines; reading the full
-      // file is fine because skills are small and called rarely.
-      raw = fs.readFileSync(skillMdPath, 'utf-8');
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException)?.code;
-      if (code !== 'ENOENT') {
-        log.warn(`Failed to read ${skillMdPath}: ${(err as Error)?.message}`);
-      }
-      return { id, name: id };
-    }
-    return { id, ...parseFrontmatter(raw) };
   }
 }
 
@@ -69,27 +63,138 @@ interface ParsedFrontmatter {
   description?: string;
 }
 
+async function resolveSkillsDirectory(mindPath: string, skillsDir: string): Promise<string | null> {
+  try {
+    const [resolvedMindPath, skillsStat] = await Promise.all([
+      fs.realpath(mindPath),
+      fs.lstat(skillsDir),
+    ]);
+    if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) {
+      log.warn(`Skills path ${skillsDir} is not a direct directory`);
+      return null;
+    }
+
+    const resolvedSkillsDir = await fs.realpath(skillsDir);
+    if (!isWithin(resolvedMindPath, resolvedSkillsDir)) {
+      log.warn(`Skills directory ${skillsDir} resolves outside the mind directory`);
+      return null;
+    }
+    return resolvedSkillsDir;
+  } catch (error) {
+    if (errorCode(error) !== 'ENOENT') {
+      logReadFailure(`skills directory ${skillsDir}`, error);
+    }
+    return null;
+  }
+}
+
+async function readSkillManifest(
+  resolvedSkillsDir: string,
+  id: string,
+): Promise<SkillManifest | null> {
+  const skillDir = path.join(resolvedSkillsDir, id);
+  let resolvedSkillDir: string;
+  try {
+    const skillDirStat = await fs.lstat(skillDir);
+    if (!skillDirStat.isDirectory() || skillDirStat.isSymbolicLink()) {
+      log.warn(`Skill path ${skillDir} is not a direct directory`);
+      return null;
+    }
+    resolvedSkillDir = await fs.realpath(skillDir);
+    if (path.dirname(resolvedSkillDir) !== resolvedSkillsDir) {
+      log.warn(`Skill directory ${skillDir} resolves outside the skills directory`);
+      return null;
+    }
+  } catch (error) {
+    logReadFailure(`skill directory ${skillDir}`, error);
+    return null;
+  }
+
+  const raw = await readSkillMarkdown(resolvedSkillDir);
+  if (raw === null) return { id, name: id };
+
+  const parsed = parseFrontmatter(raw);
+  return {
+    id,
+    name: parsed.name || id,
+    ...(parsed.version ? { version: parsed.version } : {}),
+    ...(parsed.description ? { description: parsed.description } : {}),
+  };
+}
+
+async function readSkillMarkdown(resolvedSkillDir: string): Promise<string | null> {
+  const skillMarkdownPath = path.join(resolvedSkillDir, SKILL_MARKDOWN_FILENAME);
+  try {
+    const markdownStat = await fs.lstat(skillMarkdownPath);
+    if (markdownStat.isSymbolicLink()) {
+      log.warn(`${skillMarkdownPath} cannot be a symbolic link`);
+      return null;
+    }
+    if (!markdownStat.isFile()) {
+      log.warn(`${skillMarkdownPath} is not a regular file`);
+      return null;
+    }
+    if (markdownStat.size > MAX_SKILL_MARKDOWN_BYTES) {
+      log.warn(`${skillMarkdownPath} exceeds the ${MAX_SKILL_MARKDOWN_BYTES} byte limit`);
+      return null;
+    }
+
+    const resolvedMarkdownPath = await fs.realpath(skillMarkdownPath);
+    if (path.dirname(resolvedMarkdownPath) !== resolvedSkillDir) {
+      log.warn(`${skillMarkdownPath} resolves outside its skill directory`);
+      return null;
+    }
+
+    const handle = await fs.open(resolvedMarkdownPath, OPEN_READ_NOFOLLOW_FLAGS);
+    try {
+      return await readBoundedUtf8(handle, skillMarkdownPath);
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    if (errorCode(error) !== 'ENOENT') {
+      logReadFailure(skillMarkdownPath, error);
+    }
+    return null;
+  }
+}
+
+async function readBoundedUtf8(handle: FileHandle, displayPath: string): Promise<string | null> {
+  const openedStat = await handle.stat();
+  if (!openedStat.isFile()) {
+    log.warn(`${displayPath} is not a regular file`);
+    return null;
+  }
+  if (openedStat.size > MAX_SKILL_MARKDOWN_BYTES) {
+    log.warn(`${displayPath} exceeds the ${MAX_SKILL_MARKDOWN_BYTES} byte limit`);
+    return null;
+  }
+
+  const buffer = Buffer.alloc(MAX_SKILL_MARKDOWN_BYTES + 1);
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  if (offset > MAX_SKILL_MARKDOWN_BYTES) {
+    log.warn(`${displayPath} exceeds the ${MAX_SKILL_MARKDOWN_BYTES} byte limit`);
+    return null;
+  }
+  return buffer.subarray(0, offset).toString('utf8');
+}
+
 /**
- * Minimal YAML frontmatter parser tailored to the SKILL.md shape:
- *   ---
- *   name: foo
- *   version: 1.2.3
- *   description: "single-line summary"
- *   ---
- *
- * We deliberately don't pull in a YAML library here -- skill frontmatter is
- * deeply constrained by the lens/automation skill author guidelines, and the
- * three fields we surface are always simple scalars. Multi-line values are
- * folded into one line, surrounding quotes are stripped.
+ * Parses the bounded scalar subset of SKILL.md frontmatter used for display.
  */
 function parseFrontmatter(raw: string): ParsedFrontmatter {
-  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const content = raw.startsWith('\uFEFF') ? raw.slice(1) : raw;
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return { name: '' };
 
   const fields = new Map<string, string>();
   let currentKey: string | null = null;
   for (const line of match[1].split(/\r?\n/)) {
-    // Continuation lines for folded scalars start with whitespace.
     if (currentKey && /^\s+\S/.test(line)) {
       fields.set(currentKey, `${fields.get(currentKey) ?? ''} ${line.trim()}`);
       continue;
@@ -103,17 +208,15 @@ function parseFrontmatter(raw: string): ParsedFrontmatter {
     fields.set(currentKey, kv[2].trim());
   }
 
-  // Strip enclosing quote pair AFTER folding so multi-line "..." values
-  // come out clean.
-  for (const [k, v] of fields) fields.set(k, stripQuotes(v));
+  for (const [key, value] of fields) fields.set(key, stripQuotes(value));
 
   const name = fields.get('name') ?? '';
   const version = fields.get('version');
   const description = fields.get('description');
   return {
     name,
-    version: version && version.length > 0 ? version : undefined,
-    description: description && description.length > 0 ? description : undefined,
+    ...(version ? { version } : {}),
+    ...(description ? { description } : {}),
   };
 }
 
@@ -126,4 +229,25 @@ function stripQuotes(value: string): string {
     }
   }
   return value;
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative.length === 0
+    || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`));
+}
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException)?.code;
+}
+
+function logReadFailure(target: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  log.warn(`Failed to read ${target}: ${message}`);
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }

--- a/packages/services/src/skills/index.ts
+++ b/packages/services/src/skills/index.ts
@@ -2,6 +2,7 @@ export { MarketplaceSkillCatalog } from './MarketplaceSkillCatalog';
 export type { MarketplaceSkillCatalogResult } from './MarketplaceSkillCatalog';
 export { MarketplaceSkillMaterializer, computeManagedFileHash } from './MarketplaceSkillMaterializer';
 export { ManagedSkillService } from './ManagedSkillService';
+export { MindSkillDiscovery } from './MindSkillDiscovery';
 export type { ManagedSkillSyncError, ManagedSkillSyncResult } from './ManagedSkillService';
 export type {
   ManagedSkillAsset,

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -51,6 +51,7 @@ import type {
   UserProfileImportResult,
   UserProfileSaveRequest,
 } from './types';
+import type { SkillManifest } from './skill-types';
 
 export interface ElectronAPI {
   chat: {
@@ -187,6 +188,10 @@ export interface ElectronAPI {
      * log (#56). Returns an unsubscribe function — call it on unmount.
      */
     onStartupProgress: (callback: (event: StartupProgressEvent) => void) => () => void;
+  };
+  skills: {
+    /** List the skills installed under `<mindPath>/.github/skills/`. */
+    listForMind: (mindId: string) => Promise<SkillManifest[]>;
   };
 }
 

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -190,7 +190,10 @@ export interface ElectronAPI {
     onStartupProgress: (callback: (event: StartupProgressEvent) => void) => () => void;
   };
   skills: {
-    /** List the skills installed under `<mindPath>/.github/skills/`. */
+    /**
+     * Lists self-declared metadata for skill directories currently on disk.
+     * This does not attest managed provenance, integrity, or lifecycle state.
+     */
     listForMind: (mindId: string) => Promise<SkillManifest[]>;
   };
 }

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -148,6 +148,9 @@ export const IPC = {
     GET_FEATURE_FLAGS: 'app:getFeatureFlags',
     STARTUP_PROGRESS: 'app:startupProgress',
   },
+  SKILLS: {
+    LIST_FOR_MIND: 'skills:listForMind',
+  },
 } as const;
 
 type IpcNamespace = typeof IPC;

--- a/packages/shared/src/skill-types.ts
+++ b/packages/shared/src/skill-types.ts
@@ -1,15 +1,18 @@
-// Shared SkillManifest type. Skills live under <mindPath>/.github/skills/<name>/SKILL.md
-// with YAML frontmatter (name, version, description) and a markdown body that
-// teaches the agent how to use the skill. The renderer surfaces these in the
-// AboutAgentPanel so users can see what a mind can do.
-
+/**
+ * Self-declared metadata discovered from a skill directory on disk.
+ *
+ * Presence in this list does not establish marketplace provenance, content
+ * hash verification, management status, update status, or trust. Managed-skill
+ * integrity and lifecycle remain the responsibility of ManagedSkillService.
+ * Values are untrusted local file content and must be rendered as text.
+ */
 export interface SkillManifest {
-  /** Directory name under .github/skills/, used as the stable id. */
+  /** Directory name under .github/skills and the stable on-disk identifier. */
   id: string;
-  /** YAML `name` from the SKILL.md frontmatter. Falls back to id. */
+  /** Display name from SKILL.md; falls back to id when absent or blank. */
   name: string;
-  /** Optional YAML `version` field. */
+  /** Self-declared version string from SKILL.md, if present. */
   version?: string;
-  /** Optional YAML `description` field (one-line summary). */
+  /** Self-declared description from SKILL.md, if present. */
   description?: string;
 }

--- a/packages/shared/src/skill-types.ts
+++ b/packages/shared/src/skill-types.ts
@@ -1,0 +1,15 @@
+// Shared SkillManifest type. Skills live under <mindPath>/.github/skills/<name>/SKILL.md
+// with YAML frontmatter (name, version, description) and a markdown body that
+// teaches the agent how to use the skill. The renderer surfaces these in the
+// AboutAgentPanel so users can see what a mind can do.
+
+export interface SkillManifest {
+  /** Directory name under .github/skills/, used as the stable id. */
+  id: string;
+  /** YAML `name` from the SKILL.md frontmatter. Falls back to id. */
+  name: string;
+  /** Optional YAML `version` field. */
+  version?: string;
+  /** Optional YAML `description` field (one-line summary). */
+  description?: string;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,4 +1,5 @@
 export type { A2AIncomingPayload } from './a2a-types';
+export type { SkillManifest } from './skill-types';
 
 // Shared types across main, preload, and renderer processes
 


### PR DESCRIPTION
## Summary

Supersedes #397 with the author's latest per-mind skill discovery implementation rebased onto current master.

## Notable changes

- Adds bounded, asynchronous per-mind skill manifest discovery.
- Adds a thin validated skills IPC adapter and preload/browser API surface.
- Rejects path escapes and unsafe links while returning renderer-safe metadata.
- Includes focused service and IPC coverage.

## Validation

- `npm run lint`
- `npm test`
- Focused Uncle Bob architecture and security review: no remaining findings.

Packaging and SDK smoke were skipped because this does not change packaging or SDK runtime paths.