### PR TITLE
feat(composer): file attachments, @-mentions, and slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 - **Add insiders-gated local voice dictation** — Adds local Foundry/Nemotron dictation with a dedicated Settings page, chat mic and push-to-talk controls, explicit runtime capability gating, and insiders-only prepared runtime packaging. (#385) (#385)
 - **Add local WTD topology advice for automation authors** — Give Insiders minds a verified local workflow-shape advisor before they author ttasks DAGs, while keeping execution in ttasks-ts (#400)
+- **Add composer power-ups** — Chat composer gains file attachments via a paperclip button (images ride the existing blob path, text files fold their contents into the prompt, unsupported or oversized files are skipped with a notice), @-mentions that insert an agent token from the loaded minds, and slash commands (/new, /clear, /model, /settings). Attachment payloads are scoped per mind and keyed by opaque id so switching agents and unusual filenames stay correct.
 
 ### Refactor
 

--- a/apps/web/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ChatInput } from './ChatInput';
-import type { ModelInfo } from '@chamber/shared/types';
+import type { ModelInfo, MindContext } from '@chamber/shared/types';
 import { VOICE_DICTATION_MODEL_ID, type VoiceDictationConfig, type VoiceModelStatus } from '@chamber/shared/voice-types';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
 
@@ -18,8 +18,12 @@ const appStateMock = vi.hoisted(() => ({
       voiceDictation: false,
       wtdTopology: false,
     },
+    minds: [] as MindContext[],
+    activeMindId: null as string | null,
   },
 }));
+
+const dispatchMock = vi.hoisted(() => vi.fn());
 
 const voiceHookMock = vi.hoisted(() => ({
   start: vi.fn(),
@@ -36,6 +40,7 @@ const voiceHookMock = vi.hoisted(() => ({
 
 vi.mock('../../lib/store', () => ({
   useAppState: () => appStateMock.current,
+  useAppDispatch: () => dispatchMock,
 }));
 
 vi.mock('../../hooks/useVoiceDictation', async () => {
@@ -123,6 +128,8 @@ beforeEach(() => {
       voiceDictation: false,
       wtdTopology: false,
     },
+    minds: [],
+    activeMindId: null,
   };
   voiceHookMock.state = 'idle';
   voiceHookMock.permissionState = 'granted';
@@ -209,6 +216,8 @@ describe('ChatInput', () => {
           voiceDictation: true,
           wtdTopology: false,
         },
+        minds: [],
+        activeMindId: null,
       };
       render(<ChatInput {...defaultProps} {...props} />);
       return await screen.findByRole('button', { name: 'Dictate message' });
@@ -223,6 +232,8 @@ describe('ChatInput', () => {
           voiceDictation: false,
           wtdTopology: false,
         },
+        minds: [],
+        activeMindId: null,
       };
 
       render(<ChatInput {...defaultProps} />);
@@ -721,3 +732,198 @@ describe('ChatInput controlled value (per-agent compose drafts #221)', () => {
     expect(textarea.value).toBe('local-only');
   });
 });
+
+function makeMind(mindId: string, name: string): MindContext {
+  return {
+    mindId,
+    mindPath: `C:\\minds\\${mindId}`,
+    identity: { name, systemMessage: '' },
+    status: 'ready',
+  };
+}
+
+function typeAtEnd(textarea: HTMLTextAreaElement, value: string) {
+  Object.defineProperty(textarea, 'selectionStart', { configurable: true, value: value.length });
+  Object.defineProperty(textarea, 'selectionEnd', { configurable: true, value: value.length });
+  fireEvent.change(textarea, { target: { value } });
+}
+
+describe('ChatInput file attachments', () => {
+  it('renders a paperclip button and a hidden file input', () => {
+    render(<ChatInput {...defaultProps} />);
+    expect(screen.getByLabelText('Attach files')).toBeTruthy();
+    expect(screen.getByTestId('composer-file-input')).toBeTruthy();
+  });
+
+  it('clicking the paperclip opens the hidden file input', () => {
+    render(<ChatInput {...defaultProps} />);
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, 'click');
+    fireEvent.click(screen.getByLabelText('Attach files'));
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('attaches an image file as a blob and sends it with the message', async () => {
+    const onSend = vi.fn();
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+    const file = new File(['image-bytes'], 'photo.png', { type: 'image/png' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await waitFor(() => expect(textarea.value).toContain('[📷 photo.png]'));
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [message, attachments] = onSend.mock.calls[0];
+    expect(message).toContain('[📷 photo.png]');
+    expect(attachments).toEqual([
+      expect.objectContaining({ name: 'photo.png', mimeType: 'image/png' }),
+    ]);
+  });
+
+  it('attaches a text file by folding its contents into the outgoing prompt', async () => {
+    const onSend = vi.fn();
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+    const file = new File(['hello world'], 'notes.txt', { type: 'text/plain' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await waitFor(() => expect(textarea.value).toContain('[📄 notes.txt]'));
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [message, attachments] = onSend.mock.calls[0];
+    expect(message).toContain('Attached file notes.txt:');
+    expect(message).toContain('hello world');
+    expect(attachments).toBeUndefined();
+  });
+
+  it('skips unsupported binary files with a clear notice', async () => {
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+    const file = new File(['\x00\x01'], 'archive.bin', { type: 'application/octet-stream' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await screen.findByText(/Skipped 1 unsupported file/);
+    expect(textarea.value).toBe('');
+  });
+});
+
+describe('ChatInput @-mentions', () => {
+  it('opens a mention menu listing loaded minds when the user types "@"', async () => {
+    appStateMock.current.minds = [makeMind('m1', 'Ada'), makeMind('m2', 'Alan')];
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '@');
+    await screen.findByTestId('mention-popover');
+    expect(screen.getByText('@Ada')).toBeTruthy();
+    expect(screen.getByText('@Alan')).toBeTruthy();
+  });
+
+  it('filters minds by the typed query', async () => {
+    appStateMock.current.minds = [makeMind('m1', 'Ada'), makeMind('m2', 'Alan')];
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '@al');
+    await screen.findByTestId('mention-popover');
+    expect(screen.queryByText('@Ada')).toBeNull();
+    expect(screen.getByText('@Alan')).toBeTruthy();
+  });
+
+  it('inserts an @Name token at the caret on selection', async () => {
+    appStateMock.current.minds = [makeMind('m1', 'Ada'), makeMind('m2', 'Alan')];
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, 'hey @al');
+    await screen.findByTestId('mention-popover');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    await waitFor(() => expect(textarea.value).toBe('hey @Alan '));
+  });
+
+  it('does not open a mention menu when no minds are loaded', () => {
+    appStateMock.current.minds = [];
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '@');
+    expect(screen.queryByTestId('mention-popover')).toBeNull();
+  });
+});
+
+describe('ChatInput slash commands', () => {
+  it('opens the command menu for a bare "/"', async () => {
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '/');
+    await screen.findByTestId('slash-popover');
+    expect(screen.getByText('/new')).toBeTruthy();
+    expect(screen.getByText('/clear')).toBeTruthy();
+    expect(screen.getByText('/settings')).toBeTruthy();
+  });
+
+  it('hides /model when no models are available and shows it when they are', async () => {
+    const { rerender } = render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '/');
+    await screen.findByTestId('slash-popover');
+    expect(screen.queryByText('/model')).toBeNull();
+
+    rerender(<ChatInput {...defaultProps} availableModels={[{ id: 'm', name: 'Claude Sonnet' }]} />);
+    typeAtEnd(textarea, '/');
+    await screen.findByTestId('slash-popover');
+    expect(screen.getByText('/model')).toBeTruthy();
+  });
+
+  it('does not send the slash text as a message on Enter', () => {
+    const onSend = vi.fn();
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '/settings');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('/clear empties the composer', async () => {
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '/clear');
+    await screen.findByTestId('slash-popover');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    await waitFor(() => expect(textarea.value).toBe(''));
+  });
+
+  it('/settings navigates to the settings view via the store', async () => {
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '/settings');
+    await screen.findByTestId('slash-popover');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(dispatchMock).toHaveBeenCalledWith({ type: 'SET_ACTIVE_VIEW', payload: 'settings' });
+  });
+
+  it('/new starts a new conversation for the active mind', async () => {
+    appStateMock.current.activeMindId = 'm1';
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '/new');
+    await screen.findByTestId('slash-popover');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    await waitFor(() => expect(api.chat.newConversation).toHaveBeenCalledWith('m1'));
+  });
+
+  it('/model opens the model picker', async () => {
+    const { container } = render(
+      <ChatInput {...defaultProps} availableModels={[{ id: 'm', name: 'Claude Sonnet' }]} selectedModel="m" />,
+    );
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const trigger = container.querySelector('[data-slot="select-trigger"]');
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    typeAtEnd(textarea, '/model');
+    await screen.findByTestId('slash-popover');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    await waitFor(() => expect(trigger?.getAttribute('aria-expanded')).toBe('true'));
+  });
+});
+

--- a/apps/web/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { ChatInput } from './ChatInput';
 import type { ModelInfo, MindContext } from '@chamber/shared/types';
 import { VOICE_DICTATION_MODEL_ID, type VoiceDictationConfig, type VoiceModelStatus } from '@chamber/shared/voice-types';
+import { MAX_IMAGE_FILE_BYTES } from '../../lib/composer';
 import { installElectronAPI, mockElectronAPI } from '../../../test/helpers';
 
 const appStateMock = vi.hoisted(() => ({
@@ -708,7 +709,7 @@ describe('ChatInput controlled value (per-agent compose drafts #221)', () => {
     });
 
     await waitFor(() => {
-      expect(onMindBValueChange).toHaveBeenCalledWith('[📷 image-1.png]');
+      expect(onMindBValueChange).toHaveBeenCalledWith(expect.stringMatching(/^\[📷#\d+ image-1\.png\]$/));
     });
     expect(onMindAValueChange).not.toHaveBeenCalled();
   });
@@ -771,15 +772,17 @@ describe('ChatInput file attachments', () => {
     const file = new File(['image-bytes'], 'photo.png', { type: 'image/png' });
 
     fireEvent.change(fileInput, { target: { files: [file] } });
-    await waitFor(() => expect(textarea.value).toContain('[📷 photo.png]'));
+    await waitFor(() => expect(textarea.value).toMatch(/\[📷#\d+ photo\.png\]/));
 
     fireEvent.keyDown(textarea, { key: 'Enter' });
     expect(onSend).toHaveBeenCalledTimes(1);
     const [message, attachments] = onSend.mock.calls[0];
-    expect(message).toContain('[📷 photo.png]');
+    expect(message).toMatch(/\[📷#\d+ photo\.png\]/);
     expect(attachments).toEqual([
       expect.objectContaining({ name: 'photo.png', mimeType: 'image/png' }),
     ]);
+    // The opaque id is stripped before the payload reaches the send path.
+    expect(attachments[0]).not.toHaveProperty('id');
   });
 
   it('attaches a text file by folding its contents into the outgoing prompt', async () => {
@@ -790,7 +793,7 @@ describe('ChatInput file attachments', () => {
     const file = new File(['hello world'], 'notes.txt', { type: 'text/plain' });
 
     fireEvent.change(fileInput, { target: { files: [file] } });
-    await waitFor(() => expect(textarea.value).toContain('[📄 notes.txt]'));
+    await waitFor(() => expect(textarea.value).toMatch(/\[📄#\d+ notes\.txt\]/));
 
     fireEvent.keyDown(textarea, { key: 'Enter' });
     expect(onSend).toHaveBeenCalledTimes(1);
@@ -809,6 +812,89 @@ describe('ChatInput file attachments', () => {
     fireEvent.change(fileInput, { target: { files: [file] } });
     await screen.findByText(/Skipped 1 unsupported file/);
     expect(textarea.value).toBe('');
+  });
+
+  it('skips images larger than the size cap with a notice', async () => {
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+    const file = new File(['x'], 'huge.png', { type: 'image/png' });
+    Object.defineProperty(file, 'size', { value: MAX_IMAGE_FILE_BYTES + 1 });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await screen.findByText(/Skipped 1 oversized file/);
+    expect(textarea.value).toBe('');
+  });
+
+  it('keeps a filename containing a closing bracket parseable via its opaque id', async () => {
+    const onSend = vi.fn();
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+    const file = new File(['bytes'], 'weird]name].png', { type: 'image/png' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await waitFor(() => expect(textarea.value).toMatch(/\[📷#\d+ /));
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [, attachments] = onSend.mock.calls[0];
+    expect(attachments).toHaveLength(1);
+    // The real filename is preserved on the payload even though the token label
+    // is sanitized of brackets.
+    expect(attachments[0].name).toBe('weird]name].png');
+  });
+});
+
+describe('ChatInput attachment scoping (per-mind)', () => {
+  function ControlledHarness({ onSend, mindId }: { onSend: (m: string, a?: unknown) => void; mindId: string }) {
+    const [drafts, setDrafts] = React.useState<Record<string, string>>({});
+    const draft = drafts[mindId] ?? '';
+    return (
+      <ChatInput
+        {...defaultProps}
+        onSend={onSend}
+        value={draft}
+        onValueChange={(next) => setDrafts((prev) => ({ ...prev, [mindId]: next }))}
+      />
+    );
+  }
+
+  it('keeps pending image and text attachments scoped to their mind across switches', async () => {
+    const onSend = vi.fn();
+    appStateMock.current.activeMindId = 'mindA';
+    const { rerender } = render(<ControlledHarness onSend={onSend} mindId="mindA" />);
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+
+    fireEvent.change(fileInput, { target: { files: [new File(['bytes'], 'a.png', { type: 'image/png' })] } });
+    await waitFor(() => expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toMatch(/\[📷#\d+ a\.png\]/));
+
+    fireEvent.change(fileInput, { target: { files: [new File(['secret text'], 'notes.txt', { type: 'text/plain' })] } });
+    await waitFor(() => expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toMatch(/\[📄#\d+ notes\.txt\]/));
+
+    // Switch to mind B: its draft and attachment bucket are independent.
+    appStateMock.current.activeMindId = 'mindB';
+    rerender(<ControlledHarness onSend={onSend} mindId="mindB" />);
+    let textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('');
+    fireEvent.change(textarea, { target: { value: 'hi from B' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith('hi from B', undefined);
+
+    // Switch back to mind A: the image + text payloads are still attached.
+    onSend.mockClear();
+    appStateMock.current.activeMindId = 'mindA';
+    rerender(<ControlledHarness onSend={onSend} mindId="mindA" />);
+    textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.value).toMatch(/\[📷#\d+ a\.png\]/);
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [message, attachments] = onSend.mock.calls[0];
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].name).toBe('a.png');
+    expect(message).toContain('Attached file notes.txt:');
+    expect(message).toContain('secret text');
   });
 });
 
@@ -849,6 +935,19 @@ describe('ChatInput @-mentions', () => {
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
     typeAtEnd(textarea, '@');
     expect(screen.queryByTestId('mention-popover')).toBeNull();
+  });
+
+  it('does not intercept Enter when the mention query matches no agent', () => {
+    const onSend = vi.fn();
+    appStateMock.current.minds = [makeMind('m1', 'Ada')];
+    render(<ChatInput {...defaultProps} onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    // "@zzz" matches nothing, so the popover is not shown and Enter must send.
+    typeAtEnd(textarea, 'hello @zzz');
+    expect(screen.queryByTestId('mention-popover')).toBeNull();
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith('hello @zzz', undefined);
   });
 });
 
@@ -911,6 +1010,18 @@ describe('ChatInput slash commands', () => {
     await screen.findByTestId('slash-popover');
     fireEvent.keyDown(textarea, { key: 'Enter' });
     await waitFor(() => expect(api.chat.newConversation).toHaveBeenCalledWith('m1'));
+  });
+
+  it('/new is ignored while a response is streaming', async () => {
+    appStateMock.current.activeMindId = 'm1';
+    render(<ChatInput {...defaultProps} isStreaming />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeAtEnd(textarea, '/new');
+    await screen.findByTestId('slash-popover');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    // The composer still clears the slash text, but no new conversation starts.
+    await waitFor(() => expect(textarea.value).toBe(''));
+    expect(api.chat.newConversation).not.toHaveBeenCalled();
   });
 
   it('/model opens the model picker', async () => {

--- a/apps/web/src/renderer/components/chat/ChatInput.test.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.test.tsx
@@ -714,6 +714,20 @@ describe('ChatInput controlled value (per-agent compose drafts #221)', () => {
     expect(onMindAValueChange).not.toHaveBeenCalled();
   });
 
+  it('skips a pasted image that exceeds the size cap with a notice', async () => {
+    render(<ChatInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const file = new File(['x'], 'huge-paste.png', { type: 'image/png' });
+    Object.defineProperty(file, 'size', { value: MAX_IMAGE_FILE_BYTES + 1 });
+
+    fireEvent.paste(textarea, {
+      clipboardData: { items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }] },
+    });
+
+    await screen.findByText(/Skipped 1 oversized file/);
+    expect(textarea.value).toBe('');
+  });
+
   it('clearing the controlled value to "" empties the textarea (post-send clear)', () => {
     const onValueChange = vi.fn();
     const { rerender } = render(
@@ -895,6 +909,38 @@ describe('ChatInput attachment scoping (per-mind)', () => {
     expect(attachments[0].name).toBe('a.png');
     expect(message).toContain('Attached file notes.txt:');
     expect(message).toContain('secret text');
+  });
+
+  it('does not corrupt the origin mind draft when a file read resolves after switching minds', async () => {
+    const onSend = vi.fn();
+    appStateMock.current.activeMindId = 'mindA';
+    const { rerender } = render(<ControlledHarness onSend={onSend} mindId="mindA" />);
+    let textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    // Mind A has typed text pending.
+    fireEvent.change(textarea, { target: { value: 'please review this' } });
+
+    // Start attaching an image on A, then switch to B before the read settles.
+    const fileInput = screen.getByTestId('composer-file-input') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [new File(['bytes'], 'a.png', { type: 'image/png' })] } });
+    appStateMock.current.activeMindId = 'mindB';
+    rerender(<ControlledHarness onSend={onSend} mindId="mindB" />);
+
+    // B's draft must stay empty: no token bleed, no A text leaking into B.
+    textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    await waitFor(() => expect(textarea.value).toBe(''));
+
+    // Back on A: the typed text survives and the image token is appended.
+    appStateMock.current.activeMindId = 'mindA';
+    rerender(<ControlledHarness onSend={onSend} mindId="mindA" />);
+    textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    await waitFor(() => expect(textarea.value).toContain('please review this'));
+    expect(textarea.value).toMatch(/\[📷#\d+ a\.png\]/);
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [, attachments] = onSend.mock.calls[0];
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].name).toBe('a.png');
   });
 });
 

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -33,10 +33,9 @@ import { getTextareaCaretCoords } from '../../lib/textarea-caret';
 import {
   imageToken,
   fileToken,
-  collectImageNames,
-  collectFileNames,
+  collectImageIds,
+  collectFileIds,
   isInsideAttachmentToken,
-  makeUniqueName,
   detectMention,
   toMentionables,
   filterMentionables,
@@ -47,12 +46,31 @@ import {
   buildMessageWithTextAttachments,
   SLASH_COMMANDS,
   MAX_TEXT_FILE_BYTES,
+  MAX_IMAGE_FILE_BYTES,
   type Mentionable,
   type MentionMatch,
   type SlashMatch,
   type SlashCommandId,
   type TextFileAttachment,
 } from '../../lib/composer';
+
+// Composer attachment payload state, scoped per conversation. Image payloads
+// carry an opaque id so their inline token can never collide with a filename.
+interface ComposerImageAttachment extends ChatImageAttachment {
+  id: number;
+}
+
+interface AttachmentBucket {
+  images: ComposerImageAttachment[];
+  texts: TextFileAttachment[];
+}
+
+const EMPTY_BUCKET: AttachmentBucket = { images: [], texts: [] };
+// Bucket keys for the controlled (single-agent, per-mind) and uncontrolled
+// (chatroom) hosts. Draft text is already per-mind; payloads must follow it so
+// switching agents never leaks one mind's attachments into another's compose.
+const NO_MIND_BUCKET_KEY = '__no-mind__';
+const UNCONTROLLED_BUCKET_KEY = '__uncontrolled__';
 
 const log = Logger.create('ChatInput');
 
@@ -279,8 +297,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     if (isControlled) onValueChange?.(resolved);
     else setInternalInput(resolved);
   }, [input, isControlled, onValueChange]);
-  const [attachments, setAttachments] = useState<ChatImageAttachment[]>([]);
-  const [textAttachments, setTextAttachments] = useState<TextFileAttachment[]>([]);
+  const [attachmentsByKey, setAttachmentsByKey] = useState<Record<string, AttachmentBucket>>({});
   const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
   const [emojiOpen, setEmojiOpen] = useState(false);
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
@@ -301,9 +318,26 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pastedSeq = useRef(0);
+  const attachmentIdRef = useRef(0);
   // Last known textarea selection — preserved across blur (e.g., when the
   // emoji popover steals focus) so insertAtCaret can land in the right place.
   const selectionRef = useRef<{ start: number; end: number } | null>(null);
+
+  // Which attachment bucket the current draft belongs to. Mirrors the per-mind
+  // draft partitioning so payloads travel with the text when agents switch.
+  const conversationKey = isControlled ? (activeMindId ?? NO_MIND_BUCKET_KEY) : UNCONTROLLED_BUCKET_KEY;
+  const activeBucket = attachmentsByKey[conversationKey] ?? EMPTY_BUCKET;
+  const activeImages = activeBucket.images;
+  const activeTexts = activeBucket.texts;
+
+  const updateBucket = useCallback((key: string, fn: (bucket: AttachmentBucket) => AttachmentBucket) => {
+    setAttachmentsByKey((prev) => {
+      const current = prev[key] ?? EMPTY_BUCKET;
+      const next = fn(current);
+      if (next === current) return prev;
+      return { ...prev, [key]: next };
+    });
+  }, []);
 
   const mentionables = useMemo<Mentionable[]>(() => toMentionables(minds), [minds]);
   const mentionResults = useMemo<Mentionable[]>(
@@ -353,29 +387,27 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     closeSlash();
   }, [closeShortcode, closeMention, closeSlash]);
 
-  // Drop attachments whose tokens no longer appear in the given text.
+  // Drop attachments from the active bucket whose token id no longer appears in
+  // the given text. Matching is by opaque id so odd filenames cannot desync it.
   const pruneAttachments = useCallback((next: string) => {
-    const imageNames = collectImageNames(next);
-    setAttachments((prev) => {
-      const pruned = prev.filter((a) => imageNames.has(a.name));
-      return pruned.length === prev.length ? prev : pruned;
+    const imageIds = collectImageIds(next);
+    const fileIds = collectFileIds(next);
+    updateBucket(conversationKey, (bucket) => {
+      const images = bucket.images.filter((a) => imageIds.has(a.id));
+      const texts = bucket.texts.filter((a) => fileIds.has(a.id));
+      if (images.length === bucket.images.length && texts.length === bucket.texts.length) return bucket;
+      return { images, texts };
     });
-    const fileNames = collectFileNames(next);
-    setTextAttachments((prev) => {
-      const pruned = prev.filter((a) => fileNames.has(a.name));
-      return pruned.length === prev.length ? prev : pruned;
-    });
-  }, []);
+  }, [conversationKey, updateBucket]);
 
   const resetComposer = useCallback(() => {
     setInput('');
-    setAttachments([]);
-    setTextAttachments([]);
+    updateBucket(conversationKey, (bucket) => (bucket === EMPTY_BUCKET ? bucket : EMPTY_BUCKET));
     setAttachmentNotice(null);
     closeAllMenus();
     setEmojiOpen(false);
     if (textareaRef.current) textareaRef.current.style.height = 'auto';
-  }, [setInput, closeAllMenus]);
+  }, [setInput, conversationKey, updateBucket, closeAllMenus]);
 
   const getMaxHeight = useCallback((el: HTMLTextAreaElement) => {
     const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20;
@@ -417,34 +449,36 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
 
   const handleFiles = useCallback(async (files: File[]) => {
     if (files.length === 0) return;
-    const used = new Set<string>([
-      ...collectImageNames(textareaRef.current?.value ?? input),
-      ...collectFileNames(textareaRef.current?.value ?? input),
-    ]);
+    // Capture the bucket at click time so an agent switch mid-read cannot
+    // misfile the payload relative to the token we insert into this draft.
+    const key = conversationKey;
     const skipped: string[] = [];
+    const oversized: string[] = [];
     for (const file of files) {
       if (isImageFile({ name: file.name, mimeType: file.type })) {
+        if (file.size > MAX_IMAGE_FILE_BYTES) {
+          oversized.push(file.name);
+          continue;
+        }
         try {
           const data = await readAsBase64(file);
-          const name = makeUniqueName(file.name, used);
-          used.add(name);
+          const id = ++attachmentIdRef.current;
           const mimeType = file.type || 'image/png';
-          setAttachments((prev) => [...prev, { name, mimeType, data }]);
-          insertAtCaret(imageToken(name));
+          updateBucket(key, (b) => ({ ...b, images: [...b.images, { id, name: file.name, mimeType, data }] }));
+          insertAtCaret(imageToken(id, file.name));
         } catch {
           skipped.push(file.name);
         }
       } else if (isTextLikeFile({ name: file.name, mimeType: file.type })) {
         if (file.size > MAX_TEXT_FILE_BYTES) {
-          skipped.push(file.name);
+          oversized.push(file.name);
           continue;
         }
         try {
           const content = await readAsText(file);
-          const name = makeUniqueName(file.name, used);
-          used.add(name);
-          setTextAttachments((prev) => [...prev, { name, mimeType: file.type || 'text/plain', content }]);
-          insertAtCaret(fileToken(name));
+          const id = ++attachmentIdRef.current;
+          updateBucket(key, (b) => ({ ...b, texts: [...b.texts, { id, name: file.name, mimeType: file.type || 'text/plain', content }] }));
+          insertAtCaret(fileToken(id, file.name));
         } catch {
           skipped.push(file.name);
         }
@@ -452,13 +486,16 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         skipped.push(file.name);
       }
     }
-    setAttachmentNotice(
-      skipped.length > 0
-        ? `Skipped ${skipped.length} unsupported file${skipped.length > 1 ? 's' : ''}: ${skipped.join(', ')}`
-        : null,
-    );
+    const notices: string[] = [];
+    if (skipped.length > 0) {
+      notices.push(`Skipped ${skipped.length} unsupported file${skipped.length > 1 ? 's' : ''}: ${skipped.join(', ')}`);
+    }
+    if (oversized.length > 0) {
+      notices.push(`Skipped ${oversized.length} oversized file${oversized.length > 1 ? 's' : ''}: ${oversized.join(', ')}`);
+    }
+    setAttachmentNotice(notices.length > 0 ? notices.join(' · ') : null);
     requestAnimationFrame(() => textareaRef.current?.focus());
-  }, [input, insertAtCaret]);
+  }, [conversationKey, updateBucket, insertAtCaret]);
 
   const acceptMention = useCallback((item: Mentionable) => {
     const match = mentionMatch;
@@ -493,7 +530,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'settings' });
         break;
       case 'new':
-        if (activeMindId) {
+        // Guard client-side: starting a fresh conversation mid-stream would
+        // race the in-flight turn. Ignore until streaming settles.
+        if (activeMindId && !isStreaming) {
           void newConversation(activeMindId).catch((error: unknown) => {
             log.error('Failed to start new conversation:', error);
           });
@@ -501,7 +540,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         break;
     }
     requestAnimationFrame(() => textareaRef.current?.focus());
-  }, [resetComposer, availableModels.length, dispatch, activeMindId, newConversation]);
+  }, [resetComposer, availableModels.length, dispatch, activeMindId, isStreaming, newConversation]);
 
   useEffect(() => {
     if (!featureFlags.voiceDictation) {
@@ -577,6 +616,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     if (imageItems.length === 0) return;
 
     e.preventDefault();
+    const key = conversationKey;
     for (const item of imageItems) {
       const file = item.getAsFile();
       if (!file) continue;
@@ -584,15 +624,15 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         const data = await readAsBase64(file);
         const mimeType = file.type || 'image/png';
         const ext = mimeToExt(mimeType);
-        const id = (++pastedSeq.current).toString(36);
-        const name = `image-${id}.${ext}`;
-        setAttachments((prev) => [...prev, { name, mimeType, data }]);
-        insertAtCaret(imageToken(name));
+        const name = `image-${(++pastedSeq.current).toString(36)}.${ext}`;
+        const id = ++attachmentIdRef.current;
+        updateBucket(key, (b) => ({ ...b, images: [...b.images, { id, name, mimeType, data }] }));
+        insertAtCaret(imageToken(id, name));
       } catch {
         // ignore unreadable clipboard entries
       }
     }
-  }, [insertAtCaret]);
+  }, [conversationKey, updateBucket, insertAtCaret]);
 
   const handleSubmit = useCallback(() => {
     if (isStreaming) {
@@ -601,18 +641,21 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     // A bare slash command is never sent as a message; it runs from the menu.
     if (slashMatch) return;
 
-    const keptImageNames = collectImageNames(input);
-    const keptImages = attachments.filter((a) => keptImageNames.has(a.name));
+    const bucket = attachmentsByKey[conversationKey] ?? EMPTY_BUCKET;
+    const keptImageIds = collectImageIds(input);
+    const keptImages: ChatImageAttachment[] = bucket.images
+      .filter((a) => keptImageIds.has(a.id))
+      .map((a) => ({ name: a.name, mimeType: a.mimeType, data: a.data }));
     const hasText = input.trim().length > 0;
-    const hasAttachments = keptImages.length > 0 || collectFileNames(input).size > 0;
+    const hasAttachments = keptImages.length > 0 || collectFileIds(input).size > 0;
     if ((!hasText && !hasAttachments) || disabled) return;
 
     // Fold any text-file contents into the outgoing prompt; images ride along
     // as blob attachments and keep their inline marker token.
-    const message = buildMessageWithTextAttachments(input, textAttachments);
+    const message = buildMessageWithTextAttachments(input, bucket.texts);
     onSend(message, keptImages.length > 0 ? keptImages : undefined);
     resetComposer();
-  }, [input, attachments, textAttachments, slashMatch, isStreaming, disabled, onSend, resetComposer]);
+  }, [input, attachmentsByKey, conversationKey, slashMatch, isStreaming, disabled, onSend, resetComposer]);
 
   const acceptShortcode = useCallback(
     (record: EmojiRecord) => {
@@ -700,8 +743,10 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         return;
       }
     }
-    // 2b) Mention popover open.
-    if (mentionMatch && handleMenuKeydown(e, {
+    // 2b) Mention popover open — only intercept when it has visible results, so
+    // arrows/Escape/Enter fall through to normal editing when the query matches
+    // no agent (the popover is not rendered in that case).
+    if (mentionMatch && mentionResults.length > 0 && handleMenuKeydown(e, {
       count: mentionResults.length,
       index: mentionIndex,
       setIndex: setMentionIndex,
@@ -788,7 +833,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   };
 
   const canSubmit = !slashMatch
-    && (input.trim().length > 0 || attachments.length > 0 || textAttachments.length > 0)
+    && (input.trim().length > 0 || activeImages.length > 0 || activeTexts.length > 0)
     && !disabled;
 
   return (

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -182,6 +182,19 @@ function readAsText(file: Blob): Promise<string> {
   });
 }
 
+// Build the composer notice for files that could not be attached. Returns null
+// when nothing was skipped so the notice line can be cleared.
+function buildSkipNotice(skipped: string[], oversized: string[]): string | null {
+  const notices: string[] = [];
+  if (skipped.length > 0) {
+    notices.push(`Skipped ${skipped.length} unsupported file${skipped.length > 1 ? 's' : ''}: ${skipped.join(', ')}`);
+  }
+  if (oversized.length > 0) {
+    notices.push(`Skipped ${oversized.length} oversized file${oversized.length > 1 ? 's' : ''}: ${oversized.join(', ')}`);
+  }
+  return notices.length > 0 ? notices.join(' · ') : null;
+}
+
 function getMenuPopoverPlacement(anchor: MenuAnchor): MenuPopoverPlacement {
   const viewportHeight = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerHeight;
   const viewportWidth = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerWidth;
@@ -326,6 +339,10 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
   // Which attachment bucket the current draft belongs to. Mirrors the per-mind
   // draft partitioning so payloads travel with the text when agents switch.
   const conversationKey = isControlled ? (activeMindId ?? NO_MIND_BUCKET_KEY) : UNCONTROLLED_BUCKET_KEY;
+  // Live mirror of the key so async file-read completions can tell whether the
+  // user has since switched agents (and skip stealing caret/focus if so).
+  const conversationKeyRef = useRef(conversationKey);
+  conversationKeyRef.current = conversationKey;
   const activeBucket = attachmentsByKey[conversationKey] ?? EMPTY_BUCKET;
   const activeImages = activeBucket.images;
   const activeTexts = activeBucket.texts;
@@ -447,11 +464,60 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     });
   }, [resize, setInput]);
 
+  // Snapshot the draft + caret that own an attachment pick, so an async file
+  // read that resolves after an agent switch composes against the origin draft
+  // rather than whatever draft is now live in the shared textarea.
+  const captureDraft = useCallback(() => {
+    const el = textareaRef.current;
+    const base = el?.value ?? input;
+    const focused = el ? document.activeElement === el : false;
+    const caret = el
+      ? (focused ? (el.selectionStart ?? base.length) : (selectionRef.current?.start ?? base.length))
+      : base.length;
+    return { base, caret };
+  }, [input]);
+
+  // File payloads and their inline tokens are committed together, against the
+  // captured base draft and via the captured (origin-mind) writer. The textarea
+  // caret/focus is only touched when the origin mind is still active.
+  const commitAttachments = useCallback((
+    key: string,
+    base: string,
+    caret: number,
+    images: ComposerImageAttachment[],
+    texts: TextFileAttachment[],
+    tokens: string[],
+  ) => {
+    if (images.length === 0 && texts.length === 0) return;
+    updateBucket(key, (b) => ({ images: [...b.images, ...images], texts: [...b.texts, ...texts] }));
+    let draft = base;
+    let pos = Math.max(0, Math.min(caret, base.length));
+    for (const token of tokens) {
+      draft = draft.slice(0, pos) + token + draft.slice(pos);
+      pos += token.length;
+    }
+    setInput(draft);
+    if (key === conversationKeyRef.current) {
+      selectionRef.current = { start: pos, end: pos };
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(pos, pos);
+        resize(el);
+      });
+    }
+  }, [updateBucket, setInput, resize]);
+
   const handleFiles = useCallback(async (files: File[]) => {
     if (files.length === 0) return;
-    // Capture the bucket at click time so an agent switch mid-read cannot
-    // misfile the payload relative to the token we insert into this draft.
+    // Capture the bucket and base draft at pick time so a mid-read agent switch
+    // cannot misfile the payload or corrupt the origin/destination drafts.
     const key = conversationKey;
+    const { base, caret } = captureDraft();
+    const images: ComposerImageAttachment[] = [];
+    const texts: TextFileAttachment[] = [];
+    const tokens: string[] = [];
     const skipped: string[] = [];
     const oversized: string[] = [];
     for (const file of files) {
@@ -463,9 +529,8 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         try {
           const data = await readAsBase64(file);
           const id = ++attachmentIdRef.current;
-          const mimeType = file.type || 'image/png';
-          updateBucket(key, (b) => ({ ...b, images: [...b.images, { id, name: file.name, mimeType, data }] }));
-          insertAtCaret(imageToken(id, file.name));
+          images.push({ id, name: file.name, mimeType: file.type || 'image/png', data });
+          tokens.push(imageToken(id, file.name));
         } catch {
           skipped.push(file.name);
         }
@@ -477,8 +542,8 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         try {
           const content = await readAsText(file);
           const id = ++attachmentIdRef.current;
-          updateBucket(key, (b) => ({ ...b, texts: [...b.texts, { id, name: file.name, mimeType: file.type || 'text/plain', content }] }));
-          insertAtCaret(fileToken(id, file.name));
+          texts.push({ id, name: file.name, mimeType: file.type || 'text/plain', content });
+          tokens.push(fileToken(id, file.name));
         } catch {
           skipped.push(file.name);
         }
@@ -486,16 +551,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         skipped.push(file.name);
       }
     }
-    const notices: string[] = [];
-    if (skipped.length > 0) {
-      notices.push(`Skipped ${skipped.length} unsupported file${skipped.length > 1 ? 's' : ''}: ${skipped.join(', ')}`);
-    }
-    if (oversized.length > 0) {
-      notices.push(`Skipped ${oversized.length} oversized file${oversized.length > 1 ? 's' : ''}: ${oversized.join(', ')}`);
-    }
-    setAttachmentNotice(notices.length > 0 ? notices.join(' · ') : null);
-    requestAnimationFrame(() => textareaRef.current?.focus());
-  }, [conversationKey, updateBucket, insertAtCaret]);
+    commitAttachments(key, base, caret, images, texts, tokens);
+    setAttachmentNotice(buildSkipNotice(skipped, oversized));
+  }, [conversationKey, captureDraft, commitAttachments]);
 
   const acceptMention = useCallback((item: Mentionable) => {
     const match = mentionMatch;
@@ -617,22 +675,31 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
 
     e.preventDefault();
     const key = conversationKey;
+    const { base, caret } = captureDraft();
+    const images: ComposerImageAttachment[] = [];
+    const tokens: string[] = [];
+    const oversized: string[] = [];
     for (const item of imageItems) {
       const file = item.getAsFile();
       if (!file) continue;
+      const mimeType = file.type || 'image/png';
+      const name = `image-${(++pastedSeq.current).toString(36)}.${mimeToExt(mimeType)}`;
+      if (file.size > MAX_IMAGE_FILE_BYTES) {
+        oversized.push(name);
+        continue;
+      }
       try {
         const data = await readAsBase64(file);
-        const mimeType = file.type || 'image/png';
-        const ext = mimeToExt(mimeType);
-        const name = `image-${(++pastedSeq.current).toString(36)}.${ext}`;
         const id = ++attachmentIdRef.current;
-        updateBucket(key, (b) => ({ ...b, images: [...b.images, { id, name, mimeType, data }] }));
-        insertAtCaret(imageToken(id, name));
+        images.push({ id, name, mimeType, data });
+        tokens.push(imageToken(id, name));
       } catch {
         // ignore unreadable clipboard entries
       }
     }
-  }, [conversationKey, updateBucket, insertAtCaret]);
+    commitAttachments(key, base, caret, images, [], tokens);
+    setAttachmentNotice(buildSkipNotice([], oversized));
+  }, [conversationKey, captureDraft, commitAttachments]);
 
   const handleSubmit = useCallback(() => {
     if (isStreaming) {
@@ -857,7 +924,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
               isComposingRef.current = false;
               setIsComposingForVoice(false);
             }}
-            placeholder={placeholder ?? (disabled ? 'Select a mind directory to start…' : 'Message your agent… (attach or paste files, @ to mention, / for commands)')}
+            placeholder={placeholder ?? (disabled ? 'Select a mind directory to start…' : 'Message your agent… (paste an image to attach)')}
             aria-label="Message your agent"
             disabled={disabled}
             rows={1}

--- a/apps/web/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/web/src/renderer/components/chat/ChatInput.tsx
@@ -1,12 +1,14 @@
-import React, { useState, useRef, useCallback, Suspense, useEffect } from 'react';
+import React, { useState, useRef, useCallback, useMemo, Suspense, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Mic, Smile } from 'lucide-react';
+import { Mic, Paperclip, Smile } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { modelSelectionKeyFromModel } from '@chamber/shared/model-selection';
 import { VOICE_DICTATION_MODEL_ID, type VoiceDictationConfig, type VoiceModelStatus } from '@chamber/shared/voice-types';
 import type { ModelInfo, ChatImageAttachment } from '@chamber/shared/types';
-import { useAppState } from '../../lib/store';
+import { useAppState, useAppDispatch } from '../../lib/store';
 import { useVoiceDictation } from '../../hooks/useVoiceDictation';
+import { useNewConversation } from '../../hooks/useNewConversation';
+import { Logger } from '../../lib/logger';
 import {
   Select,
   SelectContent,
@@ -28,6 +30,31 @@ import {
 import { pushRecentEmoji } from '../../lib/emoji-recents';
 import { loadEmojiData, type EmojiRecord } from '../../lib/emoji-data';
 import { getTextareaCaretCoords } from '../../lib/textarea-caret';
+import {
+  imageToken,
+  fileToken,
+  collectImageNames,
+  collectFileNames,
+  isInsideAttachmentToken,
+  makeUniqueName,
+  detectMention,
+  toMentionables,
+  filterMentionables,
+  detectSlash,
+  filterSlashCommands,
+  isImageFile,
+  isTextLikeFile,
+  buildMessageWithTextAttachments,
+  SLASH_COMMANDS,
+  MAX_TEXT_FILE_BYTES,
+  type Mentionable,
+  type MentionMatch,
+  type SlashMatch,
+  type SlashCommandId,
+  type TextFileAttachment,
+} from '../../lib/composer';
+
+const log = Logger.create('ChatInput');
 
 const EmojiPickerLazy = React.lazy(() =>
   import('../ui/emoji-picker').then((m) => ({ default: m.EmojiPicker })),
@@ -52,11 +79,10 @@ interface Props {
   onValueChange?: (next: string) => void;
 }
 
-const IMAGE_TOKEN_RE = /\[📷 ([^\]]+)\]/g;
-const SHORTCODE_POPOVER_GAP = 4;
-const SHORTCODE_POPOVER_MARGIN = 8;
-const SHORTCODE_POPOVER_MAX_HEIGHT = 240;
-const SHORTCODE_POPOVER_MIN_WIDTH = 220;
+const MENU_POPOVER_GAP = 4;
+const MENU_POPOVER_MARGIN = 8;
+const MENU_POPOVER_MAX_HEIGHT = 240;
+const MENU_POPOVER_MIN_WIDTH = 220;
 const VOICE_MODEL_NOT_READY_TOOLTIP = 'Download the dictation model in Settings → Voice dictation';
 const DEFAULT_VOICE_MODEL_STATUS: VoiceModelStatus = {
   id: VOICE_DICTATION_MODEL_ID,
@@ -77,13 +103,13 @@ interface ShortcodeMatch {
   query: string;
 }
 
-interface ShortcodeAnchor {
+interface MenuAnchor {
   top: number;
   left: number;
   height: number;
 }
 
-interface ShortcodePopoverPlacement {
+interface MenuPopoverPlacement {
   side: 'top' | 'bottom';
   style: React.CSSProperties;
 }
@@ -95,14 +121,8 @@ function detectShortcode(text: string, caret: number): ShortcodeMatch | null {
   const token = m[2];
   const start = caret - token.length;
 
-  // Suppress if caret is inside an existing image token span.
-  IMAGE_TOKEN_RE.lastIndex = 0;
-  let img: RegExpExecArray | null;
-  while ((img = IMAGE_TOKEN_RE.exec(text)) !== null) {
-    const imgStart = img.index;
-    const imgEnd = imgStart + img[0].length;
-    if (start >= imgStart && start < imgEnd) return null;
-  }
+  // Suppress if the caret is inside an existing attachment token span.
+  if (isInsideAttachmentToken(text, start)) return null;
 
   return { start, query: token.slice(1).toLowerCase() };
 }
@@ -135,21 +155,30 @@ function readAsBase64(file: Blob): Promise<string> {
   });
 }
 
-function getShortcodePopoverPlacement(anchor: ShortcodeAnchor): ShortcodePopoverPlacement {
+function readAsText(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsText(file);
+  });
+}
+
+function getMenuPopoverPlacement(anchor: MenuAnchor): MenuPopoverPlacement {
   const viewportHeight = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerHeight;
   const viewportWidth = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerWidth;
   const maxHeight = Math.min(
-    SHORTCODE_POPOVER_MAX_HEIGHT,
-    Math.max(0, viewportHeight - SHORTCODE_POPOVER_MARGIN * 2),
+    MENU_POPOVER_MAX_HEIGHT,
+    Math.max(0, viewportHeight - MENU_POPOVER_MARGIN * 2),
   );
-  const bottomTop = anchor.top + anchor.height + SHORTCODE_POPOVER_GAP;
-  const wouldClipBottom = bottomTop + maxHeight > viewportHeight - SHORTCODE_POPOVER_MARGIN;
+  const bottomTop = anchor.top + anchor.height + MENU_POPOVER_GAP;
+  const wouldClipBottom = bottomTop + maxHeight > viewportHeight - MENU_POPOVER_MARGIN;
   const top = wouldClipBottom
-    ? Math.max(SHORTCODE_POPOVER_MARGIN, anchor.top - maxHeight - SHORTCODE_POPOVER_GAP)
+    ? Math.max(MENU_POPOVER_MARGIN, anchor.top - maxHeight - MENU_POPOVER_GAP)
     : bottomTop;
   const left = Math.min(
-    Math.max(SHORTCODE_POPOVER_MARGIN, anchor.left),
-    Math.max(SHORTCODE_POPOVER_MARGIN, viewportWidth - SHORTCODE_POPOVER_MIN_WIDTH - SHORTCODE_POPOVER_MARGIN),
+    Math.max(MENU_POPOVER_MARGIN, anchor.left),
+    Math.max(MENU_POPOVER_MARGIN, viewportWidth - MENU_POPOVER_MIN_WIDTH - MENU_POPOVER_MARGIN),
   );
 
   return {
@@ -164,8 +193,84 @@ function getShortcodePopoverPlacement(anchor: ShortcodeAnchor): ShortcodePopover
   };
 }
 
+interface MenuNav {
+  count: number;
+  index: number;
+  setIndex: React.Dispatch<React.SetStateAction<number>>;
+  onAccept: () => void;
+  onClose: () => void;
+  /** When true, Enter/Tab are swallowed even with no results (prevents send). */
+  swallowEnterWhenEmpty?: boolean;
+}
+
+// Shared caret-menu keyboard handling for the mention and slash popovers.
+// Returns true when the key was consumed so the caller can stop processing.
+function handleMenuKeydown(e: React.KeyboardEvent<HTMLTextAreaElement>, menu: MenuNav): boolean {
+  const isAccept = (e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab';
+  if (isAccept && menu.count > 0) {
+    e.preventDefault();
+    menu.onAccept();
+    return true;
+  }
+  if (isAccept && menu.swallowEnterWhenEmpty) {
+    e.preventDefault();
+    menu.onClose();
+    return true;
+  }
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    menu.onClose();
+    return true;
+  }
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    menu.setIndex((i) => Math.min(i + 1, menu.count - 1));
+    return true;
+  }
+  if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    menu.setIndex((i) => Math.max(i - 1, 0));
+    return true;
+  }
+  return false;
+}
+
+// Portal-rendered caret menu shared by the shortcode, mention and slash
+// popovers so placement, chrome and the cmdk wrapper live in one place.
+function CaretPopover({
+  anchor,
+  testId,
+  ariaLabel,
+  children,
+}: {
+  anchor: MenuAnchor;
+  testId: string;
+  ariaLabel: string;
+  children: React.ReactNode;
+}) {
+  if (typeof document === 'undefined') return null;
+  const placement = getMenuPopoverPlacement(anchor);
+  return createPortal(
+    <div
+      role="listbox"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      data-side={placement.side}
+      style={placement.style}
+      className="min-w-[220px] overflow-hidden rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
+    >
+      <Command shouldFilter={false}>
+        <CommandList>{children}</CommandList>
+      </Command>
+    </div>,
+    document.body,
+  );
+}
+
 export function ChatInput({ onSend, onStop, isStreaming, disabled, availableModels, selectedModel, onModelChange, placeholder, value, onValueChange }: Props) {
-  const { featureFlags } = useAppState();
+  const { featureFlags, minds, activeMindId } = useAppState();
+  const dispatch = useAppDispatch();
+  const newConversation = useNewConversation();
   const isControlled = value !== undefined;
   const [internalInput, setInternalInput] = useState('');
   const input = isControlled ? value : internalInput;
@@ -175,20 +280,44 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     else setInternalInput(resolved);
   }, [input, isControlled, onValueChange]);
   const [attachments, setAttachments] = useState<ChatImageAttachment[]>([]);
+  const [textAttachments, setTextAttachments] = useState<TextFileAttachment[]>([]);
+  const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
   const [emojiOpen, setEmojiOpen] = useState(false);
+  const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const [shortcodeMatch, setShortcodeMatch] = useState<ShortcodeMatch | null>(null);
   const [shortcodeResults, setShortcodeResults] = useState<EmojiRecord[]>([]);
   const [shortcodeIndex, setShortcodeIndex] = useState(0);
-  const [shortcodeAnchor, setShortcodeAnchor] = useState<ShortcodeAnchor | null>(null);
+  const [shortcodeAnchor, setShortcodeAnchor] = useState<MenuAnchor | null>(null);
+  const [mentionMatch, setMentionMatch] = useState<MentionMatch | null>(null);
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [mentionAnchor, setMentionAnchor] = useState<MenuAnchor | null>(null);
+  const [slashMatch, setSlashMatch] = useState<SlashMatch | null>(null);
+  const [slashIndex, setSlashIndex] = useState(0);
+  const [slashAnchor, setSlashAnchor] = useState<MenuAnchor | null>(null);
   const [isComposingForVoice, setIsComposingForVoice] = useState(false);
   const [voiceConfig, setVoiceConfig] = useState<VoiceDictationConfig | null>(null);
   const [modelStatus, setModelStatus] = useState<VoiceModelStatus>(DEFAULT_VOICE_MODEL_STATUS);
   const isComposingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const pastedSeq = useRef(0);
   // Last known textarea selection — preserved across blur (e.g., when the
   // emoji popover steals focus) so insertAtCaret can land in the right place.
   const selectionRef = useRef<{ start: number; end: number } | null>(null);
+
+  const mentionables = useMemo<Mentionable[]>(() => toMentionables(minds), [minds]);
+  const mentionResults = useMemo<Mentionable[]>(
+    () => (mentionMatch ? filterMentionables(mentionables, mentionMatch.query) : []),
+    [mentionMatch, mentionables],
+  );
+  const availableSlashCommands = useMemo(
+    () => (availableModels.length > 0 ? SLASH_COMMANDS : SLASH_COMMANDS.filter((c) => c.id !== 'model')),
+    [availableModels.length],
+  );
+  const slashResults = useMemo(
+    () => (slashMatch ? filterSlashCommands(availableSlashCommands, slashMatch.query) : []),
+    [slashMatch, availableSlashCommands],
+  );
 
   const updateSelectionRef = useCallback(() => {
     const el = textareaRef.current;
@@ -205,6 +334,48 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     setShortcodeIndex(0);
     setShortcodeAnchor(null);
   }, []);
+
+  const closeMention = useCallback(() => {
+    setMentionMatch(null);
+    setMentionIndex(0);
+    setMentionAnchor(null);
+  }, []);
+
+  const closeSlash = useCallback(() => {
+    setSlashMatch(null);
+    setSlashIndex(0);
+    setSlashAnchor(null);
+  }, []);
+
+  const closeAllMenus = useCallback(() => {
+    closeShortcode();
+    closeMention();
+    closeSlash();
+  }, [closeShortcode, closeMention, closeSlash]);
+
+  // Drop attachments whose tokens no longer appear in the given text.
+  const pruneAttachments = useCallback((next: string) => {
+    const imageNames = collectImageNames(next);
+    setAttachments((prev) => {
+      const pruned = prev.filter((a) => imageNames.has(a.name));
+      return pruned.length === prev.length ? prev : pruned;
+    });
+    const fileNames = collectFileNames(next);
+    setTextAttachments((prev) => {
+      const pruned = prev.filter((a) => fileNames.has(a.name));
+      return pruned.length === prev.length ? prev : pruned;
+    });
+  }, []);
+
+  const resetComposer = useCallback(() => {
+    setInput('');
+    setAttachments([]);
+    setTextAttachments([]);
+    setAttachmentNotice(null);
+    closeAllMenus();
+    setEmojiOpen(false);
+    if (textareaRef.current) textareaRef.current.style.height = 'auto';
+  }, [setInput, closeAllMenus]);
 
   const getMaxHeight = useCallback((el: HTMLTextAreaElement) => {
     const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20;
@@ -243,6 +414,94 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
       resize(textareaRef.current);
     });
   }, [resize, setInput]);
+
+  const handleFiles = useCallback(async (files: File[]) => {
+    if (files.length === 0) return;
+    const used = new Set<string>([
+      ...collectImageNames(textareaRef.current?.value ?? input),
+      ...collectFileNames(textareaRef.current?.value ?? input),
+    ]);
+    const skipped: string[] = [];
+    for (const file of files) {
+      if (isImageFile({ name: file.name, mimeType: file.type })) {
+        try {
+          const data = await readAsBase64(file);
+          const name = makeUniqueName(file.name, used);
+          used.add(name);
+          const mimeType = file.type || 'image/png';
+          setAttachments((prev) => [...prev, { name, mimeType, data }]);
+          insertAtCaret(imageToken(name));
+        } catch {
+          skipped.push(file.name);
+        }
+      } else if (isTextLikeFile({ name: file.name, mimeType: file.type })) {
+        if (file.size > MAX_TEXT_FILE_BYTES) {
+          skipped.push(file.name);
+          continue;
+        }
+        try {
+          const content = await readAsText(file);
+          const name = makeUniqueName(file.name, used);
+          used.add(name);
+          setTextAttachments((prev) => [...prev, { name, mimeType: file.type || 'text/plain', content }]);
+          insertAtCaret(fileToken(name));
+        } catch {
+          skipped.push(file.name);
+        }
+      } else {
+        skipped.push(file.name);
+      }
+    }
+    setAttachmentNotice(
+      skipped.length > 0
+        ? `Skipped ${skipped.length} unsupported file${skipped.length > 1 ? 's' : ''}: ${skipped.join(', ')}`
+        : null,
+    );
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [input, insertAtCaret]);
+
+  const acceptMention = useCallback((item: Mentionable) => {
+    const match = mentionMatch;
+    if (!match) return;
+    const source = textareaRef.current?.value ?? input;
+    const before = source.slice(0, match.start);
+    const afterStart = match.start + 1 + match.query.length; // include the `@`
+    const after = source.slice(afterStart);
+    const token = `@${item.name} `;
+    const next = before + token + after;
+    setInput(next);
+    const caret = before.length + token.length;
+    selectionRef.current = { start: caret, end: caret };
+    closeMention();
+    requestAnimationFrame(() => {
+      if (!textareaRef.current) return;
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(caret, caret);
+      resize(textareaRef.current);
+    });
+  }, [mentionMatch, input, closeMention, resize, setInput]);
+
+  const runSlashCommand = useCallback((id: SlashCommandId) => {
+    resetComposer();
+    switch (id) {
+      case 'clear':
+        break;
+      case 'model':
+        if (availableModels.length > 0) setModelMenuOpen(true);
+        break;
+      case 'settings':
+        dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'settings' });
+        break;
+      case 'new':
+        if (activeMindId) {
+          void newConversation(activeMindId).catch((error: unknown) => {
+            log.error('Failed to start new conversation:', error);
+          });
+        }
+        break;
+    }
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [resetComposer, availableModels.length, dispatch, activeMindId, newConversation]);
 
   useEffect(() => {
     if (!featureFlags.voiceDictation) {
@@ -295,7 +554,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
 
   const voiceEnabled = featureFlags.voiceDictation && voiceConfig?.enabled === true;
   const voiceModelReady = modelStatus.status === 'ready';
-  const pttEnabled = voiceEnabled && !disabled && voiceModelReady && !shortcodeMatch && !isComposingForVoice;
+  const pttEnabled = voiceEnabled && !disabled && voiceModelReady && !shortcodeMatch && !mentionMatch && !slashMatch && !isComposingForVoice;
   const voice = useVoiceDictation({
     enabled: pttEnabled,
     shortcut: voiceConfig?.shortcut ?? '',
@@ -328,7 +587,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         const id = (++pastedSeq.current).toString(36);
         const name = `image-${id}.${ext}`;
         setAttachments((prev) => [...prev, { name, mimeType, data }]);
-        insertAtCaret(`[📷 ${name}]`);
+        insertAtCaret(imageToken(name));
       } catch {
         // ignore unreadable clipboard entries
       }
@@ -339,28 +598,21 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     if (isStreaming) {
       return;
     }
+    // A bare slash command is never sent as a message; it runs from the menu.
+    if (slashMatch) return;
+
+    const keptImageNames = collectImageNames(input);
+    const keptImages = attachments.filter((a) => keptImageNames.has(a.name));
     const hasText = input.trim().length > 0;
-    const hasAttachments = attachments.length > 0;
+    const hasAttachments = keptImages.length > 0 || collectFileNames(input).size > 0;
     if ((!hasText && !hasAttachments) || disabled) return;
 
-    // Only include attachments whose tokens still appear in the text
-    const tokensInText = new Set<string>();
-    let m: RegExpExecArray | null;
-    IMAGE_TOKEN_RE.lastIndex = 0;
-    while ((m = IMAGE_TOKEN_RE.exec(input)) !== null) {
-      tokensInText.add(m[1]);
-    }
-    const kept = attachments.filter((a) => tokensInText.has(a.name));
-
-    onSend(input, kept.length > 0 ? kept : undefined);
-    setInput('');
-    setAttachments([]);
-    setEmojiOpen(false);
-    closeShortcode();
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-    }
-  }, [input, attachments, isStreaming, disabled, onSend, closeShortcode, setInput]);
+    // Fold any text-file contents into the outgoing prompt; images ride along
+    // as blob attachments and keep their inline marker token.
+    const message = buildMessageWithTextAttachments(input, textAttachments);
+    onSend(message, keptImages.length > 0 ? keptImages : undefined);
+    resetComposer();
+  }, [input, attachments, textAttachments, slashMatch, isStreaming, disabled, onSend, resetComposer]);
 
   const acceptShortcode = useCallback(
     (record: EmojiRecord) => {
@@ -377,14 +629,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
       const caret = before.length + record.emoji.length;
       selectionRef.current = { start: caret, end: caret };
       // Prune attachments whose tokens may have been removed.
-      setAttachments((prev) => {
-        const tokens = new Set<string>();
-        let m: RegExpExecArray | null;
-        IMAGE_TOKEN_RE.lastIndex = 0;
-        while ((m = IMAGE_TOKEN_RE.exec(next)) !== null) tokens.add(m[1]);
-        const pruned = prev.filter((a) => tokens.has(a.name));
-        return pruned.length === prev.length ? prev : pruned;
-      });
+      pruneAttachments(next);
       closeShortcode();
       requestAnimationFrame(() => {
         if (!textareaRef.current) return;
@@ -393,7 +638,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         resize(textareaRef.current);
       });
     },
-    [shortcodeMatch, closeShortcode, resize, setInput],
+    [shortcodeMatch, closeShortcode, pruneAttachments, resize, setInput],
   );
 
   const handleEmojiSelect = useCallback(
@@ -455,6 +700,33 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
         return;
       }
     }
+    // 2b) Mention popover open.
+    if (mentionMatch && handleMenuKeydown(e, {
+      count: mentionResults.length,
+      index: mentionIndex,
+      setIndex: setMentionIndex,
+      onAccept: () => {
+        const pick = mentionResults[mentionIndex] ?? mentionResults[0];
+        if (pick) acceptMention(pick);
+      },
+      onClose: closeMention,
+    })) {
+      return;
+    }
+    // 2c) Slash command menu open — never let the slash text submit.
+    if (slashMatch && handleMenuKeydown(e, {
+      count: slashResults.length,
+      index: slashIndex,
+      setIndex: setSlashIndex,
+      onAccept: () => {
+        const pick = slashResults[slashIndex] ?? slashResults[0];
+        if (pick) runSlashCommand(pick.id);
+      },
+      onClose: closeSlash,
+      swallowEnterWhenEmpty: true,
+    })) {
+      return;
+    }
     if (e.key === 'Escape' && isStreaming) {
       e.preventDefault();
       onStop();
@@ -471,21 +743,38 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     const next = e.target.value;
     setInput(next);
     resize(e.target);
-    // Drop attachments whose tokens were removed by the user
-    setAttachments((prev) => {
-      const tokens = new Set<string>();
-      let m: RegExpExecArray | null;
-      IMAGE_TOKEN_RE.lastIndex = 0;
-      while ((m = IMAGE_TOKEN_RE.exec(next)) !== null) tokens.add(m[1]);
-      const pruned = prev.filter((a) => tokens.has(a.name));
-      return pruned.length === prev.length ? prev : pruned;
-    });
-    // Shortcode detection — suppressed during IME composition.
+    // Drop attachments whose tokens were removed by the user.
+    pruneAttachments(next);
+    // Menu detection — suppressed during IME composition.
     if (isComposingRef.current) {
-      closeShortcode();
+      closeAllMenus();
       return;
     }
     const caret = e.target.selectionStart ?? next.length;
+    // A bare `/command` at the very start opens the slash menu.
+    const slash = detectSlash(next);
+    if (slash) {
+      setSlashMatch(slash);
+      setSlashIndex(0);
+      setSlashAnchor(getTextareaCaretCoords(e.target, caret));
+      closeShortcode();
+      closeMention();
+      return;
+    } else if (slashMatch) {
+      closeSlash();
+    }
+    // `@name` at the caret opens the mention menu.
+    const mention = detectMention(next, caret);
+    if (mention) {
+      setMentionMatch(mention);
+      setMentionIndex(0);
+      setMentionAnchor(getTextareaCaretCoords(e.target, caret));
+      closeShortcode();
+      return;
+    } else if (mentionMatch) {
+      closeMention();
+    }
+    // `:shortcode` emoji suggestions.
     const match = detectShortcode(next, caret);
     if (match) {
       setShortcodeMatch(match);
@@ -498,10 +787,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
     }
   };
 
-  const canSubmit = (input.trim().length > 0 || attachments.length > 0) && !disabled;
-  const shortcodePopoverPlacement = shortcodeAnchor
-    ? getShortcodePopoverPlacement(shortcodeAnchor)
-    : null;
+  const canSubmit = !slashMatch
+    && (input.trim().length > 0 || attachments.length > 0 || textAttachments.length > 0)
+    && !disabled;
 
   return (
     <div className="border-t border-border px-4 py-3">
@@ -524,7 +812,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
               isComposingRef.current = false;
               setIsComposingForVoice(false);
             }}
-            placeholder={placeholder ?? (disabled ? 'Select a mind directory to start…' : 'Message your agent… (paste an image to attach)')}
+            placeholder={placeholder ?? (disabled ? 'Select a mind directory to start…' : 'Message your agent… (attach or paste files, @ to mention, / for commands)')}
             aria-label="Message your agent"
             disabled={disabled}
             rows={1}
@@ -533,6 +821,35 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
 
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-1">
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                aria-hidden="true"
+                tabIndex={-1}
+                data-testid="composer-file-input"
+                onChange={(e) => {
+                  const files = Array.from(e.target.files ?? []);
+                  e.target.value = '';
+                  if (files.length > 0) void handleFiles(files);
+                }}
+              />
+              <button
+                type="button"
+                aria-label="Attach files"
+                disabled={disabled}
+                onMouseDown={(e) => {
+                  // Preserve textarea selection across the focus shift.
+                  updateSelectionRef();
+                  e.preventDefault();
+                }}
+                onClick={() => fileInputRef.current?.click()}
+                className="h-6 w-6 shrink-0 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent disabled:opacity-50 disabled:hover:bg-transparent flex items-center justify-center"
+              >
+                <Paperclip className="w-4 h-4" />
+              </button>
+
               <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
                 <PopoverTrigger asChild>
                   <button
@@ -599,6 +916,8 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
 
               {availableModels.length > 0 ? (
                 <Select
+                  open={modelMenuOpen}
+                  onOpenChange={setModelMenuOpen}
                   value={selectedModel ?? undefined}
                   onValueChange={onModelChange}
                   disabled={isStreaming || disabled}
@@ -655,6 +974,12 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
               </button>
             </TooltipFor>
           </div>
+
+          {attachmentNotice ? (
+            <p role="status" className="text-xs text-amber-500">
+              {attachmentNotice}
+            </p>
+          ) : null}
         </div>
 
         <p className="text-xs text-muted-foreground text-center mt-2">
@@ -665,41 +990,68 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled, availableMode
           AI agents can make mistakes. Verify important information.
         </p>
       </div>
-      {shortcodeMatch && shortcodeAnchor && shortcodeResults.length > 0 && typeof document !== 'undefined'
-        ? createPortal(
-            <div
-              role="listbox"
-              aria-label="Emoji shortcode suggestions"
-              data-testid="shortcode-popover"
-              data-side={shortcodePopoverPlacement?.side}
-              style={shortcodePopoverPlacement?.style}
-              className="min-w-[220px] overflow-hidden rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
+      {shortcodeMatch && shortcodeAnchor && shortcodeResults.length > 0 ? (
+        <CaretPopover anchor={shortcodeAnchor} testId="shortcode-popover" ariaLabel="Emoji shortcode suggestions">
+          {shortcodeResults.map((rec, i) => (
+            <CommandItem
+              key={rec.hexcode}
+              value={rec.shortcodes[0]}
+              data-selected={i === shortcodeIndex || undefined}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                acceptShortcode(rec);
+              }}
+              onMouseEnter={() => setShortcodeIndex(i)}
             >
-              <Command shouldFilter={false}>
-                <CommandList>
-                  {shortcodeResults.map((rec, i) => (
-                    <CommandItem
-                      key={rec.hexcode}
-                      value={rec.shortcodes[0]}
-                      data-selected={i === shortcodeIndex || undefined}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        acceptShortcode(rec);
-                      }}
-                      onMouseEnter={() => setShortcodeIndex(i)}
-                    >
-                      <span className="text-base">{rec.emoji}</span>
-                      <span className="text-xs text-muted-foreground">
-                        :{rec.shortcodes[0]}
-                      </span>
-                    </CommandItem>
-                  ))}
-                </CommandList>
-              </Command>
-            </div>,
-            document.body,
-          )
-        : null}
+              <span className="text-base">{rec.emoji}</span>
+              <span className="text-xs text-muted-foreground">
+                :{rec.shortcodes[0]}
+              </span>
+            </CommandItem>
+          ))}
+        </CaretPopover>
+      ) : null}
+      {mentionMatch && mentionAnchor && mentionResults.length > 0 ? (
+        <CaretPopover anchor={mentionAnchor} testId="mention-popover" ariaLabel="Agent mention suggestions">
+          {mentionResults.map((item, i) => (
+            <CommandItem
+              key={item.mindId}
+              value={item.name}
+              data-selected={i === mentionIndex || undefined}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                acceptMention(item);
+              }}
+              onMouseEnter={() => setMentionIndex(i)}
+            >
+              <span className="text-sm font-medium">@{item.name}</span>
+            </CommandItem>
+          ))}
+        </CaretPopover>
+      ) : null}
+      {slashMatch && slashAnchor ? (
+        <CaretPopover anchor={slashAnchor} testId="slash-popover" ariaLabel="Slash commands">
+          {slashResults.length > 0 ? (
+            slashResults.map((command, i) => (
+              <CommandItem
+                key={command.id}
+                value={command.name}
+                data-selected={i === slashIndex || undefined}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  runSlashCommand(command.id);
+                }}
+                onMouseEnter={() => setSlashIndex(i)}
+              >
+                <span className="text-sm font-medium">{command.name}</span>
+                <span className="text-xs text-muted-foreground">{command.hint}</span>
+              </CommandItem>
+            ))
+          ) : (
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">No matching commands</div>
+          )}
+        </CaretPopover>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -3,6 +3,7 @@ import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ConversationSummary } from '@chamber/shared/types';
 import { useAppDispatch, useAppState } from '../../lib/store';
+import { useNewConversation } from '../../hooks/useNewConversation';
 import { Logger } from '../../lib/logger';
 import { cn } from '../../lib/utils';
 import {
@@ -20,6 +21,7 @@ const HISTORY_COLLAPSED_STORAGE_KEY = 'chamber:conversation-history-collapsed';
 export function ConversationHistoryPanel() {
   const { activeMindId, conversationHistoryByMind, activeConversationByMind, conversationViewByMind, streamingByMind } = useAppState();
   const dispatch = useAppDispatch();
+  const newConversation = useNewConversation();
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [isCreatingConversation, setIsCreatingConversation] = useState(false);
@@ -165,10 +167,7 @@ export function ConversationHistoryPanel() {
     creatingConversationRef.current = true;
     setIsCreatingConversation(true);
     try {
-      const result = await window.electronAPI.chat.newConversation(activeMindId);
-      await window.electronAPI.chatroom.clear();
-      applyResumeResult(activeMindId, result);
-      dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+      await newConversation(activeMindId);
     } catch (error) {
       log.error('Failed to start new conversation:', error);
     } finally {

--- a/apps/web/src/renderer/hooks/useNewConversation.ts
+++ b/apps/web/src/renderer/hooks/useNewConversation.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import { useAppDispatch } from '../lib/store';
+
+/**
+ * Starts a fresh conversation for a mind and routes the UI back to chat.
+ *
+ * Encapsulates the newConversation IPC + chatroom reset + store hydration so
+ * the flow is not duplicated between the conversation history panel and the
+ * composer `/new` slash command.
+ */
+export function useNewConversation(): (mindId: string) => Promise<void> {
+  const dispatch = useAppDispatch();
+
+  return useCallback(async (mindId: string) => {
+    const result = await window.electronAPI.chat.newConversation(mindId);
+    await window.electronAPI.chatroom.clear();
+    dispatch({
+      type: 'RESUME_CONVERSATION',
+      payload: {
+        mindId,
+        sessionId: result.sessionId,
+        messages: result.messages,
+        conversations: result.conversations,
+      },
+    });
+    dispatch({ type: 'SET_ACTIVE_VIEW', payload: 'chat' });
+  }, [dispatch]);
+}

--- a/apps/web/src/renderer/lib/composer.test.ts
+++ b/apps/web/src/renderer/lib/composer.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import type { MindContext } from '@chamber/shared/types';
+import {
+  imageToken,
+  fileToken,
+  collectImageNames,
+  collectFileNames,
+  isInsideAttachmentToken,
+  makeUniqueName,
+  detectMention,
+  toMentionables,
+  filterMentionables,
+  detectSlash,
+  filterSlashCommands,
+  SLASH_COMMANDS,
+  isImageFile,
+  isTextLikeFile,
+  buildMessageWithTextAttachments,
+} from './composer';
+
+function makeMind(mindId: string, name: string): MindContext {
+  return {
+    mindId,
+    mindPath: `C:\\minds\\${mindId}`,
+    identity: { name, systemMessage: '' },
+    status: 'ready',
+  };
+}
+
+describe('attachment tokens', () => {
+  it('builds distinct image and file token markers', () => {
+    expect(imageToken('a.png')).toBe('[📷 a.png]');
+    expect(fileToken('notes.md')).toBe('[📄 notes.md]');
+  });
+
+  it('collects image and file names independently', () => {
+    const text = `hello ${imageToken('a.png')} and ${fileToken('notes.md')}`;
+    expect(collectImageNames(text)).toEqual(new Set(['a.png']));
+    expect(collectFileNames(text)).toEqual(new Set(['notes.md']));
+  });
+
+  it('detects when an index sits inside any attachment token span', () => {
+    const text = `x ${imageToken('a.png')}`;
+    const insideStart = text.indexOf('[') + 2;
+    expect(isInsideAttachmentToken(text, insideStart)).toBe(true);
+    expect(isInsideAttachmentToken(text, 0)).toBe(false);
+  });
+});
+
+describe('makeUniqueName', () => {
+  it('returns the name unchanged when unused', () => {
+    expect(makeUniqueName('report.txt', new Set())).toBe('report.txt');
+  });
+
+  it('suffixes a counter before the extension on collision', () => {
+    const used = new Set(['report.txt', 'report (2).txt']);
+    expect(makeUniqueName('report.txt', used)).toBe('report (3).txt');
+  });
+
+  it('suffixes extensionless names', () => {
+    expect(makeUniqueName('Dockerfile', new Set(['Dockerfile']))).toBe('Dockerfile (2)');
+  });
+});
+
+describe('detectMention', () => {
+  it('matches a bare @ at the caret', () => {
+    const match = detectMention('@', 1);
+    expect(match).toEqual({ start: 0, query: '' });
+  });
+
+  it('matches @query after whitespace and lowercases the query', () => {
+    const text = 'hey @Al';
+    const match = detectMention(text, text.length);
+    expect(match).toEqual({ start: 4, query: 'al' });
+  });
+
+  it('does not match an @ glued to a preceding word (email-like)', () => {
+    const text = 'user@host';
+    expect(detectMention(text, text.length)).toBeNull();
+  });
+
+  it('does not match when the caret is not at the end of the token', () => {
+    const text = '@alice extra';
+    expect(detectMention(text, text.length)).toBeNull();
+  });
+
+  it('suppresses mentions inside an attachment token', () => {
+    const text = `${imageToken('@shot.png')}`;
+    // caret right after the "@" inside the token span
+    const caret = text.indexOf('@') + 1;
+    expect(detectMention(text, caret)).toBeNull();
+  });
+});
+
+describe('mentionables', () => {
+  const minds = [makeMind('m1', 'Ada'), makeMind('m2', 'Alan'), makeMind('m3', 'Grace')];
+
+  it('maps minds to id/name pairs', () => {
+    expect(toMentionables(minds)).toEqual([
+      { mindId: 'm1', name: 'Ada' },
+      { mindId: 'm2', name: 'Alan' },
+      { mindId: 'm3', name: 'Grace' },
+    ]);
+  });
+
+  it('returns everything (capped) for an empty query', () => {
+    expect(filterMentionables(toMentionables(minds), '')).toHaveLength(3);
+  });
+
+  it('filters case-insensitively by substring', () => {
+    const result = filterMentionables(toMentionables(minds), 'a');
+    expect(result.map((m) => m.name)).toEqual(['Ada', 'Alan', 'Grace']);
+    const al = filterMentionables(toMentionables(minds), 'al');
+    expect(al.map((m) => m.name)).toEqual(['Alan']);
+  });
+
+  it('honours the result limit', () => {
+    const many = Array.from({ length: 20 }, (_, i) => makeMind(`m${i}`, `Agent${i}`));
+    expect(filterMentionables(toMentionables(many), 'agent', 5)).toHaveLength(5);
+  });
+});
+
+describe('detectSlash', () => {
+  it('matches a bare slash and a partial command', () => {
+    expect(detectSlash('/')).toEqual({ query: '' });
+    expect(detectSlash('/ne')).toEqual({ query: 'ne' });
+  });
+
+  it('does not match once a space or newline is typed', () => {
+    expect(detectSlash('/new ')).toBeNull();
+    expect(detectSlash('hello /new')).toBeNull();
+  });
+
+  it('filters commands by id prefix', () => {
+    expect(filterSlashCommands(SLASH_COMMANDS, '')).toHaveLength(SLASH_COMMANDS.length);
+    expect(filterSlashCommands(SLASH_COMMANDS, 'cl').map((c) => c.id)).toEqual(['clear']);
+    expect(filterSlashCommands(SLASH_COMMANDS, 'zzz')).toHaveLength(0);
+  });
+});
+
+describe('file classification', () => {
+  it('treats image mime types and image extensions as images', () => {
+    expect(isImageFile({ name: 'x', mimeType: 'image/png' })).toBe(true);
+    expect(isImageFile({ name: 'photo.JPG', mimeType: '' })).toBe(true);
+    expect(isImageFile({ name: 'notes.txt', mimeType: 'text/plain' })).toBe(false);
+  });
+
+  it('treats text mime types and known code extensions as text-like', () => {
+    expect(isTextLikeFile({ name: 'a.txt', mimeType: 'text/plain' })).toBe(true);
+    expect(isTextLikeFile({ name: 'a.ts', mimeType: '' })).toBe(true);
+    expect(isTextLikeFile({ name: 'data.json', mimeType: 'application/json' })).toBe(true);
+    expect(isTextLikeFile({ name: 'feed.atom', mimeType: 'application/atom+xml' })).toBe(true);
+    expect(isTextLikeFile({ name: 'archive.zip', mimeType: 'application/zip' })).toBe(false);
+  });
+});
+
+describe('buildMessageWithTextAttachments', () => {
+  it('returns the input unchanged when there are no text attachments', () => {
+    expect(buildMessageWithTextAttachments('hi', [])).toBe('hi');
+  });
+
+  it('folds contents of attachments whose token is present', () => {
+    const input = `look at ${fileToken('notes.md')}`;
+    const out = buildMessageWithTextAttachments(input, [
+      { name: 'notes.md', mimeType: 'text/markdown', content: '# Title' },
+    ]);
+    expect(out).toContain('look at [📄 notes.md]');
+    expect(out).toContain('Attached file notes.md:');
+    expect(out).toContain('# Title');
+  });
+
+  it('ignores attachments whose token was removed from the input', () => {
+    const out = buildMessageWithTextAttachments('no tokens here', [
+      { name: 'notes.md', mimeType: 'text/markdown', content: '# Title' },
+    ]);
+    expect(out).toBe('no tokens here');
+  });
+});

--- a/apps/web/src/renderer/lib/composer.test.ts
+++ b/apps/web/src/renderer/lib/composer.test.ts
@@ -3,10 +3,10 @@ import type { MindContext } from '@chamber/shared/types';
 import {
   imageToken,
   fileToken,
-  collectImageNames,
-  collectFileNames,
+  sanitizeTokenLabel,
+  collectImageIds,
+  collectFileIds,
   isInsideAttachmentToken,
-  makeUniqueName,
   detectMention,
   toMentionables,
   filterMentionables,
@@ -15,6 +15,7 @@ import {
   SLASH_COMMANDS,
   isImageFile,
   isTextLikeFile,
+  safeFenceFor,
   buildMessageWithTextAttachments,
 } from './composer';
 
@@ -28,37 +29,42 @@ function makeMind(mindId: string, name: string): MindContext {
 }
 
 describe('attachment tokens', () => {
-  it('builds distinct image and file token markers', () => {
-    expect(imageToken('a.png')).toBe('[📷 a.png]');
-    expect(fileToken('notes.md')).toBe('[📄 notes.md]');
+  it('builds image and file tokens with opaque ids and display labels', () => {
+    expect(imageToken(1, 'a.png')).toBe('[📷#1 a.png]');
+    expect(fileToken(2, 'notes.md')).toBe('[📄#2 notes.md]');
   });
 
-  it('collects image and file names independently', () => {
-    const text = `hello ${imageToken('a.png')} and ${fileToken('notes.md')}`;
-    expect(collectImageNames(text)).toEqual(new Set(['a.png']));
-    expect(collectFileNames(text)).toEqual(new Set(['notes.md']));
+  it('collects image and file ids independently', () => {
+    const text = `hello ${imageToken(1, 'a.png')} and ${fileToken(2, 'notes.md')}`;
+    expect(collectImageIds(text)).toEqual(new Set([1]));
+    expect(collectFileIds(text)).toEqual(new Set([2]));
+  });
+
+  it('keys attachments by id even when the filename contains a closing bracket', () => {
+    // A raw "]" in the filename must not break parsing or bleed into the label.
+    const token = imageToken(7, 'weird]name].png');
+    expect(token).toBe('[📷#7 weird name .png]');
+    const text = `before ${token} after ${imageToken(8, 'clean.png')}`;
+    expect(collectImageIds(text)).toEqual(new Set([7, 8]));
+  });
+
+  it('does not let one token span into the next when labels are adjacent', () => {
+    const text = `${imageToken(1, 'a.png')}${imageToken(2, 'b.png')}`;
+    expect(collectImageIds(text)).toEqual(new Set([1, 2]));
   });
 
   it('detects when an index sits inside any attachment token span', () => {
-    const text = `x ${imageToken('a.png')}`;
+    const text = `x ${imageToken(3, 'a.png')}`;
     const insideStart = text.indexOf('[') + 2;
     expect(isInsideAttachmentToken(text, insideStart)).toBe(true);
     expect(isInsideAttachmentToken(text, 0)).toBe(false);
   });
 });
 
-describe('makeUniqueName', () => {
-  it('returns the name unchanged when unused', () => {
-    expect(makeUniqueName('report.txt', new Set())).toBe('report.txt');
-  });
-
-  it('suffixes a counter before the extension on collision', () => {
-    const used = new Set(['report.txt', 'report (2).txt']);
-    expect(makeUniqueName('report.txt', used)).toBe('report (3).txt');
-  });
-
-  it('suffixes extensionless names', () => {
-    expect(makeUniqueName('Dockerfile', new Set(['Dockerfile']))).toBe('Dockerfile (2)');
+describe('sanitizeTokenLabel', () => {
+  it('replaces brackets and newlines and collapses whitespace', () => {
+    expect(sanitizeTokenLabel('a]b[c\nd')).toBe('a b c d');
+    expect(sanitizeTokenLabel('  spaced   name  ')).toBe('spaced name');
   });
 });
 
@@ -85,7 +91,7 @@ describe('detectMention', () => {
   });
 
   it('suppresses mentions inside an attachment token', () => {
-    const text = `${imageToken('@shot.png')}`;
+    const text = `${imageToken(1, '@shot.png')}`;
     // caret right after the "@" inside the token span
     const caret = text.indexOf('@') + 1;
     expect(detectMention(text, caret)).toBeNull();
@@ -154,25 +160,44 @@ describe('file classification', () => {
   });
 });
 
+describe('safeFenceFor', () => {
+  it('uses three backticks when content has no fence', () => {
+    expect(safeFenceFor('plain text')).toBe('```');
+  });
+
+  it('grows the fence beyond the longest backtick run in the content', () => {
+    expect(safeFenceFor('a ``` b')).toBe('````');
+    expect(safeFenceFor('a ````` b')).toBe('``````');
+  });
+});
+
 describe('buildMessageWithTextAttachments', () => {
   it('returns the input unchanged when there are no text attachments', () => {
     expect(buildMessageWithTextAttachments('hi', [])).toBe('hi');
   });
 
-  it('folds contents of attachments whose token is present', () => {
-    const input = `look at ${fileToken('notes.md')}`;
+  it('folds contents of attachments whose token id is present', () => {
+    const input = `look at ${fileToken(5, 'notes.md')}`;
     const out = buildMessageWithTextAttachments(input, [
-      { name: 'notes.md', mimeType: 'text/markdown', content: '# Title' },
+      { id: 5, name: 'notes.md', mimeType: 'text/markdown', content: '# Title' },
     ]);
-    expect(out).toContain('look at [📄 notes.md]');
+    expect(out).toContain(`look at ${fileToken(5, 'notes.md')}`);
     expect(out).toContain('Attached file notes.md:');
     expect(out).toContain('# Title');
   });
 
-  it('ignores attachments whose token was removed from the input', () => {
+  it('ignores attachments whose token id is not in the input', () => {
     const out = buildMessageWithTextAttachments('no tokens here', [
-      { name: 'notes.md', mimeType: 'text/markdown', content: '# Title' },
+      { id: 5, name: 'notes.md', mimeType: 'text/markdown', content: '# Title' },
     ]);
     expect(out).toBe('no tokens here');
+  });
+
+  it('uses a fence long enough to wrap content that itself contains fences', () => {
+    const input = fileToken(1, 'snippet.md');
+    const out = buildMessageWithTextAttachments(input, [
+      { id: 1, name: 'snippet.md', mimeType: 'text/markdown', content: 'text\n```\ncode\n```' },
+    ]);
+    expect(out).toContain('````\ntext');
   });
 });

--- a/apps/web/src/renderer/lib/composer.ts
+++ b/apps/web/src/renderer/lib/composer.ts
@@ -9,48 +9,63 @@ import type { MindContext } from '@chamber/shared/types';
 // ---------------------------------------------------------------------------
 
 // Attachment tokens ---------------------------------------------------------
+//
+// A token is the inline marker the user sees for an attachment, e.g.
+// `[📷#3 photo.png]`. The authoritative key is the opaque numeric id (`#3`),
+// never the filename: filenames may contain `]`, `[` or newlines that would
+// otherwise break token parsing or let one token bleed into the next. The
+// display label is sanitized of those characters so the token is always
+// well-formed, while the real filename is preserved on the attachment payload
+// for sending and for folded-file headers.
 
 /** Marker prefix for pasted/attached images (carried to the SDK as blobs). */
 export const IMAGE_TOKEN_EMOJI = '📷';
 /** Marker prefix for text-like files (folded into the outgoing prompt). */
 export const FILE_TOKEN_EMOJI = '📄';
 
-export function imageToken(name: string): string {
-  return `[${IMAGE_TOKEN_EMOJI} ${name}]`;
+/** Strip characters that would break token structure from a display label. */
+export function sanitizeTokenLabel(name: string): string {
+  return name.replace(/[[\]\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
-export function fileToken(name: string): string {
-  return `[${FILE_TOKEN_EMOJI} ${name}]`;
+export function imageToken(id: number, name: string): string {
+  return `[${IMAGE_TOKEN_EMOJI}#${id} ${sanitizeTokenLabel(name)}]`;
+}
+
+export function fileToken(id: number, name: string): string {
+  return `[${FILE_TOKEN_EMOJI}#${id} ${sanitizeTokenLabel(name)}]`;
 }
 
 // Fresh RegExp instances per call so the global `lastIndex` is never shared.
+// The label class `[^\][\n]*` excludes brackets and newlines, so a token can
+// never span another token and the trailing `]` is unambiguous.
 function imageTokenRe(): RegExp {
-  return /\[📷 ([^\]]+)\]/g;
+  return /\[📷#(\d+) [^\][\n]*\]/g;
 }
 
 function fileTokenRe(): RegExp {
-  return /\[📄 ([^\]]+)\]/g;
+  return /\[📄#(\d+) [^\][\n]*\]/g;
 }
 
 function anyTokenRe(): RegExp {
-  return /\[(?:📷|📄) ([^\]]+)\]/g;
+  return /\[(?:📷|📄)#(\d+) [^\][\n]*\]/g;
 }
 
-function collectNames(text: string, re: RegExp): Set<string> {
-  const names = new Set<string>();
+function collectIds(text: string, re: RegExp): Set<number> {
+  const ids = new Set<number>();
   let match: RegExpExecArray | null;
-  while ((match = re.exec(text)) !== null) names.add(match[1]);
-  return names;
+  while ((match = re.exec(text)) !== null) ids.add(Number(match[1]));
+  return ids;
 }
 
-/** Names of image tokens currently present in `text`. */
-export function collectImageNames(text: string): Set<string> {
-  return collectNames(text, imageTokenRe());
+/** Ids of image tokens currently present in `text`. */
+export function collectImageIds(text: string): Set<number> {
+  return collectIds(text, imageTokenRe());
 }
 
-/** Names of file tokens currently present in `text`. */
-export function collectFileNames(text: string): Set<string> {
-  return collectNames(text, fileTokenRe());
+/** Ids of file tokens currently present in `text`. */
+export function collectFileIds(text: string): Set<number> {
+  return collectIds(text, fileTokenRe());
 }
 
 /** True when `index` falls within any attachment token span. */
@@ -63,21 +78,6 @@ export function isInsideAttachmentToken(text: string, index: number): boolean {
     if (index >= start && index < end) return true;
   }
   return false;
-}
-
-/** Suffix a name with " (n)" until it is unique against `used`. */
-export function makeUniqueName(name: string, used: Set<string>): string {
-  if (!used.has(name)) return name;
-  const dot = name.lastIndexOf('.');
-  const stem = dot > 0 ? name.slice(0, dot) : name;
-  const ext = dot > 0 ? name.slice(dot) : '';
-  let n = 2;
-  let candidate = `${stem} (${n})${ext}`;
-  while (used.has(candidate)) {
-    n += 1;
-    candidate = `${stem} (${n})${ext}`;
-  }
-  return candidate;
 }
 
 // @-mentions ----------------------------------------------------------------
@@ -162,6 +162,9 @@ export function filterSlashCommands(commands: readonly SlashCommand[], query: st
 /** Max size we will inline as text; larger text files are skipped. */
 export const MAX_TEXT_FILE_BYTES = 256 * 1024;
 
+/** Max image payload we will attach as a blob; larger images are skipped. */
+export const MAX_IMAGE_FILE_BYTES = 10 * 1024 * 1024;
+
 const IMAGE_EXT = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'avif', 'heic', 'heif', 'ico']);
 
 const TEXT_LIKE_MIME = new Set([
@@ -208,22 +211,41 @@ export function isTextLikeFile(file: { name: string; mimeType: string }): boolea
 }
 
 export interface TextFileAttachment {
+  id: number;
   name: string;
   mimeType: string;
   content: string;
 }
 
 /**
+ * Choose a backtick fence longer than any backtick run in `content`, so folded
+ * file bodies that themselves contain ``` fences cannot terminate the block
+ * early. Never shorter than the standard three backticks.
+ */
+export function safeFenceFor(content: string): string {
+  let longestRun = 0;
+  const matches = content.match(/`+/g);
+  if (matches) {
+    for (const run of matches) longestRun = Math.max(longestRun, run.length);
+  }
+  return '`'.repeat(Math.max(3, longestRun + 1));
+}
+
+/**
  * Fold the contents of any text attachments whose token still appears in
  * `input` into the outgoing prompt as labelled fenced blocks. Image tokens are
  * left untouched (their payload rides along as a separate blob attachment).
+ * Attachments are matched by opaque id, never by filename.
  */
 export function buildMessageWithTextAttachments(input: string, files: readonly TextFileAttachment[]): string {
   if (files.length === 0) return input;
-  const present = collectFileNames(input);
-  const kept = files.filter((file) => present.has(file.name));
+  const presentIds = collectFileIds(input);
+  const kept = files.filter((file) => presentIds.has(file.id));
   if (kept.length === 0) return input;
-  const blocks = kept.map((file) => `Attached file ${file.name}:\n\`\`\`\n${file.content}\n\`\`\``);
+  const blocks = kept.map((file) => {
+    const fence = safeFenceFor(file.content);
+    return `Attached file ${file.name}:\n${fence}\n${file.content}\n${fence}`;
+  });
   const base = input.trimEnd();
   return `${base}${base.length > 0 ? '\n\n' : ''}${blocks.join('\n\n')}`;
 }

--- a/apps/web/src/renderer/lib/composer.ts
+++ b/apps/web/src/renderer/lib/composer.ts
@@ -1,0 +1,229 @@
+import type { MindContext } from '@chamber/shared/types';
+
+// ---------------------------------------------------------------------------
+// Composer power-ups — pure helpers shared by ChatInput and its tests.
+//
+// Everything here is DOM-free and side-effect-free so the detection, filtering
+// and prompt-folding logic can be unit tested in isolation. ChatInput owns the
+// stateful/DOM concerns (FileReader, caret math, React state).
+// ---------------------------------------------------------------------------
+
+// Attachment tokens ---------------------------------------------------------
+
+/** Marker prefix for pasted/attached images (carried to the SDK as blobs). */
+export const IMAGE_TOKEN_EMOJI = '📷';
+/** Marker prefix for text-like files (folded into the outgoing prompt). */
+export const FILE_TOKEN_EMOJI = '📄';
+
+export function imageToken(name: string): string {
+  return `[${IMAGE_TOKEN_EMOJI} ${name}]`;
+}
+
+export function fileToken(name: string): string {
+  return `[${FILE_TOKEN_EMOJI} ${name}]`;
+}
+
+// Fresh RegExp instances per call so the global `lastIndex` is never shared.
+function imageTokenRe(): RegExp {
+  return /\[📷 ([^\]]+)\]/g;
+}
+
+function fileTokenRe(): RegExp {
+  return /\[📄 ([^\]]+)\]/g;
+}
+
+function anyTokenRe(): RegExp {
+  return /\[(?:📷|📄) ([^\]]+)\]/g;
+}
+
+function collectNames(text: string, re: RegExp): Set<string> {
+  const names = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) names.add(match[1]);
+  return names;
+}
+
+/** Names of image tokens currently present in `text`. */
+export function collectImageNames(text: string): Set<string> {
+  return collectNames(text, imageTokenRe());
+}
+
+/** Names of file tokens currently present in `text`. */
+export function collectFileNames(text: string): Set<string> {
+  return collectNames(text, fileTokenRe());
+}
+
+/** True when `index` falls within any attachment token span. */
+export function isInsideAttachmentToken(text: string, index: number): boolean {
+  const re = anyTokenRe();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const start = match.index;
+    const end = start + match[0].length;
+    if (index >= start && index < end) return true;
+  }
+  return false;
+}
+
+/** Suffix a name with " (n)" until it is unique against `used`. */
+export function makeUniqueName(name: string, used: Set<string>): string {
+  if (!used.has(name)) return name;
+  const dot = name.lastIndexOf('.');
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const ext = dot > 0 ? name.slice(dot) : '';
+  let n = 2;
+  let candidate = `${stem} (${n})${ext}`;
+  while (used.has(candidate)) {
+    n += 1;
+    candidate = `${stem} (${n})${ext}`;
+  }
+  return candidate;
+}
+
+// @-mentions ----------------------------------------------------------------
+
+export interface MentionMatch {
+  /** Index of the leading `@` in the source text. */
+  start: number;
+  /** Lowercased query typed after `@` (may be empty). */
+  query: string;
+}
+
+// `@` at start-of-string or after whitespace / ( [ { , followed by an optional
+// word-ish body up to the caret. Mirrors the boundary rules of SHORTCODE_RE.
+const MENTION_RE = /(^|[\s([{])@([a-z0-9_-]*)$/i;
+
+export function detectMention(text: string, caret: number): MentionMatch | null {
+  const upToCaret = text.slice(0, caret);
+  const match = MENTION_RE.exec(upToCaret);
+  if (!match) return null;
+  const query = match[2];
+  const start = caret - (query.length + 1); // include the `@`
+  if (isInsideAttachmentToken(text, start)) return null;
+  return { start, query: query.toLowerCase() };
+}
+
+export interface Mentionable {
+  mindId: string;
+  name: string;
+}
+
+export function toMentionables(minds: readonly MindContext[]): Mentionable[] {
+  return minds.map((mind) => ({ mindId: mind.mindId, name: mind.identity.name }));
+}
+
+export function filterMentionables(items: readonly Mentionable[], query: string, limit = 8): Mentionable[] {
+  const q = query.toLowerCase();
+  const matched = q.length === 0 ? items : items.filter((item) => item.name.toLowerCase().includes(q));
+  return matched.slice(0, limit);
+}
+
+// Slash commands ------------------------------------------------------------
+
+export type SlashCommandId = 'new' | 'clear' | 'model' | 'settings';
+
+export interface SlashCommand {
+  id: SlashCommandId;
+  /** Display label including the leading slash, e.g. `/new`. */
+  name: string;
+  hint: string;
+}
+
+export const SLASH_COMMANDS: readonly SlashCommand[] = [
+  { id: 'new', name: '/new', hint: 'Start a new conversation' },
+  { id: 'clear', name: '/clear', hint: 'Clear the composer' },
+  { id: 'model', name: '/model', hint: 'Choose the model' },
+  { id: 'settings', name: '/settings', hint: 'Open settings' },
+];
+
+export interface SlashMatch {
+  /** Lowercased query typed after the leading `/` (may be empty). */
+  query: string;
+}
+
+// Only a bare command token at the very start triggers the menu: `/`, `/ne`,
+// `/settings`. As soon as a space or newline is typed the menu closes.
+const SLASH_RE = /^\/([a-z]*)$/i;
+
+export function detectSlash(text: string): SlashMatch | null {
+  const match = SLASH_RE.exec(text);
+  if (!match) return null;
+  return { query: match[1].toLowerCase() };
+}
+
+export function filterSlashCommands(commands: readonly SlashCommand[], query: string): SlashCommand[] {
+  const q = query.toLowerCase();
+  if (q.length === 0) return [...commands];
+  return commands.filter((command) => command.id.startsWith(q));
+}
+
+// File classification + prompt folding --------------------------------------
+
+/** Max size we will inline as text; larger text files are skipped. */
+export const MAX_TEXT_FILE_BYTES = 256 * 1024;
+
+const IMAGE_EXT = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'avif', 'heic', 'heif', 'ico']);
+
+const TEXT_LIKE_MIME = new Set([
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/ecmascript',
+  'application/typescript',
+  'application/x-yaml',
+  'application/yaml',
+  'application/x-sh',
+  'application/x-httpd-php',
+  'application/sql',
+  'application/graphql',
+]);
+
+const TEXT_LIKE_EXT = new Set([
+  'txt', 'text', 'md', 'markdown', 'mdx', 'rst', 'csv', 'tsv', 'log',
+  'json', 'jsonc', 'json5', 'yaml', 'yml', 'toml', 'ini', 'env', 'conf', 'cfg', 'properties',
+  'xml', 'html', 'htm', 'svg', 'css', 'scss', 'sass', 'less',
+  'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'mts', 'cts', 'vue', 'svelte',
+  'py', 'rb', 'go', 'rs', 'java', 'kt', 'kts', 'c', 'h', 'cpp', 'cc', 'hpp', 'cs',
+  'php', 'sh', 'bash', 'zsh', 'ps1', 'psm1', 'bat', 'cmd', 'sql', 'graphql', 'gql',
+  'r', 'pl', 'lua', 'dart', 'scala', 'clj', 'ex', 'exs', 'erl', 'hs', 'elm', 'swift',
+  'dockerfile', 'gitignore', 'gitattributes', 'editorconfig', 'npmrc', 'nvmrc', 'diff', 'patch',
+]);
+
+function extensionOf(name: string): string {
+  const lower = name.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  return dot >= 0 ? lower.slice(dot + 1) : lower;
+}
+
+export function isImageFile(file: { name: string; mimeType: string }): boolean {
+  if (file.mimeType.toLowerCase().startsWith('image/')) return true;
+  return IMAGE_EXT.has(extensionOf(file.name));
+}
+
+export function isTextLikeFile(file: { name: string; mimeType: string }): boolean {
+  const mime = file.mimeType.toLowerCase();
+  if (mime.startsWith('text/')) return true;
+  if (TEXT_LIKE_MIME.has(mime) || mime.endsWith('+json') || mime.endsWith('+xml')) return true;
+  return TEXT_LIKE_EXT.has(extensionOf(file.name));
+}
+
+export interface TextFileAttachment {
+  name: string;
+  mimeType: string;
+  content: string;
+}
+
+/**
+ * Fold the contents of any text attachments whose token still appears in
+ * `input` into the outgoing prompt as labelled fenced blocks. Image tokens are
+ * left untouched (their payload rides along as a separate blob attachment).
+ */
+export function buildMessageWithTextAttachments(input: string, files: readonly TextFileAttachment[]): string {
+  if (files.length === 0) return input;
+  const present = collectFileNames(input);
+  const kept = files.filter((file) => present.has(file.name));
+  if (kept.length === 0) return input;
+  const blocks = kept.map((file) => `Attached file ${file.name}:\n\`\`\`\n${file.content}\n\`\`\``);
+  const base = input.trimEnd();
+  return `${base}${base.length > 0 ? '\n\n' : ''}${blocks.join('\n\n')}`;
+}


### PR DESCRIPTION
﻿﻿## Summary

Adds three additive composer affordances to the Chamber chat input while preserving image paste, emoji, the model picker, and voice dictation: file attachments (paperclip), `@`-mentions, and slash commands. Local S2 slice; renderer-only behavior plus a small shared hook.

This PR also folds in the principal-review blocker fixes for S2 (see below), so it is ready for review as a whole.

## Notable changes

- **File attachments** via a paperclip button + hidden file input. Images ride the existing SDK blob path; text-like files are folded into the outgoing prompt as labelled, fence-safe code blocks; unsupported and oversized files are skipped with a clear notice. The backend send path only forwards image blobs as attachments and sends the trimmed text as the prompt, so inlining text contents is the correct path and arbitrary binary is intentionally out of scope.
- **@-mentions**: typing `@` opens a caret popover of the currently loaded minds (from the store) and inserts an `@Name` token. Client-side insertion only; deeper agent routing is future work.
- **Slash commands**: a bare `/command` at the start opens a menu with `/new`, `/clear`, `/model`, `/settings`. Commands run from the menu and the slash text is never sent.
- **Shared internals**: pure detection/classification/token/fold helpers live in `apps/web/src/renderer/lib/composer.ts` (unit-tested); a `useNewConversation` hook is reused by the composer `/new` command and the conversation history panel (DRY); one shared caret-menu keyboard handler + `CaretPopover` back all three popovers.

### Review blockers addressed
- **Per-mind attachment scoping**: attachment payloads live in a per-conversation bucket keyed by active mind, mirroring the per-mind compose-draft partitioning, so switching agents cannot leak payloads across drafts.
- **Opaque token ids**: inline tokens embed an opaque numeric id with a sanitized display label, so filenames containing `]`, `[`, or newlines cannot break parsing or bleed one token into the next. The real filename is preserved on the payload.
- **Origin-draft integrity (async race)**: file reads (picker or paste) that resolve after an agent switch now compose their token against the base draft/caret captured at pick time and write through the origin-mind writer, restoring caret/focus only when that mind is still active. This prevents origin-draft loss and cross-agent text bleed.
- **Hardening**: mention keydown no longer intercepts arrows/Escape/Enter when no results are visible; `/new` is guarded against starting a conversation mid-stream; image size is capped on both the picker and paste paths; folded text files use a backtick fence longer than any run in their content.

## Tests
- `npm run lint`: clean (tsc + eslint + deps:check + yaml + md).
- `npm test`: 2256 passed, 2 skipped. New colocated coverage in `composer.test.ts` and `ChatInput.test.tsx` (menus, per-mind scoping, mid-read agent-switch draft integrity, oversized image on picker + paste, `/new` streaming guard, mention no-match keydown, bracketed filenames, safe fences).
- `npm run smoke:web`: 4 passed (boot, loopback chat, chat input send, chatroom UI).
- Uncle Bob review run; the one blocking finding (async origin-draft race) and the non-blocking paste size-cap gap are fixed here.

## Caveats
- The pre-existing Windows-only test `packages/services/src/mindProfile/MindProfileService.test.ts > rejects symlinked profile files` fails locally with `EPERM: operation not permitted, symlink` (Windows symlink privilege). Unrelated to this change (that path is untouched) and environmental.
- `@`-mentions are client-side token insertion only; agent routing is deferred.
- Follow-up worth considering (from review): extract a `useComposerAttachments(conversationKey)` hook to further slim `ChatInput`.


---

## Upstream issue linkage

Related to #404 and #48. This improves composer affordances and adds client-side @mentions, but does not close hydration polish or chatroom mention routing.

## Source branch

Fork PR: https://github.com/patschmittdev/chamber/pull/6
Head: `patschmittdev:patschmittdev-feat-composer-powerups`
