### PR TITLE
feat: Extensions hub (MCP, tools, skills, lens views)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Add theme-aware update chrome** — Adds a dismissible ready-to-install banner and update-status indicator with accessible light and dark theme colors.
 - **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 - **Add insiders-gated local voice dictation** — Adds local Foundry/Nemotron dictation with a dedicated Settings page, chat mic and push-to-talk controls, explicit runtime capability gating, and insiders-only prepared runtime packaging. (#385) (#385)
+- **Add Extensions hub** — New Extensions view (activity-bar icon) with four tabs: manage a mind's MCP servers (add/edit/remove written to .mcp.json, reusing the runtime schema so invalid entries are preserved and never normalized, with tools/type preserved across edits and renames), install/uninstall marketplace Tools, and read-only Skills and Lens view lists
 
 ### Refactor
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -62,6 +62,8 @@ import {
   MindProfileService,
   MindScaffold,
   MindSkillDiscovery,
+  readMcpServers,
+  writeMcpServers,
   TaskManager,
   TaskLedger,
   ChildProcessRunner,
@@ -121,6 +123,7 @@ import { setupConversationHistoryIPC } from './main/ipc/conversationHistory';
 import { setupUpdaterIPC } from './main/ipc/updater';
 import { setupUserProfileIPC } from './main/ipc/userProfile';
 import { setupSkillsIPC } from './main/ipc/skills';
+import { setupMcpIPC } from './main/ipc/mcp';
 import { setupVoiceIPC } from './main/ipc/voice';
 
 import { EventEmitter } from 'events';
@@ -926,6 +929,13 @@ app.on('ready', async () => {
   setupSkillsIPC(
     { getMindPath: (mindId) => mindManager.getMind(mindId)?.mindPath },
     skillDiscovery,
+  );
+  setupMcpIPC(
+    {
+      getMindPath: (mindId) => mindManager.getMind(mindId)?.mindPath,
+      getActiveMindId: () => mindManager.getActiveMindId(),
+    },
+    { read: readMcpServers, write: writeMcpServers },
   );
   setupAuthIPC(authService, mindManager, async () => {
     await chamberCopilotService?.resetAuthState();

--- a/apps/desktop/src/main/ipc/mcp.test.ts
+++ b/apps/desktop/src/main/ipc/mcp.test.ts
@@ -67,6 +67,22 @@ describe('MCP IPC', () => {
       expect(write).toHaveBeenCalledWith('C:\\minds\\lucy', entries);
     });
 
+    it('passes preserved fields through validation unchanged', async () => {
+      getMindPath.mockReturnValue('C:\\minds\\lucy');
+      const entries: McpServerEntry[] = [
+        {
+          name: 'stream',
+          transport: 'http',
+          url: 'https://mcp.example.test/sse',
+          headers: {},
+          preserved: { type: 'sse', tools: ['ping'], timeout: 1000 },
+        },
+      ];
+
+      await expect(getHandler(IPC.MCP.SET_SERVERS)(EVT, entries, 'lucy')).resolves.toEqual(entries);
+      expect(write).toHaveBeenCalledWith('C:\\minds\\lucy', entries);
+    });
+
     it('throws when no mind is selected', async () => {
       const entries: McpServerEntry[] = [
         { name: 'files', transport: 'stdio', command: 'npx', args: [], env: {} },

--- a/apps/desktop/src/main/ipc/mcp.test.ts
+++ b/apps/desktop/src/main/ipc/mcp.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+import { ipcMain } from 'electron';
+import type { IpcMainInvokeEvent } from 'electron';
+import { IPC } from '@chamber/shared';
+import type { McpServerEntry } from '@chamber/shared/mcp-types';
+import { setupMcpIPC } from './mcp';
+
+const EVT = {} as IpcMainInvokeEvent;
+type InvokeHandler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
+
+describe('MCP IPC', () => {
+  const getMindPath = vi.fn<(mindId: string) => string | undefined>();
+  const getActiveMindId = vi.fn<() => string | null>();
+  const read = vi.fn<(mindPath: string) => McpServerEntry[]>();
+  const write = vi.fn<(mindPath: string, servers: McpServerEntry[]) => McpServerEntry[]>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMindPath.mockReturnValue(undefined);
+    getActiveMindId.mockReturnValue(null);
+    read.mockReturnValue([]);
+    write.mockImplementation((_path, servers) => servers);
+    setupMcpIPC({ getMindPath, getActiveMindId }, { read, write });
+  });
+
+  describe('getServers', () => {
+    it('reads from the resolved active mind when no mindId is passed', async () => {
+      getActiveMindId.mockReturnValue('lucy');
+      getMindPath.mockReturnValue('C:\\minds\\lucy');
+      read.mockReturnValue([
+        { name: 'files', transport: 'stdio', command: 'npx', args: [], env: {} },
+      ]);
+
+      await expect(getHandler(IPC.MCP.GET_SERVERS)(EVT, undefined)).resolves.toEqual([
+        { name: 'files', transport: 'stdio', command: 'npx', args: [], env: {} },
+      ]);
+      expect(getMindPath).toHaveBeenCalledWith('lucy');
+      expect(read).toHaveBeenCalledWith('C:\\minds\\lucy');
+    });
+
+    it('returns [] when no mind can be resolved', async () => {
+      await expect(getHandler(IPC.MCP.GET_SERVERS)(EVT, undefined)).resolves.toEqual([]);
+      expect(read).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-string mindId with a channel-labeled TypeError', async () => {
+      await expect(getHandler(IPC.MCP.GET_SERVERS)(EVT, 42)).rejects.toThrow(TypeError);
+      await expect(getHandler(IPC.MCP.GET_SERVERS)(EVT, 42)).rejects.toThrow(/mcp:getServers/);
+      expect(read).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setServers', () => {
+    it('writes validated entries to the resolved mind path', async () => {
+      getMindPath.mockReturnValue('C:\\minds\\lucy');
+      const entries: McpServerEntry[] = [
+        { name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: { A: '1' } },
+        { name: 'remote', transport: 'http', url: 'https://mcp.example.test', headers: {} },
+      ];
+
+      await expect(getHandler(IPC.MCP.SET_SERVERS)(EVT, entries, 'lucy')).resolves.toEqual(entries);
+      expect(write).toHaveBeenCalledWith('C:\\minds\\lucy', entries);
+    });
+
+    it('throws when no mind is selected', async () => {
+      const entries: McpServerEntry[] = [
+        { name: 'files', transport: 'stdio', command: 'npx', args: [], env: {} },
+      ];
+      await expect(getHandler(IPC.MCP.SET_SERVERS)(EVT, entries, undefined)).rejects.toThrow(/No mind selected/);
+      expect(write).not.toHaveBeenCalled();
+    });
+
+    it('rejects a stdio entry with an empty command', async () => {
+      getMindPath.mockReturnValue('C:\\minds\\lucy');
+      const entries = [{ name: 'files', transport: 'stdio', command: '', args: [], env: {} }];
+      await expect(getHandler(IPC.MCP.SET_SERVERS)(EVT, entries, 'lucy')).rejects.toThrow(TypeError);
+      expect(write).not.toHaveBeenCalled();
+    });
+
+    it('rejects an http entry with an invalid url', async () => {
+      getMindPath.mockReturnValue('C:\\minds\\lucy');
+      const entries = [{ name: 'remote', transport: 'http', url: 'not-a-url', headers: {} }];
+      await expect(getHandler(IPC.MCP.SET_SERVERS)(EVT, entries, 'lucy')).rejects.toThrow(TypeError);
+      expect(write).not.toHaveBeenCalled();
+    });
+
+    it('rejects an entry that mixes stdio and http keys', async () => {
+      getMindPath.mockReturnValue('C:\\minds\\lucy');
+      const entries = [{ name: 'x', transport: 'stdio', command: 'a', args: [], env: {}, url: 'https://y.test' }];
+      await expect(getHandler(IPC.MCP.SET_SERVERS)(EVT, entries, 'lucy')).rejects.toThrow(TypeError);
+      expect(write).not.toHaveBeenCalled();
+    });
+  });
+});
+
+function getHandler(channel: string): InvokeHandler {
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((item) => item[0] === channel);
+  if (!call) throw new Error(`no handler registered for ${channel}`);
+  return call[1] as InvokeHandler;
+}

--- a/apps/desktop/src/main/ipc/mcp.ts
+++ b/apps/desktop/src/main/ipc/mcp.ts
@@ -18,12 +18,20 @@ export interface McpServerStorePort {
   write(mindPath: string, servers: McpServerEntry[]): McpServerEntry[];
 }
 
+const preservedSchema = z.object({
+  type: z.enum(['stdio', 'local', 'http', 'sse']).optional(),
+  tools: z.array(z.string()).optional(),
+  timeout: z.number().optional(),
+  cwd: z.string().optional(),
+}).strict();
+
 const stdioEntrySchema = z.object({
   name: z.string().trim().min(1, 'must be a non-empty string'),
   transport: z.literal('stdio'),
   command: z.string().trim().min(1, 'must be a non-empty string'),
   args: z.array(z.string()),
   env: z.record(z.string(), z.string()),
+  preserved: preservedSchema.optional(),
 }).strict();
 
 const httpEntrySchema = z.object({
@@ -31,6 +39,7 @@ const httpEntrySchema = z.object({
   transport: z.literal('http'),
   url: z.url(),
   headers: z.record(z.string(), z.string()),
+  preserved: preservedSchema.optional(),
 }).strict();
 
 const entriesSchema: z.ZodType<McpServerEntry[]> = z.array(

--- a/apps/desktop/src/main/ipc/mcp.ts
+++ b/apps/desktop/src/main/ipc/mcp.ts
@@ -1,0 +1,64 @@
+import { ipcMain } from 'electron';
+import { z } from 'zod';
+import { IPC, parseIpcArgs } from '@chamber/shared';
+import type { McpServerEntry } from '@chamber/shared/mcp-types';
+
+/**
+ * Resolves mind identity for MCP config access. The active mind is used when a
+ * channel is called without an explicit `mindId`, mirroring the Lens adapter.
+ */
+export interface McpIpcMindProvider {
+  getMindPath(mindId: string): string | undefined;
+  getActiveMindId(): string | null;
+}
+
+/** File-backed store for a mind's `.mcp.json`; injected for testability. */
+export interface McpServerStorePort {
+  read(mindPath: string): McpServerEntry[];
+  write(mindPath: string, servers: McpServerEntry[]): McpServerEntry[];
+}
+
+const stdioEntrySchema = z.object({
+  name: z.string().trim().min(1, 'must be a non-empty string'),
+  transport: z.literal('stdio'),
+  command: z.string().trim().min(1, 'must be a non-empty string'),
+  args: z.array(z.string()),
+  env: z.record(z.string(), z.string()),
+}).strict();
+
+const httpEntrySchema = z.object({
+  name: z.string().trim().min(1, 'must be a non-empty string'),
+  transport: z.literal('http'),
+  url: z.url(),
+  headers: z.record(z.string(), z.string()),
+}).strict();
+
+const entriesSchema: z.ZodType<McpServerEntry[]> = z.array(
+  z.discriminatedUnion('transport', [stdioEntrySchema, httpEntrySchema]),
+);
+
+const optionalMindIdSchema = z.string().min(1, 'must be a non-empty string').optional();
+
+export function setupMcpIPC(mindProvider: McpIpcMindProvider, store: McpServerStorePort): void {
+  const resolveMindPath = (mindId?: string): string | undefined => {
+    const id = mindId ?? mindProvider.getActiveMindId() ?? undefined;
+    return id ? mindProvider.getMindPath(id) : undefined;
+  };
+
+  ipcMain.handle(IPC.MCP.GET_SERVERS, async (_event, rawMindId: unknown) => {
+    const mindId = parseIpcArgs(IPC.MCP.GET_SERVERS, optionalMindIdSchema, rawMindId);
+    const mindPath = resolveMindPath(mindId);
+    if (!mindPath) return [];
+    return store.read(mindPath);
+  });
+
+  ipcMain.handle(IPC.MCP.SET_SERVERS, async (_event, rawServers: unknown, rawMindId: unknown) => {
+    const servers = parseIpcArgs(IPC.MCP.SET_SERVERS, entriesSchema, rawServers);
+    const mindId = parseIpcArgs(IPC.MCP.SET_SERVERS, optionalMindIdSchema, rawMindId);
+    const mindPath = resolveMindPath(mindId);
+    if (!mindPath) {
+      throw new Error('No mind selected to save MCP servers for');
+    }
+    return store.write(mindPath, servers);
+  });
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -164,6 +164,10 @@ const electronAPI: ElectronAPI = {
   skills: {
     listForMind: (mindId: string) => ipcRenderer.invoke(IPC.SKILLS.LIST_FOR_MIND, mindId),
   },
+  mcp: {
+    getServers: (mindId?) => ipcRenderer.invoke(IPC.MCP.GET_SERVERS, mindId),
+    setServers: (servers, mindId?) => ipcRenderer.invoke(IPC.MCP.SET_SERVERS, servers, mindId),
+  },
 };
 
 if (ipcRenderer.sendSync(IPC.E2E.IS_ENABLED) === true) {

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -393,6 +393,11 @@ export function installBrowserApi(): void {
       // Web host has no on-disk mind directory to scan.
       listForMind: async () => [],
     },
+    mcp: {
+      // Web host has no on-disk mind directory to read or write .mcp.json.
+      getServers: async () => [],
+      setServers: async (servers) => servers,
+    },
   };
   window.electronAPI = api;
   if (!window.desktop) {

--- a/apps/web/src/renderer/components/extensions/ExtensionsView.test.tsx
+++ b/apps/web/src/renderer/components/extensions/ExtensionsView.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import { AppStateProvider } from '../../lib/store';
+import { ExtensionsView } from './ExtensionsView';
+
+function renderView(api: ReturnType<typeof mockElectronAPI>) {
+  installElectronAPI(api);
+  return render(
+    <AppStateProvider>
+      <ExtensionsView />
+    </AppStateProvider>,
+  );
+}
+
+describe('ExtensionsView', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = mockElectronAPI();
+  });
+
+  it('renders the header and all four tabs', () => {
+    renderView(api);
+    expect(screen.getByRole('heading', { name: 'Extensions' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'MCP servers' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Tools' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Skills' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Lens views' })).toBeTruthy();
+  });
+
+  it('switches to the Tools tab and loads the catalog', async () => {
+    vi.mocked(api.tools.list).mockResolvedValue([]);
+    renderView(api);
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Tools' }));
+
+    await waitFor(() => expect(api.tools.list).toHaveBeenCalled());
+    expect(screen.getByText('No tools available')).toBeTruthy();
+  });
+});

--- a/apps/web/src/renderer/components/extensions/ExtensionsView.tsx
+++ b/apps/web/src/renderer/components/extensions/ExtensionsView.tsx
@@ -1,0 +1,48 @@
+import { Blocks } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
+import { McpServersTab } from './McpServersTab';
+import { ToolsTab } from './ToolsTab';
+import { SkillsTab } from './SkillsTab';
+import { LensViewsTab } from './LensViewsTab';
+
+export function ExtensionsView() {
+  return (
+    <div className="flex-1 overflow-auto bg-background">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+        <header className="flex items-start gap-4 rounded-2xl border border-border bg-card p-6 shadow-sm">
+          <div className="rounded-2xl border border-primary/30 bg-primary/10 p-3 text-primary">
+            <Blocks size={28} />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Extensions</h1>
+            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+              Manage the MCP servers, tools, skills, and Lens views that extend Chamber.
+            </p>
+          </div>
+        </header>
+
+        <Tabs defaultValue="mcp">
+          <TabsList>
+            <TabsTrigger value="mcp">MCP servers</TabsTrigger>
+            <TabsTrigger value="tools">Tools</TabsTrigger>
+            <TabsTrigger value="skills">Skills</TabsTrigger>
+            <TabsTrigger value="lens">Lens views</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="mcp" className="mt-4">
+            <McpServersTab />
+          </TabsContent>
+          <TabsContent value="tools" className="mt-4">
+            <ToolsTab />
+          </TabsContent>
+          <TabsContent value="skills" className="mt-4">
+            <SkillsTab />
+          </TabsContent>
+          <TabsContent value="lens" className="mt-4">
+            <LensViewsTab />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/extensions/LensViewsTab.test.tsx
+++ b/apps/web/src/renderer/components/extensions/LensViewsTab.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { installElectronAPI, makeLensViewManifest } from '../../../test/helpers';
+import { AppStateProvider } from '../../lib/store';
+import type { AppState } from '../../lib/store/state';
+import { LensViewsTab } from './LensViewsTab';
+
+function renderTab(state?: Partial<AppState>) {
+  installElectronAPI();
+  return render(
+    <AppStateProvider testInitialState={state}>
+      <LensViewsTab />
+    </AppStateProvider>,
+  );
+}
+
+describe('LensViewsTab', () => {
+  it('renders an empty state when no views are discovered', () => {
+    renderTab({ discoveredViews: [] });
+    expect(screen.getByText('No Lens views discovered')).toBeTruthy();
+  });
+
+  it('lists the discovered views from the store', () => {
+    renderTab({
+      discoveredViews: [
+        makeLensViewManifest({ id: 'daily', name: 'Daily Briefing', view: 'briefing', description: 'Morning digest' }),
+      ],
+    });
+
+    expect(screen.getByText('Daily Briefing')).toBeTruthy();
+    expect(screen.getByText('briefing')).toBeTruthy();
+    expect(screen.getByText('Morning digest')).toBeTruthy();
+  });
+});

--- a/apps/web/src/renderer/components/extensions/LensViewsTab.tsx
+++ b/apps/web/src/renderer/components/extensions/LensViewsTab.tsx
@@ -1,0 +1,41 @@
+import { useAppState } from '../../lib/store';
+import { Layout } from 'lucide-react';
+import { Badge } from '../ui/badge';
+import { TabEmptyState } from './extensionsShared';
+
+export function LensViewsTab() {
+  const { discoveredViews } = useAppState();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-lg font-semibold">Lens views</h2>
+        <p className="text-sm text-muted-foreground">
+          Custom views discovered from your minds&apos; <code className="rounded bg-muted px-1 py-0.5 text-xs">.github/lens</code>{' '}
+          directories. Each appears as an icon in the sidebar. This list is read-only.
+        </p>
+      </div>
+
+      {discoveredViews.length === 0 ? (
+        <TabEmptyState
+          icon={<Layout size={22} />}
+          title="No Lens views discovered"
+          detail="Minds can add view.json files under .github/lens to extend the UI."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {discoveredViews.map((view) => (
+            <li key={view.id} className="rounded-xl border border-border bg-card p-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium">{view.name}</span>
+                <Badge variant="outline">{view.view}</Badge>
+                <span className="text-xs text-muted-foreground">{view.id}</span>
+              </div>
+              {view.description && <p className="mt-1 text-sm text-muted-foreground">{view.description}</p>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/extensions/McpServersTab.test.tsx
+++ b/apps/web/src/renderer/components/extensions/McpServersTab.test.tsx
@@ -7,16 +7,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MindContext } from '@chamber/shared/types';
 import type { McpServerEntry } from '@chamber/shared/mcp-types';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
-import { AppStateProvider } from '../../lib/store';
+import { AppStateProvider, useAppDispatch } from '../../lib/store';
 import type { AppState } from '../../lib/store/state';
 import { McpServersTab } from './McpServersTab';
 
-const mind: MindContext = {
-  mindId: 'mind-1',
-  mindPath: 'C:\\minds\\lucy',
-  identity: { name: 'Lucy', systemMessage: '' },
-  status: 'ready',
-};
+function makeMind(id: string, name: string): MindContext {
+  return { mindId: id, mindPath: `C:\\minds\\${id}`, identity: { name, systemMessage: '' }, status: 'ready' };
+}
+
+const mind = makeMind('mind-1', 'Lucy');
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 function renderTab(api: ReturnType<typeof mockElectronAPI>, state?: Partial<AppState>) {
   installElectronAPI(api);
@@ -52,13 +59,25 @@ describe('McpServersTab', () => {
     expect(screen.getByText('https://mcp.example.test')).toBeTruthy();
   });
 
+  it('disables writes until the active mind has loaded', async () => {
+    const pending = deferred<McpServerEntry[]>();
+    vi.mocked(api.mcp.getServers).mockReturnValue(pending.promise);
+    renderTab(api);
+
+    const addButton = () => screen.getByRole('button', { name: 'Add server' }) as HTMLButtonElement;
+    expect(addButton().disabled).toBe(true);
+
+    pending.resolve([]);
+    await waitFor(() => expect(addButton().disabled).toBe(false));
+  });
+
   it('adds a new stdio server and persists it', async () => {
     vi.mocked(api.mcp.getServers).mockResolvedValue([]);
     const saved: McpServerEntry[] = [{ name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: {} }];
     vi.mocked(api.mcp.setServers).mockResolvedValue(saved);
     renderTab(api);
 
-    await screen.findByText('MCP servers');
+    await waitFor(() => expect((screen.getByRole('button', { name: 'Add server' }) as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(screen.getByRole('button', { name: 'Add server' }));
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'files' } });
     fireEvent.change(screen.getByLabelText('Command'), { target: { value: 'npx' } });
@@ -78,13 +97,38 @@ describe('McpServersTab', () => {
     vi.mocked(api.mcp.getServers).mockResolvedValue([]);
     renderTab(api);
 
-    await screen.findByText('MCP servers');
+    await waitFor(() => expect((screen.getByRole('button', { name: 'Add server' }) as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(screen.getByRole('button', { name: 'Add server' }));
     fireEvent.change(screen.getByLabelText('Command'), { target: { value: 'npx' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save server' }));
 
     await waitFor(() => expect(screen.getByText('Name is required.')).toBeTruthy());
     expect(api.mcp.setServers).not.toHaveBeenCalled();
+  });
+
+  it('carries preserved fields through an edit so the tools allowlist survives', async () => {
+    const original: McpServerEntry = {
+      name: 'files',
+      transport: 'stdio',
+      command: 'npx',
+      args: [],
+      env: {},
+      preserved: { type: 'stdio', tools: ['read'] },
+    };
+    vi.mocked(api.mcp.getServers).mockResolvedValue([original]);
+    vi.mocked(api.mcp.setServers).mockResolvedValue([]);
+    renderTab(api);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit files' }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'renamed' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save server' }));
+
+    await waitFor(() => {
+      expect(api.mcp.setServers).toHaveBeenCalledWith(
+        [{ ...original, name: 'renamed' }],
+        'mind-1',
+      );
+    });
   });
 
   it('removes a server and persists the remaining set', async () => {
@@ -94,9 +138,48 @@ describe('McpServersTab', () => {
     vi.mocked(api.mcp.setServers).mockResolvedValue([]);
     renderTab(api);
 
-    await screen.findByText('files');
-    fireEvent.click(screen.getByRole('button', { name: 'Remove files' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove files' }));
 
     await waitFor(() => expect(api.mcp.setServers).toHaveBeenCalledWith([], 'mind-1'));
+  });
+
+  it('ignores a stale load and writes to the newly active mind (blocker 3)', async () => {
+    const mindA = makeMind('mind-a', 'Ada');
+    const mindB = makeMind('mind-b', 'Boris');
+    const loadA = deferred<McpServerEntry[]>();
+    const loadB = deferred<McpServerEntry[]>();
+    vi.mocked(api.mcp.getServers).mockImplementation((id?: string) =>
+      id === 'mind-a' ? loadA.promise : loadB.promise,
+    );
+    vi.mocked(api.mcp.setServers).mockResolvedValue([]);
+
+    function Harness() {
+      const dispatch = useAppDispatch();
+      return (
+        <>
+          <button onClick={() => dispatch({ type: 'SET_ACTIVE_MIND', payload: 'mind-b' })}>switch</button>
+          <McpServersTab />
+        </>
+      );
+    }
+
+    installElectronAPI(api);
+    render(
+      <AppStateProvider testInitialState={{ activeMindId: 'mind-a', minds: [mindA, mindB] }}>
+        <Harness />
+      </AppStateProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch' }));
+    loadB.resolve([{ name: 'b-server', transport: 'stdio', command: 'b', args: [], env: {} }]);
+    await screen.findByText('b-server');
+
+    // The late response for the previously-active mind must not overwrite B.
+    loadA.resolve([{ name: 'a-server', transport: 'stdio', command: 'a', args: [], env: {} }]);
+    await waitFor(() => expect(screen.queryByText('a-server')).toBeNull());
+    expect(screen.getByText('b-server')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove b-server' }));
+    await waitFor(() => expect(api.mcp.setServers).toHaveBeenCalledWith([], 'mind-b'));
   });
 });

--- a/apps/web/src/renderer/components/extensions/McpServersTab.test.tsx
+++ b/apps/web/src/renderer/components/extensions/McpServersTab.test.tsx
@@ -182,4 +182,46 @@ describe('McpServersTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Remove b-server' }));
     await waitFor(() => expect(api.mcp.setServers).toHaveBeenCalledWith([], 'mind-b'));
   });
+
+  it('does not apply a stale write result after the mind switches (blocker 3)', async () => {
+    const mindA = makeMind('mind-a', 'Ada');
+    const mindB = makeMind('mind-b', 'Boris');
+    vi.mocked(api.mcp.getServers).mockImplementation(async (id?: string) =>
+      id === 'mind-a'
+        ? [{ name: 'a-server', transport: 'stdio', command: 'a', args: [], env: {} }]
+        : [{ name: 'b-server', transport: 'stdio', command: 'b', args: [], env: {} }],
+    );
+    const writeA = deferred<McpServerEntry[]>();
+    vi.mocked(api.mcp.setServers).mockReturnValueOnce(writeA.promise).mockResolvedValue([]);
+
+    function Harness() {
+      const dispatch = useAppDispatch();
+      return (
+        <>
+          <button onClick={() => dispatch({ type: 'SET_ACTIVE_MIND', payload: 'mind-b' })}>switch</button>
+          <McpServersTab />
+        </>
+      );
+    }
+
+    installElectronAPI(api);
+    render(
+      <AppStateProvider testInitialState={{ activeMindId: 'mind-a', minds: [mindA, mindB] }}>
+        <Harness />
+      </AppStateProvider>,
+    );
+
+    // Start a delete on mind A; its setServers stays in flight.
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove a-server' }));
+    expect(api.mcp.setServers).toHaveBeenCalledWith([], 'mind-a');
+
+    // Switch to B, which loads B's servers.
+    fireEvent.click(screen.getByRole('button', { name: 'switch' }));
+    await screen.findByText('b-server');
+
+    // The stale write for A resolves late and must not overwrite B's list.
+    writeA.resolve([]);
+    await waitFor(() => expect(screen.getByText('b-server')).toBeTruthy());
+    expect(screen.queryByText('No MCP servers yet')).toBeNull();
+  });
 });

--- a/apps/web/src/renderer/components/extensions/McpServersTab.test.tsx
+++ b/apps/web/src/renderer/components/extensions/McpServersTab.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MindContext } from '@chamber/shared/types';
+import type { McpServerEntry } from '@chamber/shared/mcp-types';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import { AppStateProvider } from '../../lib/store';
+import type { AppState } from '../../lib/store/state';
+import { McpServersTab } from './McpServersTab';
+
+const mind: MindContext = {
+  mindId: 'mind-1',
+  mindPath: 'C:\\minds\\lucy',
+  identity: { name: 'Lucy', systemMessage: '' },
+  status: 'ready',
+};
+
+function renderTab(api: ReturnType<typeof mockElectronAPI>, state?: Partial<AppState>) {
+  installElectronAPI(api);
+  return render(
+    <AppStateProvider testInitialState={{ activeMindId: 'mind-1', minds: [mind], ...state }}>
+      <McpServersTab />
+    </AppStateProvider>,
+  );
+}
+
+describe('McpServersTab', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = mockElectronAPI();
+  });
+
+  it('prompts to select a mind when none is active', () => {
+    renderTab(api, { activeMindId: null, minds: [] });
+    expect(screen.getByText('No mind selected')).toBeTruthy();
+  });
+
+  it('lists the configured servers for the active mind', async () => {
+    vi.mocked(api.mcp.getServers).mockResolvedValue([
+      { name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: {} },
+      { name: 'remote', transport: 'http', url: 'https://mcp.example.test', headers: {} },
+    ]);
+    renderTab(api);
+
+    await waitFor(() => expect(screen.getByText('files')).toBeTruthy());
+    expect(api.mcp.getServers).toHaveBeenCalledWith('mind-1');
+    expect(screen.getByText('remote')).toBeTruthy();
+    expect(screen.getByText('https://mcp.example.test')).toBeTruthy();
+  });
+
+  it('adds a new stdio server and persists it', async () => {
+    vi.mocked(api.mcp.getServers).mockResolvedValue([]);
+    const saved: McpServerEntry[] = [{ name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: {} }];
+    vi.mocked(api.mcp.setServers).mockResolvedValue(saved);
+    renderTab(api);
+
+    await screen.findByText('MCP servers');
+    fireEvent.click(screen.getByRole('button', { name: 'Add server' }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'files' } });
+    fireEvent.change(screen.getByLabelText('Command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByLabelText('Arguments'), { target: { value: 'fs' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save server' }));
+
+    await waitFor(() => {
+      expect(api.mcp.setServers).toHaveBeenCalledWith(
+        [{ name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: {} }],
+        'mind-1',
+      );
+    });
+    await waitFor(() => expect(screen.getByText('files')).toBeTruthy());
+  });
+
+  it('shows a validation error and does not persist an empty name', async () => {
+    vi.mocked(api.mcp.getServers).mockResolvedValue([]);
+    renderTab(api);
+
+    await screen.findByText('MCP servers');
+    fireEvent.click(screen.getByRole('button', { name: 'Add server' }));
+    fireEvent.change(screen.getByLabelText('Command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save server' }));
+
+    await waitFor(() => expect(screen.getByText('Name is required.')).toBeTruthy());
+    expect(api.mcp.setServers).not.toHaveBeenCalled();
+  });
+
+  it('removes a server and persists the remaining set', async () => {
+    vi.mocked(api.mcp.getServers).mockResolvedValue([
+      { name: 'files', transport: 'stdio', command: 'npx', args: [], env: {} },
+    ]);
+    vi.mocked(api.mcp.setServers).mockResolvedValue([]);
+    renderTab(api);
+
+    await screen.findByText('files');
+    fireEvent.click(screen.getByRole('button', { name: 'Remove files' }));
+
+    await waitFor(() => expect(api.mcp.setServers).toHaveBeenCalledWith([], 'mind-1'));
+  });
+});

--- a/apps/web/src/renderer/components/extensions/McpServersTab.tsx
+++ b/apps/web/src/renderer/components/extensions/McpServersTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import type { McpServerEntry } from '@chamber/shared/mcp-types';
 import { Globe, Pencil, Plus, Server, Terminal, Trash2 } from 'lucide-react';
@@ -28,6 +28,13 @@ export function McpServersTab() {
   const [entries, setEntries] = useState<McpServerEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // The mind whose entries are currently displayed. Writes are only allowed
+  // when this equals activeMindId, so a slow load for a previously-selected
+  // mind can never persist over the newly-active mind's .mcp.json (blocker 3).
+  const [loadedMindId, setLoadedMindId] = useState<string | null>(null);
+  // Monotonic token: only the most recent load may apply its result. Guards
+  // against an earlier getServers() resolving after the user switched minds.
+  const requestSeq = useRef(0);
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingName, setEditingName] = useState<string | null>(null);
@@ -36,7 +43,10 @@ export function McpServersTab() {
   const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
-    if (!activeMindId) {
+    const seq = ++requestSeq.current;
+    const mindId = activeMindId;
+    setLoadedMindId(null);
+    if (!mindId) {
       setEntries([]);
       setLoading(false);
       return;
@@ -44,11 +54,15 @@ export function McpServersTab() {
     setLoading(true);
     setError(null);
     try {
-      setEntries(await window.electronAPI.mcp.getServers(activeMindId));
+      const result = await window.electronAPI.mcp.getServers(mindId);
+      if (requestSeq.current !== seq) return;
+      setEntries(result);
+      setLoadedMindId(mindId);
     } catch (err) {
+      if (requestSeq.current !== seq) return;
       setError(getErrorMessage(err));
     } finally {
-      setLoading(false);
+      if (requestSeq.current === seq) setLoading(false);
     }
   }, [activeMindId]);
 
@@ -56,12 +70,19 @@ export function McpServersTab() {
     void load();
   }, [load]);
 
+  // Writable only once the active mind's servers have loaded. Using loadedMindId
+  // as the write target means a persist is always addressed to the mind whose
+  // data the user actually edited.
+  const canWrite = loadedMindId !== null && loadedMindId === activeMindId && !loading;
+
   const persist = useCallback(
     async (next: McpServerEntry[]): Promise<McpServerEntry[]> => {
-      if (!activeMindId) throw new Error('Select a mind first.');
-      return window.electronAPI.mcp.setServers(next, activeMindId);
+      if (loadedMindId === null || loadedMindId !== activeMindId) {
+        throw new Error('The selected mind changed. Reload before saving.');
+      }
+      return window.electronAPI.mcp.setServers(next, loadedMindId);
     },
-    [activeMindId],
+    [loadedMindId, activeMindId],
   );
 
   const otherNames = useMemo(
@@ -84,6 +105,10 @@ export function McpServersTab() {
   };
 
   const submit = async () => {
+    if (!canWrite) {
+      setFormError('The selected mind changed. Reload before saving.');
+      return;
+    }
     const message = validateMcpForm(form, otherNames);
     if (message) {
       setFormError(message);
@@ -106,6 +131,7 @@ export function McpServersTab() {
   };
 
   const remove = async (name: string) => {
+    if (!canWrite) return;
     setError(null);
     try {
       setEntries(await persist(entries.filter((entry) => entry.name !== name)));
@@ -138,7 +164,7 @@ export function McpServersTab() {
         <button
           className="inline-flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-60"
           onClick={openAdd}
-          disabled={saving}
+          disabled={saving || !canWrite}
         >
           <Plus size={16} />
           Add server
@@ -177,15 +203,17 @@ export function McpServersTab() {
               <div className="flex shrink-0 items-center gap-1">
                 <button
                   aria-label={`Edit ${entry.name}`}
-                  className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40"
                   onClick={() => openEdit(entry)}
+                  disabled={!canWrite}
                 >
                   <Pencil size={16} />
                 </button>
                 <button
                   aria-label={`Remove ${entry.name}`}
-                  className="rounded-md p-2 text-muted-foreground hover:bg-destructive/10 hover:text-red-300"
+                  className="rounded-md p-2 text-muted-foreground hover:bg-destructive/10 hover:text-red-300 disabled:opacity-40"
                   onClick={() => void remove(entry.name)}
+                  disabled={!canWrite}
                 >
                   <Trash2 size={16} />
                 </button>

--- a/apps/web/src/renderer/components/extensions/McpServersTab.tsx
+++ b/apps/web/src/renderer/components/extensions/McpServersTab.tsx
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import type { McpServerEntry } from '@chamber/shared/mcp-types';
+import { Globe, Pencil, Plus, Server, Terminal, Trash2 } from 'lucide-react';
+import { useAppState } from '../../lib/store';
+import { Badge } from '../ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { TabEmptyState, TabError } from './extensionsShared';
+import {
+  emptyMcpForm,
+  entryToForm,
+  formToEntry,
+  validateMcpForm,
+  type McpServerFormState,
+} from './mcpFormUtils';
+
+export function McpServersTab() {
+  const { activeMindId, minds } = useAppState();
+  const activeMind = minds.find((mind) => mind.mindId === activeMindId) ?? null;
+
+  const [entries, setEntries] = useState<McpServerEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingName, setEditingName] = useState<string | null>(null);
+  const [form, setForm] = useState<McpServerFormState>(emptyMcpForm);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!activeMindId) {
+      setEntries([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      setEntries(await window.electronAPI.mcp.getServers(activeMindId));
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [activeMindId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const persist = useCallback(
+    async (next: McpServerEntry[]): Promise<McpServerEntry[]> => {
+      if (!activeMindId) throw new Error('Select a mind first.');
+      return window.electronAPI.mcp.setServers(next, activeMindId);
+    },
+    [activeMindId],
+  );
+
+  const otherNames = useMemo(
+    () => entries.filter((entry) => entry.name !== editingName).map((entry) => entry.name),
+    [entries, editingName],
+  );
+
+  const openAdd = () => {
+    setEditingName(null);
+    setForm(emptyMcpForm());
+    setFormError(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (entry: McpServerEntry) => {
+    setEditingName(entry.name);
+    setForm(entryToForm(entry));
+    setFormError(null);
+    setDialogOpen(true);
+  };
+
+  const submit = async () => {
+    const message = validateMcpForm(form, otherNames);
+    if (message) {
+      setFormError(message);
+      return;
+    }
+    const entry = formToEntry(form);
+    const next = editingName
+      ? entries.map((existing) => (existing.name === editingName ? entry : existing))
+      : [...entries, entry];
+    setSaving(true);
+    setFormError(null);
+    try {
+      setEntries(await persist(next));
+      setDialogOpen(false);
+    } catch (err) {
+      setFormError(getErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (name: string) => {
+    setError(null);
+    try {
+      setEntries(await persist(entries.filter((entry) => entry.name !== name)));
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  };
+
+  if (!activeMindId) {
+    return (
+      <TabEmptyState
+        icon={<Server size={22} />}
+        title="No mind selected"
+        detail="Select a mind from the sidebar to manage the MCP servers in its .mcp.json."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">MCP servers</h2>
+          <p className="text-sm text-muted-foreground">
+            Model Context Protocol servers configured in{' '}
+            <span className="font-medium text-foreground">{activeMind?.identity.name ?? 'this mind'}</span>&apos;s{' '}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">.mcp.json</code>.
+          </p>
+        </div>
+        <button
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-60"
+          onClick={openAdd}
+          disabled={saving}
+        >
+          <Plus size={16} />
+          Add server
+        </button>
+      </div>
+
+      {error && <TabError message={error} />}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading servers…</p>
+      ) : entries.length === 0 ? (
+        <TabEmptyState
+          icon={<Server size={22} />}
+          title="No MCP servers yet"
+          detail="Add a stdio command or an HTTP endpoint to give this mind extra tools."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {entries.map((entry) => (
+            <li
+              key={entry.name}
+              className="flex items-start justify-between gap-4 rounded-xl border border-border bg-card p-4"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  {entry.transport === 'stdio' ? <Terminal size={16} className="text-muted-foreground" /> : <Globe size={16} className="text-muted-foreground" />}
+                  <span className="font-medium">{entry.name}</span>
+                  <Badge variant="outline">{entry.transport}</Badge>
+                </div>
+                <div className="mt-1 truncate text-sm text-muted-foreground">
+                  {entry.transport === 'stdio'
+                    ? [entry.command, ...entry.args].join(' ')
+                    : entry.url}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <button
+                  aria-label={`Edit ${entry.name}`}
+                  className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  onClick={() => openEdit(entry)}
+                >
+                  <Pencil size={16} />
+                </button>
+                <button
+                  aria-label={`Remove ${entry.name}`}
+                  className="rounded-md p-2 text-muted-foreground hover:bg-destructive/10 hover:text-red-300"
+                  onClick={() => void remove(entry.name)}
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingName ? 'Edit MCP server' : 'Add MCP server'}</DialogTitle>
+            <DialogDescription>
+              Configure a stdio launch command or a remote HTTP endpoint. Changes are written to{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">.mcp.json</code>.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4">
+            <TextField
+              label="Name"
+              value={form.name}
+              onChange={(value) => setForm((prev) => ({ ...prev, name: value }))}
+              placeholder="filesystem"
+            />
+            <SelectField
+              label="Transport"
+              value={form.transport}
+              onChange={(value) => setForm((prev) => ({ ...prev, transport: value as McpServerFormState['transport'] }))}
+              options={[
+                { label: 'stdio (local command)', value: 'stdio' },
+                { label: 'http (remote endpoint)', value: 'http' },
+              ]}
+            />
+
+            {form.transport === 'stdio' ? (
+              <>
+                <TextField
+                  label="Command"
+                  value={form.command}
+                  onChange={(value) => setForm((prev) => ({ ...prev, command: value }))}
+                  placeholder="npx"
+                />
+                <TextAreaField
+                  label="Arguments"
+                  hint="One argument per line."
+                  value={form.argsText}
+                  onChange={(value) => setForm((prev) => ({ ...prev, argsText: value }))}
+                  placeholder={'-y\n@modelcontextprotocol/server-filesystem'}
+                />
+                <TextAreaField
+                  label="Environment"
+                  hint="One KEY=VALUE per line."
+                  value={form.envText}
+                  onChange={(value) => setForm((prev) => ({ ...prev, envText: value }))}
+                  placeholder={'ROOT=/tmp'}
+                />
+              </>
+            ) : (
+              <>
+                <TextField
+                  label="URL"
+                  value={form.url}
+                  onChange={(value) => setForm((prev) => ({ ...prev, url: value }))}
+                  placeholder="https://mcp.example.com/v1"
+                />
+                <TextAreaField
+                  label="Headers"
+                  hint="One KEY=VALUE per line."
+                  value={form.headersText}
+                  onChange={(value) => setForm((prev) => ({ ...prev, headersText: value }))}
+                  placeholder={'Authorization=Bearer token'}
+                />
+              </>
+            )}
+
+            {formError && <TabError message={formError} />}
+          </div>
+
+          <DialogFooter>
+            <button
+              className="rounded-lg border border-border bg-muted px-4 py-2 text-sm font-semibold text-foreground disabled:opacity-60"
+              onClick={() => setDialogOpen(false)}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-60"
+              onClick={() => void submit()}
+              disabled={saving}
+            >
+              {saving ? 'Saving…' : 'Save server'}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function TextField({ label, value, onChange, placeholder }: { label: string; value: string; onChange: (value: string) => void; placeholder?: string }) {
+  const id = `mcp-field-${label.toLowerCase().replaceAll(' ', '-')}`;
+  return (
+    <div className="block">
+      <label className="text-sm font-medium text-muted-foreground" htmlFor={id}>{label}</label>
+      <input
+        className="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+        id={id}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        value={value}
+      />
+    </div>
+  );
+}
+
+function TextAreaField({ label, value, onChange, hint, placeholder }: { label: string; value: string; onChange: (value: string) => void; hint?: string; placeholder?: string }) {
+  const id = `mcp-field-${label.toLowerCase().replaceAll(' ', '-')}`;
+  return (
+    <div className="block">
+      <label className="text-sm font-medium text-muted-foreground" htmlFor={id}>{label}</label>
+      <textarea
+        className="mt-2 h-20 w-full resize-y rounded-lg border border-border bg-background px-3 py-2 font-mono text-xs text-foreground outline-none focus:border-primary"
+        id={id}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        value={value}
+      />
+      {hint && <span className="mt-1 block text-xs text-muted-foreground">{hint}</span>}
+    </div>
+  );
+}
+
+function SelectField({ label, value, onChange, options }: { label: string; value: string; onChange: (value: string) => void; options: Array<{ label: string; value: string }> }) {
+  const id = `mcp-field-${label.toLowerCase().replaceAll(' ', '-')}`;
+  return (
+    <div className="block">
+      <label className="text-sm font-medium text-muted-foreground" htmlFor={id}>{label}</label>
+      <select
+        className="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+        id={id}
+        onChange={(event) => onChange(event.target.value)}
+        value={value}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>{option.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/extensions/McpServersTab.tsx
+++ b/apps/web/src/renderer/components/extensions/McpServersTab.tsx
@@ -85,6 +85,22 @@ export function McpServersTab() {
     [loadedMindId, activeMindId],
   );
 
+  // Persists `next`, then applies the result only if the view still shows the
+  // same mind it was written for. Without this the result of an in-flight save
+  // for a previously-active mind could land after a switch and poison `entries`
+  // (which the next write would then persist into the wrong mind) (blocker 3).
+  const runWrite = useCallback(
+    async (next: McpServerEntry[]): Promise<boolean> => {
+      const seq = requestSeq.current;
+      const targetMindId = loadedMindId;
+      const result = await persist(next);
+      if (requestSeq.current !== seq || targetMindId !== activeMindId) return false;
+      setEntries(result);
+      return true;
+    },
+    [persist, loadedMindId, activeMindId],
+  );
+
   const otherNames = useMemo(
     () => entries.filter((entry) => entry.name !== editingName).map((entry) => entry.name),
     [entries, editingName],
@@ -121,8 +137,7 @@ export function McpServersTab() {
     setSaving(true);
     setFormError(null);
     try {
-      setEntries(await persist(next));
-      setDialogOpen(false);
+      if (await runWrite(next)) setDialogOpen(false);
     } catch (err) {
       setFormError(getErrorMessage(err));
     } finally {
@@ -134,7 +149,7 @@ export function McpServersTab() {
     if (!canWrite) return;
     setError(null);
     try {
-      setEntries(await persist(entries.filter((entry) => entry.name !== name)));
+      await runWrite(entries.filter((entry) => entry.name !== name));
     } catch (err) {
       setError(getErrorMessage(err));
     }

--- a/apps/web/src/renderer/components/extensions/SkillsTab.test.tsx
+++ b/apps/web/src/renderer/components/extensions/SkillsTab.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MindContext } from '@chamber/shared/types';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import { AppStateProvider } from '../../lib/store';
+import type { AppState } from '../../lib/store/state';
+import { SkillsTab } from './SkillsTab';
+
+const mind: MindContext = {
+  mindId: 'mind-1',
+  mindPath: 'C:\\minds\\lucy',
+  identity: { name: 'Lucy', systemMessage: '' },
+  status: 'ready',
+};
+
+function renderTab(api: ReturnType<typeof mockElectronAPI>, state?: Partial<AppState>) {
+  installElectronAPI(api);
+  return render(
+    <AppStateProvider testInitialState={{ activeMindId: 'mind-1', minds: [mind], ...state }}>
+      <SkillsTab />
+    </AppStateProvider>,
+  );
+}
+
+describe('SkillsTab', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = mockElectronAPI();
+  });
+
+  it('prompts to select a mind when none is active', () => {
+    renderTab(api, { activeMindId: null, minds: [] });
+    expect(screen.getByText('No mind selected')).toBeTruthy();
+  });
+
+  it('lists skills discovered for the active mind', async () => {
+    vi.mocked(api.skills.listForMind).mockResolvedValue([
+      { id: 'lens', name: 'Lens', version: '1.2.0', description: 'Build views' },
+    ]);
+    renderTab(api);
+
+    await waitFor(() => expect(screen.getByText('Lens')).toBeTruthy());
+    expect(api.skills.listForMind).toHaveBeenCalledWith('mind-1');
+    expect(screen.getByText('v1.2.0')).toBeTruthy();
+    expect(screen.getByText('Build views')).toBeTruthy();
+  });
+
+  it('renders an empty state when the mind has no skills', async () => {
+    vi.mocked(api.skills.listForMind).mockResolvedValue([]);
+    renderTab(api);
+    await waitFor(() => expect(screen.getByText('No skills found')).toBeTruthy());
+  });
+});

--- a/apps/web/src/renderer/components/extensions/SkillsTab.tsx
+++ b/apps/web/src/renderer/components/extensions/SkillsTab.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import type { SkillManifest } from '@chamber/shared/skill-types';
+import { Sparkles } from 'lucide-react';
+import { useAppState } from '../../lib/store';
+import { Badge } from '../ui/badge';
+import { TabEmptyState, TabError } from './extensionsShared';
+
+export function SkillsTab() {
+  const { activeMindId, minds } = useAppState();
+  const activeMind = minds.find((mind) => mind.mindId === activeMindId) ?? null;
+
+  const [skills, setSkills] = useState<SkillManifest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!activeMindId) {
+      setSkills([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      setSkills(await window.electronAPI.skills.listForMind(activeMindId));
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [activeMindId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (!activeMindId) {
+    return (
+      <TabEmptyState
+        icon={<Sparkles size={22} />}
+        title="No mind selected"
+        detail="Select a mind from the sidebar to see the skills it discovers on disk."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-lg font-semibold">Skills</h2>
+        <p className="text-sm text-muted-foreground">
+          Skills discovered in{' '}
+          <span className="font-medium text-foreground">{activeMind?.identity.name ?? 'this mind'}</span>&apos;s{' '}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">.github/skills</code>. This list is read-only.
+        </p>
+      </div>
+
+      {error && <TabError message={error} />}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading skills…</p>
+      ) : skills.length === 0 ? (
+        <TabEmptyState
+          icon={<Sparkles size={22} />}
+          title="No skills found"
+          detail="Add SKILL.md directories under this mind's .github/skills to extend it."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {skills.map((skill) => (
+            <li key={skill.id} className="rounded-xl border border-border bg-card p-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium">{skill.name}</span>
+                {skill.version && <Badge variant="outline">v{skill.version}</Badge>}
+                <span className="text-xs text-muted-foreground">{skill.id}</span>
+              </div>
+              {skill.description && <p className="mt-1 text-sm text-muted-foreground">{skill.description}</p>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/extensions/ToolsTab.test.tsx
+++ b/apps/web/src/renderer/components/extensions/ToolsTab.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolCatalogEntry } from '@chamber/shared/types';
+import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
+import { ToolsTab } from './ToolsTab';
+
+function makeTool(overrides?: Partial<ToolCatalogEntry>): ToolCatalogEntry {
+  return {
+    id: 'cool',
+    displayName: 'Cool Tool',
+    description: 'Does cool things',
+    install: { type: 'npm-global', package: 'cool-tool', version: '1.0.0' },
+    bin: 'cool',
+    source: {
+      owner: 'acme',
+      repo: 'tools',
+      ref: 'main',
+      plugin: 'tools',
+      marketplaceId: 'acme/tools',
+      marketplaceLabel: 'Acme Tools',
+      marketplaceUrl: 'https://github.com/acme/tools',
+    },
+    status: 'available',
+    ...overrides,
+  };
+}
+
+describe('ToolsTab', () => {
+  let api: ReturnType<typeof mockElectronAPI>;
+
+  beforeEach(() => {
+    api = mockElectronAPI();
+  });
+
+  it('renders an empty state when the catalog is empty', async () => {
+    vi.mocked(api.tools.list).mockResolvedValue([]);
+    installElectronAPI(api);
+    render(<ToolsTab />);
+    await waitFor(() => expect(screen.getByText('No tools available')).toBeTruthy());
+  });
+
+  it('installs an available tool through the tools service', async () => {
+    vi.mocked(api.tools.list)
+      .mockResolvedValueOnce([makeTool()])
+      .mockResolvedValueOnce([makeTool({ status: 'installed', installedVersion: '1.0.0' })]);
+    vi.mocked(api.tools.install).mockResolvedValue({
+      success: true,
+      tool: {
+        id: 'cool',
+        version: '1.0.0',
+        bin: 'cool',
+        displayName: 'Cool Tool',
+        description: 'Does cool things',
+        source: { marketplaceId: 'acme/tools', pluginId: 'tools' },
+        installedAt: new Date().toISOString(),
+        package: 'cool-tool',
+      },
+    });
+    installElectronAPI(api);
+    render(<ToolsTab />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install Cool Tool' }));
+
+    await waitFor(() => expect(api.tools.install).toHaveBeenCalledWith('cool', 'acme/tools'));
+    await waitFor(() => expect(screen.getByText('Installed · 1.0.0')).toBeTruthy());
+  });
+
+  it('uninstalls an installed tool through the tools service', async () => {
+    vi.mocked(api.tools.list)
+      .mockResolvedValueOnce([makeTool({ status: 'installed', installedVersion: '1.0.0' })])
+      .mockResolvedValueOnce([makeTool()]);
+    vi.mocked(api.tools.uninstall).mockResolvedValue({ success: true });
+    installElectronAPI(api);
+    render(<ToolsTab />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Uninstall Cool Tool' }));
+
+    await waitFor(() => expect(api.tools.uninstall).toHaveBeenCalledWith('cool'));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Install Cool Tool' })).toBeTruthy());
+  });
+
+  it('surfaces an install failure message', async () => {
+    vi.mocked(api.tools.list).mockResolvedValue([makeTool()]);
+    vi.mocked(api.tools.install).mockResolvedValue({ success: false, error: 'npm exploded' });
+    installElectronAPI(api);
+    render(<ToolsTab />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install Cool Tool' }));
+
+    await waitFor(() => expect(screen.getByText('npm exploded')).toBeTruthy());
+  });
+});

--- a/apps/web/src/renderer/components/extensions/ToolsTab.tsx
+++ b/apps/web/src/renderer/components/extensions/ToolsTab.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getErrorMessage } from '@chamber/shared/getErrorMessage';
+import type { ToolCatalogEntry } from '@chamber/shared/types';
+import { Blocks, Download, Loader2, Trash2 } from 'lucide-react';
+import { Badge } from '../ui/badge';
+import { TabEmptyState, TabError } from './extensionsShared';
+
+export function ToolsTab() {
+  const [tools, setTools] = useState<ToolCatalogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setTools(await window.electronAPI.tools.list());
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const install = async (tool: ToolCatalogEntry) => {
+    setBusyId(tool.id);
+    setError(null);
+    try {
+      const result = await window.electronAPI.tools.install(tool.id, tool.source.marketplaceId);
+      await load();
+      if (!result.success) {
+        setError(result.error);
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const uninstall = async (tool: ToolCatalogEntry) => {
+    setBusyId(tool.id);
+    setError(null);
+    try {
+      const result = await window.electronAPI.tools.uninstall(tool.id);
+      await load();
+      if (!result.success && result.error) {
+        setError(result.error);
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-lg font-semibold">Tools</h2>
+        <p className="text-sm text-muted-foreground">
+          CLI tools from your configured marketplaces. Installing runs the tool&apos;s package installer and makes it
+          available to every mind.
+        </p>
+      </div>
+
+      {error && <TabError message={error} />}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading tools…</p>
+      ) : tools.length === 0 ? (
+        <TabEmptyState
+          icon={<Blocks size={22} />}
+          title="No tools available"
+          detail="Add a tool marketplace in Settings to populate this catalog."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {tools.map((tool) => {
+            const installed = tool.status === 'installed';
+            const busy = busyId === tool.id;
+            return (
+              <li
+                key={`${tool.source.marketplaceId}:${tool.id}`}
+                className="flex items-start justify-between gap-4 rounded-xl border border-border bg-card p-4"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{tool.displayName}</span>
+                    {installed ? (
+                      <Badge variant="secondary">
+                        Installed{tool.installedVersion ? ` · ${tool.installedVersion}` : ''}
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline">Available</Badge>
+                    )}
+                    {tool.status === 'error' && <Badge variant="destructive">Error</Badge>}
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">{tool.description}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{tool.source.marketplaceLabel}</p>
+                  {tool.errorMessage && <p className="mt-1 text-xs text-red-300">{tool.errorMessage}</p>}
+                </div>
+                <div className="shrink-0">
+                  {installed ? (
+                    <button
+                      aria-label={`Uninstall ${tool.displayName}`}
+                      className="inline-flex items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-sm font-semibold text-foreground disabled:opacity-60"
+                      onClick={() => void uninstall(tool)}
+                      disabled={busy}
+                    >
+                      {busy ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}
+                      Uninstall
+                    </button>
+                  ) : (
+                    <button
+                      aria-label={`Install ${tool.displayName}`}
+                      className="inline-flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-60"
+                      onClick={() => void install(tool)}
+                      disabled={busy}
+                    >
+                      {busy ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+                      Install
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/extensions/extensionsShared.tsx
+++ b/apps/web/src/renderer/components/extensions/extensionsShared.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+/** Shared empty / no-selection placeholder used across the Extensions tabs. */
+export function TabEmptyState({ icon, title, detail }: { icon: ReactNode; title: string; detail: string }) {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border bg-card/40 p-10 text-center">
+      <div className="text-muted-foreground">{icon}</div>
+      <div className="font-medium">{title}</div>
+      <p className="max-w-md text-sm text-muted-foreground">{detail}</p>
+    </div>
+  );
+}
+
+/** Shared inline error banner used across the Extensions tabs. */
+export function TabError({ message }: { message: string }) {
+  return (
+    <div role="alert" className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-red-200">
+      {message}
+    </div>
+  );
+}

--- a/apps/web/src/renderer/components/extensions/mcpFormUtils.test.ts
+++ b/apps/web/src/renderer/components/extensions/mcpFormUtils.test.ts
@@ -60,6 +60,17 @@ describe('mcpFormUtils', () => {
       expect(formToEntry(entryToForm(entry))).toEqual(entry);
     });
 
+    it('round-trips preserved fields (tools/type) across the form', () => {
+      const entry: McpServerEntry = {
+        name: 'stream',
+        transport: 'http',
+        url: 'https://mcp.example.test/sse',
+        headers: {},
+        preserved: { type: 'sse', tools: ['ping'] },
+      };
+      expect(formToEntry(entryToForm(entry))).toEqual(entry);
+    });
+
     it('trims the name and command when building an entry', () => {
       const form = { ...emptyMcpForm(), name: '  files  ', command: '  npx  ' };
       expect(formToEntry(form)).toEqual({ name: 'files', transport: 'stdio', command: 'npx', args: [], env: {} });

--- a/apps/web/src/renderer/components/extensions/mcpFormUtils.test.ts
+++ b/apps/web/src/renderer/components/extensions/mcpFormUtils.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { McpServerEntry } from '@chamber/shared/mcp-types';
+import {
+  emptyMcpForm,
+  entryToForm,
+  formToEntry,
+  parseArgs,
+  parseKeyValues,
+  formatKeyValues,
+  validateMcpForm,
+} from './mcpFormUtils';
+
+describe('mcpFormUtils', () => {
+  describe('parseArgs', () => {
+    it('splits non-empty trimmed lines into arguments', () => {
+      expect(parseArgs('-y\n  @scope/pkg  \n\n--flag')).toEqual(['-y', '@scope/pkg', '--flag']);
+    });
+
+    it('returns an empty array for blank text', () => {
+      expect(parseArgs('   \n  ')).toEqual([]);
+    });
+  });
+
+  describe('parseKeyValues', () => {
+    it('parses KEY=VALUE lines and keeps the first separator', () => {
+      expect(parseKeyValues('ROOT=/tmp\nTOKEN=a=b=c')).toEqual({ ROOT: '/tmp', TOKEN: 'a=b=c' });
+    });
+
+    it('treats a keyless line as an empty value and skips blanks', () => {
+      expect(parseKeyValues('FLAG\n\n  ')).toEqual({ FLAG: '' });
+    });
+  });
+
+  describe('formatKeyValues', () => {
+    it('round-trips with parseKeyValues', () => {
+      const record = { A: '1', B: 'two' };
+      expect(parseKeyValues(formatKeyValues(record))).toEqual(record);
+    });
+  });
+
+  describe('entryToForm / formToEntry', () => {
+    it('round-trips a stdio entry', () => {
+      const entry: McpServerEntry = {
+        name: 'files',
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', 'server'],
+        env: { ROOT: '/tmp' },
+      };
+      expect(formToEntry(entryToForm(entry))).toEqual(entry);
+    });
+
+    it('round-trips an http entry', () => {
+      const entry: McpServerEntry = {
+        name: 'remote',
+        transport: 'http',
+        url: 'https://mcp.example.test/v1',
+        headers: { Authorization: 'token' },
+      };
+      expect(formToEntry(entryToForm(entry))).toEqual(entry);
+    });
+
+    it('trims the name and command when building an entry', () => {
+      const form = { ...emptyMcpForm(), name: '  files  ', command: '  npx  ' };
+      expect(formToEntry(form)).toEqual({ name: 'files', transport: 'stdio', command: 'npx', args: [], env: {} });
+    });
+  });
+
+  describe('validateMcpForm', () => {
+    it('requires a name', () => {
+      expect(validateMcpForm({ ...emptyMcpForm(), name: '  ' }, [])).toMatch(/name is required/i);
+    });
+
+    it('rejects a duplicate name', () => {
+      const form = { ...emptyMcpForm(), name: 'files', command: 'npx' };
+      expect(validateMcpForm(form, ['files'])).toMatch(/already exists/i);
+    });
+
+    it('requires a command for stdio', () => {
+      expect(validateMcpForm({ ...emptyMcpForm(), name: 'x', command: '' }, [])).toMatch(/command is required/i);
+    });
+
+    it('requires a valid url for http', () => {
+      expect(validateMcpForm({ ...emptyMcpForm(), name: 'x', transport: 'http', url: 'not-a-url' }, []))
+        .toMatch(/valid url/i);
+    });
+
+    it('accepts a valid stdio form', () => {
+      expect(validateMcpForm({ ...emptyMcpForm(), name: 'x', command: 'npx' }, [])).toBeNull();
+    });
+
+    it('accepts a valid http form', () => {
+      expect(validateMcpForm({ ...emptyMcpForm(), name: 'x', transport: 'http', url: 'https://a.test' }, []))
+        .toBeNull();
+    });
+  });
+});

--- a/apps/web/src/renderer/components/extensions/mcpFormUtils.ts
+++ b/apps/web/src/renderer/components/extensions/mcpFormUtils.ts
@@ -1,9 +1,12 @@
-import type { McpServerEntry, McpServerTransport } from '@chamber/shared/mcp-types';
+import type { McpServerEntry, McpServerTransport, McpPreservedServerFields } from '@chamber/shared/mcp-types';
 
 /**
  * Editable form representation of a single MCP server. Multi-value fields are
  * held as raw text (one item per line) so the textarea stays the source of
  * truth while the user types; {@link formToEntry} parses them on save.
+ *
+ * `preserved` carries the entry's non-UI-edited runtime fields (tools, timeout,
+ * cwd, exact type) untouched so editing or renaming a server never drops them.
  */
 export interface McpServerFormState {
   name: string;
@@ -13,6 +16,7 @@ export interface McpServerFormState {
   envText: string;
   url: string;
   headersText: string;
+  preserved?: McpPreservedServerFields;
 }
 
 export function emptyMcpForm(): McpServerFormState {
@@ -21,6 +25,7 @@ export function emptyMcpForm(): McpServerFormState {
 
 export function entryToForm(entry: McpServerEntry): McpServerFormState {
   const base = emptyMcpForm();
+  const preservedProp = entry.preserved ? { preserved: entry.preserved } : {};
   if (entry.transport === 'stdio') {
     return {
       ...base,
@@ -29,6 +34,7 @@ export function entryToForm(entry: McpServerEntry): McpServerFormState {
       command: entry.command,
       argsText: formatArgs(entry.args),
       envText: formatKeyValues(entry.env),
+      ...preservedProp,
     };
   }
   return {
@@ -37,12 +43,14 @@ export function entryToForm(entry: McpServerEntry): McpServerFormState {
     transport: 'http',
     url: entry.url,
     headersText: formatKeyValues(entry.headers),
+    ...preservedProp,
   };
 }
 
 /** Builds a normalized entry from a form. Assumes {@link validateMcpForm} passed. */
 export function formToEntry(form: McpServerFormState): McpServerEntry {
   const name = form.name.trim();
+  const preservedProp = form.preserved ? { preserved: form.preserved } : {};
   if (form.transport === 'stdio') {
     return {
       name,
@@ -50,6 +58,7 @@ export function formToEntry(form: McpServerFormState): McpServerEntry {
       command: form.command.trim(),
       args: parseArgs(form.argsText),
       env: parseKeyValues(form.envText),
+      ...preservedProp,
     };
   }
   return {
@@ -57,6 +66,7 @@ export function formToEntry(form: McpServerFormState): McpServerEntry {
     transport: 'http',
     url: form.url.trim(),
     headers: parseKeyValues(form.headersText),
+    ...preservedProp,
   };
 }
 

--- a/apps/web/src/renderer/components/extensions/mcpFormUtils.ts
+++ b/apps/web/src/renderer/components/extensions/mcpFormUtils.ts
@@ -1,0 +1,124 @@
+import type { McpServerEntry, McpServerTransport } from '@chamber/shared/mcp-types';
+
+/**
+ * Editable form representation of a single MCP server. Multi-value fields are
+ * held as raw text (one item per line) so the textarea stays the source of
+ * truth while the user types; {@link formToEntry} parses them on save.
+ */
+export interface McpServerFormState {
+  name: string;
+  transport: McpServerTransport;
+  command: string;
+  argsText: string;
+  envText: string;
+  url: string;
+  headersText: string;
+}
+
+export function emptyMcpForm(): McpServerFormState {
+  return { name: '', transport: 'stdio', command: '', argsText: '', envText: '', url: '', headersText: '' };
+}
+
+export function entryToForm(entry: McpServerEntry): McpServerFormState {
+  const base = emptyMcpForm();
+  if (entry.transport === 'stdio') {
+    return {
+      ...base,
+      name: entry.name,
+      transport: 'stdio',
+      command: entry.command,
+      argsText: formatArgs(entry.args),
+      envText: formatKeyValues(entry.env),
+    };
+  }
+  return {
+    ...base,
+    name: entry.name,
+    transport: 'http',
+    url: entry.url,
+    headersText: formatKeyValues(entry.headers),
+  };
+}
+
+/** Builds a normalized entry from a form. Assumes {@link validateMcpForm} passed. */
+export function formToEntry(form: McpServerFormState): McpServerEntry {
+  const name = form.name.trim();
+  if (form.transport === 'stdio') {
+    return {
+      name,
+      transport: 'stdio',
+      command: form.command.trim(),
+      args: parseArgs(form.argsText),
+      env: parseKeyValues(form.envText),
+    };
+  }
+  return {
+    name,
+    transport: 'http',
+    url: form.url.trim(),
+    headers: parseKeyValues(form.headersText),
+  };
+}
+
+/**
+ * Validates a form against the names already in use by other servers. Returns a
+ * human-readable message, or null when the form is valid.
+ */
+export function validateMcpForm(form: McpServerFormState, otherNames: readonly string[]): string | null {
+  const name = form.name.trim();
+  if (name.length === 0) return 'Name is required.';
+  if (otherNames.includes(name)) return `A server named "${name}" already exists.`;
+
+  if (form.transport === 'stdio') {
+    if (form.command.trim().length === 0) return 'Command is required for a stdio server.';
+    return null;
+  }
+
+  const url = form.url.trim();
+  if (url.length === 0) return 'URL is required for an HTTP server.';
+  if (!isValidUrl(url)) return 'Enter a valid URL (including the scheme, e.g. https://).';
+  return null;
+}
+
+/** Splits a textarea into trimmed, non-empty lines (one argument per line). */
+export function parseArgs(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+export function formatArgs(args: string[]): string {
+  return args.join('\n');
+}
+
+/**
+ * Parses `KEY=VALUE` lines into a record. The first `=` separates key from
+ * value so values may contain `=`. Lines without a non-empty key are skipped.
+ */
+export function parseKeyValues(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    const eq = line.indexOf('=');
+    const key = (eq === -1 ? line : line.slice(0, eq)).trim();
+    const value = eq === -1 ? '' : line.slice(eq + 1).trim();
+    if (key.length > 0) out[key] = value;
+  }
+  return out;
+}
+
+export function formatKeyValues(record: Record<string, string>): string {
+  return Object.entries(record)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    return Boolean(new URL(value));
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/renderer/components/layout/ActivityBar.test.tsx
+++ b/apps/web/src/renderer/components/layout/ActivityBar.test.tsx
@@ -60,6 +60,19 @@ describe('ActivityBar', () => {
     expect(screen.getByLabelText('Chatroom')).toBeTruthy();
   });
 
+  it('renders an Extensions button in the footer', () => {
+    renderActivityBar();
+    const extensionsButton = screen.getByLabelText('Extensions');
+    expect(extensionsButton.closest('[data-testid="activity-bar-footer"]')).toBeTruthy();
+  });
+
+  it('activates the extensions view when the Extensions button is clicked', () => {
+    renderActivityBar();
+    fireEvent.click(screen.getByLabelText('Extensions'));
+    const extensionsButton = screen.getByLabelText('Extensions');
+    expect(extensionsButton.className).toContain('bg-accent');
+  });
+
   it('renders the updater action when an update is available', async () => {
     const api = mockElectronAPI();
     api.updater.getState = vi.fn().mockResolvedValue({

--- a/apps/web/src/renderer/components/layout/ActivityBar.tsx
+++ b/apps/web/src/renderer/components/layout/ActivityBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useAppState, useAppDispatch } from '../../lib/store';
 import { cn } from '../../lib/utils';
 import { isMac } from '../../lib/platform';
-import { MessageSquare, Zap, Newspaper, Users, Clock, Settings, Layout, RadioTower, type LucideIcon } from 'lucide-react';
+import { MessageSquare, Zap, Newspaper, Users, Clock, Settings, Layout, RadioTower, Blocks, type LucideIcon } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { Separator } from '../ui/separator';
 import type { LensViewManifest } from '@chamber/shared/types';
@@ -103,6 +103,23 @@ export function ActivityBar() {
       {/* Bottom-pinned settings */}
       <div data-testid="activity-bar-footer" className="flex flex-col items-center gap-1">
         <UpdateIndicator />
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <button
+              aria-label="Extensions"
+              onClick={() => dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'extensions' })}
+              className={cn(
+                'w-10 h-10 rounded-lg flex items-center justify-center transition-colors',
+                activeView === 'extensions'
+                  ? 'bg-accent text-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+              )}
+            >
+              <Blocks size={20} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>Extensions</TooltipContent>
+        </Tooltip>
         {featureFlags.switchboardRelay && (
           <Tooltip delayDuration={300}>
             <TooltipTrigger asChild>

--- a/apps/web/src/renderer/components/layout/ViewRouter.tsx
+++ b/apps/web/src/renderer/components/layout/ViewRouter.tsx
@@ -5,6 +5,7 @@ import { ChatroomPanel } from '../chatroom/ChatroomPanel';
 import { LensViewRenderer } from '../views/LensViewRenderer';
 import { SettingsView } from '../settings/SettingsView';
 import { A2ARelayView } from '../a2a/A2ARelayView';
+import { ExtensionsView } from '../extensions/ExtensionsView';
 
 export function ViewRouter() {
   const { activeView, discoveredViews, featureFlags } = useAppState();
@@ -19,6 +20,10 @@ export function ViewRouter() {
 
   if (activeView === 'settings') {
     return <SettingsView />;
+  }
+
+  if (activeView === 'extensions') {
+    return <ExtensionsView />;
   }
 
   if (activeView === 'a2a-relay' && featureFlags.switchboardRelay) {

--- a/apps/web/src/renderer/lib/reservedViewIds.test.ts
+++ b/apps/web/src/renderer/lib/reservedViewIds.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { RESERVED_VIEW_IDS, isReservedViewId } from './reservedViewIds';
+
+describe('reservedViewIds', () => {
+  it('flags every built-in route id as reserved', () => {
+    for (const id of RESERVED_VIEW_IDS) {
+      expect(isReservedViewId(id)).toBe(true);
+    }
+  });
+
+  it('reserves the extensions route id', () => {
+    expect(isReservedViewId('extensions')).toBe(true);
+  });
+
+  it('does not reserve arbitrary discovered view ids', () => {
+    expect(isReservedViewId('daily-briefing')).toBe(false);
+    expect(isReservedViewId('')).toBe(false);
+  });
+});

--- a/apps/web/src/renderer/lib/reservedViewIds.ts
+++ b/apps/web/src/renderer/lib/reservedViewIds.ts
@@ -1,0 +1,12 @@
+/**
+ * View ids owned by Chamber's built-in routes (see ViewRouter and ActivityBar).
+ * Discovered Lens views must not reuse them: ViewRouter resolves built-in ids
+ * first, so a Lens view sharing one of these ids would be unreachable and would
+ * render a duplicate activity-bar button. Discovered views carrying a reserved
+ * id are filtered out when they enter the store.
+ */
+export const RESERVED_VIEW_IDS = ['chat', 'chatroom', 'settings', 'a2a-relay', 'extensions'] as const;
+
+export function isReservedViewId(id: string): boolean {
+  return (RESERVED_VIEW_IDS as readonly string[]).includes(id);
+}

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -764,6 +764,16 @@ describe('appReducer', () => {
     expect(state.discoveredViews).toEqual(views);
   });
 
+  it('SET_DISCOVERED_VIEWS drops views that collide with reserved built-in route ids', () => {
+    const views = [
+      makeLensViewManifest({ id: 'v1' }),
+      makeLensViewManifest({ id: 'extensions' }),
+      makeLensViewManifest({ id: 'settings' }),
+    ];
+    const state = appReducer(initialState, { type: 'SET_DISCOVERED_VIEWS', payload: views });
+    expect(state.discoveredViews.map((view) => view.id)).toEqual(['v1']);
+  });
+
   it('SHOW_LANDING sets showLanding true', () => {
     const state = appReducer(initialState, { type: 'SHOW_LANDING' });
     expect(state.showLanding).toBe(true);

--- a/apps/web/src/renderer/lib/store/reducers/lifecycleReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/lifecycleReducer.ts
@@ -1,4 +1,5 @@
 import type { AppState, AppAction } from '../state';
+import { isReservedViewId } from '../../reservedViewIds';
 
 type Handler<T extends AppAction['type']> = (
   state: AppState,
@@ -20,7 +21,9 @@ function setDiscoveredViews(
   _state: AppState,
   action: Extract<AppAction, { type: 'SET_DISCOVERED_VIEWS' }>,
 ): Partial<AppState> {
-  return { discoveredViews: action.payload };
+  // Drop any discovered view that collides with a built-in route id so it can
+  // neither shadow nor be shadowed by Chamber's own views (e.g. extensions).
+  return { discoveredViews: action.payload.filter((view) => !isReservedViewId(view.id)) };
 }
 
 function showLanding(): Partial<AppState> {

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -369,6 +369,10 @@ export function mockElectronAPI(): ElectronAPI {
     skills: {
       listForMind: vi.fn().mockResolvedValue([]),
     },
+    mcp: {
+      getServers: vi.fn().mockResolvedValue([]),
+      setServers: vi.fn().mockResolvedValue([]),
+    },
   };
 }
 

--- a/packages/services/src/mind/index.ts
+++ b/packages/services/src/mind/index.ts
@@ -1,3 +1,5 @@
 export { MindManager } from './MindManager';
 export { generateMindId } from './generateMindId';
+export { readMcpServers, writeMcpServers } from './mcpServerStore';
+export { loadMcpServersFromMindPath, MCP_CONFIG_FILENAME } from './mcpConfig';
 export type { CopilotSession, InternalMindContext } from './types';

--- a/packages/services/src/mind/mcpConfig.ts
+++ b/packages/services/src/mind/mcpConfig.ts
@@ -46,6 +46,15 @@ const httpSchema = z.object({
 
 const serverSchema = z.union([stdioSchema, httpSchema]);
 
+// Re-exported under public names so the Extensions management layer
+// (`mcpServerStore.ts`) classifies entries with the *same* validation the
+// runtime uses. This keeps management and runtime in lockstep: an entry the
+// runtime would skip is never surfaced as editable nor normalized into an
+// executable config.
+export const mcpStdioServerSchema = stdioSchema;
+export const mcpHttpServerSchema = httpSchema;
+export const mcpServerSchema = serverSchema;
+
 // Top-level shape: the file MUST be a valid JSON object whose `mcpServers` is
 // an object map. Each entry is validated independently below so a single typo
 // only drops that one server, not every server in the file (#199).

--- a/packages/services/src/mind/mcpServerStore.test.ts
+++ b/packages/services/src/mind/mcpServerStore.test.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { McpServerEntry } from '@chamber/shared/mcp-types';
 import { readMcpServers, writeMcpServers } from './mcpServerStore';
-import { MCP_CONFIG_FILENAME } from './mcpConfig';
+import { loadMcpServersFromMindPath, MCP_CONFIG_FILENAME } from './mcpConfig';
 
 describe('mcpServerStore', () => {
   let tmpDir: string;
@@ -25,12 +25,16 @@ describe('mcpServerStore', () => {
     return JSON.parse(fs.readFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), 'utf-8'));
   }
 
+  function readServers(): Record<string, Record<string, unknown>> {
+    return readFile().mcpServers as Record<string, Record<string, unknown>>;
+  }
+
   describe('readMcpServers', () => {
     it('returns an empty array when the file is absent', () => {
       expect(readMcpServers(tmpDir)).toEqual([]);
     });
 
-    it('normalizes stdio and http servers sorted by name', () => {
+    it('surfaces stdio and http servers sorted by name', () => {
       writeFile({
         mcpServers: {
           zeta: { type: 'http', url: 'https://mcp.example.test/v1', headers: { Authorization: 'token' } },
@@ -40,25 +44,58 @@ describe('mcpServerStore', () => {
 
       expect(readMcpServers(tmpDir)).toEqual([
         { name: 'alpha', transport: 'stdio', command: 'npx', args: ['-y', 'server'], env: { ROOT: '/tmp' } },
-        { name: 'zeta', transport: 'http', url: 'https://mcp.example.test/v1', headers: { Authorization: 'token' } },
+        {
+          name: 'zeta',
+          transport: 'http',
+          url: 'https://mcp.example.test/v1',
+          headers: { Authorization: 'token' },
+          preserved: { type: 'http' },
+        },
       ]);
     });
 
-    it('defaults missing args, env, and headers to empty collections', () => {
-      writeFile({ mcpServers: { bare: { command: 'cli' } } });
+    it('captures tools, timeout, and cwd as preserved fields', () => {
+      writeFile({
+        mcpServers: {
+          files: { type: 'stdio', command: 'npx', args: [], tools: ['read'], timeout: 5000, cwd: '/work' },
+        },
+      });
+
       expect(readMcpServers(tmpDir)).toEqual([
-        { name: 'bare', transport: 'stdio', command: 'cli', args: [], env: {} },
+        {
+          name: 'files',
+          transport: 'stdio',
+          command: 'npx',
+          args: [],
+          env: {},
+          preserved: { type: 'stdio', tools: ['read'], timeout: 5000, cwd: '/work' },
+        },
       ]);
     });
 
-    it('skips ambiguous entries that mix command and url', () => {
-      writeFile({ mcpServers: { confused: { command: 'x', url: 'https://y.test' } } });
-      expect(readMcpServers(tmpDir)).toEqual([]);
+    it('omits entries the runtime schema would reject (not surfaced as editable)', () => {
+      writeFile({
+        mcpServers: {
+          good: { command: 'real-cli' },
+          missingType: { url: 'https://mcp.example.test' }, // http requires type
+          unknownKey: { command: 'x', bogus: true }, // strict schema rejects
+        },
+      });
+
+      expect(readMcpServers(tmpDir).map((entry) => entry.name)).toEqual(['good']);
     });
 
-    it('returns an empty array for malformed JSON without throwing', () => {
-      fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), '{not json', 'utf-8');
-      expect(readMcpServers(tmpDir)).toEqual([]);
+    it('agrees with the runtime loader on which entries are valid', () => {
+      writeFile({
+        mcpServers: {
+          good: { command: 'real-cli' },
+          broken: { type: 'stdio' }, // missing command
+        },
+      });
+
+      const managed = readMcpServers(tmpDir).map((entry) => entry.name).sort();
+      const runtime = Object.keys(loadMcpServersFromMindPath(tmpDir)).sort();
+      expect(managed).toEqual(runtime);
     });
   });
 
@@ -69,17 +106,11 @@ describe('mcpServerStore', () => {
         { name: 'remote', transport: 'http', url: 'https://mcp.example.test', headers: { Authorization: 'k' } },
       ];
 
-      const result = writeMcpServers(tmpDir, entries);
+      writeMcpServers(tmpDir, entries);
 
-      expect(result).toEqual([
-        { name: 'files', transport: 'stdio', command: 'npx', args: ['-y', 'fs'], env: { ROOT: '/tmp' } },
-        { name: 'remote', transport: 'http', url: 'https://mcp.example.test', headers: { Authorization: 'k' } },
-      ]);
-      expect(readFile()).toEqual({
-        mcpServers: {
-          files: { type: 'stdio', command: 'npx', args: ['-y', 'fs'], env: { ROOT: '/tmp' } },
-          remote: { type: 'http', url: 'https://mcp.example.test', headers: { Authorization: 'k' } },
-        },
+      expect(readServers()).toEqual({
+        files: { type: 'stdio', command: 'npx', args: ['-y', 'fs'], env: { ROOT: '/tmp' } },
+        remote: { type: 'http', url: 'https://mcp.example.test', headers: { Authorization: 'k' } },
       });
     });
 
@@ -87,8 +118,7 @@ describe('mcpServerStore', () => {
       writeMcpServers(tmpDir, [
         { name: 'files', transport: 'stdio', command: 'cli', args: [], env: {} },
       ]);
-      const written = readFile().mcpServers as Record<string, Record<string, unknown>>;
-      expect(Object.prototype.hasOwnProperty.call(written.files, 'env')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(readServers().files, 'env')).toBe(false);
     });
 
     it('preserves unknown top-level keys across a write', () => {
@@ -99,41 +129,99 @@ describe('mcpServerStore', () => {
       expect(readFile().$schema).toBe('https://schema.test');
     });
 
-    it('preserves tools and timeout when a server keeps the same transport', () => {
+    it('preserves invalid/unsupported raw entries verbatim (blocker 1)', () => {
       writeFile({
         mcpServers: {
-          files: { type: 'stdio', command: 'old', args: [], tools: ['read'], timeout: 5000, cwd: '/work' },
+          weird: { command: 'x', bogus: true, nested: { a: 1 } }, // not runtime-valid
         },
       });
 
       writeMcpServers(tmpDir, [
-        { name: 'files', transport: 'stdio', command: 'new', args: ['--flag'], env: {} },
+        { name: 'files', transport: 'stdio', command: 'cli', args: [], env: {} },
       ]);
 
-      const written = readFile().mcpServers as Record<string, Record<string, unknown>>;
-      expect(written.files).toEqual({
+      const servers = readServers();
+      expect(servers.weird).toEqual({ command: 'x', bogus: true, nested: { a: 1 } });
+      expect(servers.files).toEqual({ type: 'stdio', command: 'cli', args: [] });
+    });
+
+    it('does not normalize a skipped invalid entry into an executable config', () => {
+      writeFile({ mcpServers: { broken: { type: 'stdio' } } }); // missing command
+      // Re-saving the (empty) managed set must leave the invalid entry as-is,
+      // never turning it into a runnable server.
+      writeMcpServers(tmpDir, readMcpServers(tmpDir));
+      expect(readServers().broken).toEqual({ type: 'stdio' });
+      expect(loadMcpServersFromMindPath(tmpDir)).toEqual({});
+    });
+
+    it('keeps the tools allowlist when a server is renamed (blocker 2)', () => {
+      writeFile({
+        mcpServers: {
+          old: { type: 'stdio', command: 'npx', args: [], tools: ['read'], timeout: 5000, cwd: '/work' },
+        },
+      });
+
+      const [entry] = readMcpServers(tmpDir);
+      // Rename carries the preserved bag with the entry.
+      writeMcpServers(tmpDir, [{ ...entry, name: 'renamed' }]);
+
+      const servers = readServers();
+      expect(servers.old).toBeUndefined();
+      expect(servers.renamed).toEqual({
         type: 'stdio',
-        command: 'new',
-        args: ['--flag'],
+        command: 'npx',
+        args: [],
+        cwd: '/work',
         tools: ['read'],
         timeout: 5000,
-        cwd: '/work',
       });
     });
 
-    it('drops non-managed fields when the transport changes', () => {
+    it('does not widen tools to all when editing a scoped server', () => {
+      writeFile({
+        mcpServers: { svc: { type: 'stdio', command: 'old', args: [], tools: ['read'] } },
+      });
+      const [entry] = readMcpServers(tmpDir);
+      writeMcpServers(tmpDir, [{ ...entry, command: 'new' } as McpServerEntry]);
+
+      const loaded = loadMcpServersFromMindPath(tmpDir);
+      expect(loaded.svc.tools).toEqual(['read']);
+    });
+
+    it('preserves an sse server type rather than rewriting it as http (blocker 4)', () => {
       writeFile({
         mcpServers: {
-          svc: { type: 'stdio', command: 'old', tools: ['read'], cwd: '/work' },
+          stream: { type: 'sse', url: 'https://mcp.example.test/sse', tools: ['ping'] },
         },
       });
 
+      const [entry] = readMcpServers(tmpDir);
+      expect(entry.preserved?.type).toBe('sse');
+
+      // Edit the URL and rename; the sse type must survive serialization.
       writeMcpServers(tmpDir, [
-        { name: 'svc', transport: 'http', url: 'https://mcp.example.test', headers: {} },
+        { ...entry, name: 'renamed-stream', url: 'https://mcp.example.test/sse2' } as McpServerEntry,
       ]);
 
-      const written = readFile().mcpServers as Record<string, Record<string, unknown>>;
-      expect(written.svc).toEqual({ type: 'http', url: 'https://mcp.example.test' });
+      expect(readServers()['renamed-stream']).toEqual({
+        type: 'sse',
+        url: 'https://mcp.example.test/sse2',
+        tools: ['ping'],
+      });
+    });
+
+    it('clamps a stale sse type to http when the entry becomes stdio', () => {
+      writeMcpServers(tmpDir, [
+        {
+          name: 'svc',
+          transport: 'stdio',
+          command: 'cli',
+          args: [],
+          env: {},
+          preserved: { type: 'sse', tools: ['read'] },
+        },
+      ]);
+      expect(readServers().svc).toEqual({ type: 'stdio', command: 'cli', args: [], tools: ['read'] });
     });
 
     it('rejects empty names', () => {
@@ -149,9 +237,9 @@ describe('mcpServerStore', () => {
       ])).toThrow(/Duplicate MCP server name: dup/);
     });
 
-    it('round-trips through readMcpServers', () => {
+    it('round-trips a stdio entry through readMcpServers', () => {
       const entries: McpServerEntry[] = [
-        { name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: { A: '1' } },
+        { name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: { A: '1' }, preserved: { type: 'stdio' } },
       ];
       writeMcpServers(tmpDir, entries);
       expect(readMcpServers(tmpDir)).toEqual(entries);

--- a/packages/services/src/mind/mcpServerStore.test.ts
+++ b/packages/services/src/mind/mcpServerStore.test.ts
@@ -97,6 +97,16 @@ describe('mcpServerStore', () => {
       const runtime = Object.keys(loadMcpServersFromMindPath(tmpDir)).sort();
       expect(managed).toEqual(runtime);
     });
+
+    it('throws rather than treating an unparseable file as empty (blocker 1)', () => {
+      fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), '{ not json', 'utf-8');
+      expect(() => readMcpServers(tmpDir)).toThrow(/not valid JSON/);
+    });
+
+    it('throws when the file is not a JSON object', () => {
+      fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), '["array"]', 'utf-8');
+      expect(() => readMcpServers(tmpDir)).toThrow(/not valid JSON/);
+    });
   });
 
   describe('writeMcpServers', () => {
@@ -235,6 +245,30 @@ describe('mcpServerStore', () => {
         { name: 'dup', transport: 'stdio', command: 'a', args: [], env: {} },
         { name: 'dup', transport: 'http', url: 'https://b.test', headers: {} },
       ])).toThrow(/Duplicate MCP server name: dup/);
+    });
+
+    it('refuses to overwrite a file it cannot parse (blocker 1)', () => {
+      fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), '{ oops', 'utf-8');
+      expect(() => writeMcpServers(tmpDir, [
+        { name: 'files', transport: 'stdio', command: 'cli', args: [], env: {} },
+      ])).toThrow(/Refusing to overwrite/);
+      // The original bytes are left intact.
+      expect(fs.readFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), 'utf-8')).toBe('{ oops');
+    });
+
+    it('rejects a managed name that collides with a preserved invalid entry', () => {
+      writeFile({ mcpServers: { conflict: { type: 'stdio' } } }); // invalid: missing command
+      expect(() => writeMcpServers(tmpDir, [
+        { name: 'conflict', transport: 'stdio', command: 'cli', args: [], env: {} },
+      ])).toThrow(/in use by an unmanaged entry: conflict/);
+      // The preserved invalid entry is untouched.
+      expect(readServers().conflict).toEqual({ type: 'stdio' });
+    });
+
+    it('rejects an entry whose serialized form would fail the runtime schema', () => {
+      expect(() => writeMcpServers(tmpDir, [
+        { name: 'bad', transport: 'http', url: 'not-a-url', headers: {} },
+      ])).toThrow(/Invalid MCP server configuration for bad/);
     });
 
     it('round-trips a stdio entry through readMcpServers', () => {

--- a/packages/services/src/mind/mcpServerStore.test.ts
+++ b/packages/services/src/mind/mcpServerStore.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { McpServerEntry } from '@chamber/shared/mcp-types';
+import { readMcpServers, writeMcpServers } from './mcpServerStore';
+import { MCP_CONFIG_FILENAME } from './mcpConfig';
+
+describe('mcpServerStore', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-mcp-store-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(value: unknown): void {
+    fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), JSON.stringify(value), 'utf-8');
+  }
+
+  function readFile(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), 'utf-8'));
+  }
+
+  describe('readMcpServers', () => {
+    it('returns an empty array when the file is absent', () => {
+      expect(readMcpServers(tmpDir)).toEqual([]);
+    });
+
+    it('normalizes stdio and http servers sorted by name', () => {
+      writeFile({
+        mcpServers: {
+          zeta: { type: 'http', url: 'https://mcp.example.test/v1', headers: { Authorization: 'token' } },
+          alpha: { command: 'npx', args: ['-y', 'server'], env: { ROOT: '/tmp' } },
+        },
+      });
+
+      expect(readMcpServers(tmpDir)).toEqual([
+        { name: 'alpha', transport: 'stdio', command: 'npx', args: ['-y', 'server'], env: { ROOT: '/tmp' } },
+        { name: 'zeta', transport: 'http', url: 'https://mcp.example.test/v1', headers: { Authorization: 'token' } },
+      ]);
+    });
+
+    it('defaults missing args, env, and headers to empty collections', () => {
+      writeFile({ mcpServers: { bare: { command: 'cli' } } });
+      expect(readMcpServers(tmpDir)).toEqual([
+        { name: 'bare', transport: 'stdio', command: 'cli', args: [], env: {} },
+      ]);
+    });
+
+    it('skips ambiguous entries that mix command and url', () => {
+      writeFile({ mcpServers: { confused: { command: 'x', url: 'https://y.test' } } });
+      expect(readMcpServers(tmpDir)).toEqual([]);
+    });
+
+    it('returns an empty array for malformed JSON without throwing', () => {
+      fs.writeFileSync(path.join(tmpDir, MCP_CONFIG_FILENAME), '{not json', 'utf-8');
+      expect(readMcpServers(tmpDir)).toEqual([]);
+    });
+  });
+
+  describe('writeMcpServers', () => {
+    it('persists stdio and http entries with an explicit type', () => {
+      const entries: McpServerEntry[] = [
+        { name: 'files', transport: 'stdio', command: 'npx', args: ['-y', 'fs'], env: { ROOT: '/tmp' } },
+        { name: 'remote', transport: 'http', url: 'https://mcp.example.test', headers: { Authorization: 'k' } },
+      ];
+
+      const result = writeMcpServers(tmpDir, entries);
+
+      expect(result).toEqual([
+        { name: 'files', transport: 'stdio', command: 'npx', args: ['-y', 'fs'], env: { ROOT: '/tmp' } },
+        { name: 'remote', transport: 'http', url: 'https://mcp.example.test', headers: { Authorization: 'k' } },
+      ]);
+      expect(readFile()).toEqual({
+        mcpServers: {
+          files: { type: 'stdio', command: 'npx', args: ['-y', 'fs'], env: { ROOT: '/tmp' } },
+          remote: { type: 'http', url: 'https://mcp.example.test', headers: { Authorization: 'k' } },
+        },
+      });
+    });
+
+    it('omits env and headers when they are empty', () => {
+      writeMcpServers(tmpDir, [
+        { name: 'files', transport: 'stdio', command: 'cli', args: [], env: {} },
+      ]);
+      const written = readFile().mcpServers as Record<string, Record<string, unknown>>;
+      expect(Object.prototype.hasOwnProperty.call(written.files, 'env')).toBe(false);
+    });
+
+    it('preserves unknown top-level keys across a write', () => {
+      writeFile({ $schema: 'https://schema.test', mcpServers: {} });
+      writeMcpServers(tmpDir, [
+        { name: 'files', transport: 'stdio', command: 'cli', args: [], env: {} },
+      ]);
+      expect(readFile().$schema).toBe('https://schema.test');
+    });
+
+    it('preserves tools and timeout when a server keeps the same transport', () => {
+      writeFile({
+        mcpServers: {
+          files: { type: 'stdio', command: 'old', args: [], tools: ['read'], timeout: 5000, cwd: '/work' },
+        },
+      });
+
+      writeMcpServers(tmpDir, [
+        { name: 'files', transport: 'stdio', command: 'new', args: ['--flag'], env: {} },
+      ]);
+
+      const written = readFile().mcpServers as Record<string, Record<string, unknown>>;
+      expect(written.files).toEqual({
+        type: 'stdio',
+        command: 'new',
+        args: ['--flag'],
+        tools: ['read'],
+        timeout: 5000,
+        cwd: '/work',
+      });
+    });
+
+    it('drops non-managed fields when the transport changes', () => {
+      writeFile({
+        mcpServers: {
+          svc: { type: 'stdio', command: 'old', tools: ['read'], cwd: '/work' },
+        },
+      });
+
+      writeMcpServers(tmpDir, [
+        { name: 'svc', transport: 'http', url: 'https://mcp.example.test', headers: {} },
+      ]);
+
+      const written = readFile().mcpServers as Record<string, Record<string, unknown>>;
+      expect(written.svc).toEqual({ type: 'http', url: 'https://mcp.example.test' });
+    });
+
+    it('rejects empty names', () => {
+      expect(() => writeMcpServers(tmpDir, [
+        { name: '  ', transport: 'stdio', command: 'cli', args: [], env: {} },
+      ])).toThrow(/name must not be empty/);
+    });
+
+    it('rejects duplicate names', () => {
+      expect(() => writeMcpServers(tmpDir, [
+        { name: 'dup', transport: 'stdio', command: 'a', args: [], env: {} },
+        { name: 'dup', transport: 'http', url: 'https://b.test', headers: {} },
+      ])).toThrow(/Duplicate MCP server name: dup/);
+    });
+
+    it('round-trips through readMcpServers', () => {
+      const entries: McpServerEntry[] = [
+        { name: 'files', transport: 'stdio', command: 'npx', args: ['fs'], env: { A: '1' } },
+      ];
+      writeMcpServers(tmpDir, entries);
+      expect(readMcpServers(tmpDir)).toEqual(entries);
+    });
+  });
+});

--- a/packages/services/src/mind/mcpServerStore.ts
+++ b/packages/services/src/mind/mcpServerStore.ts
@@ -4,18 +4,27 @@
 // this module round-trips the raw file so users can add, edit, and remove
 // servers without losing unrelated content.
 //
-// Round-trip guarantees:
+// Safety invariants:
+//   - Manageability is decided by the *runtime* MCP schema (`mcpServerSchema`).
+//     An entry the runtime would reject is never surfaced as editable and is
+//     preserved on disk verbatim — management must not normalize an inert,
+//     invalid entry into a valid, executable stdio/http config (#S5-1).
+//   - Non-managed per-server fields (`type`, `tools`, `timeout`, `cwd`) are
+//     carried with the entry (see `preserved`) so a rename keeps them. Losing
+//     `tools` would widen a server from its allowlist to all tools (#S5-2), and
+//     losing `type` would rewrite an `sse` server as `http` (#S5-4).
 //   - Unknown top-level keys in `.mcp.json` are preserved on write.
-//   - Non-managed per-server fields (`tools`, `timeout`, and stdio `cwd`) are
-//     preserved for a server that is kept on the same transport. This matters
-//     for security: `tools` scopes which tools a server may expose, and a UI
-//     edit must never silently widen that scope by dropping the field.
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { McpServerEntry, McpServerTransport } from '@chamber/shared/mcp-types';
+import type {
+  McpHttpType,
+  McpPreservedServerFields,
+  McpServerEntry,
+  McpStdioType,
+} from '@chamber/shared/mcp-types';
 import { Logger } from '../logger';
-import { MCP_CONFIG_FILENAME } from './mcpConfig';
+import { MCP_CONFIG_FILENAME, mcpServerSchema } from './mcpConfig';
 
 const log = Logger.create('mcpServerStore');
 
@@ -29,25 +38,50 @@ interface RawConfig {
 }
 
 /**
- * Reads and normalizes the MCP servers configured for `mindPath`. Invalid or
- * ambiguous entries are skipped rather than throwing so a single bad entry
- * never hides the rest. Returns an empty array when the file is absent.
+ * True when a raw entry validates against the runtime MCP schema — i.e. the
+ * runtime would actually load it. Only manageable entries are surfaced to the
+ * UI; everything else is preserved untouched.
  */
-export function readMcpServers(mindPath: string): McpServerEntry[] {
-  const { servers } = readRawConfig(path.join(mindPath, MCP_CONFIG_FILENAME));
-  return normalizeServers(servers);
+function isManageable(raw: unknown): boolean {
+  return mcpServerSchema.safeParse(raw).success;
 }
 
 /**
- * Replaces the MCP server set in `mindPath`'s `.mcp.json` and returns the
- * persisted, normalized list. Throws on empty or duplicate names so the IPC
- * layer can surface a clear error to the renderer.
+ * Reads the manageable MCP servers configured for `mindPath`. Entries the
+ * runtime schema rejects are intentionally omitted (they remain on disk,
+ * untouched). Returns an empty array when the file is absent.
+ */
+export function readMcpServers(mindPath: string): McpServerEntry[] {
+  const { servers } = readRawConfig(path.join(mindPath, MCP_CONFIG_FILENAME));
+  const entries: McpServerEntry[] = [];
+  for (const [name, raw] of Object.entries(servers)) {
+    if (!isManageable(raw)) continue;
+    entries.push(toEntry(name, raw));
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Replaces the *manageable* MCP server set in `mindPath`'s `.mcp.json` and
+ * returns the persisted, normalized list. Raw entries the runtime rejects are
+ * preserved verbatim; managed entries are replaced/added by name and removed by
+ * omission. Throws on empty or duplicate names.
  */
 export function writeMcpServers(mindPath: string, entries: McpServerEntry[]): McpServerEntry[] {
   const filePath = path.join(mindPath, MCP_CONFIG_FILENAME);
-  const existing = readRawConfig(filePath);
+  const { top, servers: rawServers } = readRawConfig(filePath);
 
   const nextServers: Record<string, RawServer> = {};
+
+  // Preserve every entry the runtime schema rejects, exactly as written. These
+  // are invalid/unsupported servers the UI never surfaced; management must not
+  // rewrite them (blocker 1).
+  for (const [name, raw] of Object.entries(rawServers)) {
+    if (!isManageable(raw)) nextServers[name] = raw;
+  }
+
+  // Serialize the managed entries, replacing/adding by name. Managed entries
+  // omitted from `entries` are dropped (removal by name).
   const seen = new Set<string>();
   for (const entry of entries) {
     const name = entry.name.trim();
@@ -58,13 +92,13 @@ export function writeMcpServers(mindPath: string, entries: McpServerEntry[]): Mc
       throw new Error(`Duplicate MCP server name: ${name}`);
     }
     seen.add(name);
-    nextServers[name] = serializeEntry(entry, existing.servers[name]);
+    nextServers[name] = serializeEntry(entry);
   }
 
-  const document = { ...existing.top, mcpServers: nextServers };
+  const document = { ...top, mcpServers: nextServers };
   fs.mkdirSync(mindPath, { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(document, null, 2)}\n`, 'utf-8');
-  return normalizeServers(nextServers);
+  return readMcpServers(mindPath);
 }
 
 function readRawConfig(filePath: string): RawConfig {
@@ -78,88 +112,77 @@ function readRawConfig(filePath: string): RawConfig {
     return { top: {}, servers: {} };
   }
 
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return { top: {}, servers: {} };
-  }
+  if (!isRecord(parsed)) return { top: {}, servers: {} };
 
-  const record = parsed as Record<string, unknown>;
-  const { mcpServers, ...top } = record;
+  const { mcpServers, ...top } = parsed;
   const servers = isRecord(mcpServers) ? (mcpServers as Record<string, RawServer>) : {};
   return { top, servers };
 }
 
-function normalizeServers(servers: Record<string, RawServer>): McpServerEntry[] {
-  const entries: McpServerEntry[] = [];
-  for (const [name, raw] of Object.entries(servers)) {
-    const entry = normalizeEntry(name, raw);
-    if (entry) entries.push(entry);
-  }
-  return entries.sort((a, b) => a.name.localeCompare(b.name));
-}
-
-function normalizeEntry(name: string, raw: unknown): McpServerEntry | null {
-  if (!isRecord(raw)) return null;
-  const hasCommand = typeof raw.command === 'string' && raw.command.length > 0;
-  const hasUrl = typeof raw.url === 'string' && raw.url.length > 0;
-  // Reject entries that mix stdio and http keys — the same guard the SDK
-  // loader applies — so an ambiguous entry is dropped, not coerced.
-  if (hasCommand === hasUrl) return null;
-
-  if (hasCommand) {
+/** Maps a schema-valid raw entry to the renderer model, capturing preserved fields. */
+function toEntry(name: string, raw: RawServer): McpServerEntry {
+  const preserved = readPreserved(raw);
+  const preservedProp = preserved ? { preserved } : {};
+  if (typeof raw.url === 'string') {
     return {
       name,
-      transport: 'stdio',
-      command: raw.command as string,
-      args: toStringArray(raw.args),
-      env: toStringRecord(raw.env),
+      transport: 'http',
+      url: raw.url,
+      headers: toStringRecord(raw.headers),
+      ...preservedProp,
     };
   }
   return {
     name,
-    transport: 'http',
-    url: raw.url as string,
-    headers: toStringRecord(raw.headers),
+    transport: 'stdio',
+    command: raw.command as string,
+    args: toStringArray(raw.args),
+    env: toStringRecord(raw.env),
+    ...preservedProp,
   };
 }
 
-function serializeEntry(entry: McpServerEntry, prior: RawServer | undefined): RawServer {
-  const carried = preservedFields(prior, entry.transport);
-  if (entry.transport === 'stdio') {
-    return {
-      type: 'stdio',
-      command: entry.command,
-      args: entry.args,
-      ...(Object.keys(entry.env).length > 0 ? { env: entry.env } : {}),
-      ...carried,
-    };
+/** Extracts the non-UI-edited runtime fields to round-trip verbatim. */
+function readPreserved(raw: RawServer): McpPreservedServerFields | undefined {
+  const preserved: McpPreservedServerFields = {};
+  if (typeof raw.type === 'string') preserved.type = raw.type as McpStdioType | McpHttpType;
+  if (Array.isArray(raw.tools)) {
+    preserved.tools = raw.tools.filter((item): item is string => typeof item === 'string');
   }
-  return {
-    type: 'http',
-    url: entry.url,
-    ...(Object.keys(entry.headers).length > 0 ? { headers: entry.headers } : {}),
-    ...carried,
-  };
+  if (typeof raw.timeout === 'number') preserved.timeout = raw.timeout;
+  if (typeof raw.cwd === 'string') preserved.cwd = raw.cwd;
+  return Object.keys(preserved).length > 0 ? preserved : undefined;
 }
 
 /**
- * Copies forward the non-managed fields the UI never edits, but only when the
- * prior entry used the same transport — switching stdio <-> http must not carry
- * stale scoping across shapes.
+ * Serializes an entry back to raw `.mcp.json` shape. The written `type` is
+ * clamped to the arm's valid values so a stale `preserved.type` left over from
+ * a transport change can never produce an invalid config (e.g. `sse` on a
+ * stdio server). `tools` and `timeout` are carried across transports; `cwd` is
+ * stdio-only.
  */
-function preservedFields(prior: RawServer | undefined, transport: McpServerTransport): RawServer {
-  if (!isRecord(prior)) return {};
-  const priorTransport: McpServerTransport | null = typeof prior.url === 'string'
-    ? 'http'
-    : typeof prior.command === 'string'
-      ? 'stdio'
-      : null;
-  if (priorTransport !== transport) return {};
-
-  const carried: RawServer = {};
-  if (Array.isArray(prior.tools)) carried.tools = prior.tools;
-  if (typeof prior.timeout === 'number') carried.timeout = prior.timeout;
-  if (transport === 'stdio' && typeof prior.cwd === 'string') carried.cwd = prior.cwd;
-  return carried;
+function serializeEntry(entry: McpServerEntry): RawServer {
+  const preserved = entry.preserved ?? {};
+  if (entry.transport === 'stdio') {
+    const out: RawServer = {
+      type: preserved.type === 'local' ? 'local' : 'stdio',
+      command: entry.command,
+      args: entry.args,
+    };
+    if (Object.keys(entry.env).length > 0) out.env = entry.env;
+    if (typeof preserved.cwd === 'string') out.cwd = preserved.cwd;
+    if (Array.isArray(preserved.tools)) out.tools = preserved.tools;
+    if (typeof preserved.timeout === 'number') out.timeout = preserved.timeout;
+    return out;
+  }
+  const out: RawServer = {
+    type: preserved.type === 'sse' ? 'sse' : 'http',
+    url: entry.url,
+  };
+  if (Object.keys(entry.headers).length > 0) out.headers = entry.headers;
+  if (Array.isArray(preserved.tools)) out.tools = preserved.tools;
+  if (typeof preserved.timeout === 'number') out.timeout = preserved.timeout;
+  return out;
 }
 
 function toStringArray(value: unknown): string[] {

--- a/packages/services/src/mind/mcpServerStore.ts
+++ b/packages/services/src/mind/mcpServerStore.ts
@@ -30,7 +30,12 @@ const log = Logger.create('mcpServerStore');
 
 type RawServer = Record<string, unknown>;
 
+/** Whether the on-disk file could be safely parsed and round-tripped. */
+type RawConfigStatus = 'empty' | 'loaded' | 'unreadable';
+
 interface RawConfig {
+  /** `empty` = no file; `loaded` = valid JSON object; `unreadable` = present but unsafe to round-trip. */
+  status: RawConfigStatus;
   /** Top-level keys other than `mcpServers`, preserved across writes. */
   top: Record<string, unknown>;
   /** The raw `mcpServers` map exactly as read from disk. */
@@ -49,12 +54,19 @@ function isManageable(raw: unknown): boolean {
 /**
  * Reads the manageable MCP servers configured for `mindPath`. Entries the
  * runtime schema rejects are intentionally omitted (they remain on disk,
- * untouched). Returns an empty array when the file is absent.
+ * untouched). Returns an empty array when the file is absent. Throws when the
+ * file exists but cannot be parsed, so the caller surfaces an error and keeps
+ * the file read-only rather than silently treating it as empty.
  */
 export function readMcpServers(mindPath: string): McpServerEntry[] {
-  const { servers } = readRawConfig(path.join(mindPath, MCP_CONFIG_FILENAME));
+  const config = readRawConfig(path.join(mindPath, MCP_CONFIG_FILENAME));
+  if (config.status === 'unreadable') {
+    throw new Error(
+      `Cannot read ${MCP_CONFIG_FILENAME}: it is not valid JSON. Fix or remove the file to manage MCP servers.`,
+    );
+  }
   const entries: McpServerEntry[] = [];
-  for (const [name, raw] of Object.entries(servers)) {
+  for (const [name, raw] of Object.entries(config.servers)) {
     if (!isManageable(raw)) continue;
     entries.push(toEntry(name, raw));
   }
@@ -65,20 +77,27 @@ export function readMcpServers(mindPath: string): McpServerEntry[] {
  * Replaces the *manageable* MCP server set in `mindPath`'s `.mcp.json` and
  * returns the persisted, normalized list. Raw entries the runtime rejects are
  * preserved verbatim; managed entries are replaced/added by name and removed by
- * omission. Throws on empty or duplicate names.
+ * omission. Refuses to overwrite a file it could not parse, and throws on empty,
+ * duplicate, or preserved-name-colliding entries.
  */
 export function writeMcpServers(mindPath: string, entries: McpServerEntry[]): McpServerEntry[] {
   const filePath = path.join(mindPath, MCP_CONFIG_FILENAME);
-  const { top, servers: rawServers } = readRawConfig(filePath);
+  const existing = readRawConfig(filePath);
+  if (existing.status === 'unreadable') {
+    throw new Error(
+      `Refusing to overwrite ${MCP_CONFIG_FILENAME}: the existing file is not valid JSON. Fix or remove it first.`,
+    );
+  }
 
   const nextServers: Record<string, RawServer> = {};
 
   // Preserve every entry the runtime schema rejects, exactly as written. These
   // are invalid/unsupported servers the UI never surfaced; management must not
   // rewrite them (blocker 1).
-  for (const [name, raw] of Object.entries(rawServers)) {
+  for (const [name, raw] of Object.entries(existing.servers)) {
     if (!isManageable(raw)) nextServers[name] = raw;
   }
+  const preservedNames = new Set(Object.keys(nextServers));
 
   // Serialize the managed entries, replacing/adding by name. Managed entries
   // omitted from `entries` are dropped (removal by name).
@@ -91,32 +110,62 @@ export function writeMcpServers(mindPath: string, entries: McpServerEntry[]): Mc
     if (seen.has(name)) {
       throw new Error(`Duplicate MCP server name: ${name}`);
     }
+    // A managed name must not silently clobber a preserved (invalid) entry that
+    // the UI never showed; keep the preserve-verbatim contract total.
+    if (preservedNames.has(name)) {
+      throw new Error(`MCP server name in use by an unmanaged entry: ${name}`);
+    }
     seen.add(name);
-    nextServers[name] = serializeEntry(entry);
+    const serialized = serializeEntry(entry);
+    // Defense in depth: the IPC layer validates input, but this is a public
+    // service API. Never persist an entry that would fail the runtime schema
+    // (and then vanish from the returned list), which would diverge disk from UI.
+    if (!isManageable(serialized)) {
+      throw new Error(`Invalid MCP server configuration for ${name}`);
+    }
+    nextServers[name] = serialized;
   }
 
-  const document = { ...top, mcpServers: nextServers };
+  const document = { ...existing.top, mcpServers: nextServers };
   fs.mkdirSync(mindPath, { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(document, null, 2)}\n`, 'utf-8');
   return readMcpServers(mindPath);
 }
 
 function readRawConfig(filePath: string): RawConfig {
-  if (!fs.existsSync(filePath)) return { top: {}, servers: {} };
+  if (!fs.existsSync(filePath)) return { status: 'empty', top: {}, servers: {} };
+
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    log.warn(`Failed to read ${filePath}; refusing to manage it:`, err);
+    return { status: 'unreadable', top: {}, servers: {} };
+  }
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    parsed = JSON.parse(text);
   } catch (err) {
-    log.warn(`Failed to read or parse ${filePath}; treating as empty:`, err);
-    return { top: {}, servers: {} };
+    log.warn(`Invalid JSON in ${filePath}; refusing to manage it:`, err);
+    return { status: 'unreadable', top: {}, servers: {} };
   }
 
-  if (!isRecord(parsed)) return { top: {}, servers: {} };
+  if (!isRecord(parsed)) {
+    log.warn(`${filePath} is not a JSON object; refusing to manage it.`);
+    return { status: 'unreadable', top: {}, servers: {} };
+  }
 
   const { mcpServers, ...top } = parsed;
+  // A present-but-malformed `mcpServers` means we don't understand the file's
+  // shape; refuse rather than clobber it with our own map.
+  if (mcpServers !== undefined && !isRecord(mcpServers)) {
+    log.warn(`${filePath} has a non-object mcpServers; refusing to manage it.`);
+    return { status: 'unreadable', top: {}, servers: {} };
+  }
+
   const servers = isRecord(mcpServers) ? (mcpServers as Record<string, RawServer>) : {};
-  return { top, servers };
+  return { status: 'loaded', top, servers };
 }
 
 /** Maps a schema-valid raw entry to the renderer model, capturing preserved fields. */

--- a/packages/services/src/mind/mcpServerStore.ts
+++ b/packages/services/src/mind/mcpServerStore.ts
@@ -1,0 +1,181 @@
+// Read/write access to a mind's `.mcp.json` for the Extensions hub. This is the
+// management counterpart to `mcpConfig.ts`: where `loadMcpServersFromMindPath`
+// coerces entries into the SDK's `MCPServerConfig` shape for session creation,
+// this module round-trips the raw file so users can add, edit, and remove
+// servers without losing unrelated content.
+//
+// Round-trip guarantees:
+//   - Unknown top-level keys in `.mcp.json` are preserved on write.
+//   - Non-managed per-server fields (`tools`, `timeout`, and stdio `cwd`) are
+//     preserved for a server that is kept on the same transport. This matters
+//     for security: `tools` scopes which tools a server may expose, and a UI
+//     edit must never silently widen that scope by dropping the field.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { McpServerEntry, McpServerTransport } from '@chamber/shared/mcp-types';
+import { Logger } from '../logger';
+import { MCP_CONFIG_FILENAME } from './mcpConfig';
+
+const log = Logger.create('mcpServerStore');
+
+type RawServer = Record<string, unknown>;
+
+interface RawConfig {
+  /** Top-level keys other than `mcpServers`, preserved across writes. */
+  top: Record<string, unknown>;
+  /** The raw `mcpServers` map exactly as read from disk. */
+  servers: Record<string, RawServer>;
+}
+
+/**
+ * Reads and normalizes the MCP servers configured for `mindPath`. Invalid or
+ * ambiguous entries are skipped rather than throwing so a single bad entry
+ * never hides the rest. Returns an empty array when the file is absent.
+ */
+export function readMcpServers(mindPath: string): McpServerEntry[] {
+  const { servers } = readRawConfig(path.join(mindPath, MCP_CONFIG_FILENAME));
+  return normalizeServers(servers);
+}
+
+/**
+ * Replaces the MCP server set in `mindPath`'s `.mcp.json` and returns the
+ * persisted, normalized list. Throws on empty or duplicate names so the IPC
+ * layer can surface a clear error to the renderer.
+ */
+export function writeMcpServers(mindPath: string, entries: McpServerEntry[]): McpServerEntry[] {
+  const filePath = path.join(mindPath, MCP_CONFIG_FILENAME);
+  const existing = readRawConfig(filePath);
+
+  const nextServers: Record<string, RawServer> = {};
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const name = entry.name.trim();
+    if (name.length === 0) {
+      throw new Error('MCP server name must not be empty');
+    }
+    if (seen.has(name)) {
+      throw new Error(`Duplicate MCP server name: ${name}`);
+    }
+    seen.add(name);
+    nextServers[name] = serializeEntry(entry, existing.servers[name]);
+  }
+
+  const document = { ...existing.top, mcpServers: nextServers };
+  fs.mkdirSync(mindPath, { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(document, null, 2)}\n`, 'utf-8');
+  return normalizeServers(nextServers);
+}
+
+function readRawConfig(filePath: string): RawConfig {
+  if (!fs.existsSync(filePath)) return { top: {}, servers: {} };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch (err) {
+    log.warn(`Failed to read or parse ${filePath}; treating as empty:`, err);
+    return { top: {}, servers: {} };
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { top: {}, servers: {} };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const { mcpServers, ...top } = record;
+  const servers = isRecord(mcpServers) ? (mcpServers as Record<string, RawServer>) : {};
+  return { top, servers };
+}
+
+function normalizeServers(servers: Record<string, RawServer>): McpServerEntry[] {
+  const entries: McpServerEntry[] = [];
+  for (const [name, raw] of Object.entries(servers)) {
+    const entry = normalizeEntry(name, raw);
+    if (entry) entries.push(entry);
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function normalizeEntry(name: string, raw: unknown): McpServerEntry | null {
+  if (!isRecord(raw)) return null;
+  const hasCommand = typeof raw.command === 'string' && raw.command.length > 0;
+  const hasUrl = typeof raw.url === 'string' && raw.url.length > 0;
+  // Reject entries that mix stdio and http keys — the same guard the SDK
+  // loader applies — so an ambiguous entry is dropped, not coerced.
+  if (hasCommand === hasUrl) return null;
+
+  if (hasCommand) {
+    return {
+      name,
+      transport: 'stdio',
+      command: raw.command as string,
+      args: toStringArray(raw.args),
+      env: toStringRecord(raw.env),
+    };
+  }
+  return {
+    name,
+    transport: 'http',
+    url: raw.url as string,
+    headers: toStringRecord(raw.headers),
+  };
+}
+
+function serializeEntry(entry: McpServerEntry, prior: RawServer | undefined): RawServer {
+  const carried = preservedFields(prior, entry.transport);
+  if (entry.transport === 'stdio') {
+    return {
+      type: 'stdio',
+      command: entry.command,
+      args: entry.args,
+      ...(Object.keys(entry.env).length > 0 ? { env: entry.env } : {}),
+      ...carried,
+    };
+  }
+  return {
+    type: 'http',
+    url: entry.url,
+    ...(Object.keys(entry.headers).length > 0 ? { headers: entry.headers } : {}),
+    ...carried,
+  };
+}
+
+/**
+ * Copies forward the non-managed fields the UI never edits, but only when the
+ * prior entry used the same transport — switching stdio <-> http must not carry
+ * stale scoping across shapes.
+ */
+function preservedFields(prior: RawServer | undefined, transport: McpServerTransport): RawServer {
+  if (!isRecord(prior)) return {};
+  const priorTransport: McpServerTransport | null = typeof prior.url === 'string'
+    ? 'http'
+    : typeof prior.command === 'string'
+      ? 'stdio'
+      : null;
+  if (priorTransport !== transport) return {};
+
+  const carried: RawServer = {};
+  if (Array.isArray(prior.tools)) carried.tools = prior.tools;
+  if (typeof prior.timeout === 'number') carried.timeout = prior.timeout;
+  if (transport === 'stdio' && typeof prior.cwd === 'string') carried.cwd = prior.cwd;
+  return carried;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function toStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'string') out[key] = item;
+  }
+  return out;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -60,6 +60,7 @@ import type {
   UserProfileSaveRequest,
 } from './types';
 import type { SkillManifest } from './skill-types';
+import type { McpServerEntry } from './mcp-types';
 
 export interface ElectronAPI {
   chat: {
@@ -226,6 +227,20 @@ export interface ElectronAPI {
      * This does not attest managed provenance, integrity, or lifecycle state.
      */
     listForMind: (mindId: string) => Promise<SkillManifest[]>;
+  };
+  mcp: {
+    /**
+     * Reads the configured MCP servers from a mind's `.mcp.json`. Defaults to
+     * the active mind when `mindId` is omitted. Returns [] when no mind is
+     * resolved or the file is absent/invalid.
+     */
+    getServers: (mindId?: string) => Promise<McpServerEntry[]>;
+    /**
+     * Replaces the MCP server set in a mind's `.mcp.json` and returns the
+     * persisted, normalized list. Non-managed per-server fields (tools,
+     * timeout, cwd) are preserved for servers kept on the same transport.
+     */
+    setServers: (servers: McpServerEntry[], mindId?: string) => Promise<McpServerEntry[]>;
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
+export * from './mcp-types';
 export * from './model-selection';
 export * from './feature-flags';
 export * from './voice-types';

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -172,6 +172,10 @@ export const IPC = {
   SKILLS: {
     LIST_FOR_MIND: 'skills:listForMind',
   },
+  MCP: {
+    GET_SERVERS: 'mcp:getServers',
+    SET_SERVERS: 'mcp:setServers',
+  },
 } as const;
 
 type IpcNamespace = typeof IPC;

--- a/packages/shared/src/mcp-types.ts
+++ b/packages/shared/src/mcp-types.ts
@@ -3,16 +3,45 @@
  *
  * These types describe the subset of a mind's `.mcp.json` that the Extensions
  * hub lets users manage: a name plus either a stdio launch command or an HTTP
- * endpoint. They are intentionally narrower than the SDK's `MCPServerConfig`
- * (see `mcpConfig.ts`) — the store (`mcpServerStore.ts`) normalizes on read and
- * preserves non-managed fields (`tools`, `timeout`, `cwd`) on write so editing a
- * server through the UI never silently drops its tool scoping.
+ * endpoint. Management reads reuse the runtime MCP schema (`mcpConfig.ts`) to
+ * decide which raw entries are surfaced as editable — entries the runtime would
+ * reject are preserved on disk unchanged rather than normalized into an
+ * executable config.
+ *
+ * The `preserved` bag carries runtime fields the UI does not edit but must
+ * round-trip verbatim (including across a rename) so a management edit never
+ * silently drops server configuration. `tools` is a security-sensitive
+ * allowlist: losing it widens a server to all tools, so it is always preserved.
  */
 
 export type McpServerTransport = 'stdio' | 'http';
 
-export interface McpStdioServerEntry {
+/** Exact runtime discriminator for a command-based (stdio-family) server. */
+export type McpStdioType = 'stdio' | 'local';
+/** Exact runtime discriminator for a URL-based (http-family) server. */
+export type McpHttpType = 'http' | 'sse';
+
+/**
+ * Runtime server fields Chamber's Extensions UI does not edit but preserves
+ * verbatim on save. Carried with the entry so a rename keeps them (rather than
+ * dropping `tools` and widening the server to `['*']`).
+ */
+export interface McpPreservedServerFields {
+  /** Exact runtime type, e.g. `sse` vs `http`, preserved through serialization. */
+  type?: McpStdioType | McpHttpType;
+  /** Tool allowlist. Absence means the runtime defaults to all tools (`['*']`). */
+  tools?: string[];
+  timeout?: number;
+  /** stdio-only working directory. */
+  cwd?: string;
+}
+
+interface McpServerEntryBase {
   name: string;
+  preserved?: McpPreservedServerFields;
+}
+
+export interface McpStdioServerEntry extends McpServerEntryBase {
   transport: 'stdio';
   /** Executable to launch, e.g. `npx`. */
   command: string;
@@ -22,8 +51,7 @@ export interface McpStdioServerEntry {
   env: Record<string, string>;
 }
 
-export interface McpHttpServerEntry {
-  name: string;
+export interface McpHttpServerEntry extends McpServerEntryBase {
   transport: 'http';
   /** Remote MCP endpoint URL. */
   url: string;

--- a/packages/shared/src/mcp-types.ts
+++ b/packages/shared/src/mcp-types.ts
@@ -1,0 +1,38 @@
+/**
+ * Renderer-facing MCP server configuration model.
+ *
+ * These types describe the subset of a mind's `.mcp.json` that the Extensions
+ * hub lets users manage: a name plus either a stdio launch command or an HTTP
+ * endpoint. They are intentionally narrower than the SDK's `MCPServerConfig`
+ * (see `mcpConfig.ts`) — the store (`mcpServerStore.ts`) normalizes on read and
+ * preserves non-managed fields (`tools`, `timeout`, `cwd`) on write so editing a
+ * server through the UI never silently drops its tool scoping.
+ */
+
+export type McpServerTransport = 'stdio' | 'http';
+
+export interface McpStdioServerEntry {
+  name: string;
+  transport: 'stdio';
+  /** Executable to launch, e.g. `npx`. */
+  command: string;
+  /** Arguments passed to the command. */
+  args: string[];
+  /** Environment variables for the spawned process. */
+  env: Record<string, string>;
+}
+
+export interface McpHttpServerEntry {
+  name: string;
+  transport: 'http';
+  /** Remote MCP endpoint URL. */
+  url: string;
+  /** Extra request headers (e.g. Authorization). */
+  headers: Record<string, string>;
+}
+
+/**
+ * A single configured MCP server as surfaced to the renderer. The `transport`
+ * discriminant selects the stdio or http shape.
+ */
+export type McpServerEntry = McpStdioServerEntry | McpHttpServerEntry;


### PR DESCRIPTION
﻿## Summary

Adds a discoverable **Extensions** hub to the Chamber desktop app: one activity-bar view with four tabs that surface Chamber's existing extensibility, plus a new, safe management surface for a mind's `.mcp.json`. This is the S5 UX slice; it wires existing services rather than inventing new engines.

## Notable changes

- **MCP servers (full CRUD).** New `mcpServerStore` (`readMcpServers`/`writeMcpServers`) round-trips `.mcp.json`. It reuses the runtime MCP schema (`mcpServerSchema`, now exported from `mcpConfig.ts`) to classify entries, so an entry the runtime would reject is preserved on disk verbatim and never normalized into an executable config. New zod-validated `mcp:getServers` / `mcp:setServers` IPC, preload, and `ElectronAPI` methods. `McpServersTab` adds/edits/removes stdio (command/args/env) and http (url/headers) servers.
- **Tools.** `ToolsTab` lists the marketplace catalog with installed state and installs/uninstalls via the existing `ToolsService` IPC (no reimplementation).
- **Skills / Lens views (read-only).** `SkillsTab` lists per active mind via the existing skills IPC; `LensViewsTab` lists discovered views from the store.
- **Navigation.** New Blocks icon in `ActivityBar` and an `extensions` branch in `ViewRouter`. Built-in route ids (including `extensions`) are reserved so a discovered Lens view cannot shadow or duplicate them.

## Safety hardening (principal review blockers)

- Reuse the runtime schema for management reads; invalid/unsupported raw entries are preserved verbatim, never upgraded into runnable configs.
- Preserve non-UI fields (`type`, `tools`, `timeout`, `cwd`) with each entry so a **rename keeps the `tools` allowlist** (no widening to `['*']`) and an **`sse` server keeps its type** instead of being rewritten as `http`.
- Renderer guards stale MCP loads with a request token + loaded-mind id, and guards the write-result apply, so a slow load/save cannot overwrite another mind's `.mcp.json`.
- Refuse to overwrite an unparseable `.mcp.json` (no whole-file clobber); reject a managed name colliding with a preserved invalid entry; validate serialized output against the runtime schema before writing.

## Tests

- Colocated Vitest for the store (schema parity, invalid-entry preservation, rename/`sse` preservation, unreadable-file refusal, collision, serialized-output validation), the mcp IPC adapter, the form utils, each renderer tab, the stale-load and write-apply race guards, and reserved-route filtering.
- `npm run lint` clean (tsc + eslint + dependency-cruiser + yaml + md). `npm test`: 2279 passed, 2 skipped. `npm run smoke:web`: passed.
- Security review: no vulnerabilities. Uncle Bob review: findings addressed in-branch.

## Caveats

- One unrelated test, `MindProfileService > rejects symlinked profile files`, fails locally with a Windows `EPERM` on `fs.symlinkSync` (creating a symlink requires elevation). It fails identically on `master` and is environmental, not caused by this change.
- Skills and Lens tabs are read-only by design (their existing IPC is read-only; no cheap persistent enable/disable exists for discovered views).

---

## Upstream issue linkage

No open exact upstream issue found. Related prior art: #41 and #116 are closed; this PR introduces the new Extensions hub surface.

## Source branch

Fork PR: https://github.com/patschmittdev/chamber/pull/4
Head: `patschmittdev:patschmittdev-feat-extensions-hub`
