### PR TITLE
feat: appearance settings (theme, font size, density)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Add theme-aware update chrome** — Adds a dismissible ready-to-install banner and update-status indicator with accessible light and dark theme colors.
 - **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 - **Add insiders-gated local voice dictation** — Adds local Foundry/Nemotron dictation with a dedicated Settings page, chat mic and push-to-talk controls, explicit runtime capability gating, and insiders-only prepared runtime packaging. (#385) (#385)
+- **Add appearance preferences** — Adds a Settings > Appearance section with light/dark/system theme, font size (small/medium/large), and density (comfortable/compact) that apply live and persist across reloads. An always-on renderer store follows the OS color scheme for the system option and syncs preferences across windows, and the native Windows title-bar overlay repaints to match the active theme.
 
 ### Refactor
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -125,6 +125,7 @@ import { setupVoiceIPC } from './main/ipc/voice';
 
 import { EventEmitter } from 'events';
 import { wireLifecycleEvents } from './main/wireLifecycleEvents';
+import { applyTitleBarTheme, titleBarOverlayFor } from './main/titleBarTheme';
 import { cleanupLegacySquirrelInstall } from './main/squirrelMigration';
 import { runUpdaterSmoke } from './main/updaterSmoke';
 import { UpdaterService } from './main/updater/UpdaterService';
@@ -789,11 +790,7 @@ const createWindow = () => {
     minWidth: 600,
     minHeight: 400,
     titleBarStyle: 'hiddenInset',
-    titleBarOverlay: process.platform === 'win32' ? {
-      color: '#09090b',
-      symbolColor: '#fafafa',
-      height: 36,
-    } : undefined,
+    titleBarOverlay: process.platform === 'win32' ? titleBarOverlayFor('dark') : undefined,
     icon: windowIcon,
     backgroundColor: '#09090b',
     webPreferences: {
@@ -987,6 +984,12 @@ app.on('ready', async () => {
   ipcMain.on(IPC.WINDOW.CLOSE, () => mainWindow?.close());
   ipcMain.handle(IPC.DESKTOP.GET_BRANDING, () => ({ name: app.getName(), version: app.getVersion() }));
   ipcMain.handle(IPC.APP.GET_FEATURE_FLAGS, () => appFeatureFlags);
+  // Repaint the native title-bar overlay to match the renderer theme. The sender
+  // may be the main window or a mind popout, so target whichever window invoked.
+  ipcMain.handle(IPC.DESKTOP.SET_THEME, (event, theme: unknown) => {
+    if (theme !== 'light' && theme !== 'dark') return;
+    applyTitleBarTheme(BrowserWindow.fromWebContents(event.sender), theme);
+  });
   ipcMain.handle(IPC.DESKTOP.CONFIRM, (_event, message: string) => {
     const choice = mainWindow
       ? dialog.showMessageBoxSync(mainWindow, {

--- a/apps/desktop/src/main/ipc/mind.ts
+++ b/apps/desktop/src/main/ipc/mind.ts
@@ -8,6 +8,7 @@ import type { ChatService, MindManager } from '@chamber/services';
 import { Logger } from '@chamber/services';
 import type { MindContext } from '@chamber/shared/types';
 import { installExternalNavigationGuard } from '../navigationGuard';
+import { titleBarOverlayFor } from '../titleBarTheme';
 
 const log = Logger.create('mind-ipc');
 
@@ -91,11 +92,7 @@ export function setupMindIPC(mindManager: MindManager, chatService: ChatService,
       minHeight: 400,
       title: `${mind.identity.name} — Chamber`,
       titleBarStyle: 'hiddenInset',
-      titleBarOverlay: process.platform === 'win32' ? {
-        color: '#09090b',
-        symbolColor: '#fafafa',
-        height: 36,
-      } : undefined,
+      titleBarOverlay: process.platform === 'win32' ? titleBarOverlayFor('dark') : undefined,
       icon: config.windowIcon,
       backgroundColor: '#09090b',
       webPreferences: {

--- a/apps/desktop/src/main/titleBarTheme.test.ts
+++ b/apps/desktop/src/main/titleBarTheme.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyTitleBarTheme, titleBarOverlayFor, TITLE_BAR_OVERLAY_HEIGHT } from './titleBarTheme';
+
+describe('titleBarOverlayFor', () => {
+  it('returns dark chrome colors for the dark theme', () => {
+    expect(titleBarOverlayFor('dark')).toEqual({
+      color: '#09090b',
+      symbolColor: '#fafafa',
+      height: TITLE_BAR_OVERLAY_HEIGHT,
+    });
+  });
+
+  it('returns light chrome colors for the light theme', () => {
+    expect(titleBarOverlayFor('light')).toEqual({
+      color: '#ffffff',
+      symbolColor: '#0a0a0a',
+      height: TITLE_BAR_OVERLAY_HEIGHT,
+    });
+  });
+});
+
+describe('applyTitleBarTheme', () => {
+  it('repaints the overlay on win32', () => {
+    const setTitleBarOverlay = vi.fn();
+    applyTitleBarTheme({ setTitleBarOverlay }, 'light', 'win32');
+    expect(setTitleBarOverlay).toHaveBeenCalledWith(titleBarOverlayFor('light'));
+  });
+
+  it('is a no-op on non-win32 platforms', () => {
+    const setTitleBarOverlay = vi.fn();
+    applyTitleBarTheme({ setTitleBarOverlay }, 'dark', 'darwin');
+    expect(setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no window is provided', () => {
+    expect(() => applyTitleBarTheme(null, 'dark', 'win32')).not.toThrow();
+    expect(() => applyTitleBarTheme(undefined, 'light', 'win32')).not.toThrow();
+  });
+});

--- a/apps/desktop/src/main/titleBarTheme.ts
+++ b/apps/desktop/src/main/titleBarTheme.ts
@@ -1,0 +1,46 @@
+import type { BrowserWindow, TitleBarOverlay } from 'electron';
+
+/**
+ * Native Windows title-bar overlay theming.
+ *
+ * The frameless windows use a Windows `titleBarOverlay` for the min/max/close
+ * chrome. Its colors are baked in at window creation, so when the renderer theme
+ * changes we must repaint the overlay to keep the OS chrome legible against the
+ * new app background. Both the initial window options and the runtime repaint go
+ * through this single source of truth.
+ */
+
+export type TitleBarTheme = 'light' | 'dark';
+
+export const TITLE_BAR_OVERLAY_HEIGHT = 36;
+
+interface TitleBarOverlayColors {
+  /** Background of the overlay strip. Matches `--color-background`. */
+  readonly color: string;
+  /** Color of the min/max/close glyphs. Matches `--color-foreground`. */
+  readonly symbolColor: string;
+}
+
+const OVERLAY_COLORS: Record<TitleBarTheme, TitleBarOverlayColors> = {
+  dark: { color: '#09090b', symbolColor: '#fafafa' },
+  light: { color: '#ffffff', symbolColor: '#0a0a0a' },
+};
+
+/** Build the `titleBarOverlay` window option for a theme. */
+export function titleBarOverlayFor(theme: TitleBarTheme): TitleBarOverlay {
+  return { ...OVERLAY_COLORS[theme], height: TITLE_BAR_OVERLAY_HEIGHT };
+}
+
+/**
+ * Repaint a window's native title-bar overlay to match the given theme. A no-op
+ * on platforms without an overlay (only Windows renders one) and when the target
+ * window is missing.
+ */
+export function applyTitleBarTheme(
+  win: Pick<BrowserWindow, 'setTitleBarOverlay'> | null | undefined,
+  theme: TitleBarTheme,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (!win || platform !== 'win32') return;
+  win.setTitleBarOverlay(titleBarOverlayFor(theme));
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -202,6 +202,7 @@ contextBridge.exposeInMainWorld('desktop', {
   openMindWindow: (mindId: string) => ipcRenderer.invoke(IPC.MIND.OPEN_WINDOW, mindId),
   getAppBranding: () => ipcRenderer.invoke(IPC.DESKTOP.GET_BRANDING),
   confirm: (message: string) => ipcRenderer.invoke(IPC.DESKTOP.CONFIRM, message),
+  setTheme: (theme: 'light' | 'dark') => ipcRenderer.invoke(IPC.DESKTOP.SET_THEME, theme),
   window: {
     minimize: () => ipcRenderer.send(IPC.WINDOW.MINIMIZE),
     maximize: () => ipcRenderer.send(IPC.WINDOW.MAXIMIZE),

--- a/apps/web/src/renderer.tsx
+++ b/apps/web/src/renderer.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './renderer/App';
 import { installBrowserApi } from './browserApi';
-import { initializeAppearance } from './renderer/lib/appearance';
+import { startAppearanceSync } from './renderer/lib/appearanceStore';
 
 installBrowserApi();
-// Restore the saved theme, font scale, and density before React mounts so a
-// reload does not flash the default appearance.
-initializeAppearance();
+// Start app-wide appearance synchronization (theme, font scale, density) before
+// React mounts so a reload restores the user's choices without a flash and the
+// OS/cross-window listeners run for the whole session, not just while Settings
+// is open.
+startAppearanceSync();
 
 const container = document.getElementById('root');
 if (container) {

--- a/apps/web/src/renderer.tsx
+++ b/apps/web/src/renderer.tsx
@@ -7,10 +7,16 @@ import { installBrowserApi } from './browserApi';
 import { startAppearanceSync } from './renderer/lib/appearanceStore';
 
 installBrowserApi();
-// Start app-wide appearance synchronization (theme, font scale, density) before
-// React mounts so a reload restores the user's choices without a flash and the
-// OS/cross-window listeners run for the whole session, not just while Settings
-// is open.
+// Start app-wide appearance synchronization (theme, font scale, density) as the
+// bundle loads and before React mounts, and keep the OS/cross-window listeners
+// running for the whole session (not just while Settings is open).
+//
+// Note: this is a deferred ES module, so it runs after the document's first
+// paint. `index.html` ships `class="dark"`, so default-dark users see the
+// correct theme immediately, but a light/system-light user may see one dark
+// frame on a cold load. A fuller fix (a render-blocking same-origin
+// `theme-init` script in <head>, which the `script-src 'self'` CSP permits) is
+// a possible follow-up; it is intentionally out of scope here.
 startAppearanceSync();
 
 const container = document.getElementById('root');

--- a/apps/web/src/renderer.tsx
+++ b/apps/web/src/renderer.tsx
@@ -4,8 +4,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './renderer/App';
 import { installBrowserApi } from './browserApi';
+import { initializeAppearance } from './renderer/lib/appearance';
 
 installBrowserApi();
+// Restore the saved theme, font scale, and density before React mounts so a
+// reload does not flash the default appearance.
+initializeAppearance();
 
 const container = document.getElementById('root');
 if (container) {

--- a/apps/web/src/renderer/components/settings/AppearanceSettingsSection.tsx
+++ b/apps/web/src/renderer/components/settings/AppearanceSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type KeyboardEvent, type ReactNode } from 'react';
 import { useDensity, useFontScale, type Density, type FontScale } from '../../hooks/useAppearance';
 import { useTheme, type ThemePreference } from '../../hooks/useTheme';
 import { cn } from '../../lib/utils';
@@ -36,10 +36,26 @@ function SegmentedControl<T extends string>({
   readonly options: readonly SegmentOption<T>[];
   readonly onChange: (value: T) => void;
 }) {
+  // Arrow keys move the selection (the WAI-ARIA radio group pattern); focus
+  // follows via roving tabindex so the group is a single tab stop.
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const forward = event.key === 'ArrowRight' || event.key === 'ArrowDown';
+    const backward = event.key === 'ArrowLeft' || event.key === 'ArrowUp';
+    if (!forward && !backward) return;
+    event.preventDefault();
+    const currentIndex = options.findIndex((option) => option.value === value);
+    const delta = forward ? 1 : -1;
+    const next = options[(currentIndex + delta + options.length) % options.length];
+    onChange(next.value);
+    const buttons = event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    buttons[(currentIndex + delta + options.length) % options.length]?.focus();
+  };
+
   return (
     <div
       role="radiogroup"
       aria-label={label}
+      onKeyDown={handleKeyDown}
       className="inline-flex rounded-lg border border-border bg-background p-0.5"
     >
       {options.map((option) => {
@@ -50,6 +66,7 @@ function SegmentedControl<T extends string>({
             type="button"
             role="radio"
             aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
             onClick={() => onChange(option.value)}
             className={cn(
               'rounded-md px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',

--- a/apps/web/src/renderer/components/settings/AppearanceSettingsSection.tsx
+++ b/apps/web/src/renderer/components/settings/AppearanceSettingsSection.tsx
@@ -1,0 +1,130 @@
+import { type ReactNode } from 'react';
+import { useDensity, useFontScale, type Density, type FontScale } from '../../hooks/useAppearance';
+import { useTheme, type ThemePreference } from '../../hooks/useTheme';
+import { cn } from '../../lib/utils';
+
+interface SegmentOption<T extends string> {
+  readonly value: T;
+  readonly label: string;
+}
+
+const THEME_OPTIONS: readonly SegmentOption<ThemePreference>[] = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+];
+
+const FONT_SCALE_OPTIONS: readonly SegmentOption<FontScale>[] = [
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'large', label: 'Large' },
+];
+
+const DENSITY_OPTIONS: readonly SegmentOption<Density>[] = [
+  { value: 'comfortable', label: 'Comfortable' },
+  { value: 'compact', label: 'Compact' },
+];
+
+function SegmentedControl<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  readonly label: string;
+  readonly value: T;
+  readonly options: readonly SegmentOption<T>[];
+  readonly onChange: (value: T) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      className="inline-flex rounded-lg border border-border bg-background p-0.5"
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              selected
+                ? 'bg-selected text-foreground font-medium'
+                : 'text-foreground/70 hover:bg-hover hover:text-foreground',
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function AppearanceRow({
+  title,
+  description,
+  children,
+}: {
+  readonly title: string;
+  readonly description: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-background/40 p-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  );
+}
+
+export function AppearanceSettingsSection() {
+  const { theme, setTheme } = useTheme();
+  const { fontScale, setFontScale } = useFontScale();
+  const { density, setDensity } = useDensity();
+
+  return (
+    <section className="space-y-3">
+      <header>
+        <h2 className="text-lg font-semibold text-foreground">Appearance</h2>
+        <p className="text-xs text-foreground/60">
+          How Chamber looks on this device. Changes apply instantly and are saved locally.
+        </p>
+      </header>
+      <div className="space-y-4 rounded-lg border border-border bg-card p-4">
+        <AppearanceRow title="Theme" description="Use a light or dark palette, or follow your operating system.">
+          <SegmentedControl<ThemePreference>
+            label="Theme"
+            value={theme}
+            options={THEME_OPTIONS}
+            onChange={setTheme}
+          />
+        </AppearanceRow>
+        <AppearanceRow title="Font size" description="Scale the interface text and spacing.">
+          <SegmentedControl<FontScale>
+            label="Font size"
+            value={fontScale}
+            options={FONT_SCALE_OPTIONS}
+            onChange={setFontScale}
+          />
+        </AppearanceRow>
+        <AppearanceRow title="Density" description="Comfortable adds breathing room; compact fits more on screen.">
+          <SegmentedControl<Density>
+            label="Density"
+            value={density}
+            options={DENSITY_OPTIONS}
+            onChange={setDensity}
+          />
+        </AppearanceRow>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/renderer/components/settings/SettingsView.test.tsx
+++ b/apps/web/src/renderer/components/settings/SettingsView.test.tsx
@@ -8,6 +8,7 @@ import { version } from '../../../../../../package.json';
 import { SettingsView } from './SettingsView';
 import { AppStateProvider } from '../../lib/store';
 import { APPEARANCE_STORAGE_KEYS } from '../../lib/appearance';
+import { appearanceStore } from '../../lib/appearanceStore';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
 
 // Settings is now tabbed. Tests that assert on Account / Marketplaces /
@@ -501,6 +502,9 @@ describe('SettingsView', () => {
       localStorage.clear();
       document.documentElement.className = '';
       delete document.documentElement.dataset.theme;
+      // The store is an app-lifetime singleton; re-sync it from the cleared
+      // storage so each case starts from the default snapshot.
+      appearanceStore.resetForTests();
     });
 
     it('renders theme, font size, and density controls', async () => {
@@ -543,6 +547,18 @@ describe('SettingsView', () => {
 
       expect(document.documentElement.classList.contains('density-compact')).toBe(true);
       expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.density)).toBe('compact');
+    });
+
+    it('moves theme selection with arrow keys', async () => {
+      render(<SettingsView />);
+      gotoTab('Appearance');
+
+      const group = await screen.findByRole('radiogroup', { name: 'Theme' });
+      // Dark is selected by default; ArrowRight advances to System.
+      fireEvent.keyDown(group, { key: 'ArrowRight' });
+
+      expect(screen.getByRole('radio', { name: 'System' }).getAttribute('aria-checked')).toBe('true');
+      expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.theme)).toBe('system');
     });
   });
 });

--- a/apps/web/src/renderer/components/settings/SettingsView.test.tsx
+++ b/apps/web/src/renderer/components/settings/SettingsView.test.tsx
@@ -7,12 +7,13 @@ import { render, screen, waitFor, fireEvent, within } from '@testing-library/rea
 import { version } from '../../../../../../package.json';
 import { SettingsView } from './SettingsView';
 import { AppStateProvider } from '../../lib/store';
+import { APPEARANCE_STORAGE_KEYS } from '../../lib/appearance';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
 
 // Settings is now tabbed. Tests that assert on Account / Marketplaces /
 // feature-specific content must first activate that tab (the Profile tab is the
 // default). Profile-tab tests don't need this helper.
-function gotoTab(label: 'Profile' | 'Account' | 'Marketplaces' | 'Local LLM' | 'Voice dictation') {
+function gotoTab(label: 'Profile' | 'Account' | 'Marketplaces' | 'Appearance' | 'Local LLM' | 'Voice dictation') {
   const nav = screen.getByRole('navigation', { name: /settings sections/i });
   fireEvent.click(within(nav).getByRole('button', { name: label }));
 }
@@ -492,6 +493,56 @@ describe('SettingsView', () => {
       expect(api.marketplace.setGenesisRegistryEnabled).toHaveBeenCalledWith('github:agency-microsoft/genesis-minds', false);
       expect(api.marketplace.refreshGenesisRegistry).toHaveBeenCalledWith('github:agency-microsoft/genesis-minds');
       expect(api.marketplace.removeGenesisRegistry).toHaveBeenCalledWith('github:agency-microsoft/genesis-minds');
+    });
+  });
+
+  describe('Appearance section', () => {
+    beforeEach(() => {
+      localStorage.clear();
+      document.documentElement.className = '';
+      delete document.documentElement.dataset.theme;
+    });
+
+    it('renders theme, font size, and density controls', async () => {
+      render(<SettingsView />);
+      gotoTab('Appearance');
+
+      expect(await screen.findByRole('heading', { name: 'Appearance' })).toBeTruthy();
+      expect(screen.getByRole('radiogroup', { name: 'Theme' })).toBeTruthy();
+      expect(screen.getByRole('radiogroup', { name: 'Font size' })).toBeTruthy();
+      expect(screen.getByRole('radiogroup', { name: 'Density' })).toBeTruthy();
+      // Dark is the default preference, so its radio reads as checked.
+      expect(screen.getByRole('radio', { name: 'Dark' }).getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('applies and persists a theme change live', async () => {
+      render(<SettingsView />);
+      gotoTab('Appearance');
+
+      fireEvent.click(await screen.findByRole('radio', { name: 'Light' }));
+
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+      expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.theme)).toBe('light');
+    });
+
+    it('applies and persists a font-size change live', async () => {
+      render(<SettingsView />);
+      gotoTab('Appearance');
+
+      fireEvent.click(await screen.findByRole('radio', { name: 'Large' }));
+
+      expect(document.documentElement.classList.contains('font-scale-large')).toBe(true);
+      expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.fontScale)).toBe('large');
+    });
+
+    it('applies and persists a density change live', async () => {
+      render(<SettingsView />);
+      gotoTab('Appearance');
+
+      fireEvent.click(await screen.findByRole('radio', { name: 'Compact' }));
+
+      expect(document.documentElement.classList.contains('density-compact')).toBe(true);
+      expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.density)).toBe('compact');
     });
   });
 });

--- a/apps/web/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/web/src/renderer/components/settings/SettingsView.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { AddAccountModal } from './AddAccountModal';
+import { AppearanceSettingsSection } from './AppearanceSettingsSection';
 import { LocalLlmSettingsSection } from './LocalLlmSettingsSection';
 import { Skeleton } from '../ui/skeleton';
 import { VoiceDictationSettingsSection } from './VoiceDictationSettingsSection';
@@ -461,6 +462,10 @@ export function SettingsView() {
             </section>
           )}
 
+          {activeSection === 'appearance' && (
+            <AppearanceSettingsSection />
+          )}
+
           {activeSection === 'local-llm' && featureFlags.byoLlm && (
             <section className="space-y-3">
               <LocalLlmSettingsSection />
@@ -494,7 +499,7 @@ export function SettingsView() {
 // index.css so navigating between sections matches the rest of the app.
 // ---------------------------------------------------------------------------
 
-export type SettingsSectionId = 'profile' | 'account' | 'marketplaces' | 'local-llm' | 'voice-dictation';
+export type SettingsSectionId = 'profile' | 'account' | 'marketplaces' | 'appearance' | 'local-llm' | 'voice-dictation';
 
 interface SettingsRailItem {
   id: SettingsSectionId;
@@ -513,6 +518,7 @@ function SettingsLayout({ children, showLocalLlm, showVoiceDictation }: Settings
       { id: 'profile', label: 'Profile' },
       { id: 'account', label: 'Account' },
       { id: 'marketplaces', label: 'Marketplaces' },
+      { id: 'appearance', label: 'Appearance' },
     ];
     if (showLocalLlm) items.push({ id: 'local-llm', label: 'Local LLM' });
     if (showVoiceDictation) items.push({ id: 'voice-dictation', label: 'Voice dictation' });

--- a/apps/web/src/renderer/hooks/index.ts
+++ b/apps/web/src/renderer/hooks/index.ts
@@ -4,5 +4,7 @@ export { useChatStreaming } from './useChatStreaming';
 export { useResponsiveLayout } from './useResponsiveLayout';
 export type { ResponsiveLayout } from './useResponsiveLayout';
 export { useTheme } from './useTheme';
-export type { Theme } from './useTheme';
+export type { Theme, ThemePreference, ResolvedTheme, UseThemeResult } from './useTheme';
+export { useFontScale, useDensity } from './useAppearance';
+export type { FontScale, Density, UseFontScaleResult, UseDensityResult } from './useAppearance';
 export { useVoiceDictation, type UseVoiceDictationOptions, type UseVoiceDictationResult } from './useVoiceDictation';

--- a/apps/web/src/renderer/hooks/useAppearance.test.ts
+++ b/apps/web/src/renderer/hooks/useAppearance.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { useDensity, useFontScale } from './useAppearance';
+import { appearanceStore } from '../lib/appearanceStore';
 import { APPEARANCE_STORAGE_KEYS } from '../lib/appearance';
 
 describe('useFontScale', () => {
@@ -13,11 +14,14 @@ describe('useFontScale', () => {
   });
 
   afterEach(() => {
+    appearanceStore.resetForTests();
     document.documentElement.className = '';
   });
 
-  it('starts from the persisted scale and applies it', () => {
+  it('reflects the persisted scale and applies it on start', () => {
     localStorage.setItem(APPEARANCE_STORAGE_KEYS.fontScale, 'large');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
 
     const { result } = renderHook(() => useFontScale());
 
@@ -26,16 +30,21 @@ describe('useFontScale', () => {
   });
 
   it('applies and persists a change', () => {
+    appearanceStore.resetForTests();
+    appearanceStore.start();
     const { result } = renderHook(() => useFontScale());
 
     act(() => result.current.setFontScale('small'));
 
+    expect(result.current.fontScale).toBe('small');
     expect(document.documentElement.classList.contains('font-scale-small')).toBe(true);
     expect(document.documentElement.classList.contains('font-scale-medium')).toBe(false);
     expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.fontScale)).toBe('small');
   });
 
   it('mirrors a change made in another window', () => {
+    appearanceStore.resetForTests();
+    appearanceStore.start();
     const { result } = renderHook(() => useFontScale());
 
     act(() => {
@@ -56,11 +65,14 @@ describe('useDensity', () => {
   });
 
   afterEach(() => {
+    appearanceStore.resetForTests();
     document.documentElement.className = '';
   });
 
-  it('starts from the persisted density and applies it', () => {
+  it('reflects the persisted density and applies it on start', () => {
     localStorage.setItem(APPEARANCE_STORAGE_KEYS.density, 'compact');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
 
     const { result } = renderHook(() => useDensity());
 
@@ -69,10 +81,13 @@ describe('useDensity', () => {
   });
 
   it('applies and persists a change', () => {
+    appearanceStore.resetForTests();
+    appearanceStore.start();
     const { result } = renderHook(() => useDensity());
 
     act(() => result.current.setDensity('compact'));
 
+    expect(result.current.density).toBe('compact');
     expect(document.documentElement.classList.contains('density-compact')).toBe(true);
     expect(document.documentElement.classList.contains('density-comfortable')).toBe(false);
     expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.density)).toBe('compact');

--- a/apps/web/src/renderer/hooks/useAppearance.test.ts
+++ b/apps/web/src/renderer/hooks/useAppearance.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDensity, useFontScale } from './useAppearance';
+import { APPEARANCE_STORAGE_KEYS } from '../lib/appearance';
+
+describe('useFontScale', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+  });
+
+  afterEach(() => {
+    document.documentElement.className = '';
+  });
+
+  it('starts from the persisted scale and applies it', () => {
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.fontScale, 'large');
+
+    const { result } = renderHook(() => useFontScale());
+
+    expect(result.current.fontScale).toBe('large');
+    expect(document.documentElement.classList.contains('font-scale-large')).toBe(true);
+  });
+
+  it('applies and persists a change', () => {
+    const { result } = renderHook(() => useFontScale());
+
+    act(() => result.current.setFontScale('small'));
+
+    expect(document.documentElement.classList.contains('font-scale-small')).toBe(true);
+    expect(document.documentElement.classList.contains('font-scale-medium')).toBe(false);
+    expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.fontScale)).toBe('small');
+  });
+
+  it('mirrors a change made in another window', () => {
+    const { result } = renderHook(() => useFontScale());
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: APPEARANCE_STORAGE_KEYS.fontScale, newValue: 'large' }),
+      );
+    });
+
+    expect(result.current.fontScale).toBe('large');
+    expect(document.documentElement.classList.contains('font-scale-large')).toBe(true);
+  });
+});
+
+describe('useDensity', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+  });
+
+  afterEach(() => {
+    document.documentElement.className = '';
+  });
+
+  it('starts from the persisted density and applies it', () => {
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.density, 'compact');
+
+    const { result } = renderHook(() => useDensity());
+
+    expect(result.current.density).toBe('compact');
+    expect(document.documentElement.classList.contains('density-compact')).toBe(true);
+  });
+
+  it('applies and persists a change', () => {
+    const { result } = renderHook(() => useDensity());
+
+    act(() => result.current.setDensity('compact'));
+
+    expect(document.documentElement.classList.contains('density-compact')).toBe(true);
+    expect(document.documentElement.classList.contains('density-comfortable')).toBe(false);
+    expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.density)).toBe('compact');
+  });
+});

--- a/apps/web/src/renderer/hooks/useAppearance.ts
+++ b/apps/web/src/renderer/hooks/useAppearance.ts
@@ -1,73 +1,21 @@
-import { useCallback, useEffect, useState } from 'react';
-import {
-  APPEARANCE_STORAGE_KEYS,
-  applyDensity,
-  applyFontScale,
-  DENSITIES,
-  FONT_SCALES,
-  persistDensity,
-  persistFontScale,
-  readStoredDensity,
-  readStoredFontScale,
-  type Density,
-  type FontScale,
-} from '../lib/appearance';
+import { useSyncExternalStore } from 'react';
+import { appearanceStore } from '../lib/appearanceStore';
+import type { Density, FontScale } from '../lib/appearance';
 
 export type { FontScale, Density } from '../lib/appearance';
-
-/**
- * Shared machinery for a preference that maps to a document-root class: it reads
- * an initial value from storage, applies it live, persists changes, and mirrors
- * changes made in other windows. Powers both the font-scale and density hooks so
- * their behavior stays identical. All collaborators are module-level stable
- * references, so the effects below never re-subscribe on re-render.
- */
-function usePersistedRootClass<T extends string>(
-  read: () => T,
-  apply: (value: T) => void,
-  persist: (value: T) => void,
-  storageKey: string,
-  allowed: readonly T[],
-): readonly [T, (value: T) => void] {
-  const [value, setValue] = useState<T>(read);
-
-  useEffect(() => {
-    apply(value);
-  }, [apply, value]);
-
-  useEffect(() => {
-    const handler = (event: StorageEvent) => {
-      if (event.key === storageKey && (allowed as readonly string[]).includes(event.newValue ?? '')) {
-        setValue(event.newValue as T);
-      }
-    };
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
-  }, [allowed, storageKey]);
-
-  const set = useCallback((next: T) => {
-    setValue(next);
-    persist(next);
-  }, [persist]);
-
-  return [value, set] as const;
-}
 
 export interface UseFontScaleResult {
   readonly fontScale: FontScale;
   readonly setFontScale: (scale: FontScale) => void;
 }
 
-/** Reads, applies, and persists the interface font-scale preference. */
+/**
+ * Reads the interface font-scale from the always-on appearance store and exposes
+ * a setter. The store owns application and cross-window synchronization.
+ */
 export function useFontScale(): UseFontScaleResult {
-  const [fontScale, setFontScale] = usePersistedRootClass(
-    readStoredFontScale,
-    applyFontScale,
-    persistFontScale,
-    APPEARANCE_STORAGE_KEYS.fontScale,
-    FONT_SCALES,
-  );
-  return { fontScale, setFontScale };
+  const state = useSyncExternalStore(appearanceStore.subscribe, appearanceStore.getSnapshot);
+  return { fontScale: state.fontScale, setFontScale: appearanceStore.setFontScale };
 }
 
 export interface UseDensityResult {
@@ -75,14 +23,11 @@ export interface UseDensityResult {
   readonly setDensity: (density: Density) => void;
 }
 
-/** Reads, applies, and persists the interface density preference. */
+/**
+ * Reads the interface density from the always-on appearance store and exposes a
+ * setter. The store owns application and cross-window synchronization.
+ */
 export function useDensity(): UseDensityResult {
-  const [density, setDensity] = usePersistedRootClass(
-    readStoredDensity,
-    applyDensity,
-    persistDensity,
-    APPEARANCE_STORAGE_KEYS.density,
-    DENSITIES,
-  );
-  return { density, setDensity };
+  const state = useSyncExternalStore(appearanceStore.subscribe, appearanceStore.getSnapshot);
+  return { density: state.density, setDensity: appearanceStore.setDensity };
 }

--- a/apps/web/src/renderer/hooks/useAppearance.ts
+++ b/apps/web/src/renderer/hooks/useAppearance.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  APPEARANCE_STORAGE_KEYS,
+  applyDensity,
+  applyFontScale,
+  DENSITIES,
+  FONT_SCALES,
+  persistDensity,
+  persistFontScale,
+  readStoredDensity,
+  readStoredFontScale,
+  type Density,
+  type FontScale,
+} from '../lib/appearance';
+
+export type { FontScale, Density } from '../lib/appearance';
+
+/**
+ * Shared machinery for a preference that maps to a document-root class: it reads
+ * an initial value from storage, applies it live, persists changes, and mirrors
+ * changes made in other windows. Powers both the font-scale and density hooks so
+ * their behavior stays identical. All collaborators are module-level stable
+ * references, so the effects below never re-subscribe on re-render.
+ */
+function usePersistedRootClass<T extends string>(
+  read: () => T,
+  apply: (value: T) => void,
+  persist: (value: T) => void,
+  storageKey: string,
+  allowed: readonly T[],
+): readonly [T, (value: T) => void] {
+  const [value, setValue] = useState<T>(read);
+
+  useEffect(() => {
+    apply(value);
+  }, [apply, value]);
+
+  useEffect(() => {
+    const handler = (event: StorageEvent) => {
+      if (event.key === storageKey && (allowed as readonly string[]).includes(event.newValue ?? '')) {
+        setValue(event.newValue as T);
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [allowed, storageKey]);
+
+  const set = useCallback((next: T) => {
+    setValue(next);
+    persist(next);
+  }, [persist]);
+
+  return [value, set] as const;
+}
+
+export interface UseFontScaleResult {
+  readonly fontScale: FontScale;
+  readonly setFontScale: (scale: FontScale) => void;
+}
+
+/** Reads, applies, and persists the interface font-scale preference. */
+export function useFontScale(): UseFontScaleResult {
+  const [fontScale, setFontScale] = usePersistedRootClass(
+    readStoredFontScale,
+    applyFontScale,
+    persistFontScale,
+    APPEARANCE_STORAGE_KEYS.fontScale,
+    FONT_SCALES,
+  );
+  return { fontScale, setFontScale };
+}
+
+export interface UseDensityResult {
+  readonly density: Density;
+  readonly setDensity: (density: Density) => void;
+}
+
+/** Reads, applies, and persists the interface density preference. */
+export function useDensity(): UseDensityResult {
+  const [density, setDensity] = usePersistedRootClass(
+    readStoredDensity,
+    applyDensity,
+    persistDensity,
+    APPEARANCE_STORAGE_KEYS.density,
+    DENSITIES,
+  );
+  return { density, setDensity };
+}

--- a/apps/web/src/renderer/hooks/useTheme.test.ts
+++ b/apps/web/src/renderer/hooks/useTheme.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { useTheme } from './useTheme';
+import { appearanceStore } from '../lib/appearanceStore';
 import { APPEARANCE_STORAGE_KEYS } from '../lib/appearance';
 
 function installMatchMedia(initialDark: boolean) {
@@ -38,22 +39,26 @@ describe('useTheme', () => {
   });
 
   afterEach(() => {
+    appearanceStore.resetForTests();
     delete (window as { matchMedia?: unknown }).matchMedia;
   });
 
-  it('starts from the persisted preference and resolves it', () => {
+  it('reflects the persisted preference and its resolved theme', () => {
     installMatchMedia(false);
     localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'light');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
 
     const { result } = renderHook(() => useTheme());
 
     expect(result.current.theme).toBe('light');
     expect(result.current.resolvedTheme).toBe('light');
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
   it('persists and applies an explicit preference change', () => {
     installMatchMedia(true);
+    appearanceStore.resetForTests();
+    appearanceStore.start();
     const { result } = renderHook(() => useTheme());
 
     act(() => result.current.setTheme('light'));
@@ -66,11 +71,12 @@ describe('useTheme', () => {
 
   it('follows the OS scheme live when the preference is system', () => {
     const media = installMatchMedia(false);
+    appearanceStore.resetForTests();
+    appearanceStore.start();
     const { result } = renderHook(() => useTheme());
 
     act(() => result.current.setTheme('system'));
     expect(result.current.resolvedTheme).toBe('light');
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
 
     act(() => media.emit(true));
     expect(result.current.resolvedTheme).toBe('dark');
@@ -79,6 +85,9 @@ describe('useTheme', () => {
 
   it('mirrors a preference change made in another window', () => {
     installMatchMedia(true);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'dark');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
     const { result } = renderHook(() => useTheme());
     expect(result.current.theme).toBe('dark');
 
@@ -95,6 +104,8 @@ describe('useTheme', () => {
   it('toggles between light and dark', () => {
     installMatchMedia(true);
     localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'dark');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
     const { result } = renderHook(() => useTheme());
 
     act(() => result.current.toggle());

--- a/apps/web/src/renderer/hooks/useTheme.test.ts
+++ b/apps/web/src/renderer/hooks/useTheme.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useTheme } from './useTheme';
+import { APPEARANCE_STORAGE_KEYS } from '../lib/appearance';
+
+function installMatchMedia(initialDark: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initialDark;
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: (_type: string, cb: (event: MediaQueryListEvent) => void) => listeners.add(cb),
+    removeEventListener: (_type: string, cb: (event: MediaQueryListEvent) => void) => listeners.delete(cb),
+  };
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: () => mql,
+  });
+  return {
+    emit(next: boolean) {
+      matches = next;
+      listeners.forEach((cb) => cb({ matches: next } as MediaQueryListEvent));
+    },
+  };
+}
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    delete (window as { matchMedia?: unknown }).matchMedia;
+  });
+
+  it('starts from the persisted preference and resolves it', () => {
+    installMatchMedia(false);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'light');
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('light');
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('persists and applies an explicit preference change', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme('light'));
+
+    expect(result.current.theme).toBe('light');
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.theme)).toBe('light');
+  });
+
+  it('follows the OS scheme live when the preference is system', () => {
+    const media = installMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme('system'));
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    act(() => media.emit(true));
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('mirrors a preference change made in another window', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('dark');
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: APPEARANCE_STORAGE_KEYS.theme, newValue: 'light' }),
+      );
+    });
+
+    expect(result.current.theme).toBe('light');
+    expect(result.current.resolvedTheme).toBe('light');
+  });
+
+  it('toggles between light and dark', () => {
+    installMatchMedia(true);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'dark');
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.toggle());
+    expect(result.current.resolvedTheme).toBe('light');
+
+    act(() => result.current.toggle());
+    expect(result.current.resolvedTheme).toBe('dark');
+  });
+});

--- a/apps/web/src/renderer/hooks/useTheme.ts
+++ b/apps/web/src/renderer/hooks/useTheme.ts
@@ -1,15 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  APPEARANCE_STORAGE_KEYS,
-  applyResolvedTheme,
-  isThemePreference,
-  persistThemePreference,
-  readStoredThemePreference,
-  resolveTheme,
-  systemPrefersDark,
-  type ResolvedTheme,
-  type ThemePreference,
-} from '../lib/appearance';
+import { useSyncExternalStore } from 'react';
+import { appearanceStore } from '../lib/appearanceStore';
+import type { ResolvedTheme, ThemePreference } from '../lib/appearance';
 
 export type { ThemePreference, ResolvedTheme } from '../lib/appearance';
 
@@ -19,8 +10,6 @@ export type { ThemePreference, ResolvedTheme } from '../lib/appearance';
  * imports keep compiling.
  */
 export type Theme = ResolvedTheme;
-
-const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 
 export interface UseThemeResult {
   /** The user's stored preference, which may be `system`. */
@@ -32,59 +21,16 @@ export interface UseThemeResult {
 }
 
 /**
- * Reads, applies, and persists the theme preference. Supports a `system`
- * preference that follows `prefers-color-scheme` and updates live via
- * `matchMedia`, and mirrors changes made in other windows via the `storage`
- * event.
+ * Reads the current theme from the always-on appearance store and exposes
+ * setters. The store owns live `prefers-color-scheme` and cross-window
+ * synchronization, so this hook only reflects state and forwards user intent.
  */
 export function useTheme(): UseThemeResult {
-  const [preference, setPreference] = useState<ThemePreference>(readStoredThemePreference);
-  const [prefersDark, setPrefersDark] = useState<boolean>(systemPrefersDark);
-
-  // Follow the OS scheme so a `system` preference reacts live to OS changes.
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
-    const media = window.matchMedia(DARK_MEDIA_QUERY);
-    const handler = (event: MediaQueryListEvent) => setPrefersDark(event.matches);
-    media.addEventListener('change', handler);
-    return () => media.removeEventListener('change', handler);
-  }, []);
-
-  // Cross-tab sync: another window changed the stored preference.
-  useEffect(() => {
-    const handler = (event: StorageEvent) => {
-      if (event.key === APPEARANCE_STORAGE_KEYS.theme && isThemePreference(event.newValue)) {
-        setPreference(event.newValue);
-      }
-    };
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
-  }, []);
-
-  const resolvedTheme = resolveTheme(preference, prefersDark);
-
-  // Paint whenever the resolved theme changes. Skip the crossfade on the first
-  // application so loading the app does not animate.
-  const firstApply = useRef(true);
-  useEffect(() => {
-    applyResolvedTheme(resolvedTheme, { animate: !firstApply.current });
-    firstApply.current = false;
-  }, [resolvedTheme]);
-
-  const setTheme = useCallback((next: ThemePreference) => {
-    setPreference(next);
-    persistThemePreference(next);
-  }, []);
-
-  const toggle = useCallback(() => {
-    // Toggling picks an explicit light/dark preference based on what is shown.
-    setPreference((current) => {
-      const shown = resolveTheme(current, systemPrefersDark());
-      const next: ThemePreference = shown === 'dark' ? 'light' : 'dark';
-      persistThemePreference(next);
-      return next;
-    });
-  }, []);
-
-  return { theme: preference, resolvedTheme, setTheme, toggle };
+  const state = useSyncExternalStore(appearanceStore.subscribe, appearanceStore.getSnapshot);
+  return {
+    theme: state.themePreference,
+    resolvedTheme: state.resolvedTheme,
+    setTheme: appearanceStore.setThemePreference,
+    toggle: appearanceStore.toggleTheme,
+  };
 }

--- a/apps/web/src/renderer/hooks/useTheme.ts
+++ b/apps/web/src/renderer/hooks/useTheme.ts
@@ -1,67 +1,90 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  APPEARANCE_STORAGE_KEYS,
+  applyResolvedTheme,
+  isThemePreference,
+  persistThemePreference,
+  readStoredThemePreference,
+  resolveTheme,
+  systemPrefersDark,
+  type ResolvedTheme,
+  type ThemePreference,
+} from '../lib/appearance';
 
-export type Theme = 'light' | 'dark';
+export type { ThemePreference, ResolvedTheme } from '../lib/appearance';
 
-const STORAGE_KEY = 'chamber.theme';
+/**
+ * @deprecated Use {@link ThemePreference} (the user's choice) or
+ * {@link ResolvedTheme} (the value actually painted). Retained so existing
+ * imports keep compiling.
+ */
+export type Theme = ResolvedTheme;
 
-function readInitialTheme(): Theme {
-  if (typeof document === 'undefined') return 'dark';
-  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+export interface UseThemeResult {
+  /** The user's stored preference, which may be `system`. */
+  readonly theme: ThemePreference;
+  /** The concrete theme currently painted; never `system`. */
+  readonly resolvedTheme: ResolvedTheme;
+  readonly setTheme: (preference: ThemePreference) => void;
+  readonly toggle: () => void;
 }
 
-function applyTheme(theme: Theme): void {
-  const root = document.documentElement;
-  // Mark the document as "mid-swap" so the global color transition kicks
-  // in just for this paint. We clear the class after the transition ends
-  // so it doesn't interfere with per-component hover transitions.
-  root.classList.add('theme-switching');
-  root.classList.toggle('dark', theme === 'dark');
-  root.dataset.theme = theme;
-  // Keep this aligned with THEME_MS (ambientScene.ts) and the 450ms CSS
-  // color transition in index.css so the class clears as the crossfade ends.
-  window.setTimeout(() => {
-    root.classList.remove('theme-switching');
-  }, 450);
-  try {
-    localStorage.setItem(STORAGE_KEY, theme);
-  } catch {
-    /* storage may be unavailable */
-  }
-  // Repaint the native Windows titleBarOverlay so the OS chrome stays
-  // legible against the new app background.
-  try {
-    void window.desktop?.setTheme?.(theme);
-  } catch {
-    /* desktop bridge may not be present in browser smoke tests */
-  }
-}
+/**
+ * Reads, applies, and persists the theme preference. Supports a `system`
+ * preference that follows `prefers-color-scheme` and updates live via
+ * `matchMedia`, and mirrors changes made in other windows via the `storage`
+ * event.
+ */
+export function useTheme(): UseThemeResult {
+  const [preference, setPreference] = useState<ThemePreference>(readStoredThemePreference);
+  const [prefersDark, setPrefersDark] = useState<boolean>(systemPrefersDark);
 
-export function useTheme(): { theme: Theme; setTheme: (t: Theme) => void; toggle: () => void } {
-  const [theme, setThemeState] = useState<Theme>(readInitialTheme);
-
+  // Follow the OS scheme so a `system` preference reacts live to OS changes.
   useEffect(() => {
-    const handler = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY && (e.newValue === 'light' || e.newValue === 'dark')) {
-        setThemeState(e.newValue);
-        applyTheme(e.newValue);
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const media = window.matchMedia(DARK_MEDIA_QUERY);
+    const handler = (event: MediaQueryListEvent) => setPrefersDark(event.matches);
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
+  // Cross-tab sync: another window changed the stored preference.
+  useEffect(() => {
+    const handler = (event: StorageEvent) => {
+      if (event.key === APPEARANCE_STORAGE_KEYS.theme && isThemePreference(event.newValue)) {
+        setPreference(event.newValue);
       }
     };
     window.addEventListener('storage', handler);
     return () => window.removeEventListener('storage', handler);
   }, []);
 
-  const setTheme = useCallback((next: Theme) => {
-    setThemeState(next);
-    applyTheme(next);
+  const resolvedTheme = resolveTheme(preference, prefersDark);
+
+  // Paint whenever the resolved theme changes. Skip the crossfade on the first
+  // application so loading the app does not animate.
+  const firstApply = useRef(true);
+  useEffect(() => {
+    applyResolvedTheme(resolvedTheme, { animate: !firstApply.current });
+    firstApply.current = false;
+  }, [resolvedTheme]);
+
+  const setTheme = useCallback((next: ThemePreference) => {
+    setPreference(next);
+    persistThemePreference(next);
   }, []);
 
   const toggle = useCallback(() => {
-    setThemeState((current) => {
-      const next: Theme = current === 'dark' ? 'light' : 'dark';
-      applyTheme(next);
+    // Toggling picks an explicit light/dark preference based on what is shown.
+    setPreference((current) => {
+      const shown = resolveTheme(current, systemPrefersDark());
+      const next: ThemePreference = shown === 'dark' ? 'light' : 'dark';
+      persistThemePreference(next);
       return next;
     });
   }, []);
 
-  return { theme, setTheme, toggle };
+  return { theme: preference, resolvedTheme, setTheme, toggle };
 }

--- a/apps/web/src/renderer/index.css
+++ b/apps/web/src/renderer/index.css
@@ -167,6 +167,32 @@ html.theme-switching .surface-card {
   transition-timing-function: cubic-bezier(0.65, 0, 0.35, 1) !important;
 }
 
+/* Appearance preferences (Settings > Appearance). Both levers are applied as a
+ * single class on the document root by the appearance hooks. */
+
+/* Font scale drives the document root font-size so all rem-based text and
+ * spacing scale together with the user's chosen size. `medium` restates the
+ * browser default, so it is the no-op baseline. */
+html.font-scale-small {
+  font-size: 14px;
+}
+html.font-scale-medium {
+  font-size: 16px;
+}
+html.font-scale-large {
+  font-size: 18px;
+}
+
+/* Density retunes Tailwind's spacing base (`--spacing`, default 0.25rem), which
+ * every spacing and sizing utility multiplies, so tightening it compacts the
+ * whole interface at once. `comfortable` restates the default baseline. */
+html.density-comfortable {
+  --spacing: 0.25rem;
+}
+html.density-compact {
+  --spacing: 0.2rem;
+}
+
 .titlebar-drag {
   -webkit-app-region: drag;
 }

--- a/apps/web/src/renderer/lib/appearance.test.ts
+++ b/apps/web/src/renderer/lib/appearance.test.ts
@@ -7,7 +7,6 @@ import {
   applyDensity,
   applyFontScale,
   applyResolvedTheme,
-  initializeAppearance,
   isThemePreference,
   readStoredDensity,
   readStoredFontScale,
@@ -131,31 +130,6 @@ describe('appearance preferences', () => {
     it('default to medium and comfortable', () => {
       expect(readStoredFontScale()).toBe('medium');
       expect(readStoredDensity()).toBe('comfortable');
-    });
-  });
-
-  describe('initializeAppearance', () => {
-    it('applies every persisted preference to the document root', () => {
-      setMatchMedia(false);
-      localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'light');
-      localStorage.setItem(APPEARANCE_STORAGE_KEYS.fontScale, 'large');
-      localStorage.setItem(APPEARANCE_STORAGE_KEYS.density, 'compact');
-
-      initializeAppearance();
-
-      const root = document.documentElement;
-      expect(root.classList.contains('dark')).toBe(false);
-      expect(root.classList.contains('font-scale-large')).toBe(true);
-      expect(root.classList.contains('density-compact')).toBe(true);
-    });
-
-    it('resolves a stored system preference against the OS scheme', () => {
-      setMatchMedia(true);
-      localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'system');
-
-      initializeAppearance();
-
-      expect(document.documentElement.classList.contains('dark')).toBe(true);
     });
   });
 });

--- a/apps/web/src/renderer/lib/appearance.test.ts
+++ b/apps/web/src/renderer/lib/appearance.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  APPEARANCE_STORAGE_KEYS,
+  applyDensity,
+  applyFontScale,
+  applyResolvedTheme,
+  initializeAppearance,
+  isThemePreference,
+  readStoredDensity,
+  readStoredFontScale,
+  readStoredThemePreference,
+  resolveTheme,
+  systemPrefersDark,
+} from './appearance';
+
+function setMatchMedia(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('dark') ? prefersDark : false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+}
+
+describe('appearance preferences', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('resolveTheme', () => {
+    it('passes explicit light and dark preferences through unchanged', () => {
+      expect(resolveTheme('light', true)).toBe('light');
+      expect(resolveTheme('dark', false)).toBe('dark');
+    });
+
+    it('resolves system to the OS scheme', () => {
+      expect(resolveTheme('system', true)).toBe('dark');
+      expect(resolveTheme('system', false)).toBe('light');
+    });
+  });
+
+  describe('readStoredThemePreference', () => {
+    it('defaults to dark when nothing is stored', () => {
+      expect(readStoredThemePreference()).toBe('dark');
+    });
+
+    it('reads a valid stored preference', () => {
+      localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'system');
+      expect(readStoredThemePreference()).toBe('system');
+    });
+
+    it('falls back to the default for an unrecognized value', () => {
+      localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'neon');
+      expect(readStoredThemePreference()).toBe('dark');
+    });
+  });
+
+  describe('isThemePreference', () => {
+    it('accepts the three known preferences and rejects everything else', () => {
+      expect(isThemePreference('light')).toBe(true);
+      expect(isThemePreference('dark')).toBe(true);
+      expect(isThemePreference('system')).toBe(true);
+      expect(isThemePreference('bright')).toBe(false);
+      expect(isThemePreference(null)).toBe(false);
+    });
+  });
+
+  describe('systemPrefersDark', () => {
+    it('reflects the OS media query', () => {
+      setMatchMedia(false);
+      expect(systemPrefersDark()).toBe(false);
+      setMatchMedia(true);
+      expect(systemPrefersDark()).toBe(true);
+    });
+  });
+
+  describe('applyResolvedTheme', () => {
+    it('toggles the dark class and records the theme without animating by default', () => {
+      applyResolvedTheme('dark');
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.classList.contains('theme-switching')).toBe(false);
+
+      applyResolvedTheme('light');
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+      expect(document.documentElement.dataset.theme).toBe('light');
+    });
+
+    it('adds the transition class when animating', () => {
+      applyResolvedTheme('dark', { animate: true });
+      expect(document.documentElement.classList.contains('theme-switching')).toBe(true);
+    });
+  });
+
+  describe('applyFontScale', () => {
+    it('applies exactly one font-scale class', () => {
+      applyFontScale('large');
+      expect(document.documentElement.classList.contains('font-scale-large')).toBe(true);
+
+      applyFontScale('small');
+      expect(document.documentElement.classList.contains('font-scale-small')).toBe(true);
+      expect(document.documentElement.classList.contains('font-scale-large')).toBe(false);
+    });
+  });
+
+  describe('applyDensity', () => {
+    it('applies exactly one density class', () => {
+      applyDensity('compact');
+      expect(document.documentElement.classList.contains('density-compact')).toBe(true);
+
+      applyDensity('comfortable');
+      expect(document.documentElement.classList.contains('density-comfortable')).toBe(true);
+      expect(document.documentElement.classList.contains('density-compact')).toBe(false);
+    });
+  });
+
+  describe('readStoredFontScale / readStoredDensity', () => {
+    it('default to medium and comfortable', () => {
+      expect(readStoredFontScale()).toBe('medium');
+      expect(readStoredDensity()).toBe('comfortable');
+    });
+  });
+
+  describe('initializeAppearance', () => {
+    it('applies every persisted preference to the document root', () => {
+      setMatchMedia(false);
+      localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'light');
+      localStorage.setItem(APPEARANCE_STORAGE_KEYS.fontScale, 'large');
+      localStorage.setItem(APPEARANCE_STORAGE_KEYS.density, 'compact');
+
+      initializeAppearance();
+
+      const root = document.documentElement;
+      expect(root.classList.contains('dark')).toBe(false);
+      expect(root.classList.contains('font-scale-large')).toBe(true);
+      expect(root.classList.contains('density-compact')).toBe(true);
+    });
+
+    it('resolves a stored system preference against the OS scheme', () => {
+      setMatchMedia(true);
+      localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'system');
+
+      initializeAppearance();
+
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/renderer/lib/appearance.ts
+++ b/apps/web/src/renderer/lib/appearance.ts
@@ -159,18 +159,3 @@ export function persistDensity(density: Density): void {
 export function applyDensity(density: Density): void {
   applyRootClass(Object.values(DENSITY_CLASSES), DENSITY_CLASSES[density]);
 }
-
-// ---------------------------------------------------------------------------
-// Startup
-// ---------------------------------------------------------------------------
-
-/**
- * Apply every persisted appearance preference to the document. Called once from
- * the renderer entry before React mounts so a reload restores the user's choice
- * without a flash of the default appearance.
- */
-export function initializeAppearance(): void {
-  applyResolvedTheme(resolveTheme(readStoredThemePreference(), systemPrefersDark()));
-  applyFontScale(readStoredFontScale());
-  applyDensity(readStoredDensity());
-}

--- a/apps/web/src/renderer/lib/appearance.ts
+++ b/apps/web/src/renderer/lib/appearance.ts
@@ -1,10 +1,12 @@
 /**
  * Appearance preferences: the single source of truth for how Chamber's theme,
- * font scale, and density are read, persisted, and applied to the document.
+ * font scale, and density are read, persisted, and applied.
  *
  * Kept framework-agnostic (no React) so the renderer entry can apply stored
- * preferences before first paint and the appearance hooks can share the exact
- * same read/apply logic instead of duplicating it.
+ * preferences at startup and the appearance hooks/store can share the exact same
+ * read/apply logic instead of duplicating it. "Apply" means reflecting a
+ * preference everywhere it shows: DOM classes for all three, plus the native
+ * Windows title-bar overlay for the theme (see `applyResolvedTheme`).
  */
 
 export type ThemePreference = 'light' | 'dark' | 'system';
@@ -40,7 +42,8 @@ const DENSITY_CLASSES: Record<Density, string> = {
   compact: 'density-compact',
 };
 
-const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+/** The `matchMedia` query used to detect the OS dark color-scheme preference. */
+export const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 
 // Keep aligned with the 450ms color transition in index.css so the
 // `theme-switching` class clears exactly as the crossfade ends.
@@ -136,6 +139,10 @@ export function readStoredFontScale(): FontScale {
   return readChoice(APPEARANCE_STORAGE_KEYS.fontScale, FONT_SCALES, DEFAULT_FONT_SCALE);
 }
 
+export function isFontScale(value: unknown): value is FontScale {
+  return typeof value === 'string' && (FONT_SCALES as readonly string[]).includes(value);
+}
+
 export function persistFontScale(scale: FontScale): void {
   persistChoice(APPEARANCE_STORAGE_KEYS.fontScale, scale);
 }
@@ -150,6 +157,10 @@ export function applyFontScale(scale: FontScale): void {
 
 export function readStoredDensity(): Density {
   return readChoice(APPEARANCE_STORAGE_KEYS.density, DENSITIES, DEFAULT_DENSITY);
+}
+
+export function isDensity(value: unknown): value is Density {
+  return typeof value === 'string' && (DENSITIES as readonly string[]).includes(value);
 }
 
 export function persistDensity(density: Density): void {

--- a/apps/web/src/renderer/lib/appearance.ts
+++ b/apps/web/src/renderer/lib/appearance.ts
@@ -1,0 +1,176 @@
+/**
+ * Appearance preferences: the single source of truth for how Chamber's theme,
+ * font scale, and density are read, persisted, and applied to the document.
+ *
+ * Kept framework-agnostic (no React) so the renderer entry can apply stored
+ * preferences before first paint and the appearance hooks can share the exact
+ * same read/apply logic instead of duplicating it.
+ */
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+/** The concrete theme applied to the DOM once `system` has been resolved. */
+export type ResolvedTheme = 'light' | 'dark';
+export type FontScale = 'small' | 'medium' | 'large';
+export type Density = 'comfortable' | 'compact';
+
+export const THEME_PREFERENCES = ['light', 'dark', 'system'] as const;
+export const FONT_SCALES = ['small', 'medium', 'large'] as const;
+export const DENSITIES = ['comfortable', 'compact'] as const;
+
+// Defaults preserve the previously hardcoded dark look so existing users see no
+// change until they opt into a different appearance.
+export const DEFAULT_THEME_PREFERENCE: ThemePreference = 'dark';
+export const DEFAULT_FONT_SCALE: FontScale = 'medium';
+export const DEFAULT_DENSITY: Density = 'comfortable';
+
+export const APPEARANCE_STORAGE_KEYS = {
+  theme: 'chamber.theme',
+  fontScale: 'chamber.fontScale',
+  density: 'chamber.density',
+} as const;
+
+const FONT_SCALE_CLASSES: Record<FontScale, string> = {
+  small: 'font-scale-small',
+  medium: 'font-scale-medium',
+  large: 'font-scale-large',
+};
+
+const DENSITY_CLASSES: Record<Density, string> = {
+  comfortable: 'density-comfortable',
+  compact: 'density-compact',
+};
+
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+// Keep aligned with the 450ms color transition in index.css so the
+// `theme-switching` class clears exactly as the crossfade ends.
+const THEME_TRANSITION_MS = 450;
+
+// ---------------------------------------------------------------------------
+// Generic persistence
+// ---------------------------------------------------------------------------
+
+function readChoice<T extends string>(key: string, allowed: readonly T[], fallback: T): T {
+  if (typeof localStorage === 'undefined') return fallback;
+  try {
+    const stored = localStorage.getItem(key);
+    return (allowed as readonly string[]).includes(stored ?? '') ? (stored as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function persistChoice(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* storage may be unavailable */
+  }
+}
+
+/** Swap the single active class from `classes` on the document root. */
+function applyRootClass(classes: readonly string[], active: string): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.classList.remove(...classes);
+  root.classList.add(active);
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return typeof value === 'string' && (THEME_PREFERENCES as readonly string[]).includes(value);
+}
+
+export function readStoredThemePreference(): ThemePreference {
+  return readChoice(APPEARANCE_STORAGE_KEYS.theme, THEME_PREFERENCES, DEFAULT_THEME_PREFERENCE);
+}
+
+export function persistThemePreference(preference: ThemePreference): void {
+  persistChoice(APPEARANCE_STORAGE_KEYS.theme, preference);
+}
+
+/** Whether the OS currently reports a dark color-scheme preference. */
+export function systemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true;
+  return window.matchMedia(DARK_MEDIA_QUERY).matches;
+}
+
+export function resolveTheme(preference: ThemePreference, prefersDark: boolean): ResolvedTheme {
+  if (preference === 'system') return prefersDark ? 'dark' : 'light';
+  return preference;
+}
+
+export interface ApplyThemeOptions {
+  /** Play the global crossfade transition. Off for the first paint on load. */
+  readonly animate?: boolean;
+}
+
+export function applyResolvedTheme(resolved: ResolvedTheme, options: ApplyThemeOptions = {}): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (options.animate) {
+    // Mark the document as "mid-swap" so the global color transition kicks in
+    // just for this paint, then clear it once the crossfade ends.
+    root.classList.add('theme-switching');
+    window.setTimeout(() => root.classList.remove('theme-switching'), THEME_TRANSITION_MS);
+  }
+  root.classList.toggle('dark', resolved === 'dark');
+  root.dataset.theme = resolved;
+  // Repaint the native Windows titleBarOverlay so the OS chrome stays legible
+  // against the new app background.
+  try {
+    void window.desktop?.setTheme?.(resolved);
+  } catch {
+    /* desktop bridge may not be present in browser smoke tests */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Font scale
+// ---------------------------------------------------------------------------
+
+export function readStoredFontScale(): FontScale {
+  return readChoice(APPEARANCE_STORAGE_KEYS.fontScale, FONT_SCALES, DEFAULT_FONT_SCALE);
+}
+
+export function persistFontScale(scale: FontScale): void {
+  persistChoice(APPEARANCE_STORAGE_KEYS.fontScale, scale);
+}
+
+export function applyFontScale(scale: FontScale): void {
+  applyRootClass(Object.values(FONT_SCALE_CLASSES), FONT_SCALE_CLASSES[scale]);
+}
+
+// ---------------------------------------------------------------------------
+// Density
+// ---------------------------------------------------------------------------
+
+export function readStoredDensity(): Density {
+  return readChoice(APPEARANCE_STORAGE_KEYS.density, DENSITIES, DEFAULT_DENSITY);
+}
+
+export function persistDensity(density: Density): void {
+  persistChoice(APPEARANCE_STORAGE_KEYS.density, density);
+}
+
+export function applyDensity(density: Density): void {
+  applyRootClass(Object.values(DENSITY_CLASSES), DENSITY_CLASSES[density]);
+}
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply every persisted appearance preference to the document. Called once from
+ * the renderer entry before React mounts so a reload restores the user's choice
+ * without a flash of the default appearance.
+ */
+export function initializeAppearance(): void {
+  applyResolvedTheme(resolveTheme(readStoredThemePreference(), systemPrefersDark()));
+  applyFontScale(readStoredFontScale());
+  applyDensity(readStoredDensity());
+}

--- a/apps/web/src/renderer/lib/appearance.ts
+++ b/apps/web/src/renderer/lib/appearance.ts
@@ -124,10 +124,11 @@ export function applyResolvedTheme(resolved: ResolvedTheme, options: ApplyThemeO
   root.dataset.theme = resolved;
   // Repaint the native Windows titleBarOverlay so the OS chrome stays legible
   // against the new app background.
-  try {
-    void window.desktop?.setTheme?.(resolved);
-  } catch {
-    /* desktop bridge may not be present in browser smoke tests */
+  const setTheme = window.desktop?.setTheme;
+  if (setTheme) {
+    void setTheme(resolved).catch(() => {
+      /* desktop bridge call can fail in browser-targeted tests */
+    });
   }
 }
 

--- a/apps/web/src/renderer/lib/appearanceStore.test.ts
+++ b/apps/web/src/renderer/lib/appearanceStore.test.ts
@@ -120,6 +120,22 @@ describe('appearanceStore', () => {
     expect(appearanceStore.getSnapshot().resolvedTheme).toBe('dark');
   });
 
+  it('ignores OS scheme changes when the preference is explicit', () => {
+    const media = installMatchMedia(true);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'dark');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
+    const listener = vi.fn();
+    appearanceStore.subscribe(listener);
+
+    media.emit(false);
+
+    expect(appearanceStore.getSnapshot().resolvedTheme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('theme-switching')).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it('stops responding to OS changes after reset', () => {
     const media = installMatchMedia(false);
     localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'system');

--- a/apps/web/src/renderer/lib/appearanceStore.test.ts
+++ b/apps/web/src/renderer/lib/appearanceStore.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appearanceStore } from './appearanceStore';
+import { APPEARANCE_STORAGE_KEYS } from './appearance';
+
+function installMatchMedia(initialDark: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initialDark;
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: (_type: string, cb: (event: MediaQueryListEvent) => void) => listeners.add(cb),
+    removeEventListener: (_type: string, cb: (event: MediaQueryListEvent) => void) => listeners.delete(cb),
+  };
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: () => mql,
+  });
+  return {
+    emit(next: boolean) {
+      matches = next;
+      listeners.forEach((cb) => cb({ matches: next } as MediaQueryListEvent));
+    },
+  };
+}
+
+describe('appearanceStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    appearanceStore.resetForTests();
+    delete (window as { matchMedia?: unknown }).matchMedia;
+  });
+
+  it('applies persisted preferences to the document when started', () => {
+    installMatchMedia(false);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'light');
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.fontScale, 'large');
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.density, 'compact');
+    appearanceStore.resetForTests();
+
+    appearanceStore.start();
+
+    const root = document.documentElement;
+    expect(root.classList.contains('dark')).toBe(false);
+    expect(root.classList.contains('font-scale-large')).toBe(true);
+    expect(root.classList.contains('density-compact')).toBe(true);
+    // The initial paint must not animate the crossfade.
+    expect(root.classList.contains('theme-switching')).toBe(false);
+  });
+
+  it('follows the OS scheme live for a system preference without any UI mounted', () => {
+    const media = installMatchMedia(false);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'system');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    media.emit(true);
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(appearanceStore.getSnapshot().resolvedTheme).toBe('dark');
+  });
+
+  it('mirrors theme, font size, and density changes from other windows', () => {
+    installMatchMedia(true);
+    appearanceStore.resetForTests();
+    appearanceStore.start();
+
+    window.dispatchEvent(new StorageEvent('storage', { key: APPEARANCE_STORAGE_KEYS.theme, newValue: 'light' }));
+    window.dispatchEvent(new StorageEvent('storage', { key: APPEARANCE_STORAGE_KEYS.fontScale, newValue: 'small' }));
+    window.dispatchEvent(new StorageEvent('storage', { key: APPEARANCE_STORAGE_KEYS.density, newValue: 'compact' }));
+
+    const snapshot = appearanceStore.getSnapshot();
+    expect(snapshot.themePreference).toBe('light');
+    expect(snapshot.fontScale).toBe('small');
+    expect(snapshot.density).toBe('compact');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.documentElement.classList.contains('font-scale-small')).toBe(true);
+    expect(document.documentElement.classList.contains('density-compact')).toBe(true);
+  });
+
+  it('persists and applies setter changes and notifies subscribers', () => {
+    installMatchMedia(true);
+    appearanceStore.resetForTests();
+    appearanceStore.start();
+    const listener = vi.fn();
+    appearanceStore.subscribe(listener);
+
+    appearanceStore.setThemePreference('light');
+    appearanceStore.setFontScale('large');
+    appearanceStore.setDensity('compact');
+
+    expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.theme)).toBe('light');
+    expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.fontScale)).toBe('large');
+    expect(localStorage.getItem(APPEARANCE_STORAGE_KEYS.density)).toBe('compact');
+    expect(document.documentElement.classList.contains('font-scale-large')).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it('toggles between light and dark from the shown theme', () => {
+    installMatchMedia(true);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'dark');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
+
+    appearanceStore.toggleTheme();
+    expect(appearanceStore.getSnapshot().resolvedTheme).toBe('light');
+
+    appearanceStore.toggleTheme();
+    expect(appearanceStore.getSnapshot().resolvedTheme).toBe('dark');
+  });
+
+  it('stops responding to OS changes after reset', () => {
+    const media = installMatchMedia(false);
+    localStorage.setItem(APPEARANCE_STORAGE_KEYS.theme, 'system');
+    appearanceStore.resetForTests();
+    appearanceStore.start();
+
+    appearanceStore.resetForTests();
+    media.emit(true);
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/apps/web/src/renderer/lib/appearanceStore.ts
+++ b/apps/web/src/renderer/lib/appearanceStore.ts
@@ -17,8 +17,9 @@ import {
   applyDensity,
   applyFontScale,
   applyResolvedTheme,
-  DENSITIES,
-  FONT_SCALES,
+  DARK_MEDIA_QUERY,
+  isDensity,
+  isFontScale,
   isThemePreference,
   persistDensity,
   persistFontScale,
@@ -44,16 +45,6 @@ export interface AppearanceState {
 
 type Listener = () => void;
 
-const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
-
-function isFontScale(value: string | null): value is FontScale {
-  return (FONT_SCALES as readonly string[]).includes(value ?? '');
-}
-
-function isDensity(value: string | null): value is Density {
-  return (DENSITIES as readonly string[]).includes(value ?? '');
-}
-
 class AppearanceStore {
   private themePreference: ThemePreference = readStoredThemePreference();
   private fontScale: FontScale = readStoredFontScale();
@@ -66,6 +57,9 @@ class AppearanceStore {
 
   private readonly handleMedia = (event: MediaQueryListEvent): void => {
     this.prefersDark = event.matches;
+    // The OS scheme only changes the resolved theme when following `system`;
+    // for an explicit light/dark preference there is nothing to repaint.
+    if (this.themePreference !== 'system') return;
     this.applyTheme(true);
     this.publish();
   };

--- a/apps/web/src/renderer/lib/appearanceStore.ts
+++ b/apps/web/src/renderer/lib/appearanceStore.ts
@@ -1,0 +1,185 @@
+/**
+ * Appearance store: the always-on owner of runtime appearance synchronization.
+ *
+ * Started once from the renderer entry (not from any screen), it holds the
+ * current preferences, applies them to the document, and keeps them in sync with
+ * two external sources for the whole app session:
+ *   - the OS color-scheme (`prefers-color-scheme`) for the `system` theme, and
+ *   - other windows/tabs via the `storage` event.
+ *
+ * React consumes it through `useSyncExternalStore` (see the appearance hooks).
+ * Settings only reads the snapshot and calls the setters; it never owns the
+ * ongoing synchronization.
+ */
+
+import {
+  APPEARANCE_STORAGE_KEYS,
+  applyDensity,
+  applyFontScale,
+  applyResolvedTheme,
+  DENSITIES,
+  FONT_SCALES,
+  isThemePreference,
+  persistDensity,
+  persistFontScale,
+  persistThemePreference,
+  readStoredDensity,
+  readStoredFontScale,
+  readStoredThemePreference,
+  resolveTheme,
+  systemPrefersDark,
+  type Density,
+  type FontScale,
+  type ResolvedTheme,
+  type ThemePreference,
+} from './appearance';
+
+export interface AppearanceState {
+  readonly themePreference: ThemePreference;
+  /** The concrete theme currently painted; never `system`. */
+  readonly resolvedTheme: ResolvedTheme;
+  readonly fontScale: FontScale;
+  readonly density: Density;
+}
+
+type Listener = () => void;
+
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+function isFontScale(value: string | null): value is FontScale {
+  return (FONT_SCALES as readonly string[]).includes(value ?? '');
+}
+
+function isDensity(value: string | null): value is Density {
+  return (DENSITIES as readonly string[]).includes(value ?? '');
+}
+
+class AppearanceStore {
+  private themePreference: ThemePreference = readStoredThemePreference();
+  private fontScale: FontScale = readStoredFontScale();
+  private density: Density = readStoredDensity();
+  private prefersDark: boolean = systemPrefersDark();
+  private snapshot: AppearanceState = this.computeSnapshot();
+  private readonly listeners = new Set<Listener>();
+  private mediaQuery: MediaQueryList | null = null;
+  private started = false;
+
+  private readonly handleMedia = (event: MediaQueryListEvent): void => {
+    this.prefersDark = event.matches;
+    this.applyTheme(true);
+    this.publish();
+  };
+
+  private readonly handleStorage = (event: StorageEvent): void => {
+    if (event.key === APPEARANCE_STORAGE_KEYS.theme && isThemePreference(event.newValue)) {
+      this.themePreference = event.newValue;
+      this.applyTheme(true);
+      this.publish();
+    } else if (event.key === APPEARANCE_STORAGE_KEYS.fontScale && isFontScale(event.newValue)) {
+      this.fontScale = event.newValue;
+      applyFontScale(this.fontScale);
+      this.publish();
+    } else if (event.key === APPEARANCE_STORAGE_KEYS.density && isDensity(event.newValue)) {
+      this.density = event.newValue;
+      applyDensity(this.density);
+      this.publish();
+    }
+  };
+
+  /**
+   * Apply the persisted preferences and begin listening for OS and cross-window
+   * changes. Idempotent: safe to call once at startup. The initial paint skips
+   * the theme crossfade so loading the app does not animate.
+   */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.applyTheme(false);
+    applyFontScale(this.fontScale);
+    applyDensity(this.density);
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      this.mediaQuery = window.matchMedia(DARK_MEDIA_QUERY);
+      this.mediaQuery.addEventListener('change', this.handleMedia);
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', this.handleStorage);
+    }
+  }
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): AppearanceState => this.snapshot;
+
+  setThemePreference = (preference: ThemePreference): void => {
+    this.themePreference = preference;
+    persistThemePreference(preference);
+    this.applyTheme(true);
+    this.publish();
+  };
+
+  toggleTheme = (): void => {
+    const shown = resolveTheme(this.themePreference, this.prefersDark);
+    this.setThemePreference(shown === 'dark' ? 'light' : 'dark');
+  };
+
+  setFontScale = (scale: FontScale): void => {
+    this.fontScale = scale;
+    persistFontScale(scale);
+    applyFontScale(scale);
+    this.publish();
+  };
+
+  setDensity = (density: Density): void => {
+    this.density = density;
+    persistDensity(density);
+    applyDensity(density);
+    this.publish();
+  };
+
+  private applyTheme(animate: boolean): void {
+    applyResolvedTheme(resolveTheme(this.themePreference, this.prefersDark), { animate });
+  }
+
+  private computeSnapshot(): AppearanceState {
+    return {
+      themePreference: this.themePreference,
+      resolvedTheme: resolveTheme(this.themePreference, this.prefersDark),
+      fontScale: this.fontScale,
+      density: this.density,
+    };
+  }
+
+  private publish(): void {
+    this.snapshot = this.computeSnapshot();
+    for (const listener of this.listeners) listener();
+  }
+
+  /**
+   * Detach listeners and re-read persisted state. Intended for tests so each
+   * case starts from a clean, storage-derived snapshot.
+   */
+  resetForTests(): void {
+    this.mediaQuery?.removeEventListener('change', this.handleMedia);
+    if (typeof window !== 'undefined') window.removeEventListener('storage', this.handleStorage);
+    this.mediaQuery = null;
+    this.started = false;
+    this.listeners.clear();
+    this.themePreference = readStoredThemePreference();
+    this.fontScale = readStoredFontScale();
+    this.density = readStoredDensity();
+    this.prefersDark = systemPrefersDark();
+    this.snapshot = this.computeSnapshot();
+  }
+}
+
+export const appearanceStore = new AppearanceStore();
+
+/** Begin app-wide appearance synchronization. Call once from the renderer entry. */
+export function startAppearanceSync(): void {
+  appearanceStore.start();
+}

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -153,6 +153,7 @@ export const IPC = {
   DESKTOP: {
     GET_BRANDING: 'desktop:getBranding',
     CONFIRM: 'desktop:confirm',
+    SET_THEME: 'desktop:setTheme',
   },
   E2E: {
     IS_ENABLED: 'e2e:is-enabled',


### PR DESCRIPTION
﻿## Summary

Exposes Chamber's existing theme engine through a new **Settings > Appearance** section and adds live, persisted **font size** and **density** controls. Theme gains a **system** option that follows the OS color scheme. All three preferences apply instantly and survive a reload.

This branch also resolves the S3 principal-review blockers (see below).

## Notable changes

**Appearance section (renderer)**
- New `AppearanceSettingsSection` with keyboard-navigable segmented controls (radiogroup + roving tabindex + arrow keys) for theme (light/dark/system), font size (small/medium/large -> root `font-size`), and density (comfortable/compact -> Tailwind `--spacing` base).
- Added an `appearance` member to `SettingsSectionId` and a matching left-rail item, following the existing section pattern.

**App-wide sync moved out of Settings (blocker 1)**
- New framework-agnostic `appearanceStore` (a singleton) owns runtime synchronization: it follows `prefers-color-scheme` for the `system` theme and mirrors preferences across windows via the `storage` event. It is started once from `renderer.tsx` (`startAppearanceSync`), so sync runs for the whole session, not only while Settings is open.
- `useTheme`, `useFontScale`, and `useDensity` are now thin `useSyncExternalStore` consumers. Settings only reads the snapshot and forwards user intent.

**Native title-bar overlay repaint (blocker 2)**
- Added a typed `IPC.DESKTOP.SET_THEME` channel, exposed `desktop.setTheme` from the preload bridge, and handle it in main by repainting the sending window's Windows title-bar overlay via `BrowserWindow.fromWebContents(event.sender)?.setTitleBarOverlay(...)`.
- A single `titleBarTheme` helper is the source of truth for the overlay colors, shared by `createWindow`, the mind popout window, and the runtime repaint. It targets the calling window, so main and popout windows each repaint independently.

**Accessibility (blocker 3)**
- The segmented controls are a proper WAI-ARIA radio group with arrow-key selection and roving tabindex.

**Changelog**
- Added a `## [Unreleased]` `### Added` entry.

## Tests

- `appearance.test.ts` (pure helpers), `appearanceStore.test.ts` (app-wide sync without any UI mounted, cross-window `storage` sync, explicit-theme guard, setters, toggle), `useTheme.test.ts` / `useAppearance.test.ts` (store-backed hooks), `SettingsView.test.tsx` (Appearance section renders, live change + persist, arrow-key navigation), and `titleBarTheme.test.ts` (color mapping + win32/no-op branches).
- `npm run typecheck`: clean. `npm run lint`: clean (0 errors, 0 warnings, no dependency violations).
- `npm test`: 2245 passed, 2 skipped. The one failure is a pre-existing, environment-specific Windows symlink `EPERM` test in `packages/services/.../MindProfileService.test.ts`, confirmed failing identically on `master` with these changes stashed (unrelated).
- Electron boot smoke (`tests/e2e/electron/boot.spec.ts`): passed. Confirms the app boots with the new main-process handler and preload bridge, `window.desktop` is intact, and there are zero console errors.

## Reviewed

Ran Uncle Bob (renderer root / theme / window chrome). Verdict: no blocking issues. Addressed the non-blocking findings in scope:
- Skip repaint/crossfade/IPC/re-render when the OS scheme changes under an explicit light/dark preference.
- De-duplicated the pure layer (`DARK_MEDIA_QUERY`, `isFontScale`/`isDensity`).
- Corrected the first-paint comments (see caveat).

## Caveats

- **First-paint flash:** the renderer is a deferred module, so preferences apply after the document's first paint. `index.html` ships `class="dark"`, so default-dark users see the correct theme immediately, but a light/system-light user may see one dark frame on a cold load. The standard fix (a render-blocking same-origin `theme-init` script in `<head>`, which the production `script-src 'self'` CSP permits) is noted as an out-of-scope follow-up; it needs packaged `file://` path validation before landing.
- `AppConfig.theme` (in `ConfigService`) currently has no consumers; the renderer store is the appearance source of truth. Wiring `AppConfig.theme` to anything later should defer to the store to avoid a second source of truth.

No issue reference: this is feature work with no tracked issue.

---

## Upstream issue linkage

Refs #401. This addresses most appearance persistence/sync work, but does not close #401 because first-paint parity and ConfigService desktop ownership remain follow-ups.

## Source branch

Fork PR: https://github.com/patschmittdev/chamber/pull/3
Head: `patschmittdev:patschmittdev-feat-appearance-settings`
