### PR TITLE
feat: add global Cmd/Ctrl-K command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Add theme-aware update chrome** — Adds a dismissible ready-to-install banner and update-status indicator with accessible light and dark theme colors.
 - **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 - **Add insiders-gated local voice dictation** — Adds local Foundry/Nemotron dictation with a dedicated Settings page, chat mic and push-to-talk controls, explicit runtime capability gating, and insiders-only prepared runtime packaging. (#385) (#385)
+- **Add global command palette** — Adds a Cmd/Ctrl-K command palette built on the existing cmdk primitive and mounted once in the app shell, to switch between loaded agents, open Chat, Chatroom, Settings, and discovered Lens views, add an agent, and start a guarded new conversation for the active mind that is withheld while it is streaming or switching models.
 
 ### Refactor
 

--- a/apps/web/src/renderer/components/command/CommandPalette.test.tsx
+++ b/apps/web/src/renderer/components/command/CommandPalette.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { MindContext } from '@chamber/shared/types';
+import { AppStateProvider } from '../../lib/store';
+import type { AppState } from '../../lib/store/state';
+import { installElectronAPI, mockElectronAPI, makeLensViewManifest } from '../../../test/helpers';
+import { CommandPalette, buildCommandItems, type CommandPaletteDeps } from './CommandPalette';
+
+// jsdom does not provide ResizeObserver; cmdk needs it.
+class MockResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
+  MockResizeObserver;
+// jsdom does not implement Element.scrollIntoView; cmdk calls it on focus.
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}
+
+const mind: MindContext = {
+  mindId: 'mind-1',
+  mindPath: 'C:\\agents\\monica',
+  identity: { name: 'Monica', systemMessage: '# Monica' },
+  status: 'ready',
+};
+
+const PLACEHOLDER = 'Type a command or search...';
+const NEW_CONVERSATION = 'action:new-conversation';
+
+function makeDeps(overrides: Partial<CommandPaletteDeps> = {}): CommandPaletteDeps {
+  return {
+    minds: [],
+    discoveredViews: [],
+    activeMindId: null,
+    isActiveMindBusy: false,
+    creationGuard: { current: false },
+    dispatch: vi.fn(),
+    electronAPI: mockElectronAPI(),
+    ...overrides,
+  };
+}
+
+function renderPalette(testInitialState?: Partial<AppState>) {
+  return render(
+    <AppStateProvider testInitialState={testInitialState}>
+      <CommandPalette />
+    </AppStateProvider>,
+  );
+}
+
+function pressCtrlK() {
+  fireEvent.keyDown(document.body, { key: 'k', ctrlKey: true });
+}
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    installElectronAPI();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('is closed until the Ctrl+K shortcut is pressed', () => {
+    renderPalette({ activeMindId: mind.mindId, minds: [mind] });
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull();
+
+    pressCtrlK();
+
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeTruthy();
+  });
+
+  it('also opens with the Meta+K shortcut for macOS', () => {
+    renderPalette({ minds: [mind] });
+
+    fireEvent.keyDown(document.body, { key: 'k', metaKey: true });
+
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeTruthy();
+  });
+
+  it('toggles closed when Ctrl+K is pressed again', () => {
+    renderPalette({ activeMindId: mind.mindId, minds: [mind] });
+
+    pressCtrlK();
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeTruthy();
+
+    pressCtrlK();
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull();
+  });
+
+  it('closes when Escape is pressed', async () => {
+    renderPalette({ activeMindId: mind.mindId, minds: [mind] });
+
+    pressCtrlK();
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull();
+    });
+  });
+
+  it('exposes an accessible label on the search input', () => {
+    renderPalette({ activeMindId: mind.mindId, minds: [mind] });
+
+    pressCtrlK();
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
+    expect(input.getAttribute('aria-label')).toBe('Search commands');
+  });
+
+  it('filters the visible commands as the user types', async () => {
+    renderPalette({ activeMindId: null, minds: [] });
+
+    pressCtrlK();
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: 'settings' } });
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('option').map((option) => option.textContent);
+      expect(labels).toContain('Open Settings');
+      expect(labels).not.toContain('Open Chat');
+      expect(labels).not.toContain('Open Chatroom');
+    });
+  });
+
+  it('dispatches SET_ACTIVE_VIEW when the Open Settings command runs', () => {
+    const dispatch = vi.fn();
+    const commands = buildCommandItems(makeDeps({ dispatch }));
+
+    const settings = commands.find((command) => command.id === 'view:settings');
+    expect(settings).toBeDefined();
+    settings?.perform();
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_ACTIVE_VIEW', payload: 'settings' });
+  });
+
+  it('switches the active mind through electron and the store', () => {
+    const dispatch = vi.fn();
+    const electronAPI = mockElectronAPI();
+    const commands = buildCommandItems(
+      makeDeps({ minds: [mind], activeMindId: mind.mindId, dispatch, electronAPI }),
+    );
+
+    const switchCommand = commands.find((command) => command.id === `mind:${mind.mindId}`);
+    expect(switchCommand).toBeDefined();
+    switchCommand?.perform();
+
+    expect(electronAPI.mind.setActive).toHaveBeenCalledWith(mind.mindId);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_ACTIVE_MIND', payload: mind.mindId });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  });
+
+  it('offers the new conversation command only for an idle active mind', () => {
+    const withoutMind = buildCommandItems(makeDeps());
+    expect(withoutMind.some((command) => command.id === NEW_CONVERSATION)).toBe(false);
+
+    const idleMind = buildCommandItems(makeDeps({ minds: [mind], activeMindId: mind.mindId }));
+    expect(idleMind.some((command) => command.id === NEW_CONVERSATION)).toBe(true);
+  });
+
+  it('namespaces discovered Lens view commands so they cannot collide with reserved view ids', () => {
+    const dispatch = vi.fn();
+    const commands = buildCommandItems(
+      makeDeps({ dispatch, discoveredViews: [makeLensViewManifest({ id: 'chat', name: 'Custom Chat' })] }),
+    );
+
+    const ids = commands.map((command) => command.id);
+    expect(ids).toContain('view:chat');
+    expect(ids).toContain('lens:chat');
+
+    commands.find((command) => command.id === 'lens:chat')?.perform();
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  });
+
+  it('omits the new conversation command while the active mind is busy', () => {
+    const busy = buildCommandItems(
+      makeDeps({ minds: [mind], activeMindId: mind.mindId, isActiveMindBusy: true }),
+    );
+    expect(busy.some((command) => command.id === NEW_CONVERSATION)).toBe(false);
+  });
+
+  it('hides the new conversation command while the active mind is streaming', async () => {
+    renderPalette({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      streamingByMind: { [mind.mindId]: true },
+    });
+
+    pressCtrlK();
+    await screen.findByPlaceholderText(PLACEHOLDER);
+
+    expect(screen.getByText('Open Chat')).toBeTruthy();
+    expect(screen.queryByText('New conversation')).toBeNull();
+  });
+
+  it('guards against duplicate concurrent conversation creation', async () => {
+    const electronAPI = mockElectronAPI();
+    let resolveNewConversation: (value: { sessionId: string; messages: []; conversations: [] }) => void = () => {};
+    (electronAPI.chat.newConversation as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => { resolveNewConversation = resolve; }),
+    );
+    const creationGuard = { current: false };
+    const commands = buildCommandItems(
+      makeDeps({ minds: [mind], activeMindId: mind.mindId, creationGuard, electronAPI }),
+    );
+    const newConversation = commands.find((command) => command.id === NEW_CONVERSATION);
+    expect(newConversation).toBeDefined();
+
+    newConversation?.perform();
+    newConversation?.perform();
+
+    expect(electronAPI.chat.newConversation).toHaveBeenCalledTimes(1);
+
+    resolveNewConversation({ sessionId: 's1', messages: [], conversations: [] });
+    await waitFor(() => expect(creationGuard.current).toBe(false));
+
+    newConversation?.perform();
+    expect(electronAPI.chat.newConversation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/renderer/components/command/CommandPalette.test.tsx
+++ b/apps/web/src/renderer/components/command/CommandPalette.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { MindContext } from '@chamber/shared/types';
 import { AppStateProvider } from '../../lib/store';
@@ -15,9 +15,10 @@ class MockResizeObserver {
   unobserve(): void {}
   disconnect(): void {}
 }
-(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
-  MockResizeObserver;
+const originalResizeObserver = (globalThis as unknown as { ResizeObserver?: typeof MockResizeObserver }).ResizeObserver;
+(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver = MockResizeObserver;
 // jsdom does not implement Element.scrollIntoView; cmdk calls it on focus.
+const originalScrollIntoView = typeof Element !== 'undefined' ? Element.prototype.scrollIntoView : undefined;
 if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = function () {};
 }
@@ -65,6 +66,13 @@ describe('CommandPalette', () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    (globalThis as unknown as { ResizeObserver?: typeof MockResizeObserver }).ResizeObserver = originalResizeObserver;
+    if (typeof Element !== 'undefined') {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    }
   });
 
   it('is closed until the Ctrl+K shortcut is pressed', () => {

--- a/apps/web/src/renderer/components/command/CommandPalette.tsx
+++ b/apps/web/src/renderer/components/command/CommandPalette.tsx
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch } from 'react';
+import {
+  Bot,
+  Layout,
+  MessageSquare,
+  MessageSquarePlus,
+  Plus,
+  Settings,
+  Users,
+  type LucideIcon,
+} from 'lucide-react';
+import type { LensViewManifest, MindContext } from '@chamber/shared/types';
+import type { ElectronAPI } from '@chamber/shared/electron-types';
+import { useAppDispatch, useAppState } from '../../lib/store';
+import type { AppAction, LensView } from '../../lib/store';
+import { Logger } from '../../lib/logger';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../ui/command';
+
+const log = Logger.create('CommandPalette');
+
+const GROUP_VIEWS = 'Views';
+const GROUP_AGENTS = 'Agents';
+const GROUP_CONVERSATION = 'Conversation';
+
+const INPUT_PLACEHOLDER = 'Type a command or search...';
+
+/** Always-present views that exist on master, rendered first in the Views group. */
+const STATIC_VIEWS: readonly { id: LensView; label: string; icon: LucideIcon }[] = [
+  { id: 'chat', label: 'Open Chat', icon: MessageSquare },
+  { id: 'chatroom', label: 'Open Chatroom', icon: Users },
+  { id: 'settings', label: 'Open Settings', icon: Settings },
+];
+
+/** A single, self-contained palette entry. `perform` is pre-bound to its side effects. */
+export interface PaletteCommand {
+  id: string;
+  label: string;
+  group: string;
+  icon: LucideIcon;
+  keywords?: string[];
+  perform: () => void;
+}
+
+/**
+ * Mutable in-flight flag guarding against duplicate conversation creation. Shaped
+ * like a React ref so the component can pass `useRef(false)` straight through.
+ */
+export interface CreationGuard {
+  current: boolean;
+}
+
+/** Live state plus injected effects the commands act on. Kept injectable for testing. */
+export interface CommandPaletteDeps {
+  minds: MindContext[];
+  discoveredViews: LensViewManifest[];
+  activeMindId: string | null;
+  /** True while the active mind is streaming or switching models; blocks conversation resets. */
+  isActiveMindBusy: boolean;
+  /** Shared in-flight flag so rapid repeat selections cannot spawn two sessions. */
+  creationGuard: CreationGuard;
+  dispatch: Dispatch<AppAction>;
+  electronAPI: ElectronAPI;
+}
+
+function switchToMind(mind: MindContext, dispatch: Dispatch<AppAction>, electronAPI: ElectronAPI): void {
+  // Mirror MindSidebar.handleSwitchMind: focus a popout window if the mind is
+  // windowed, otherwise switch the active mind in the main window.
+  if (mind.windowed) {
+    void electronAPI.mind.openWindow(mind.mindId);
+    return;
+  }
+  void electronAPI.mind.setActive(mind.mindId);
+  dispatch({ type: 'SET_ACTIVE_MIND', payload: mind.mindId });
+  dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+}
+
+async function startNewConversation(
+  mindId: string,
+  dispatch: Dispatch<AppAction>,
+  electronAPI: ElectronAPI,
+  guard: CreationGuard,
+): Promise<void> {
+  // Mirror ConversationHistoryPanel.startNewConversation: skip if a creation is
+  // already in flight, reset the backend session, then hydrate the fresh session.
+  if (guard.current) return;
+  guard.current = true;
+  try {
+    const result = await electronAPI.chat.newConversation(mindId);
+    await electronAPI.chatroom.clear();
+    dispatch({
+      type: 'RESUME_CONVERSATION',
+      payload: {
+        mindId,
+        sessionId: result.sessionId,
+        messages: result.messages,
+        conversations: result.conversations,
+      },
+    });
+    dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  } catch (error) {
+    log.error('Failed to start new conversation from command palette:', error);
+  } finally {
+    guard.current = false;
+  }
+}
+
+/**
+ * Build the palette command list from live app state. Pure and side-effect free
+ * to construct; each command's `perform` closure owns its dispatch / electron work.
+ * Adding a future view is a one-line push, keeping the list trivially extensible.
+ */
+export function buildCommandItems(deps: CommandPaletteDeps): PaletteCommand[] {
+  const { minds, discoveredViews, activeMindId, isActiveMindBusy, creationGuard, dispatch, electronAPI } = deps;
+  const commands: PaletteCommand[] = [];
+
+  for (const view of STATIC_VIEWS) {
+    commands.push({
+      id: `view:${view.id}`,
+      label: view.label,
+      group: GROUP_VIEWS,
+      icon: view.icon,
+      perform: () => dispatch({ type: 'SET_ACTIVE_VIEW', payload: view.id }),
+    });
+  }
+
+  for (const view of discoveredViews) {
+    commands.push({
+      // Namespace discovered views under `lens:` so a Lens declaring a reserved
+      // id (chat/chatroom/settings) cannot collide with a STATIC_VIEWS command.
+      id: `lens:${view.id}`,
+      label: `Open ${view.name}`,
+      group: GROUP_VIEWS,
+      icon: Layout,
+      keywords: [view.name, view.id],
+      perform: () => dispatch({ type: 'SET_ACTIVE_VIEW', payload: view.id }),
+    });
+  }
+
+  for (const mind of minds) {
+    commands.push({
+      id: `mind:${mind.mindId}`,
+      label: `Switch to ${mind.identity.name}`,
+      group: GROUP_AGENTS,
+      icon: Bot,
+      keywords: [mind.identity.name, 'agent'],
+      perform: () => switchToMind(mind, dispatch, electronAPI),
+    });
+  }
+
+  commands.push({
+    id: 'action:add-agent',
+    label: 'Add agent',
+    group: GROUP_AGENTS,
+    icon: Plus,
+    keywords: ['new agent', 'create mind'],
+    perform: () => dispatch({ type: 'SHOW_LANDING' }),
+  });
+
+  // Omit conversation reset while the mind is streaming or switching models so the
+  // palette cannot bypass the same guard the history panel enforces.
+  if (activeMindId && !isActiveMindBusy) {
+    commands.push({
+      id: 'action:new-conversation',
+      label: 'New conversation',
+      group: GROUP_CONVERSATION,
+      icon: MessageSquarePlus,
+      keywords: ['reset chat', 'start over', 'clear'],
+      perform: () => {
+        void startNewConversation(activeMindId, dispatch, electronAPI, creationGuard);
+      },
+    });
+  }
+
+  return commands;
+}
+
+interface CommandGroupView {
+  group: string;
+  items: PaletteCommand[];
+}
+
+/** Group commands by their `group` field, preserving first-seen order. */
+function groupCommands(commands: PaletteCommand[]): CommandGroupView[] {
+  const groups: CommandGroupView[] = [];
+  const byGroup = new Map<string, CommandGroupView>();
+  for (const command of commands) {
+    let view = byGroup.get(command.group);
+    if (!view) {
+      view = { group: command.group, items: [] };
+      byGroup.set(command.group, view);
+      groups.push(view);
+    }
+    view.items.push(command);
+  }
+  return groups;
+}
+
+/**
+ * Global command palette. Opens on Cmd+K (mac) / Ctrl+K (win/linux), filters as
+ * you type, runs the selected command, and closes on selection or Escape. Mounted
+ * once by AppShell; it self-registers the global shortcut and cleans it up on unmount.
+ */
+export function CommandPalette() {
+  const { minds, discoveredViews, activeMindId, streamingByMind, conversationViewByMind } = useAppState();
+  const dispatch = useAppDispatch();
+  const [open, setOpen] = useState(false);
+  const creationGuard = useRef(false);
+
+  // Mirror ConversationHistoryPanel: streaming or model-switching means the active
+  // mind is busy and conversation resets must be withheld.
+  const activeConversationView = activeMindId ? conversationViewByMind[activeMindId] : undefined;
+  const isActiveMindBusy = activeMindId
+    ? Boolean(streamingByMind[activeMindId] || activeConversationView?.streaming || activeConversationView?.modelSwitching)
+    : false;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && !event.altKey && (event.key === 'k' || event.key === 'K')) {
+        event.preventDefault();
+        setOpen((previous) => !previous);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const commands = useMemo(
+    () => buildCommandItems({
+      minds,
+      discoveredViews,
+      activeMindId,
+      isActiveMindBusy,
+      creationGuard,
+      dispatch,
+      electronAPI: window.electronAPI,
+    }),
+    [minds, discoveredViews, activeMindId, isActiveMindBusy, dispatch],
+  );
+  const groups = useMemo(() => groupCommands(commands), [commands]);
+
+  const runCommand = useCallback((command: PaletteCommand) => {
+    command.perform();
+    setOpen(false);
+  }, []);
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Command palette"
+      description="Search for a command to run"
+    >
+      <CommandInput aria-label="Search commands" placeholder={INPUT_PLACEHOLDER} />
+      <CommandList className="max-h-[400px]">
+        <CommandEmpty>No results found.</CommandEmpty>
+        {groups.map(({ group, items }) => (
+          <CommandGroup key={group} heading={group}>
+            {items.map((command) => {
+              const Icon = command.icon;
+              return (
+                <CommandItem
+                  key={command.id}
+                  value={`${command.id} ${command.label} ${command.keywords?.join(' ') ?? ''}`}
+                  onSelect={() => runCommand(command)}
+                >
+                  <Icon size={16} className="text-muted-foreground" aria-hidden />
+                  <span>{command.label}</span>
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/renderer/components/command/CommandPalette.tsx
+++ b/apps/web/src/renderer/components/command/CommandPalette.tsx
@@ -222,6 +222,9 @@ export function CommandPalette() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || event.isComposing) {
+        return;
+      }
       if ((event.metaKey || event.ctrlKey) && !event.altKey && (event.key === 'k' || event.key === 'K')) {
         event.preventDefault();
         setOpen((previous) => !previous);

--- a/apps/web/src/renderer/components/layout/AppShell.tsx
+++ b/apps/web/src/renderer/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useAppSubscriptions } from '../../hooks/useAppSubscriptions';
 import { useAppDispatch, useAppState } from '../../lib/store';
 import { TooltipProvider } from '../ui/tooltip';
+import { CommandPalette } from '../command/CommandPalette';
 import { ActivityBar } from './ActivityBar';
 import { ConversationHistoryPanel } from '../history/ConversationHistoryPanel';
 import { MacTitlebarDrag } from './MacTitlebarDrag';
@@ -48,6 +49,7 @@ export function AppShell() {
   return (
     <TooltipProvider>
       <MacTitlebarDrag />
+      <CommandPalette />
       <div className="flex flex-col h-screen w-screen bg-background text-foreground">
         {/* Main layout: activity bar | mind sidebar | content | conversation history */}
         <div className="flex flex-1 min-h-0 gap-2 p-2">

--- a/apps/web/src/renderer/components/ui/command.tsx
+++ b/apps/web/src/renderer/components/ui/command.tsx
@@ -1,7 +1,15 @@
 import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
+import { Search } from "lucide-react"
 
 import { cn } from "@/renderer/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog"
 
 function Command({
   className,
@@ -16,6 +24,57 @@ function Command({
       )}
       {...props}
     />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run",
+  children,
+  className,
+  showCloseButton = false,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogContent
+        showCloseButton={showCloseButton}
+        className={cn("overflow-hidden gap-0 p-0 max-w-lg", className)}
+      >
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <Command>{children}</Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex items-center gap-2 border-b border-border px-3"
+    >
+      <Search size={16} className="shrink-0 text-muted-foreground" aria-hidden />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full bg-transparent py-2 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
   )
 }
 
@@ -52,7 +111,11 @@ function CommandGroup({
   return (
     <CommandPrimitive.Group
       data-slot="command-group"
-      className={cn("overflow-hidden p-1", className)}
+      className={cn(
+        "overflow-hidden p-1 text-foreground",
+        "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className,
+      )}
       {...props}
     />
   )
@@ -76,4 +139,4 @@ function CommandItem({
   )
 }
 
-export { Command, CommandList, CommandEmpty, CommandGroup, CommandItem }
+export { Command, CommandDialog, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem }


### PR DESCRIPTION
﻿## Summary

Adds a global command palette to the Chamber renderer. Press Cmd+K (mac) or Ctrl+K (win/linux) from anywhere to open it, type to filter, select to run a command, and press Escape (or select) to close. It is mounted once in `AppShell` and self-registers its global shortcut.

Commands are generated from live app state through a small, pure, extensible `buildCommandItems` array, so future views drop in with a one-line push. Each command dispatches the matching store action, mirroring the existing `ActivityBar`, `MindSidebar`, and `ConversationHistoryPanel` flows.

## Notable changes

- `apps/web/src/renderer/components/command/CommandPalette.tsx` (new)
  - `CommandPalette`: opens/toggles on Cmd/Ctrl+K via a `window` keydown handler registered on mount and cleaned up on unmount; cmdk handles filtering; runs a command and closes on select; Escape closes via the Radix dialog.
  - `buildCommandItems(deps)`: pure builder returning `{ id, label, group, icon, keywords?, perform }`. Groups: Views (Open Chat / Chatroom / Settings + each discovered Lens view), Agents (Switch to each loaded mind + Add agent), Conversation (New conversation for the active mind).
  - Actions: `SET_ACTIVE_VIEW`, `SET_ACTIVE_MIND` (+ `mind.setActive` / windowed `mind.openWindow`), `SHOW_LANDING`, and a guarded new conversation (`chat.newConversation` -> `chatroom.clear` -> `RESUME_CONVERSATION` -> `SET_ACTIVE_VIEW: 'chat'`).
- `apps/web/src/renderer/components/ui/command.tsx` (edit): added `CommandInput` and `CommandDialog` built on the existing cmdk primitive + `ui/dialog`, and centralized group-heading styling in `CommandGroup`. Purely additive; existing exports unchanged (the current `ChatInput` consumer only uses `Command`/`CommandList`/`CommandItem`).
- `apps/web/src/renderer/components/layout/AppShell.tsx` (edit): mounts `<CommandPalette />` once in the main shell.
- `CHANGELOG.md`: `## [Unreleased]` -> `### Added` bullet via `scripts/append-changelog-entry.js`.

## Review-driven hardening

- **New conversation respects the busy guard.** The command is omitted while the active mind is streaming or switching models (`isActiveMindBusy`, derived exactly as in `ConversationHistoryPanel`), and an in-flight `CreationGuard` ref prevents duplicate concurrent sessions. This closes the principal blocker where the palette bypassed the history panel guard.
- **Unique cmdk values.** Each item's cmdk `value` includes its unique command id, and discovered Lens views are namespaced `lens:<id>` so a Lens declaring a reserved id (chat/chatroom/settings) cannot collide with a static view command.
- **Accessible input.** The search input carries an explicit `aria-label`.
- Uncle Bob review verdict: clean, no critical or major defects. Two remaining notes were deliberate: a call-time busy re-check is redundant here (the command is reactively omitted when busy and the backend `assertCanSwitchConversation` rejects a streaming mind), and the feature-flagged `a2a-relay` view is out of this slice's scope.

## Tests

- Colocated Vitest `CommandPalette.test.tsx` (13 tests): keyboard open, Meta+K, Ctrl+K toggle-close, Escape close, accessible-label, type-to-filter, dispatch of Open Settings and Switch-to-mind, idle-only new conversation, busy omission (builder + streaming render), duplicate-creation guard (with reset), and discovered-view id namespacing.
- `npm run lint`: clean (tsc + eslint + deps:check + yaml + md).
- `apps/web` suite: 601 tests across 59 files pass, including the existing `ui/command` consumer.
- Full `npm test`: 2218 passed, 2 skipped, 1 failure.

## Caveats

- The single full-suite failure is the pre-existing Windows-only test `packages/services/src/mindProfile/MindProfileService.test.ts > rejects symlinked profile files`, which throws `EPERM: operation not permitted, symlink` from `fs.symlinkSync` (Windows requires elevated privilege to create symlinks). That file is unchanged on this branch and the failure is environmental, unrelated to this change.
- This worktree started without `node_modules`; dependencies were installed and native modules (better-sqlite3, keytar, sharp) were rebuilt locally so the full suite could run. No source or lockfile changes resulted.
- Renderer-only change: no packaging, runtime, or Electron config surface touched, so packaging smoke was not run.
- No closing issue reference: no matching tracked issue was found for this slice.



---

## Upstream issue linkage

No matching upstream issue found. New platform capability: global Cmd/Ctrl-K command palette.

## Source branch

Fork PR: https://github.com/patschmittdev/chamber/pull/2
Head: `patschmittdev:patschmittdev-feat-command-palette`
