### PR TITLE
feat(chat): add message actions (regenerate, edit, delete, copy as markdown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Add theme-aware update chrome** — Adds a dismissible ready-to-install banner and update-status indicator with accessible light and dark theme colors.
 - **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 - **Add insiders-gated local voice dictation** — Adds local Foundry/Nemotron dictation with a dedicated Settings page, chat mic and push-to-talk controls, explicit runtime capability gating, and insiders-only prepared runtime packaging. (#385) (#385)
+- **Add chat message actions** — Adds hover-revealed message actions to single-agent chat: regenerate the newest assistant turn, edit and resubmit a user turn, delete from a turn onward (Delete from here), and copy as raw markdown alongside plain text. Edits and deletes truncate persisted SDK session history so they survive reload; edit and regenerate are disabled for turns containing images, and the actions are hidden where history mutation is unsupported (browser mode).
 
 ### Refactor
 

--- a/apps/desktop/src/main/ipc/chat.ts
+++ b/apps/desktop/src/main/ipc/chat.ts
@@ -65,6 +65,28 @@ export function setupChatIPC(chatService: ChatService, mindManager: MindManager)
     return chatService.newConversation(mindId);
   });
 
+  ipcMain.handle(IPC.CHAT.DELETE_MESSAGE, async (_event, mindId: string, eventId: string) => {
+    return chatService.deleteMessage(mindId, eventId);
+  });
+
+  ipcMain.handle(IPC.CHAT.EDIT_MESSAGE, async (event, mindId: string, eventId: string, prompt: string, messageId: string, model?: string) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win) return;
+    const emit = (evt: ChatEvent) => sendChatEvent(win, mindId, messageId, evt);
+    await chatService.editMessage(mindId, eventId, prompt, messageId, emit, model);
+  });
+
+  ipcMain.handle(IPC.CHAT.REGENERATE, async (event, mindId: string, messageId: string, model?: string) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win) return;
+    const emit = (evt: ChatEvent) => sendChatEvent(win, mindId, messageId, evt);
+    await chatService.regenerate(mindId, messageId, emit, model);
+  });
+
+  ipcMain.handle(IPC.CHAT.GET_CONVERSATION_EVENTS, async (_event, mindId: string) => {
+    return chatService.getConversationEvents(mindId);
+  });
+
   ipcMain.handle(IPC.CHAT.GET_EVENT_SEQUENCE, () => chatEventSequence);
 
   ipcMain.handle(IPC.CHAT.REPLAY_EVENTS, (_event, afterSequence: number) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -16,6 +16,14 @@ const electronAPI: ElectronAPI = {
     getEventSequence: () => ipcRenderer.invoke(IPC.CHAT.GET_EVENT_SEQUENCE),
     replayEvents: (afterSequence) => ipcRenderer.invoke(IPC.CHAT.REPLAY_EVENTS, afterSequence),
     onEvent: (callback) => createIpcListener(ipcRenderer, IPC.CHAT.EVENT, callback),
+    deleteMessage: (mindId, eventId) =>
+      ipcRenderer.invoke(IPC.CHAT.DELETE_MESSAGE, mindId, eventId),
+    editMessage: (mindId, eventId, prompt, messageId, model) =>
+      ipcRenderer.invoke(IPC.CHAT.EDIT_MESSAGE, mindId, eventId, prompt, messageId, model),
+    regenerate: (mindId, messageId, model) =>
+      ipcRenderer.invoke(IPC.CHAT.REGENERATE, mindId, messageId, model),
+    getConversationEvents: (mindId) =>
+      ipcRenderer.invoke(IPC.CHAT.GET_CONVERSATION_EVENTS, mindId),
   },
   conversationHistory: {
     list: (mindId) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.LIST, mindId),

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -149,6 +149,14 @@ export function installBrowserApi(): void {
           chatEventHandlers.delete(callback);
         };
       },
+      // Message actions (edit/delete/regenerate) are wired for the desktop
+      // (Electron IPC) surface. Browser mode has no server route for history
+      // mutation yet, so these stay unavailable; the reconcile read is a safe
+      // no-op so it never throws after a turn completes.
+      deleteMessage: async () => unavailable('deleting messages'),
+      editMessage: async () => unavailable('editing messages'),
+      regenerate: async () => unavailable('regenerating messages'),
+      getConversationEvents: async () => [],
     },
     conversationHistory: {
       list: async () => [],

--- a/apps/web/src/renderer/components/chat/MessageActions.test.tsx
+++ b/apps/web/src/renderer/components/chat/MessageActions.test.tsx
@@ -1,0 +1,120 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ChatMessage } from '@chamber/shared/types';
+import { MessageActions } from './MessageActions';
+
+function assistantMsg(overrides?: Partial<ChatMessage>): ChatMessage {
+  return { id: 'a1', role: 'assistant', blocks: [{ type: 'text', content: '# Title\n\nBody' }], timestamp: 2, eventId: 'evt-a1', ...overrides };
+}
+
+function button(name: string): HTMLButtonElement {
+  return screen.getByRole('button', { name }) as HTMLButtonElement;
+}
+
+function queryButton(name: string): HTMLButtonElement | null {
+  return screen.queryByRole('button', { name }) as HTMLButtonElement | null;
+}
+
+describe('MessageActions', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  });
+
+  it('copies plain text and raw markdown from distinct buttons', () => {
+    render(<MessageActions message={assistantMsg()} isStreaming={false} />);
+
+    fireEvent.click(button('Copy message'));
+    expect(writeText).toHaveBeenCalledWith('Title\n\nBody');
+
+    fireEvent.click(button('Copy as markdown'));
+    expect(writeText).toHaveBeenCalledWith('# Title\n\nBody');
+  });
+
+  it('hides mutating actions when the parent supplies none (e.g. browser mode)', () => {
+    render(<MessageActions message={assistantMsg()} isStreaming={false} />);
+
+    expect(queryButton('Regenerate response')).toBeNull();
+    expect(queryButton('Edit message')).toBeNull();
+    expect(queryButton('Delete this message and all following messages')).toBeNull();
+    expect(button('Copy message')).toBeTruthy();
+  });
+
+  it('runs Regenerate when enabled and disables it with a tooltip when a reason is given', () => {
+    const onRun = vi.fn();
+    const { rerender } = render(
+      <MessageActions message={assistantMsg()} isStreaming={false} regenerate={{ onRun }} />,
+    );
+
+    fireEvent.click(button('Regenerate response'));
+    expect(onRun).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MessageActions message={assistantMsg()} isStreaming={false} regenerate={{ onRun, disabledReason: 'no images yet' }} />,
+    );
+    const regen = button('Regenerate response');
+    expect(regen.disabled).toBe(true);
+    expect(regen.title).toBe('no images yet');
+    fireEvent.click(regen);
+    expect(onRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs Edit when enabled and disables it with a tooltip when a reason is given', () => {
+    const onRun = vi.fn();
+    const { rerender } = render(
+      <MessageActions message={assistantMsg()} isStreaming={false} edit={{ onRun }} />,
+    );
+
+    fireEvent.click(button('Edit message'));
+    expect(onRun).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MessageActions message={assistantMsg()} isStreaming={false} edit={{ onRun, disabledReason: 'has images' }} />,
+    );
+    const edit = button('Edit message');
+    expect(edit.disabled).toBe(true);
+    expect(edit.title).toBe('has images');
+  });
+
+  it('requires a confirmation before deleting and clarifies the range', () => {
+    const onDelete = vi.fn();
+    render(<MessageActions message={assistantMsg()} isStreaming={false} onDelete={onDelete} />);
+
+    fireEvent.click(button('Delete this message and all following messages'));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.getByText('Remove this and all later turns?')).toBeTruthy();
+
+    fireEvent.click(button('Confirm delete from here'));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a pending delete without invoking the handler', () => {
+    const onDelete = vi.fn();
+    render(<MessageActions message={assistantMsg()} isStreaming={false} onDelete={onDelete} />);
+
+    fireEvent.click(button('Delete this message and all following messages'));
+    fireEvent.click(button('Cancel delete'));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(button('Delete this message and all following messages')).toBeTruthy();
+  });
+
+  it('holds mutating actions while a turn is streaming but still allows copy', () => {
+    render(
+      <MessageActions
+        message={assistantMsg()}
+        isStreaming
+        regenerate={{ onRun: vi.fn() }}
+        edit={{ onRun: vi.fn() }}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(button('Regenerate response').disabled).toBe(true);
+    expect(button('Edit message').disabled).toBe(true);
+    expect(button('Delete this message and all following messages').disabled).toBe(true);
+    expect(button('Copy message').disabled).toBe(false);
+  });
+});

--- a/apps/web/src/renderer/components/chat/MessageActions.tsx
+++ b/apps/web/src/renderer/components/chat/MessageActions.tsx
@@ -1,29 +1,158 @@
-import { useCallback } from 'react';
-import { Check, Copy } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { Check, Copy, FileCode, Pencil, RefreshCw, Trash2, X, type LucideIcon } from 'lucide-react';
+import type { ChatMessage } from '@chamber/shared/types';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { toMarkdown, toPlainText } from './messageContent';
+
+interface MessageActionsProps {
+  message: ChatMessage;
+  /** True while a turn is streaming somewhere; mutating actions wait until it settles. */
+  isStreaming: boolean;
+  /** Regenerate the assistant response. Omit to hide (not the newest turn, or unsupported). */
+  regenerate?: RowAction;
+  /** Edit a user turn in place. Omit to hide (assistant turn, unsaved turn, or unsupported). */
+  edit?: RowAction;
+  /** Delete this turn and every turn after it. Omit to hide (unsaved turn or unsupported). */
+  onDelete?: () => void;
+}
 
 /**
- * Hover-revealed action row for a completed assistant turn. Mirrors the
- * M365/Anthropic pattern: actions stay out of the way until the row is
- * hovered (or the button is focused for keyboard users), then offer a quick
- * copy of the message's plain-text content. Shared by single-agent chat and
- * the chatroom transcript.
+ * A mutating row action. Presence of the object means the action is available
+ * for this row; `disabledReason`, when set, renders the control disabled and
+ * surfaces the reason as a tooltip (e.g. turns with images cannot be replayed).
+ * Omitting the action entirely hides it — used for unsupported hosts (browser
+ * mode) and turns not yet persisted to conversation history.
  */
-export function MessageActions({ content }: { content: string }) {
-  const { copied, copy } = useCopyToClipboard();
-  const handleCopy = useCallback(() => copy(content), [copy, content]);
+export interface RowAction {
+  onRun: () => void;
+  disabledReason?: string;
+}
+
+/**
+ * Hover-revealed action row for a completed message. Mirrors the
+ * M365/Anthropic pattern: actions stay out of the way until the row is hovered
+ * (or a control is focused for keyboard users). Copy and Copy as markdown are
+ * always available; the mutating actions (regenerate, edit, delete) are passed
+ * in by the parent only when the host and persisted history support them, so
+ * this component never has to know about capabilities itself.
+ */
+export function MessageActions({ message, isStreaming, regenerate, edit, onDelete }: MessageActionsProps) {
+  const plain = useCopyToClipboard();
+  const markdown = useCopyToClipboard();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const handleCopyPlain = useCallback(() => plain.copy(toPlainText(message)), [plain, message]);
+  const handleCopyMarkdown = useCallback(() => markdown.copy(toMarkdown(message)), [markdown, message]);
+  const handleConfirmDelete = useCallback(() => {
+    setConfirmingDelete(false);
+    onDelete?.();
+  }, [onDelete]);
 
   return (
-    <div className="mt-1.5 flex items-center opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-      <button
-        type="button"
-        onClick={handleCopy}
-        aria-label={copied ? 'Copied' : 'Copy message'}
-        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        {copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
-        {copied ? 'Copied' : 'Copy'}
-      </button>
+    <div className="mt-1.5 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+      <ActionButton
+        onClick={handleCopyPlain}
+        icon={plain.copied ? Check : Copy}
+        label={plain.copied ? 'Copied' : 'Copy'}
+        ariaLabel={plain.copied ? 'Copied' : 'Copy message'}
+      />
+      <ActionButton
+        onClick={handleCopyMarkdown}
+        icon={markdown.copied ? Check : FileCode}
+        label={markdown.copied ? 'Copied' : 'Markdown'}
+        ariaLabel={markdown.copied ? 'Copied as markdown' : 'Copy as markdown'}
+      />
+
+      {regenerate && (
+        <ActionButton
+          onClick={regenerate.onRun}
+          icon={RefreshCw}
+          label="Regenerate"
+          ariaLabel="Regenerate response"
+          disabled={isStreaming || Boolean(regenerate.disabledReason)}
+          title={regenerate.disabledReason}
+        />
+      )}
+
+      {edit && (
+        <ActionButton
+          onClick={edit.onRun}
+          icon={Pencil}
+          label="Edit"
+          ariaLabel="Edit message"
+          disabled={isStreaming || Boolean(edit.disabledReason)}
+          title={edit.disabledReason}
+        />
+      )}
+
+      {onDelete && (
+        confirmingDelete ? (
+          <span className="flex items-center gap-1.5">
+            <span className="text-[11px] text-muted-foreground">Remove this and all later turns?</span>
+            <ActionButton
+              onClick={handleConfirmDelete}
+              icon={Trash2}
+              label="Delete"
+              ariaLabel="Confirm delete from here"
+              disabled={isStreaming}
+              variant="danger"
+            />
+            <ActionButton
+              onClick={() => setConfirmingDelete(false)}
+              icon={X}
+              label="Cancel"
+              ariaLabel="Cancel delete"
+            />
+          </span>
+        ) : (
+          <ActionButton
+            onClick={() => setConfirmingDelete(true)}
+            icon={Trash2}
+            label="Delete from here"
+            ariaLabel="Delete this message and all following messages"
+            title="Removes this message and every turn after it"
+            disabled={isStreaming}
+          />
+        )
+      )}
     </div>
   );
 }
+
+function ActionButton({
+  onClick,
+  icon: Icon,
+  label,
+  ariaLabel,
+  disabled,
+  title,
+  variant,
+}: {
+  onClick: () => void;
+  icon: LucideIcon;
+  label: string;
+  ariaLabel: string;
+  disabled?: boolean;
+  title?: string;
+  variant?: 'danger';
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      title={title}
+      className={
+        'flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-40 '
+        + (variant === 'danger'
+          ? 'text-destructive hover:bg-destructive/10'
+          : 'text-muted-foreground hover:bg-accent hover:text-foreground')
+      }
+    >
+      <Icon size={12} aria-hidden />
+      {label}
+    </button>
+  );
+}
+

--- a/apps/web/src/renderer/components/chat/MessageList.test.tsx
+++ b/apps/web/src/renderer/components/chat/MessageList.test.tsx
@@ -268,4 +268,157 @@ describe('MessageList', () => {
     expect(scroller.scrollTop).toBe(2000);
     expect(screen.queryByLabelText('Jump to latest message')).toBeNull();
   });
+
+  describe('message action gating', () => {
+    function query(name: RegExp | string) {
+      return screen.queryByRole('button', { name }) as HTMLButtonElement | null;
+    }
+
+    it('disables Edit for a saved user turn that mixes text and an image', () => {
+      renderMessages([
+        {
+          id: 'u-mixed',
+          role: 'user',
+          eventId: 'evt-mixed',
+          blocks: [
+            { type: 'image', name: 'shot.png', mimeType: 'image/png', dataUrl: 'data:image/png;base64,aaa' },
+            { type: 'text', content: 'What is this?' },
+          ],
+          timestamp: 1000,
+        },
+      ]);
+
+      const edit = query('Edit message');
+      expect(edit).not.toBeNull();
+      expect(edit?.disabled).toBe(true);
+      expect(edit?.title).toMatch(/images/i);
+    });
+
+    it('disables Edit for a saved image-only user turn', () => {
+      renderMessages([
+        {
+          id: 'u-image',
+          role: 'user',
+          eventId: 'evt-image',
+          blocks: [{ type: 'image', name: 'only.png', mimeType: 'image/png', dataUrl: 'data:image/png;base64,bbb' }],
+          timestamp: 1000,
+        },
+      ]);
+
+      const edit = query('Edit message');
+      expect(edit).not.toBeNull();
+      expect(edit?.disabled).toBe(true);
+    });
+
+    it('disables Regenerate on the newest reply when the preceding user turn has images', () => {
+      renderMessages([
+        {
+          id: 'u-image',
+          role: 'user',
+          eventId: 'evt-image',
+          blocks: [{ type: 'image', name: 'only.png', mimeType: 'image/png', dataUrl: 'data:image/png;base64,ccc' }],
+          timestamp: 1000,
+        },
+        {
+          id: 'a-reply',
+          role: 'assistant',
+          eventId: 'evt-reply',
+          blocks: [{ type: 'text', content: 'That is a cat.' }],
+          timestamp: 1001,
+        },
+      ]);
+
+      const regen = query('Regenerate response');
+      expect(regen).not.toBeNull();
+      expect(regen?.disabled).toBe(true);
+      expect(regen?.title).toMatch(/images/i);
+    });
+
+    it('hides Edit, Delete, and Regenerate for turns not yet persisted (no event id, e.g. browser mode)', () => {
+      renderMessages([
+        {
+          id: 'u-unsaved',
+          role: 'user',
+          blocks: [{ type: 'text', content: 'just typed' }],
+          timestamp: 1000,
+        },
+        {
+          id: 'a-unsaved',
+          role: 'assistant',
+          blocks: [{ type: 'text', content: 'a reply' }],
+          timestamp: 1001,
+        },
+      ]);
+
+      expect(query('Edit message')).toBeNull();
+      expect(query('Delete this message and all following messages')).toBeNull();
+      expect(query('Regenerate response')).toBeNull();
+      // Copy stays available regardless of persistence.
+      expect(screen.getAllByRole('button', { name: 'Copy message' }).length).toBeGreaterThan(0);
+    });
+
+    it('enables Edit and Delete for a saved text-only user turn', () => {
+      renderMessages([
+        {
+          id: 'u-text',
+          role: 'user',
+          eventId: 'evt-text',
+          blocks: [{ type: 'text', content: 'plain question' }],
+          timestamp: 1000,
+        },
+      ]);
+
+      const edit = query('Edit message');
+      const del = query('Delete this message and all following messages');
+      expect(edit?.disabled).toBe(false);
+      expect(del?.disabled).toBe(false);
+    });
+
+    it('warns that editing an earlier turn removes the turns after it', () => {
+      renderMessages([
+        {
+          id: 'u-first',
+          role: 'user',
+          eventId: 'evt-u1',
+          blocks: [{ type: 'text', content: 'first question' }],
+          timestamp: 1000,
+        },
+        {
+          id: 'a-first',
+          role: 'assistant',
+          eventId: 'evt-a1',
+          blocks: [{ type: 'text', content: 'first answer' }],
+          timestamp: 1001,
+        },
+        {
+          id: 'u-second',
+          role: 'user',
+          eventId: 'evt-u2',
+          blocks: [{ type: 'text', content: 'second question' }],
+          timestamp: 1002,
+        },
+      ]);
+
+      // Enter the editor for the first (earliest) user turn — two turns follow it.
+      const edits = screen.getAllByRole('button', { name: 'Edit message' });
+      fireEvent.click(edits[0]);
+
+      expect(screen.getByText('Resubmitting removes the 2 turns after this one.')).toBeTruthy();
+    });
+
+    it('does not warn when editing the most recent user turn', () => {
+      renderMessages([
+        {
+          id: 'u-only',
+          role: 'user',
+          eventId: 'evt-only',
+          blocks: [{ type: 'text', content: 'only question' }],
+          timestamp: 1000,
+        },
+      ]);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit message' }));
+      expect(screen.queryByText(/Resubmitting removes/)).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/renderer/components/chat/MessageList.tsx
+++ b/apps/web/src/renderer/components/chat/MessageList.tsx
@@ -1,8 +1,11 @@
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowDown, ChevronDown, ChevronRight, Sparkles } from 'lucide-react';
-import { MessageActions } from './MessageActions';
+import { MessageActions, type RowAction } from './MessageActions';
 import { useAppState, getPlainContent } from '../../lib/store';
+import { useChatStreaming } from '../../hooks/useChatStreaming';
+import { useConversationActions } from '../../hooks/useConversationActions';
 import { StreamingMessage } from './StreamingMessage';
+import { hasImageBlocks } from './messageContent';
 import { cn, formatTime, parseSkillContextInjection } from '../../lib/utils';
 import type { ChatMessage, MindContext } from '@chamber/shared/types';
 import type { AgentProfileSummary } from '../../lib/store/state';
@@ -10,6 +13,9 @@ import { AgentAvatar } from '../profile/AgentAvatar';
 import { useMindProfiles } from '../../hooks/useMindProfiles';
 import { useUserProfile } from '../../hooks/useUserProfile';
 import { agentColor, readableTextColor } from './agentColors';
+
+const EDIT_IMAGE_REASON = "Editing isn't available for messages with images yet";
+const REGENERATE_IMAGE_REASON = "Regenerating isn't available for turns with images yet";
 
 function displayName(name: string, fallback: string): string {
   const trimmed = name.trim();
@@ -63,6 +69,17 @@ export function MessageList() {
   const profileByMindId = useMindProfiles(minds);
   const userProfile = useUserProfile();
   const messages = activeMindId ? (messagesByMind[activeMindId] ?? []) : [];
+  const { regenerate, editAndResubmit, isStreaming } = useChatStreaming();
+  const { deleteMessage } = useConversationActions();
+  // Regenerate re-runs the most recent user turn, so its availability depends on
+  // that turn: it must be persisted (has an event id — false in browser mode,
+  // which never reconciles ids) and must not contain images (which cannot be
+  // replayed yet).
+  const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user');
+  const regenerateSupported = Boolean(lastUserMessage?.eventId);
+  const regenerateDisabledReason = lastUserMessage && hasImageBlocks(lastUserMessage)
+    ? REGENERATE_IMAGE_REASON
+    : undefined;
   const activeMind = minds.find(m => m.mindId === activeMindId);
   const activeProfile = activeMind ? profileByMindId[activeMind.mindId] : undefined;
   const agentName = activeMind ? profileName(activeProfile, activeMind.identity.name) : 'Agent';
@@ -123,13 +140,14 @@ export function MessageList() {
         className="flex-1 overflow-y-auto px-4 py-4"
       >
         <div className="max-w-3xl mx-auto space-y-6">
-          {messages.map((message) => {
+          {messages.map((message, index) => {
             const presenter = messagePresenter(message, agentName, minds, profileByMindId);
             const avatarDataUrl = message.role === 'assistant'
               ? activeProfile?.avatarDataUrl
               : presenter.isAgentSender
                 ? presenter.avatarDataUrl
                 : userProfile?.avatarDataUrl;
+            const isLastMessage = index === messages.length - 1;
 
             return (
               <MessageRow
@@ -137,8 +155,15 @@ export function MessageList() {
                 message={message}
                 presenter={presenter}
                 avatarDataUrl={avatarDataUrl}
-                animate={message.id === messages[messages.length - 1]?.id}
-                launch={message.id === messages[messages.length - 1]?.id && message.role === 'user'}
+                animate={isLastMessage}
+                launch={isLastMessage && message.role === 'user'}
+                isStreaming={isStreaming}
+                onRegenerate={regenerate}
+                onDelete={deleteMessage}
+                onEditSubmit={editAndResubmit}
+                regenerateSupported={isLastMessage && message.role === 'assistant' && regenerateSupported}
+                regenerateDisabledReason={regenerateDisabledReason}
+                followingTurnCount={messages.length - 1 - index}
               />
             );
           })}
@@ -177,13 +202,60 @@ interface MessageRowProps {
   // The newest row when it is the user's just-sent message: plays the launch
   // entrance instead of the generic fade.
   launch: boolean;
+  // A turn is streaming somewhere — mutating actions are held until it settles.
+  isStreaming: boolean;
+  onRegenerate: () => void;
+  onDelete: (message: ChatMessage) => void;
+  onEditSubmit: (message: ChatMessage, text: string) => void;
+  // Whether this row may offer Regenerate (newest assistant turn whose target
+  // user turn is persisted). Computed by the parent so the memoized row keeps
+  // receiving primitives.
+  regenerateSupported: boolean;
+  regenerateDisabledReason: string | undefined;
+  // Number of turns after this one. Editing a user turn resubmits it and drops
+  // everything after, so the editor warns when this is non-zero.
+  followingTurnCount: number;
 }
 
 // Memoized so an inbound message at the end of a long transcript doesn't force
 // every prior message subtree (markdown + rehype-highlight + work-group cells)
 // to re-render. content-visibility hint lets the browser skip layout/paint
 // work for off-screen rows.
-const MessageRow = memo(function MessageRow({ message, presenter, avatarDataUrl, animate, launch }: MessageRowProps) {
+const MessageRow = memo(function MessageRow({
+  message,
+  presenter,
+  avatarDataUrl,
+  animate,
+  launch,
+  isStreaming,
+  onRegenerate,
+  onDelete,
+  onEditSubmit,
+  regenerateSupported,
+  regenerateDisabledReason,
+  followingTurnCount,
+}: MessageRowProps) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  // A turn can be mutated only once it is persisted (has a backing event id).
+  // Browser mode never reconciles ids, so these actions stay hidden there; on
+  // desktop they appear a moment after the turn settles.
+  const canMutate = Boolean(message.eventId);
+  const handleDelete = useCallback(() => onDelete(message), [onDelete, message]);
+  const deleteAction = canMutate ? handleDelete : undefined;
+
+  const regenerate = useMemo<RowAction | undefined>(
+    () => regenerateSupported ? { onRun: onRegenerate, disabledReason: regenerateDisabledReason } : undefined,
+    [regenerateSupported, onRegenerate, regenerateDisabledReason],
+  );
+
+  const edit = useMemo<RowAction | undefined>(
+    () => canMutate
+      ? { onRun: () => setIsEditing(true), disabledReason: hasImageBlocks(message) ? EDIT_IMAGE_REASON : undefined }
+      : undefined,
+    [canMutate, message],
+  );
+
   return (
     <div
       className={cn('group flex gap-3', launch ? 'chamber-launch' : animate && 'chamber-fade-in')}
@@ -219,9 +291,25 @@ const MessageRow = memo(function MessageRow({ message, presenter, avatarDataUrl,
               isStreaming={message.isStreaming}
             />
             {!message.isStreaming && getPlainContent(message).trim() && (
-              <MessageActions content={getPlainContent(message)} />
+              <MessageActions
+                message={message}
+                isStreaming={isStreaming}
+                regenerate={regenerate}
+                onDelete={deleteAction}
+              />
             )}
           </>
+        ) : isEditing ? (
+          <MessageEditor
+            initialText={getPlainContent(message)}
+            disabled={isStreaming}
+            followingTurnCount={followingTurnCount}
+            onCancel={() => setIsEditing(false)}
+            onSubmit={(text) => {
+              setIsEditing(false);
+              onEditSubmit(message, text);
+            }}
+          />
         ) : (
           <div className="space-y-2">
             {message.blocks
@@ -247,12 +335,88 @@ const MessageRow = memo(function MessageRow({ message, presenter, avatarDataUrl,
                 </p>
               );
             })()}
+            {!message.isStreaming && (
+              <MessageActions
+                message={message}
+                isStreaming={isStreaming}
+                edit={edit}
+                onDelete={deleteAction}
+              />
+            )}
           </div>
         )}
       </div>
     </div>
   );
 });
+
+/**
+ * Inline editor for a user turn. Submitting resends the edited prompt, which
+ * replaces this turn and everything after it; Escape or Cancel discards. Cmd/Ctrl
+ * plus Enter submits for keyboard users. When later turns exist, it warns that
+ * they will be removed so the resubmit is never a silent multi-turn delete.
+ */
+function MessageEditor({
+  initialText,
+  disabled,
+  followingTurnCount,
+  onSubmit,
+  onCancel,
+}: {
+  initialText: string;
+  disabled: boolean;
+  followingTurnCount: number;
+  onSubmit: (text: string) => void;
+  onCancel: () => void;
+}) {
+  const [text, setText] = useState(initialText);
+  const trimmed = text.trim();
+  const rows = Math.min(10, Math.max(2, text.split('\n').length));
+
+  return (
+    <div className="space-y-2">
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onCancel();
+          } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && trimmed) {
+            e.preventDefault();
+            onSubmit(trimmed);
+          }
+        }}
+        rows={rows}
+        autoFocus
+        aria-label="Edit message"
+        className="w-full resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+      {followingTurnCount > 0 && (
+        <p className="text-[11px] text-muted-foreground" role="note">
+          Resubmitting removes the {followingTurnCount === 1 ? 'turn' : `${followingTurnCount} turns`} after this one.
+        </p>
+      )}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => trimmed && onSubmit(trimmed)}
+          disabled={disabled || !trimmed}
+          className="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Save and submit
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
 
 /**
  * Collapsed marker for a Copilot SDK skill-context injection. The SDK injects

--- a/apps/web/src/renderer/components/chat/messageContent.test.ts
+++ b/apps/web/src/renderer/components/chat/messageContent.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import type { ChatMessage } from '@chamber/shared/types';
+import { hasImageBlocks, stripMarkdown, toMarkdown, toPlainText } from './messageContent';
+
+function assistant(content: string): ChatMessage {
+  return { id: 'a1', role: 'assistant', blocks: [{ type: 'text', content }], timestamp: 1 };
+}
+
+describe('messageContent', () => {
+  describe('toMarkdown', () => {
+    it('returns the raw markdown source of the text blocks', () => {
+      const message = assistant('# Title\n\nSome **bold** text with `code`.');
+      expect(toMarkdown(message)).toBe('# Title\n\nSome **bold** text with `code`.');
+    });
+
+    it('joins multiple text blocks and ignores non-text blocks', () => {
+      const message: ChatMessage = {
+        id: 'a1',
+        role: 'assistant',
+        timestamp: 1,
+        blocks: [
+          { type: 'text', content: 'First. ' },
+          { type: 'tool_call', toolCallId: 't1', toolName: 'grep', status: 'done' },
+          { type: 'text', content: 'Second.' },
+        ],
+      };
+      expect(toMarkdown(message)).toBe('First. Second.');
+    });
+  });
+
+  describe('toPlainText', () => {
+    it('strips markdown formatting to readable text', () => {
+      const message = assistant('# Heading\n\nSome **bold** and *italic* and `code` here.');
+      expect(toPlainText(message)).toBe('Heading\n\nSome bold and italic and code here.');
+    });
+
+    it('is distinct from the raw markdown copy', () => {
+      const message = assistant('See [the docs](https://example.com) for **details**.');
+      expect(toMarkdown(message)).toBe('See [the docs](https://example.com) for **details**.');
+      expect(toPlainText(message)).toBe('See the docs for details.');
+    });
+  });
+
+  describe('stripMarkdown', () => {
+    it('removes list markers while keeping item text', () => {
+      expect(stripMarkdown('- one\n- two\n1. three')).toBe('one\ntwo\nthree');
+    });
+
+    it('unwraps fenced code blocks and inline code', () => {
+      expect(stripMarkdown('```ts\nconst x = 1;\n```')).toBe('const x = 1;');
+      expect(stripMarkdown('use `npm test` now')).toBe('use npm test now');
+    });
+
+    it('drops blockquote markers and horizontal rules', () => {
+      expect(stripMarkdown('> quoted line\n\n---\n\ntail')).toBe('quoted line\n\ntail');
+    });
+
+    it('reduces images to their alt text', () => {
+      expect(stripMarkdown('![diagram](data:image/png;base64,zzz)')).toBe('diagram');
+    });
+  });
+
+  describe('hasImageBlocks', () => {
+    it('is false for a text-only message', () => {
+      expect(hasImageBlocks(assistant('just text'))).toBe(false);
+    });
+
+    it('is true when an image block is present alongside text', () => {
+      const message: ChatMessage = {
+        id: 'u1',
+        role: 'user',
+        timestamp: 1,
+        blocks: [
+          { type: 'image', name: 'shot.png', mimeType: 'image/png', dataUrl: 'data:image/png;base64,aaa' },
+          { type: 'text', content: 'what is this?' },
+        ],
+      };
+      expect(hasImageBlocks(message)).toBe(true);
+    });
+
+    it('is true for an image-only message', () => {
+      const message: ChatMessage = {
+        id: 'u1',
+        role: 'user',
+        timestamp: 1,
+        blocks: [{ type: 'image', name: 'only.png', mimeType: 'image/png', dataUrl: 'data:image/png;base64,bbb' }],
+      };
+      expect(hasImageBlocks(message)).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/renderer/components/chat/messageContent.ts
+++ b/apps/web/src/renderer/components/chat/messageContent.ts
@@ -1,0 +1,62 @@
+import type { ChatMessage, ContentBlock } from '@chamber/shared/types';
+
+/**
+ * Copy helpers for a chat message. Two distinct clipboard payloads:
+ * `toMarkdown` returns the raw markdown source (verbatim text blocks), while
+ * `toPlainText` returns the same content with markdown formatting stripped for
+ * pasting into plain-text surfaces.
+ */
+
+function textBlocks(message: ChatMessage): string[] {
+  return message.blocks
+    .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+    .map((block) => block.content);
+}
+
+/**
+ * True when a message carries image content. Edit and regenerate resend only
+ * the text prompt, so turns with images cannot be safely replayed yet; callers
+ * use this to disable those actions rather than silently drop the attachments.
+ */
+export function hasImageBlocks(message: ChatMessage): boolean {
+  return message.blocks.some((block) => block.type === 'image');
+}
+
+/** Raw markdown source of a message: its text blocks joined verbatim. */
+export function toMarkdown(message: ChatMessage): string {
+  return textBlocks(message).join('').trim();
+}
+
+/** Human-readable plain text: the message's markdown with formatting removed. */
+export function toPlainText(message: ChatMessage): string {
+  return stripMarkdown(toMarkdown(message));
+}
+
+/**
+ * Best-effort markdown-to-plaintext conversion covering the common constructs
+ * Chamber renders (headings, emphasis, code, links, images, lists, quotes,
+ * rules). Not a full parser; intended for clipboard readability, not fidelity.
+ */
+export function stripMarkdown(markdown: string): string {
+  const withoutFences = markdown.replace(/```[^\n]*\n?([\s\S]*?)```/g, (_match, code: string) => code);
+  const lines = withoutFences.split('\n').map((line) => stripBlockPrefixes(line));
+  return stripInline(lines.join('\n')).replace(/\n{3,}/g, '\n\n').trim();
+}
+
+function stripBlockPrefixes(line: string): string {
+  if (/^\s{0,3}([-*_])\s*(?:\1\s*){2,}$/.test(line)) return '';
+  return line
+    .replace(/^\s{0,3}#{1,6}\s+/, '')
+    .replace(/^\s{0,3}>\s?/, '')
+    .replace(/^(\s*)(?:[-*+]|\d+\.)\s+/, '$1');
+}
+
+function stripInline(text: string): string {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/(\*|_)(.*?)\1/g, '$2')
+    .replace(/~~(.*?)~~/g, '$1');
+}

--- a/apps/web/src/renderer/hooks/useAppSubscriptions.ts
+++ b/apps/web/src/renderer/hooks/useAppSubscriptions.ts
@@ -64,7 +64,7 @@ export function useAppSubscriptions() {
           }
         }
         for (const mindId of terminalMindIds) {
-          void refreshConversationHistory(mindId);
+          onTurnSettled(mindId);
         }
       } catch (err) {
         log.error('Failed to replay missed chat events:', err);
@@ -80,6 +80,25 @@ export function useAppSubscriptions() {
       } catch (err) {
         log.warn('Failed to refresh conversation history after chat event:', err);
       }
+    };
+
+    // After a turn settles, annotate live messages with their backing SDK event
+    // ids so message actions (edit/delete) can address the persisted turn even
+    // before the conversation is reloaded.
+    const reconcileEventIds = async (mindId: string) => {
+      try {
+        const events = await window.electronAPI.chat.getConversationEvents(mindId);
+        if (!cancelled) {
+          dispatch({ type: 'RECONCILE_EVENT_IDS', payload: { mindId, events } });
+        }
+      } catch (err) {
+        log.warn('Failed to reconcile conversation event ids after chat event:', err);
+      }
+    };
+
+    const onTurnSettled = (mindId: string) => {
+      void refreshConversationHistory(mindId);
+      void reconcileEventIds(mindId);
     };
 
     void window.electronAPI.chat.getEventSequence()
@@ -99,7 +118,7 @@ export function useAppSubscriptions() {
       }
       dispatch({ type: 'CHAT_EVENT', payload: { mindId, messageId, event } });
       if (isTerminalChatEvent(event.type)) {
-        void refreshConversationHistory(mindId);
+        onTurnSettled(mindId);
       }
     });
 

--- a/apps/web/src/renderer/hooks/useChatStreaming.ts
+++ b/apps/web/src/renderer/hooks/useChatStreaming.ts
@@ -1,15 +1,40 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { useAppState, useAppDispatch } from '../lib/store';
+import { useCallback, useEffect } from 'react';
+import { useAppState, useAppDispatch, getPlainContent } from '../lib/store';
 import { generateId } from '../lib/utils';
-import type { ChatImageAttachment, ImageBlock } from '@chamber/shared/types';
+import type { ChatImageAttachment, ChatMessage, ImageBlock } from '@chamber/shared/types';
+import { hasImageBlocks } from '../components/chat/messageContent';
 import { Logger } from '../lib/logger';
 
 const log = Logger.create('useChatStreaming');
 
+// Tracks the in-flight assistant messageId per mind so Stop can target the
+// active turn. Module-scoped (not a per-hook ref) so a turn started from one
+// consumer (e.g. a message-row Regenerate) can still be stopped from another
+// (e.g. the composer's Stop button).
+const currentMessageIdByMind: Record<string, string> = {};
+
 export function useChatStreaming() {
-  const { activeMindId, isStreaming, selectedModel, streamingByMind } = useAppState();
+  const { activeMindId, isStreaming, selectedModel, streamingByMind, messagesByMind } = useAppState();
   const dispatch = useAppDispatch();
-  const currentMessageIdByMind = useRef<Record<string, string>>({});
+
+  const refreshConversationHistory = useCallback(async (mindId: string) => {
+    try {
+      const conversations = await window.electronAPI.conversationHistory.list(mindId);
+      dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId, conversations } });
+    } catch (error) {
+      log.warn('Failed to refresh conversation history:', error);
+    }
+  }, [dispatch]);
+
+  const beginAssistantTurn = useCallback((mindId: string): string => {
+    const assistantId = generateId();
+    currentMessageIdByMind[mindId] = assistantId;
+    dispatch({
+      type: 'ADD_ASSISTANT_MESSAGE',
+      payload: { id: assistantId, timestamp: Date.now() },
+    });
+    return assistantId;
+  }, [dispatch]);
 
   const sendMessage = useCallback(async (content: string, attachments?: ChatImageAttachment[]) => {
     const hasText = content.trim().length > 0;
@@ -23,42 +48,70 @@ export function useChatStreaming() {
       dataUrl: `data:${a.mimeType};base64,${a.data}`,
     }));
 
-    const userMessage = {
-      id: generateId(),
-      content: content.trim(),
-      timestamp: Date.now(),
-      images,
-    };
-    dispatch({ type: 'ADD_USER_MESSAGE', payload: userMessage });
-
-    const assistantId = generateId();
-    currentMessageIdByMind.current[activeMindId] = assistantId;
     dispatch({
-      type: 'ADD_ASSISTANT_MESSAGE',
-      payload: { id: assistantId, timestamp: Date.now() },
+      type: 'ADD_USER_MESSAGE',
+      payload: { id: generateId(), content: content.trim(), timestamp: Date.now(), images },
     });
 
     const mindId = activeMindId;
+    const assistantId = beginAssistantTurn(mindId);
     await window.electronAPI.chat.send(mindId, content.trim(), assistantId, selectedModel ?? undefined, attachments);
-    try {
-      const conversations = await window.electronAPI.conversationHistory.list(mindId);
-      dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId, conversations } });
-    } catch (error) {
-      log.warn('Failed to refresh conversation history after send:', error);
-    }
-  }, [activeMindId, isStreaming, selectedModel, dispatch]);
+    await refreshConversationHistory(mindId);
+  }, [activeMindId, isStreaming, selectedModel, dispatch, beginAssistantTurn, refreshConversationHistory]);
+
+  // Re-run the most recent user turn. The main process resolves and truncates
+  // the last user turn from persisted history, so the renderer only replaces
+  // the last exchange optimistically and streams a fresh response.
+  const regenerate = useCallback(async () => {
+    if (isStreaming || !activeMindId) return;
+    const messages = messagesByMind[activeMindId] ?? [];
+    const lastUser = [...messages].reverse().find((message) => message.role === 'user');
+    if (!lastUser) return;
+    // Images cannot be replayed yet (only the text prompt is resent), and an
+    // unsaved turn has no backing event id for the main process to truncate.
+    // The UI already hides Regenerate in these cases; guard here too.
+    if (!lastUser.eventId || hasImageBlocks(lastUser)) return;
+
+    const mindId = activeMindId;
+    const prompt = getPlainContent(lastUser);
+    dispatch({ type: 'TRUNCATE_AFTER', payload: { mindId, messageId: lastUser.id } });
+    dispatch({ type: 'ADD_USER_MESSAGE', payload: { id: generateId(), content: prompt, timestamp: Date.now() } });
+    const assistantId = beginAssistantTurn(mindId);
+    await window.electronAPI.chat.regenerate(mindId, assistantId, selectedModel ?? undefined);
+    await refreshConversationHistory(mindId);
+  }, [activeMindId, isStreaming, selectedModel, messagesByMind, dispatch, beginAssistantTurn, refreshConversationHistory]);
+
+  // Replace a user turn with edited text. Requires the turn's backing event id
+  // so the main process can truncate history back to it (dropping the old
+  // exchange) before streaming the new response.
+  const editAndResubmit = useCallback(async (message: ChatMessage, newText: string) => {
+    if (isStreaming || !activeMindId || message.role !== 'user' || !message.eventId) return;
+    // Images cannot be reconstructed and resent yet; refuse rather than silently
+    // dropping them (the UI disables Edit for these turns as well).
+    if (hasImageBlocks(message)) return;
+    const text = newText.trim();
+    if (!text) return;
+
+    const mindId = activeMindId;
+    const eventId = message.eventId;
+    dispatch({ type: 'TRUNCATE_AFTER', payload: { mindId, messageId: message.id } });
+    dispatch({ type: 'ADD_USER_MESSAGE', payload: { id: generateId(), content: text, timestamp: Date.now() } });
+    const assistantId = beginAssistantTurn(mindId);
+    await window.electronAPI.chat.editMessage(mindId, eventId, text, assistantId, selectedModel ?? undefined);
+    await refreshConversationHistory(mindId);
+  }, [activeMindId, isStreaming, selectedModel, dispatch, beginAssistantTurn, refreshConversationHistory]);
 
   const stopStreaming = useCallback(async () => {
-    if (activeMindId && currentMessageIdByMind.current[activeMindId]) {
-      await window.electronAPI.chat.stop(activeMindId, currentMessageIdByMind.current[activeMindId]);
+    if (activeMindId && currentMessageIdByMind[activeMindId]) {
+      await window.electronAPI.chat.stop(activeMindId, currentMessageIdByMind[activeMindId]);
     }
   }, [activeMindId]);
 
   useEffect(() => {
     if (activeMindId && !streamingByMind[activeMindId]) {
-      delete currentMessageIdByMind.current[activeMindId];
+      delete currentMessageIdByMind[activeMindId];
     }
   }, [activeMindId, streamingByMind]);
 
-  return { sendMessage, stopStreaming, isStreaming };
+  return { sendMessage, stopStreaming, regenerate, editAndResubmit, isStreaming };
 }

--- a/apps/web/src/renderer/hooks/useConversationActions.ts
+++ b/apps/web/src/renderer/hooks/useConversationActions.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useAppState, useAppDispatch } from '../lib/store';
+import type { ChatMessage } from '@chamber/shared/types';
+import { Logger } from '../lib/logger';
+
+const log = Logger.create('useConversationActions');
+
+/**
+ * Non-streaming conversation mutations invoked from message rows. Delete
+ * truncates persisted history back to the target turn (removing it and any
+ * later turns). It is backend-first: the main process performs (and persists)
+ * the truncation before the transcript is trimmed, so a failed delete leaves
+ * the visible conversation untouched instead of dropping turns the backend
+ * still holds.
+ */
+export function useConversationActions() {
+  const { activeMindId } = useAppState();
+  const dispatch = useAppDispatch();
+
+  const deleteMessage = useCallback(async (message: ChatMessage) => {
+    if (!activeMindId || !message.eventId) return;
+    const mindId = activeMindId;
+    try {
+      const conversations = await window.electronAPI.chat.deleteMessage(mindId, message.eventId);
+      dispatch({ type: 'TRUNCATE_AFTER', payload: { mindId, messageId: message.id } });
+      dispatch({ type: 'SET_CONVERSATION_HISTORY', payload: { mindId, conversations } });
+    } catch (error) {
+      log.error('Failed to delete message:', error);
+    }
+  }, [activeMindId, dispatch]);
+
+  return { deleteMessage };
+}

--- a/apps/web/src/renderer/lib/store/reducer.test.ts
+++ b/apps/web/src/renderer/lib/store/reducer.test.ts
@@ -362,6 +362,93 @@ describe('appReducer', () => {
     expect(state.isStreaming).toBe(false);
   });
 
+  describe('TRUNCATE_AFTER', () => {
+    const seeded: AppState = {
+      ...withActiveMind,
+      messagesByMind: {
+        [mindId]: [
+          makeMessage([makeTextBlock('u1')], { id: 'u1', role: 'user' }),
+          makeMessage([makeTextBlock('a1')], { id: 'a1', role: 'assistant' }),
+          makeMessage([makeTextBlock('u2')], { id: 'u2', role: 'user' }),
+          makeMessage([makeTextBlock('a2')], { id: 'a2', role: 'assistant' }),
+        ],
+      },
+    };
+
+    it('removes the target message and everything after it', () => {
+      const state = appReducer(seeded, { type: 'TRUNCATE_AFTER', payload: { mindId, messageId: 'u2' } });
+      expect(getMsgs(state).map((m) => m.id)).toEqual(['u1', 'a1']);
+    });
+
+    it('returns the same state when the target id is not present', () => {
+      const state = appReducer(seeded, { type: 'TRUNCATE_AFTER', payload: { mindId, messageId: 'missing' } });
+      expect(state).toBe(seeded);
+    });
+  });
+
+  describe('RECONCILE_EVENT_IDS', () => {
+    it('annotates live messages with backing event ids by role order and sdkMessageId', () => {
+      const seeded: AppState = {
+        ...withActiveMind,
+        messagesByMind: {
+          [mindId]: [
+            makeMessage([makeTextBlock('hi')], { id: 'local-user', role: 'user' }),
+            makeMessage([makeTextBlock('reply', 'sdk-a1')], { id: 'local-assistant', role: 'assistant' }),
+          ],
+        },
+      };
+      const state = appReducer(seeded, {
+        type: 'RECONCILE_EVENT_IDS',
+        payload: {
+          mindId,
+          events: [
+            { eventId: 'evt-u1', messageId: 'sdk-u1', role: 'user' },
+            { eventId: 'evt-a1', messageId: 'sdk-a1', role: 'assistant' },
+          ],
+        },
+      });
+      expect(getMsgs(state)[0].eventId).toBe('evt-u1');
+      expect(getMsgs(state)[1].eventId).toBe('evt-a1');
+    });
+
+    it('returns the same state when nothing needs annotating', () => {
+      const seeded: AppState = {
+        ...withActiveMind,
+        messagesByMind: {
+          [mindId]: [makeMessage([makeTextBlock('hi')], { id: 'u1', role: 'user', eventId: 'evt-u1' })],
+        },
+      };
+      const state = appReducer(seeded, { type: 'RECONCILE_EVENT_IDS', payload: { mindId, events: [] } });
+      expect(state).toBe(seeded);
+    });
+
+    it('skips positional user matching when displayed and persisted user turns disagree', () => {
+      const seeded: AppState = {
+        ...withActiveMind,
+        messagesByMind: {
+          [mindId]: [
+            makeMessage([makeTextBlock('first')], { id: 'user-a', role: 'user' }),
+            makeMessage([makeTextBlock('second')], { id: 'user-b', role: 'user' }),
+            makeMessage([makeTextBlock('reply', 'sdk-a1')], { id: 'assistant-a', role: 'assistant' }),
+          ],
+        },
+      };
+      const state = appReducer(seeded, {
+        type: 'RECONCILE_EVENT_IDS',
+        payload: {
+          mindId,
+          events: [
+            { eventId: 'evt-u1', messageId: 'sdk-u1', role: 'user' },
+            { eventId: 'evt-a1', messageId: 'sdk-a1', role: 'assistant' },
+          ],
+        },
+      });
+      expect(getMsgs(state)[0].eventId).toBeUndefined();
+      expect(getMsgs(state)[1].eventId).toBeUndefined();
+      expect(getMsgs(state)[2].eventId).toBe('evt-a1');
+    });
+  });
+
   it('HYDRATE_CHAT_STATE restores messages and active streaming state', () => {
     const messages = [makeMessage([makeTextBlock('from popout')], { id: 'msg-1' })];
     const state = appReducer(withActiveMind, {

--- a/apps/web/src/renderer/lib/store/reducers/helpers.ts
+++ b/apps/web/src/renderer/lib/store/reducers/helpers.ts
@@ -1,5 +1,5 @@
 import { modelSelectionEqualsModel, modelSelectionKey, modelSelectionKeyFromModel } from '@chamber/shared/model-selection';
-import type { ChatEvent, ChatMessage, ContentBlock, ConversationSummary } from '@chamber/shared/types';
+import type { ChatEvent, ChatMessage, ContentBlock, ConversationEventRef, ConversationSummary } from '@chamber/shared/types';
 import type { AppState, ConversationViewState } from '../state';
 
 export function nonEmptyString(value: unknown, fallback: string): string {
@@ -92,6 +92,79 @@ export function getPlainContent(message: ChatMessage): string {
     .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
     .map((b) => b.content)
     .join('');
+}
+
+/**
+ * Annotates live messages with the backing SDK event ids they lack, using the
+ * persisted turn references returned after a turn completes. Assistant turns
+ * match by their streamed `sdkMessageId`; user turns (which carry no SDK id in
+ * the renderer) match positionally against the persisted user turns in order.
+ * Messages that already have an `eventId` are left untouched. Returns the same
+ * array reference when nothing changed so the reducer can no-op.
+ */
+export function reconcileMessageEventIds(
+  messages: ChatMessage[],
+  events: ConversationEventRef[],
+): ChatMessage[] {
+  const assistantEventByMessageId = new Map<string, string>();
+  const userEventIds: string[] = [];
+  for (const ref of events) {
+    if (ref.role === 'assistant') {
+      assistantEventByMessageId.set(ref.messageId, ref.eventId);
+    } else {
+      userEventIds.push(ref.eventId);
+    }
+  }
+
+  // User turns carry no SDK id in the renderer, so they can only be matched
+  // positionally. Only trust that when the displayed and persisted user turns
+  // line up 1:1 — otherwise a turn that failed to persist could shift every id
+  // and mistarget a later edit/delete. Assistant turns always match by their
+  // streamed sdkMessageId, which is unaffected.
+  //
+  // KNOWN LIMITATION: SDK skill-context injections are persisted as synthetic
+  // `user.message` events but are never streamed as user rows, so mid-session
+  // their presence trips this guard (counts disagree) and user-turn actions
+  // simply do not appear until a resume re-hydrates the injections and the
+  // counts line up again. That is graceful (no mistargeting), just surprising
+  // for lens/cron workflows.
+  const displayedUserCount = messages.reduce((count, message) => message.role === 'user' ? count + 1 : count, 0);
+  const canPositionUsers = displayedUserCount === userEventIds.length;
+
+  let userIndex = 0;
+  let changed = false;
+  const next = messages.map((message) => {
+    if (message.role === 'user') {
+      const eventId = userEventIds[userIndex];
+      userIndex += 1;
+      if (canPositionUsers && !message.eventId && eventId) {
+        changed = true;
+        return { ...message, eventId };
+      }
+      return message;
+    }
+
+    // Assistant rows match by their streamed sdkMessageId. KNOWN LIMITATION: a
+    // tool-first assistant turn (whose eliciting `assistant.message` carries no
+    // text and is dropped by the main-process mapper) reconciles to its FINAL
+    // message event. Deleting such a row truncates at that final event, so the
+    // turn's earlier tool events remain in SDK history (they are invisible after
+    // reload, since the mapper only surfaces user/assistant messages). Follow-up
+    // would surface a turn-boundary event id for turn-atomic truncation.
+    if (message.eventId) return message;
+    const sdkMessageId = message.blocks.find(
+      (block): block is Extract<ContentBlock, { type: 'text' }> =>
+        block.type === 'text' && typeof block.sdkMessageId === 'string',
+    )?.sdkMessageId;
+    const eventId = sdkMessageId ? assistantEventByMessageId.get(sdkMessageId) : undefined;
+    if (eventId) {
+      changed = true;
+      return { ...message, eventId };
+    }
+    return message;
+  });
+
+  return changed ? next : messages;
 }
 
 export function handleChatEvent<T extends ChatMessage>(messages: T[], messageId: string, event: ChatEvent): T[] {

--- a/apps/web/src/renderer/lib/store/reducers/messagesReducer.ts
+++ b/apps/web/src/renderer/lib/store/reducers/messagesReducer.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, ContentBlock } from '@chamber/shared/types';
 import type { AppState, AppAction } from '../state';
-import { conversationViewFor, handleChatEvent, isMindChatStreaming, setConversationView } from './helpers';
+import { conversationViewFor, handleChatEvent, isMindChatStreaming, reconcileMessageEventIds, setConversationView } from './helpers';
 
 type Handler<T extends AppAction['type']> = (
   state: AppState,
@@ -181,10 +181,34 @@ function setModelSwitching(state: AppState, action: Extract<AppAction, { type: '
   };
 }
 
+function truncateAfter(state: AppState, action: Extract<AppAction, { type: 'TRUNCATE_AFTER' }>): Partial<AppState> | AppState {
+  const { mindId, messageId } = action.payload;
+  const messages = state.messagesByMind[mindId];
+  if (!messages) return state;
+  const index = messages.findIndex((message) => message.id === messageId);
+  if (index < 0) return state;
+  return {
+    messagesByMind: { ...state.messagesByMind, [mindId]: messages.slice(0, index) },
+  };
+}
+
+function reconcileEventIds(state: AppState, action: Extract<AppAction, { type: 'RECONCILE_EVENT_IDS' }>): Partial<AppState> | AppState {
+  const { mindId, events } = action.payload;
+  const messages = state.messagesByMind[mindId];
+  if (!messages) return state;
+  const next = reconcileMessageEventIds(messages, events);
+  if (next === messages) return state;
+  return {
+    messagesByMind: { ...state.messagesByMind, [mindId]: next },
+  };
+}
+
 export const messagesHandlers: {
   ADD_USER_MESSAGE: Handler<'ADD_USER_MESSAGE'>;
   ADD_ASSISTANT_MESSAGE: Handler<'ADD_ASSISTANT_MESSAGE'>;
   CHAT_EVENT: Handler<'CHAT_EVENT'>;
+  TRUNCATE_AFTER: Handler<'TRUNCATE_AFTER'>;
+  RECONCILE_EVENT_IDS: Handler<'RECONCILE_EVENT_IDS'>;
   HYDRATE_CHAT_STATE: Handler<'HYDRATE_CHAT_STATE'>;
   CLEAR_MESSAGES: Handler<'CLEAR_MESSAGES'>;
   NEW_CONVERSATION: Handler<'NEW_CONVERSATION'>;
@@ -194,6 +218,8 @@ export const messagesHandlers: {
   ADD_USER_MESSAGE: addUserMessage,
   ADD_ASSISTANT_MESSAGE: addAssistantMessage,
   CHAT_EVENT: chatEvent,
+  TRUNCATE_AFTER: truncateAfter,
+  RECONCILE_EVENT_IDS: reconcileEventIds,
   HYDRATE_CHAT_STATE: hydrateChatState,
   CLEAR_MESSAGES: clearMessages,
   NEW_CONVERSATION: newConversation,

--- a/apps/web/src/renderer/lib/store/state.ts
+++ b/apps/web/src/renderer/lib/store/state.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ChatEvent, ConversationSummary, ModelInfo, LensViewManifest, MindContext, ImageBlock } from '@chamber/shared/types';
+import type { ChatMessage, ChatEvent, ConversationEventRef, ConversationSummary, ModelInfo, LensViewManifest, MindContext, ImageBlock } from '@chamber/shared/types';
 import type { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '@chamber/shared/a2a-types';
 import type { ChatroomMessage, ChatroomStreamEvent, OrchestrationMode, GroupChatConfig, HandoffConfig, MagenticConfig, TaskLedgerItem } from '@chamber/shared/chatroom-types';
 import { DEFAULT_APP_FEATURE_FLAGS, type AppFeatureFlags } from '@chamber/shared/feature-flags';
@@ -73,6 +73,8 @@ export type AppAction =
   | { type: 'ADD_USER_MESSAGE'; payload: { id: string; content: string; timestamp: number; images?: ImageBlock[] } }
   | { type: 'ADD_ASSISTANT_MESSAGE'; payload: { id: string; timestamp: number } }
   | { type: 'CHAT_EVENT'; payload: { mindId: string; messageId: string; event: ChatEvent } }
+  | { type: 'TRUNCATE_AFTER'; payload: { mindId: string; messageId: string } }
+  | { type: 'RECONCILE_EVENT_IDS'; payload: { mindId: string; events: ConversationEventRef[] } }
   | { type: 'HYDRATE_CHAT_STATE'; payload: { messagesByMind: Record<string, ChatMessage[]>; streamingByMind: Record<string, boolean>; conversationViewByMind?: Record<string, ConversationViewState> } }
   | { type: 'SET_CONVERSATION_HISTORY'; payload: { mindId: string; conversations: ConversationSummary[] } }
   | { type: 'CONVERSATION_HYDRATING'; payload: { mindId: string; sessionId: string } }

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -114,6 +114,10 @@ export function mockElectronAPI(): ElectronAPI {
       getEventSequence: vi.fn().mockResolvedValue(0),
       replayEvents: vi.fn().mockResolvedValue([]),
       onEvent: vi.fn().mockReturnValue(vi.fn()),
+      deleteMessage: vi.fn().mockResolvedValue([]),
+      editMessage: vi.fn().mockResolvedValue(undefined),
+      regenerate: vi.fn().mockResolvedValue(undefined),
+      getConversationEvents: vi.fn().mockResolvedValue([]),
     },
     conversationHistory: {
       list: vi.fn().mockResolvedValue([]),

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -3,6 +3,7 @@ import { ChatService } from './ChatService';
 import { TurnQueue } from './TurnQueue';
 import { Logger } from '../logger';
 import type { MindManager } from '../mind';
+import type { ChatMessage, ConversationEventRef, ConversationSummary } from '@chamber/shared/types';
 
 type AllEventsHandler = (event: unknown) => void;
 type TypedHandler = (event: unknown) => void;
@@ -96,6 +97,9 @@ const mockMindManager = {
   deleteConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
   renameConversation: vi.fn(() => []),
   setMindModel: vi.fn(async () => null),
+  truncateActiveConversation: vi.fn(async (): Promise<ConversationSummary[]> => [{ sessionId: 'session-1', title: 'Chat', createdAt: '', updatedAt: '', kind: 'chat', active: true, hasMessages: true }]),
+  getActiveConversationMessages: vi.fn(async (): Promise<ChatMessage[]> => []),
+  getConversationEventRefs: vi.fn(async (): Promise<ConversationEventRef[]> => []),
 };
 
 describe('ChatService', () => {
@@ -219,6 +223,98 @@ describe('ChatService', () => {
         consoleError.mockRestore();
         mockSession.send.mockResolvedValue(undefined);
       }
+    });
+  });
+
+  describe('message actions', () => {
+    const idleOnSend = () => {
+      mockSession.on.mockImplementation((eventOrCb: string | ((...args: unknown[]) => void), cb?: (...args: unknown[]) => void) => {
+        if (eventOrCb === 'session.idle' && cb) {
+          setTimeout(() => cb(), 0);
+        }
+        return vi.fn();
+      });
+    };
+
+    it('deleteMessage truncates the active conversation and returns the refreshed history', async () => {
+      const conversations = await svc.deleteMessage('valid-mind', 'evt-42');
+      expect(mockMindManager.truncateActiveConversation).toHaveBeenCalledWith('valid-mind', 'evt-42');
+      expect(conversations).toEqual([expect.objectContaining({ sessionId: 'session-1', hasMessages: true })]);
+    });
+
+    it('getConversationEvents delegates to the mind manager', async () => {
+      mockMindManager.getConversationEventRefs.mockResolvedValueOnce([
+        { eventId: 'evt-1', messageId: 'm1', role: 'user' },
+      ]);
+      const refs = await svc.getConversationEvents('valid-mind');
+      expect(mockMindManager.getConversationEventRefs).toHaveBeenCalledWith('valid-mind');
+      expect(refs).toEqual([{ eventId: 'evt-1', messageId: 'm1', role: 'user' }]);
+    });
+
+    it('editMessage truncates back to the target turn then streams the edited prompt', async () => {
+      idleOnSend();
+      const emit = vi.fn();
+      await svc.editMessage('valid-mind', 'evt-7', 'edited prompt', 'msg-9', emit);
+
+      expect(mockMindManager.truncateActiveConversation).toHaveBeenCalledWith('valid-mind', 'evt-7');
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: expect.stringContaining('edited prompt'),
+      });
+      expect(emit).toHaveBeenCalledWith({ type: 'done' });
+    });
+
+    it('regenerate re-runs the most recent user turn from persisted history', async () => {
+      idleOnSend();
+      mockMindManager.getActiveConversationMessages.mockResolvedValueOnce([
+        { id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'first question' }], timestamp: 1, eventId: 'evt-u1' },
+        { id: 'a1', role: 'assistant', blocks: [{ type: 'text', content: 'answer' }], timestamp: 2, eventId: 'evt-a1' },
+      ]);
+      const emit = vi.fn();
+      await svc.regenerate('valid-mind', 'msg-regen', emit);
+
+      expect(mockMindManager.truncateActiveConversation).toHaveBeenCalledWith('valid-mind', 'evt-u1');
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: expect.stringContaining('first question'),
+      });
+      expect(emit).toHaveBeenCalledWith({ type: 'done' });
+    });
+
+    it('regenerate emits an error when there is no user turn to re-run', async () => {
+      idleOnSend();
+      mockMindManager.getActiveConversationMessages.mockResolvedValueOnce([]);
+      const emit = vi.fn();
+      await svc.regenerate('valid-mind', 'msg-regen', emit);
+
+      expect(mockMindManager.truncateActiveConversation).not.toHaveBeenCalled();
+      expect(mockSession.send).not.toHaveBeenCalled();
+      expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+      expect(emit).toHaveBeenCalledWith({ type: 'done' });
+    });
+
+    it('editMessage truncates exactly once and re-sends the same prompt after a stale-session retry', async () => {
+      // First send throws stale AFTER the truncate has already run. The retry
+      // must reuse the cached prompt and must NOT truncate again (re-truncating
+      // would drop additional turns because the target event is already gone).
+      mockSession.send.mockRejectedValueOnce(new Error('Session not found: abc-123'));
+      mockSession.on.mockReturnValue(vi.fn());
+      const freshSession = {
+        send: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn((event: string, cb?: (...args: unknown[]) => void) => {
+          if (event === 'session.idle' && cb) setTimeout(() => cb(), 0);
+          return vi.fn();
+        }),
+      };
+      mockMindManager.recoverActiveConversationSession.mockResolvedValueOnce(freshSession);
+
+      const emit = vi.fn();
+      await svc.editMessage('valid-mind', 'evt-7', 'edited prompt', 'msg-9', emit);
+
+      expect(mockMindManager.truncateActiveConversation).toHaveBeenCalledTimes(1);
+      expect(mockMindManager.truncateActiveConversation).toHaveBeenCalledWith('valid-mind', 'evt-7');
+      expect(emit).toHaveBeenCalledWith({ type: 'reconnecting' });
+      expect(freshSession.send).toHaveBeenCalledWith({ prompt: expect.stringContaining('edited prompt') });
+      expect(emit).toHaveBeenCalledWith({ type: 'done' });
     });
   });
 

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -3,7 +3,7 @@
 
 import type { MindManager } from '../mind';
 import { getErrorMessage } from '@chamber/shared/getErrorMessage';
-import type { ChatEvent, ChatImageAttachment, ConversationResumeResult, ConversationSummary, ModelInfo } from '@chamber/shared/types';
+import type { ChatEvent, ChatImageAttachment, ChatMessage, ContentBlock, ConversationEventRef, ConversationResumeResult, ConversationSummary, ModelInfo } from '@chamber/shared/types';
 import { modelSelectionKeyFromModel } from '@chamber/shared/model-selection';
 import type { CopilotSession } from '../mind/types';
 import { isStaleSessionError, SEND_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
@@ -59,9 +59,107 @@ export class ChatService {
     model?: string,
     attachments?: ChatImageAttachment[],
   ): Promise<void> {
+    return this.runTurn(mindId, messageId, emit, async () => prompt, { model, attachments });
+  }
+
+  /**
+   * Deletes a turn from the active conversation. Truncation removes the target
+   * event and every later event, so this also drops any turns that followed it.
+   * Serialized through the turn queue so it never races an in-flight stream.
+   */
+  async deleteMessage(mindId: string, eventId: string): Promise<ConversationSummary[]> {
+    return this.turnQueue.enqueue(mindId, () => this.mindManager.truncateActiveConversation(mindId, eventId));
+  }
+
+  /**
+   * Replaces a user turn with an edited prompt: truncates history back to that
+   * turn (removing it and the assistant reply that followed), then streams a
+   * fresh response to the new prompt.
+   */
+  async editMessage(
+    mindId: string,
+    eventId: string,
+    prompt: string,
+    messageId: string,
+    emit: (event: ChatEvent) => void,
+    model?: string,
+  ): Promise<void> {
+    return this.runTurn(mindId, messageId, emit, async () => {
+      await this.mindManager.truncateActiveConversation(mindId, eventId);
+      return prompt;
+    }, { model });
+  }
+
+  /**
+   * Re-runs the most recent user turn to produce a fresh assistant response.
+   * Resolves the last user turn from persisted history, truncates back to it,
+   * and resends its original prompt.
+   */
+  async regenerate(
+    mindId: string,
+    messageId: string,
+    emit: (event: ChatEvent) => void,
+    model?: string,
+  ): Promise<void> {
+    return this.runTurn(mindId, messageId, emit, async () => {
+      const messages = await this.mindManager.getActiveConversationMessages(mindId);
+      const lastUser = [...messages].reverse().find((message) => message.role === 'user');
+      if (!lastUser?.eventId) {
+        emit({ type: 'error', message: 'There is no user message to regenerate.' });
+        return null;
+      }
+      await this.mindManager.truncateActiveConversation(mindId, lastUser.eventId);
+      return plainTextOf(lastUser);
+    }, { model });
+  }
+
+  /** Ordered references to persisted user/assistant turns, for reconciling live messages with event ids. */
+  async getConversationEvents(mindId: string): Promise<ConversationEventRef[]> {
+    return this.mindManager.getConversationEventRefs(mindId);
+  }
+
+  /**
+   * Shared turn driver for send/edit/regenerate. `resolvePrompt` performs any
+   * one-time history mutation (e.g. truncation) and returns the prompt to send,
+   * or null to abort the turn. It is invoked at most once per action: the
+   * resolved prompt is cached so a stale-session retry re-sends the same prompt
+   * WITHOUT re-running the resolver. Re-truncating on retry would remove the
+   * target event (already gone) plus the turns after it, so idempotency here is
+   * a correctness requirement, not an optimization. The resolver only throws if
+   * the truncation RPC itself fails to commit (truncateActiveConversation
+   * swallows post-truncate read failures), so a thrown resolver always means the
+   * mutation did NOT happen and the recovered attempt can safely re-run it.
+   */
+  private async runTurn(
+    mindId: string,
+    messageId: string,
+    emit: (event: ChatEvent) => void,
+    resolvePrompt: () => Promise<string | null>,
+    options: { model?: string; attachments?: ChatImageAttachment[] } = {},
+  ): Promise<void> {
     return this.turnQueue.enqueue(mindId, async () => {
       const abortController = new AbortController();
       this.abortControllers.set(mindId, { messageId, controller: abortController });
+
+      let prepared = false;
+      let preparedPrompt: string | null = null;
+      const prepareOnce = async (): Promise<string | null> => {
+        if (prepared) return preparedPrompt;
+        preparedPrompt = await resolvePrompt();
+        prepared = true;
+        return preparedPrompt;
+      };
+
+      const streamOn = async (session: CopilotSession): Promise<void> => {
+        const prompt = await prepareOnce();
+        if (prompt === null) {
+          if (!abortController.signal.aborted) emit({ type: 'done' });
+          return;
+        }
+        await this.streamTurn(session, prompt, abortController, emit, options.attachments, () => {
+          this.mindManager.markActiveConversationHasMessages(mindId, prompt);
+        });
+      };
 
       try {
         const context = this.mindManager.getMind(mindId);
@@ -70,12 +168,10 @@ export class ChatService {
         }
 
         try {
-          const session = model ? await this.mindManager.setMindModel(mindId, model) : null;
+          const session = options.model ? await this.mindManager.setMindModel(mindId, options.model) : null;
           const currentSession = session ? this.mindManager.getMind(mindId)?.session : context.session;
           if (!currentSession) throw new Error(`Mind ${mindId} not found or has no session`);
-          await this.streamTurn(currentSession, prompt, abortController, emit, attachments, () => {
-            this.mindManager.markActiveConversationHasMessages(mindId, prompt);
-          });
+          await streamOn(currentSession);
         } catch (err) {
           if (abortController.signal.aborted) return;
           if (!isStaleSessionError(err)) throw err;
@@ -85,9 +181,7 @@ export class ChatService {
           emit({ type: 'reconnecting' });
           const recoveredSession = await this.mindManager.recoverActiveConversationSession(mindId);
           if (abortController.signal.aborted) return;
-          await this.streamTurn(recoveredSession, prompt, abortController, emit, attachments, () => {
-            this.mindManager.markActiveConversationHasMessages(mindId, prompt);
-          });
+          await streamOn(recoveredSession);
         }
       } catch (err) {
         if (abortController.signal.aborted) return;
@@ -478,6 +572,17 @@ export class ChatService {
   }
 }
 
+
+/**
+ * Concatenates a chat message's text blocks. Used to recover the original
+ * prompt of a persisted user turn when regenerating its response.
+ */
+function plainTextOf(message: ChatMessage): string {
+  return message.blocks
+    .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+    .map((block) => block.content)
+    .join('');
+}
 
 /**
  * Friendly mapper for upstream LLM errors that originate from BYO LLM endpoints.

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -44,7 +44,10 @@ function createSessionStub(sessionId = `sdk-session-${sessionCounter += 1}`) {
   off: vi.fn(),
   disconnect: vi.fn(async () => undefined),
   setModel: vi.fn(async () => undefined),
-  rpc: { permissions: { setApproveAll: vi.fn(async () => ({ success: true })) } },
+  rpc: {
+    permissions: { setApproveAll: vi.fn(async () => ({ success: true })) },
+    history: { truncate: vi.fn(async () => ({ eventsRemoved: 0 })) },
+  },
   };
 }
 
@@ -707,6 +710,74 @@ describe('MindManager', () => {
       const sessionConfig = mockCreateSession.mock.calls[0][0] as { onPermissionRequest?: unknown };
       expect(sessionConfig.onPermissionRequest).toBe(approveForSessionCompat);
       expect(created.rpc.permissions.setApproveAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('conversation history mutations', () => {
+    const liveSessionFor = (mindId: string) =>
+      manager.getMind(mindId)?.session as unknown as ReturnType<typeof createSessionStub>;
+
+    it('maps persisted events to chat messages with their backing event ids', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      liveSessionFor(mind.mindId).getEvents.mockResolvedValue([
+        { id: 'evt-1', type: 'user.message', timestamp: 1, data: { messageId: 'u1', content: 'Hi' } },
+        { id: 'evt-2', type: 'assistant.message', timestamp: 2, data: { messageId: 'a1', content: 'Hello' } },
+      ]);
+
+      const messages = await manager.getActiveConversationMessages(mind.mindId);
+
+      expect(messages).toEqual([
+        { id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'Hi' }], timestamp: 1, eventId: 'evt-1' },
+        { id: 'a1', role: 'assistant', blocks: [{ type: 'text', content: 'Hello' }], timestamp: 2, eventId: 'evt-2' },
+      ]);
+    });
+
+    it('exposes ordered event references for reconciliation', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      liveSessionFor(mind.mindId).getEvents.mockResolvedValue([
+        { id: 'evt-1', type: 'user.message', timestamp: 1, data: { messageId: 'u1', content: 'Hi' } },
+        { id: 'evt-2', type: 'assistant.message', timestamp: 2, data: { messageId: 'a1', content: 'Hello' } },
+      ]);
+
+      expect(await manager.getConversationEventRefs(mind.mindId)).toEqual([
+        { eventId: 'evt-1', messageId: 'u1', role: 'user' },
+        { eventId: 'evt-2', messageId: 'a1', role: 'assistant' },
+      ]);
+    });
+
+    it('truncates SDK history and keeps hasMessages when turns remain', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const session = liveSessionFor(mind.mindId);
+      session.getEvents.mockResolvedValue([
+        { id: 'evt-1', type: 'user.message', timestamp: 1, data: { messageId: 'u1', content: 'Hi' } },
+      ]);
+
+      const conversations = await manager.truncateActiveConversation(mind.mindId, 'evt-9');
+
+      expect(session.rpc.history.truncate).toHaveBeenCalledWith({ eventId: 'evt-9' });
+      expect(conversations.find((conversation) => conversation.active)?.hasMessages).toBe(true);
+    });
+
+    it('clears hasMessages when truncation empties the conversation', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      liveSessionFor(mind.mindId).getEvents.mockResolvedValue([]);
+
+      const conversations = await manager.truncateActiveConversation(mind.mindId, 'evt-1');
+
+      expect(conversations.find((conversation) => conversation.active)?.hasMessages).toBe(false);
+    });
+
+    it('treats truncation as committed even when the post-truncate readback fails', async () => {
+      // The truncate RPC succeeded; a failing read-back (e.g. session went stale
+      // right after) must not resurface as a truncate failure, or the caller
+      // would retry and truncate again — removing further turns.
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const session = liveSessionFor(mind.mindId);
+      session.getEvents.mockRejectedValueOnce(new Error('Session not found: abc-123'));
+
+      await expect(manager.truncateActiveConversation(mind.mindId, 'evt-9')).resolves.toBeDefined();
+      expect(session.rpc.history.truncate).toHaveBeenCalledTimes(1);
+      expect(session.rpc.history.truncate).toHaveBeenCalledWith({ eventId: 'evt-9' });
     });
   });
 

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import type { PermissionHandler, ResumeSessionConfig, SessionConfig } from '@github/copilot-sdk';
 import { parseModelSelectionKey } from '@chamber/shared/model-selection';
 import { isStaleSessionError } from '@chamber/shared/sessionErrors';
-import type { AppConfig, ChamberConversationRecord, ChatMessage, ConversationResumeResult, ConversationSummary, MindContext, MindRecord, ModelProvider, ModelSelection } from '@chamber/shared/types';
+import type { AppConfig, ChamberConversationRecord, ChatMessage, ConversationEventRef, ConversationResumeResult, ConversationSummary, MindContext, MindRecord, ModelProvider, ModelSelection } from '@chamber/shared/types';
 import { Logger } from '../logger';
 import type { InternalMindContext, CopilotClient, CopilotSession, Tool, UserInputHandler } from './types';
 import { generateMindId } from './generateMindId';
@@ -709,6 +709,72 @@ export class MindManager extends EventEmitter {
     };
   }
 
+  /**
+   * Persisted user/assistant turns for the mind's active conversation, mapped
+   * to chat messages (text-only, carrying their backing SDK event ids). Used
+   * to reconcile live messages with event ids and to resolve the most recent
+   * user turn for regeneration.
+   */
+  async getActiveConversationMessages(mindId: string): Promise<ChatMessage[]> {
+    const context = this.minds.get(mindId);
+    if (!context?.session) return [];
+    return this.getMessagesForSession(context.session);
+  }
+
+  /** Ordered references to persisted user/assistant turns for the active conversation. */
+  async getConversationEventRefs(mindId: string): Promise<ConversationEventRef[]> {
+    const messages = await this.getActiveConversationMessages(mindId);
+    const refs: ConversationEventRef[] = [];
+    for (const message of messages) {
+      if (message.eventId) {
+        refs.push({ eventId: message.eventId, messageId: message.id, role: message.role });
+      }
+    }
+    return refs;
+  }
+
+  /**
+   * Truncates the active conversation's persisted history to `eventId` — the
+   * SDK removes that event and every later one — then refreshes the record's
+   * hasMessages flag. Returns the updated conversation summaries.
+   */
+  async truncateActiveConversation(mindId: string, eventId: string): Promise<ConversationSummary[]> {
+    const context = this.minds.get(mindId);
+    if (!context?.session) throw new Error(`Mind ${mindId} not found or has no session`);
+    await context.session.rpc.history.truncate({ eventId });
+    // The truncate above is the commit point and is not idempotent (a second
+    // truncate to the same, now-removed, event would drop further turns). If
+    // reading back the remaining events fails — e.g. the session goes stale
+    // immediately after — swallow it rather than rethrow: a thrown truncate
+    // signals "not done yet" to callers, who would then retry and truncate
+    // again. We only lose the hasMessages refresh, which the next settled turn
+    // repairs.
+    try {
+      const remaining = await this.getMessagesForSession(context.session);
+      this.updateActiveConversationHasMessages(mindId, remaining.length > 0);
+    } catch (error) {
+      log.warn(`Truncated conversation for mind ${mindId} but could not refresh message state`, error);
+    }
+    return this.listConversationHistory(mindId);
+  }
+
+  private updateActiveConversationHasMessages(mindId: string, hasMessages: boolean): void {
+    const context = this.minds.get(mindId);
+    const record = this.knownMindRecords.get(mindId);
+    const activeSessionId = context?.activeSessionId ?? record?.activeSessionId;
+    if (!record?.conversations || !activeSessionId) return;
+    const updatedAt = new Date().toISOString();
+    this.knownMindRecords.set(mindId, {
+      ...record,
+      conversations: record.conversations.map((conversation) =>
+        conversation.sessionId === activeSessionId
+          ? { ...conversation, hasMessages, updatedAt }
+          : conversation,
+      ),
+    });
+    this.persistConfig();
+  }
+
   async setMindModel(mindId: string, model: string | null): Promise<MindContext | null> {
     const previousUpdate = this.modelUpdates.get(mindId) ?? Promise.resolve();
     let releaseUpdate: () => void;
@@ -1342,11 +1408,12 @@ export class MindManager extends EventEmitter {
     const id = typeof data.messageId === 'string'
       ? data.messageId
       : `${String(record.type ?? 'session-event')}-${index}`;
+    const eventId = typeof record.id === 'string' ? record.id : undefined;
     if (record.type === 'user.message') {
-      return [{ id, role: 'user', blocks: [{ type: 'text', content }], timestamp }];
+      return [{ id, role: 'user', blocks: [{ type: 'text', content }], timestamp, ...(eventId ? { eventId } : {}) }];
     }
     if (record.type === 'assistant.message') {
-      return [{ id, role: 'assistant', blocks: [{ type: 'text', content }], timestamp }];
+      return [{ id, role: 'assistant', blocks: [{ type: 'text', content }], timestamp, ...(eventId ? { eventId } : {}) }];
     }
     return [];
   }

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -42,6 +42,7 @@ import type {
   ChatEvent,
   ChatImageAttachment,
   ChatReplayEvent,
+  ConversationEventRef,
   ConversationResumeResult,
   ConversationSummary,
   DesktopUpdateActionResult,
@@ -70,6 +71,14 @@ export interface ElectronAPI {
     getEventSequence: () => Promise<number>;
     replayEvents: (afterSequence: number) => Promise<ChatReplayEvent[]>;
     onEvent: (callback: (mindId: string, messageId: string, event: ChatEvent, sequence?: number) => void) => () => void;
+    /** Deletes a turn (and everything after it) from persisted history. Returns the refreshed conversation list. */
+    deleteMessage: (mindId: string, eventId: string) => Promise<ConversationSummary[]>;
+    /** Replaces a user turn (and everything after it) with an edited prompt, streaming a fresh response under `messageId`. */
+    editMessage: (mindId: string, eventId: string, prompt: string, messageId: string, model?: string) => Promise<void>;
+    /** Re-runs the most recent user turn, streaming a fresh response under `messageId`. */
+    regenerate: (mindId: string, messageId: string, model?: string) => Promise<void>;
+    /** Ordered references to persisted user/assistant turns, for reconciling live messages with their event ids. */
+    getConversationEvents: (mindId: string) => Promise<ConversationEventRef[]>;
   };
   conversationHistory: {
     list: (mindId: string) => Promise<ConversationSummary[]>;

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -20,6 +20,10 @@ export const IPC = {
     GET_EVENT_SEQUENCE: 'chat:getEventSequence',
     REPLAY_EVENTS: 'chat:replayEvents',
     EVENT: 'chat:event',
+    DELETE_MESSAGE: 'chat:deleteMessage',
+    EDIT_MESSAGE: 'chat:editMessage',
+    REGENERATE: 'chat:regenerate',
+    GET_CONVERSATION_EVENTS: 'chat:getConversationEvents',
   },
   CONVERSATION_HISTORY: {
     LIST: 'conversationHistory:list',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -117,6 +117,25 @@ export interface ChatMessage {
   timestamp: number;
   isStreaming?: boolean;
   sender?: { mindId: string; name: string };
+  /**
+   * Stable identifier of the backing SDK session event (UUID). Present for
+   * messages hydrated from the SDK (resume/reconcile); undefined for a live
+   * message until it has been reconciled against persisted history. Message
+   * actions (edit/delete) address the persisted turn through this id.
+   */
+  eventId?: string;
+}
+
+/**
+ * Lightweight reference to a persisted user/assistant turn, used to reconcile
+ * a live conversation's messages with their backing SDK event ids after a turn
+ * completes. `messageId` is the SDK message id (matches a streamed text block's
+ * `sdkMessageId`); `eventId` is the id passed to history truncation.
+ */
+export interface ConversationEventRef {
+  eventId: string;
+  messageId: string;
+  role: 'user' | 'assistant';
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary

Adds hover-revealed message actions to single-agent chat, wired end to end so edits and deletes persist across reload:

- **Regenerate** the newest assistant turn (re-runs the most recent user turn).
- **Edit** a user turn in place and resubmit, replacing the turns after it.
- **Delete from here** removes a turn and everything after it, with explicit confirmation.
- **Copy as markdown** (raw source) alongside the existing plain-text **Copy**.

`MessageActions` is used only by single-agent chat, so scope is single-agent (the chatroom transcript does not share it).

## How it works

The Copilot SDK session is the persistence layer and is not append-only: `session.rpc.history.truncate({ eventId })` removes an event and everything after it. Every SDK event has a stable `id`, surfaced as a new optional `ChatMessage.eventId`. After each turn settles, live messages reconcile their event ids (new `chat:getConversationEvents` IPC), so actions work without a reload and survive reload because history is genuinely truncated.

## Notable changes

- **shared**: `ChatMessage.eventId`, `ConversationEventRef`, 4 new `CHAT` IPC channels, electron-types.
- **desktop**: 4 ipc handlers in `chat.ts` + preload bindings.
- **services**: `ChatService` (`deleteMessage`/`editMessage`/`regenerate`/`getConversationEvents` + a shared, idempotent `runTurn`); `MindManager` (event-id mapping, `truncateActiveConversation`, event refs).
- **renderer**: store actions `TRUNCATE_AFTER` + `RECONCILE_EVENT_IDS`; `useChatStreaming` (regenerate/edit); `useConversationActions` (backend-first delete); reconcile-after-turn subscription; capability-driven `MessageActions`; `MessageList` inline editor + gating; `messageContent` copy/image helpers. Browser mode keeps the mutations unavailable and no-ops the reconcile read.

## Safeguards (principal-review blockers)

- **Images**: edit and regenerate are disabled with a tooltip for turns containing images (only text is resent today).
- **Retry-safe truncation**: the edit/regenerate resolver caches the prompt and truncates at most once per action; `truncateActiveConversation` treats the truncate RPC as the commit point (post-truncate read failures are swallowed), so a stale-session/send-timeout retry re-sends without truncating again.
- **Capability gating**: edit/delete/regenerate are gated on persisted-event support, so browser mode never surfaces unsupported actions.
- **Delete UX**: relabelled "Delete from here" with an explicit confirmation; delete is backend-first, so a failed delete leaves the transcript intact.
- **Edit UX**: the inline editor warns when later turns will be removed, so a resubmit is never a silent multi-turn delete.

## Tests

- `npm run lint`: clean (tsc + eslint + deps:check + yaml + md).
- `npm test`: 2245 passed, 2 skipped, 1 failed. The single failure is the pre-existing Windows-only `MindProfileService > rejects symlinked profile files` (EPERM creating a symlink without admin), unrelated to this change.
- `npm run smoke:sdk`: passed (the SDK history path is the surface touched).
- `npm run smoke:web`: 4 passed.
- `npm run smoke:desktop`: 33 passed, 21 skipped, 2 failed - both unrelated to chat (`cron-tools-smoke` ttasks TaskGraph assertion, and a flaky `per-agent-compose-drafts` teardown "browser has been closed").
- New colocated Vitest for the copy/image helpers, reducer actions, ChatService actions and retry idempotency, MindManager truncation/mapping (incl. readback-failure resilience), the MessageActions UI, and MessageList gating + edit warning.

## Known limitations (documented in code, follow-ups)

- Deleting a tool-first assistant turn truncates at that turn's final message; the turn's earlier tool events remain in SDK history (invisible after reload). A turn-boundary event id would make truncation turn-atomic.
- On a non-stale backend error during edit/regenerate, the optimistically trimmed transcript can sit ahead of persisted history until the next resume (delete does not have this since it is backend-first).
- SDK skill-context injections can hide user-turn actions mid-session until a resume re-aligns the reconcile count guard.

No closing issue reference (none identified for this slice).

---

## Upstream issue linkage

Refs #182. This adds edit/resubmit plus other chat message actions, but does not fully close #182 because assistant-turn Markdown editing remains out of scope.

## Source branch

Fork PR: https://github.com/patschmittdev/chamber/pull/5
Head: `patschmittdev:patschmittdev-feat-chat-message-actions`
