### PR TITLE
Fix WTD runtime promotion across Windows volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Refresh the packaged Copilot runtime** — Pins @github/copilot-sdk 1.0.6-preview.1 with its compatible @github/copilot 1.0.69-1 runtime and updates Chamber for the SDK's current session configuration and event contracts.
 - **Stop Copilot CLI auth popups after sign-in** — Pass Chamber's stored GitHub OAuth token into SDK-created CLI clients and disable CLI auto-login so device-flow browser prompts only occur from Chamber's explicit sign-in flow.
 - **Isolate packaged Copilot runtime validation** — Runs the bundled CLI smoke check with a temporary home so self-updated developer cache builds cannot cause false package-version mismatches.
+- **Promote WTD runtimes across Windows volumes** — Falls back to copy-and-remove when temporary staging and the Actions workspace are on different drives, so Insiders packaging can complete (#400)
 
 ### Tests
 

--- a/scripts/prepare-wtd-runtime.js
+++ b/scripts/prepare-wtd-runtime.js
@@ -199,28 +199,50 @@ function validateRuntimeFiles(runtimeRoot, target) {
   return { wtdVersion: installedWtd.version, onnxVersion: installedOnnx.version };
 }
 
-function promoteRuntime(target) {
-  fs.rmSync(backupDir, { recursive: true, force: true });
+function isRecoverableRenameError(error) {
+  return error
+    && typeof error === 'object'
+    && (error.code === 'EPERM' || error.code === 'EXDEV');
+}
+
+function promoteDirectory(dirs, validate = () => {}, fsImpl = fs) {
+  fsImpl.rmSync(dirs.backupDir, { recursive: true, force: true });
 
   let movedExistingTarget = false;
   try {
-    if (fs.existsSync(targetDir)) {
-      fs.renameSync(targetDir, backupDir);
+    if (fsImpl.existsSync(dirs.targetDir)) {
+      fsImpl.renameSync(dirs.targetDir, dirs.backupDir);
       movedExistingTarget = true;
     }
 
-    fs.renameSync(stagingDir, targetDir);
-    validateRuntimeDir(targetDir, target);
-    fs.rmSync(backupDir, { recursive: true, force: true });
+    try {
+      fsImpl.renameSync(dirs.stagingDir, dirs.targetDir);
+    } catch (error) {
+      if (!isRecoverableRenameError(error)) {
+        throw error;
+      }
+      fsImpl.rmSync(dirs.targetDir, { recursive: true, force: true });
+      fsImpl.cpSync(dirs.stagingDir, dirs.targetDir, { recursive: true });
+    }
+
+    validate(dirs.targetDir);
+    fsImpl.rmSync(dirs.backupDir, { recursive: true, force: true });
   } catch (error) {
-    fs.rmSync(targetDir, { recursive: true, force: true });
-    if (movedExistingTarget && fs.existsSync(backupDir)) {
-      fs.renameSync(backupDir, targetDir);
+    fsImpl.rmSync(dirs.targetDir, { recursive: true, force: true });
+    if (movedExistingTarget && fsImpl.existsSync(dirs.backupDir)) {
+      fsImpl.renameSync(dirs.backupDir, dirs.targetDir);
     }
     throw error;
   } finally {
-    fs.rmSync(stagingDir, { recursive: true, force: true });
+    fsImpl.rmSync(dirs.stagingDir, { recursive: true, force: true });
   }
+}
+
+function promoteRuntime(target) {
+  promoteDirectory(
+    { stagingDir, targetDir, backupDir },
+    (runtimeRoot) => validateRuntimeDir(runtimeRoot, target),
+  );
 }
 
 function cleanStaleResources() {
@@ -304,6 +326,7 @@ module.exports = {
   readPinnedVersion,
   cleanStaleResources,
   prepareDevRuntime,
+  promoteDirectory,
 };
 
 if (require.main === module) {

--- a/tests/regression/prepare-wtd-runtime.test.ts
+++ b/tests/regression/prepare-wtd-runtime.test.ts
@@ -19,6 +19,11 @@ async function loadPrepareWtdRuntime(): Promise<{
   readPinnedVersion: () => string;
   cleanStaleResources: () => void;
   createNestedNpmEnvironment: (baseEnv?: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
+  promoteDirectory: (
+    dirs: { stagingDir: string; targetDir: string; backupDir: string },
+    validate?: (runtimeRoot: string) => void,
+    fsImpl?: typeof fs,
+  ) => void;
 }> {
   const module = await import('../../scripts/prepare-wtd-runtime.js');
   return ('default' in module ? module.default : module) as never;
@@ -250,6 +255,35 @@ describe('prepare-wtd-runtime', () => {
       PATH: 'C:\\tools',
       npm_config_update_notifier: 'false',
     });
+  });
+
+  it('copies the staged runtime when promotion crosses Windows volumes', async () => {
+    const { promoteDirectory } = await loadPrepareWtdRuntime();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-wtd-promote-'));
+    const stagingDir = path.join(root, 'wtd-runtime.new');
+    const targetDir = path.join(root, 'wtd-runtime');
+    const backupDir = path.join(root, 'wtd-runtime.old');
+    fs.mkdirSync(stagingDir, { recursive: true });
+    fs.writeFileSync(path.join(stagingDir, 'sentinel.txt'), 'ready');
+    const fsWithCrossVolumeRename = {
+      ...fs,
+      renameSync: (oldPath: fs.PathLike, newPath: fs.PathLike) => {
+        if (String(oldPath) === stagingDir && String(newPath) === targetDir) {
+          throw Object.assign(new Error('EXDEV: cross-device link not permitted, rename'), { code: 'EXDEV' });
+        }
+        return fs.renameSync(oldPath, newPath);
+      },
+    } as typeof fs;
+
+    try {
+      promoteDirectory({ stagingDir, targetDir, backupDir }, undefined, fsWithCrossVolumeRename);
+
+      expect(fs.readFileSync(path.join(targetDir, 'sentinel.txt'), 'utf-8')).toBe('ready');
+      expect(fs.existsSync(stagingDir)).toBe(false);
+      expect(fs.existsSync(backupDir)).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('keeps chamber-automation-runtime advisory-only: it must never depend on @ianphil/ttasks-wtd or onnxruntime-node', () => {


### PR DESCRIPTION
## Summary

- Fall back to recursive copy when WTD runtime promotion crosses Windows volumes.
- Preserve validation, rollback, and staging cleanup semantics.
- Add regression coverage for the Actions `C:` temporary directory to `D:` workspace failure.

## Release blocker

Insiders run https://github.com/ianphil/chamber/actions/runs/29162132903 failed before Windows signing with `EXDEV` while moving the staged WTD runtime. macOS completed, but publication was correctly blocked.

## Validation

- Targeted WTD and Forge regression tests
- `npm run typecheck`
- Full Windows Insiders `npm run package`
- Uncle Bob review: safe to ship, no blocking findings

Refs #400