### PR TITLE
feat: conversation history search and export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ resources/automation-runtime/
 chamber-automation-runtime/node_modules/
 
 .playwright-cli/
+
+# Impeccable design-hook cache (local tooling artifact)
+.impeccable/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Add theme-aware update chrome** — Adds a dismissible ready-to-install banner and update-status indicator with accessible light and dark theme colors.
 - **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 - **Add insiders-gated local voice dictation** — Adds local Foundry/Nemotron dictation with a dedicated Settings page, chat mic and push-to-talk controls, explicit runtime capability gating, and insiders-only prepared runtime packaging. (#385) (#385)
+- **Add conversation history search and export** — Search the active mind's conversations by title and message content, and export any conversation as Markdown or JSON via a save dialog. Resumed, exported, and searched transcripts now preserve tool, reasoning, and permission blocks consistent with live chat.
 
 ### Refactor
 

--- a/apps/desktop/src/main/ipc/conversationHistory.test.ts
+++ b/apps/desktop/src/main/ipc/conversationHistory.test.ts
@@ -40,6 +40,7 @@ function createChatService(overrides: Partial<ChatService> = {}): ChatService {
     renameConversation: vi.fn(() => []),
     deleteConversation: vi.fn(async () => ({ sessionId: '', messages: [], conversations: [] })),
     getConversationMessages: vi.fn(async () => []),
+    getConversationExportFilename: vi.fn(() => markdownExport.filename),
     exportConversation: vi.fn(async () => markdownExport),
     ...overrides,
   } as unknown as ChatService;
@@ -84,6 +85,7 @@ describe('setupConversationHistoryIPC', () => {
 
     const result = await handlerFor('conversationHistory:export')(EVT, 'mind-1', 'session-1', 'markdown');
 
+    expect(chatService.getConversationExportFilename).toHaveBeenCalledWith('mind-1', 'session-1', 'markdown');
     expect(chatService.exportConversation).toHaveBeenCalledWith('mind-1', 'session-1', 'markdown');
     expect(dialog.showSaveDialog).toHaveBeenCalledWith(
       expect.anything(),
@@ -93,20 +95,42 @@ describe('setupConversationHistoryIPC', () => {
     expect(result).toEqual({ status: 'saved', path: 'C:/tmp/planning.md', format: 'markdown' });
   });
 
+  it('export handler shows the save dialog before doing expensive transcript work', async () => {
+    const order: string[] = [];
+    vi.mocked(dialog.showSaveDialog).mockImplementation(async () => {
+      order.push('dialog');
+      return { canceled: true, filePath: undefined } as never;
+    });
+    const chatService = createChatService({
+      exportConversation: vi.fn(async () => { order.push('export'); return markdownExport; }) as never,
+    });
+    setupConversationHistoryIPC(chatService);
+
+    await handlerFor('conversationHistory:export')(EVT, 'mind-1', 'session-1', 'markdown');
+
+    expect(order).toEqual(['dialog']);
+    expect(chatService.exportConversation).not.toHaveBeenCalled();
+  });
+
   it('export handler returns canceled and writes nothing when the dialog is dismissed', async () => {
     vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: true, filePath: undefined } as never);
-    setupConversationHistoryIPC(createChatService());
+    const chatService = createChatService();
+    setupConversationHistoryIPC(chatService);
 
     const result = await handlerFor('conversationHistory:export')(EVT, 'mind-1', 'session-1', 'markdown');
 
     expect(writeFile).not.toHaveBeenCalled();
+    expect(chatService.exportConversation).not.toHaveBeenCalled();
     expect(result).toEqual({ status: 'canceled' });
   });
 
   it('export handler normalizes the json format and requests it from the service', async () => {
     const jsonExport: ConversationExport = { format: 'json', filename: 'planning.json', content: '{}\n' };
     vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: 'C:/tmp/planning.json' } as never);
-    const chatService = createChatService({ exportConversation: vi.fn(async () => jsonExport) as never });
+    const chatService = createChatService({
+      getConversationExportFilename: vi.fn(() => 'planning.json') as never,
+      exportConversation: vi.fn(async () => jsonExport) as never,
+    });
     setupConversationHistoryIPC(chatService);
 
     const result = await handlerFor('conversationHistory:export')(EVT, 'mind-1', 'session-1', 'json');

--- a/apps/desktop/src/main/ipc/conversationHistory.test.ts
+++ b/apps/desktop/src/main/ipc/conversationHistory.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  dialog: { showSaveDialog: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(async () => undefined),
+}));
+
+import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { writeFile } from 'node:fs/promises';
+import type { IpcMainInvokeEvent } from 'electron';
+import { setupConversationHistoryIPC } from './conversationHistory';
+import type { ChatService } from '@chamber/services';
+import type { ConversationExport } from '@chamber/shared/types';
+
+type InvokeHandler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
+
+const EVT = { sender: {} } as IpcMainInvokeEvent;
+
+const markdownExport: ConversationExport = {
+  format: 'markdown',
+  filename: 'planning.md',
+  content: '# Planning\n',
+};
+
+function handlerFor(channel: string): InvokeHandler {
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((entry) => entry[0] === channel);
+  if (!call) throw new Error(`No handler registered for ${channel}`);
+  return call[1] as InvokeHandler;
+}
+
+function createChatService(overrides: Partial<ChatService> = {}): ChatService {
+  return {
+    listConversationHistory: vi.fn(() => []),
+    resumeConversation: vi.fn(async () => ({ sessionId: '', messages: [], conversations: [] })),
+    renameConversation: vi.fn(() => []),
+    deleteConversation: vi.fn(async () => ({ sessionId: '', messages: [], conversations: [] })),
+    getConversationMessages: vi.fn(async () => []),
+    exportConversation: vi.fn(async () => markdownExport),
+    ...overrides,
+  } as unknown as ChatService;
+}
+
+describe('setupConversationHistoryIPC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue({ id: 1 } as never);
+  });
+
+  it('registers list, resume, rename, delete, messages, and export handlers', () => {
+    setupConversationHistoryIPC(createChatService());
+
+    const channels = vi.mocked(ipcMain.handle).mock.calls.map((entry) => entry[0]);
+
+    expect(channels).toEqual(expect.arrayContaining([
+      'conversationHistory:list',
+      'conversationHistory:resume',
+      'conversationHistory:rename',
+      'conversationHistory:delete',
+      'conversationHistory:messages',
+      'conversationHistory:export',
+    ]));
+  });
+
+  it('messages handler delegates to chatService.getConversationMessages', async () => {
+    const messages = [{ id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'hi' }], timestamp: 1 }];
+    const chatService = createChatService({ getConversationMessages: vi.fn(async () => messages) as never });
+    setupConversationHistoryIPC(chatService);
+
+    const result = await handlerFor('conversationHistory:messages')(EVT, 'mind-1', 'session-1');
+
+    expect(chatService.getConversationMessages).toHaveBeenCalledWith('mind-1', 'session-1');
+    expect(result).toBe(messages);
+  });
+
+  it('export handler serializes, writes the chosen file, and returns the saved path', async () => {
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: 'C:/tmp/planning.md' } as never);
+    const chatService = createChatService();
+    setupConversationHistoryIPC(chatService);
+
+    const result = await handlerFor('conversationHistory:export')(EVT, 'mind-1', 'session-1', 'markdown');
+
+    expect(chatService.exportConversation).toHaveBeenCalledWith('mind-1', 'session-1', 'markdown');
+    expect(dialog.showSaveDialog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ defaultPath: 'planning.md' }),
+    );
+    expect(writeFile).toHaveBeenCalledWith('C:/tmp/planning.md', '# Planning\n', 'utf-8');
+    expect(result).toEqual({ status: 'saved', path: 'C:/tmp/planning.md', format: 'markdown' });
+  });
+
+  it('export handler returns canceled and writes nothing when the dialog is dismissed', async () => {
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: true, filePath: undefined } as never);
+    setupConversationHistoryIPC(createChatService());
+
+    const result = await handlerFor('conversationHistory:export')(EVT, 'mind-1', 'session-1', 'markdown');
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'canceled' });
+  });
+
+  it('export handler normalizes the json format and requests it from the service', async () => {
+    const jsonExport: ConversationExport = { format: 'json', filename: 'planning.json', content: '{}\n' };
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: 'C:/tmp/planning.json' } as never);
+    const chatService = createChatService({ exportConversation: vi.fn(async () => jsonExport) as never });
+    setupConversationHistoryIPC(chatService);
+
+    const result = await handlerFor('conversationHistory:export')(EVT, 'mind-1', 'session-1', 'json');
+
+    expect(chatService.exportConversation).toHaveBeenCalledWith('mind-1', 'session-1', 'json');
+    expect(writeFile).toHaveBeenCalledWith('C:/tmp/planning.json', '{}\n', 'utf-8');
+    expect(result).toEqual({ status: 'saved', path: 'C:/tmp/planning.json', format: 'json' });
+  });
+});

--- a/apps/desktop/src/main/ipc/conversationHistory.ts
+++ b/apps/desktop/src/main/ipc/conversationHistory.ts
@@ -33,12 +33,14 @@ export function setupConversationHistoryIPC(chatService: ChatService): void {
     IPC.CONVERSATION_HISTORY.EXPORT,
     async (event, mindId: string, sessionId: string, format: ConversationExportFormat): Promise<ConversationExportResult> => {
       const normalizedFormat = normalizeExportFormat(format);
-      const conversationExport = await chatService.exportConversation(mindId, sessionId, normalizedFormat);
+      // Resolve the file name cheaply and show the save dialog before reading or
+      // serializing the transcript, so a cancel costs no expensive work.
+      const filename = chatService.getConversationExportFilename(mindId, sessionId, normalizedFormat);
 
       const win = BrowserWindow.fromWebContents(event.sender);
       const options = {
         title: 'Export conversation',
-        defaultPath: conversationExport.filename,
+        defaultPath: filename,
         filters: [EXPORT_DIALOG_FILTERS[normalizedFormat], { name: 'All Files', extensions: ['*'] }],
       };
       const result = win
@@ -49,6 +51,7 @@ export function setupConversationHistoryIPC(chatService: ChatService): void {
         return { status: 'canceled' };
       }
 
+      const conversationExport = await chatService.exportConversation(mindId, sessionId, normalizedFormat);
       await writeFile(result.filePath, conversationExport.content, 'utf-8');
       return { status: 'saved', path: result.filePath, format: normalizedFormat };
     },

--- a/apps/desktop/src/main/ipc/conversationHistory.ts
+++ b/apps/desktop/src/main/ipc/conversationHistory.ts
@@ -1,6 +1,17 @@
-import { ipcMain } from 'electron';
+import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { writeFile } from 'node:fs/promises';
 import { IPC } from '@chamber/shared';
 import type { ChatService } from '@chamber/services';
+import type { ConversationExportFormat, ConversationExportResult } from '@chamber/shared/types';
+
+const EXPORT_DIALOG_FILTERS: Record<ConversationExportFormat, { name: string; extensions: string[] }> = {
+  markdown: { name: 'Markdown', extensions: ['md'] },
+  json: { name: 'JSON', extensions: ['json'] },
+};
+
+function normalizeExportFormat(format: ConversationExportFormat): ConversationExportFormat {
+  return format === 'json' ? 'json' : 'markdown';
+}
 
 export function setupConversationHistoryIPC(chatService: ChatService): void {
   ipcMain.handle(IPC.CONVERSATION_HISTORY.LIST, async (_event, mindId: string) =>
@@ -14,4 +25,32 @@ export function setupConversationHistoryIPC(chatService: ChatService): void {
 
   ipcMain.handle(IPC.CONVERSATION_HISTORY.DELETE, async (_event, mindId: string, sessionId: string) =>
     chatService.deleteConversation(mindId, sessionId));
+
+  ipcMain.handle(IPC.CONVERSATION_HISTORY.MESSAGES, async (_event, mindId: string, sessionId: string) =>
+    chatService.getConversationMessages(mindId, sessionId));
+
+  ipcMain.handle(
+    IPC.CONVERSATION_HISTORY.EXPORT,
+    async (event, mindId: string, sessionId: string, format: ConversationExportFormat): Promise<ConversationExportResult> => {
+      const normalizedFormat = normalizeExportFormat(format);
+      const conversationExport = await chatService.exportConversation(mindId, sessionId, normalizedFormat);
+
+      const win = BrowserWindow.fromWebContents(event.sender);
+      const options = {
+        title: 'Export conversation',
+        defaultPath: conversationExport.filename,
+        filters: [EXPORT_DIALOG_FILTERS[normalizedFormat], { name: 'All Files', extensions: ['*'] }],
+      };
+      const result = win
+        ? await dialog.showSaveDialog(win, options)
+        : await dialog.showSaveDialog(options);
+
+      if (result.canceled || !result.filePath) {
+        return { status: 'canceled' };
+      }
+
+      await writeFile(result.filePath, conversationExport.content, 'utf-8');
+      return { status: 'saved', path: result.filePath, format: normalizedFormat };
+    },
+  );
 }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -22,6 +22,8 @@ const electronAPI: ElectronAPI = {
     resume: (mindId, sessionId) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.RESUME, mindId, sessionId),
     rename: (mindId, sessionId, title) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.RENAME, mindId, sessionId, title),
     delete: (mindId, sessionId) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.DELETE, mindId, sessionId),
+    messages: (mindId, sessionId) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.MESSAGES, mindId, sessionId),
+    export: (mindId, sessionId, format) => ipcRenderer.invoke(IPC.CONVERSATION_HISTORY.EXPORT, mindId, sessionId, format),
   },
   mind: {
     add: (mindPath) => ipcRenderer.invoke(IPC.MIND.ADD, mindPath),

--- a/apps/web/src/browserApi.ts
+++ b/apps/web/src/browserApi.ts
@@ -155,6 +155,8 @@ export function installBrowserApi(): void {
       resume: async () => ({ sessionId: '', messages: [], conversations: [] }),
       rename: async () => [],
       delete: async () => ({ sessionId: '', messages: [], conversations: [] }),
+      messages: async () => [],
+      export: async () => ({ status: 'canceled' as const }),
     },
     mind: {
       add: (mindPath): Promise<MindContext> => client.addMind(mindPath) as Promise<MindContext>,

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.test.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.test.tsx
@@ -182,6 +182,120 @@ describe('ConversationHistoryPanel', () => {
       expect(api.conversationHistory.delete).toHaveBeenCalledWith(mind.mindId, conversation.sessionId);
     });
   });
+
+  it('filters the conversation list by title as the user types', async () => {
+    const roadmap = makeConversation({ sessionId: 's-roadmap', title: 'Q3 Roadmap', active: false });
+    const standup = makeConversation({ sessionId: 's-standup', title: 'Daily standup', active: false });
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [roadmap, standup] },
+    });
+
+    expect(screen.getByText('Q3 Roadmap')).toBeTruthy();
+    expect(screen.getByText('Daily standup')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Search conversations'), { target: { value: 'roadmap' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Daily standup')).toBeNull();
+    });
+    expect(screen.getByText('Q3 Roadmap')).toBeTruthy();
+  });
+
+  it('shows an empty state and restores the list when the search is cleared', async () => {
+    const roadmap = makeConversation({ sessionId: 's-roadmap', title: 'Q3 Roadmap', active: false });
+    const standup = makeConversation({ sessionId: 's-standup', title: 'Daily standup', active: false });
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [roadmap, standup] },
+    });
+
+    fireEvent.change(screen.getByLabelText('Search conversations'), { target: { value: 'zzz no match' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('No conversations match your search')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByLabelText('Clear search'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Daily standup')).toBeTruthy();
+    });
+    expect(screen.getByText('Q3 Roadmap')).toBeTruthy();
+  });
+
+  it('matches conversations by message content when the title does not match', async () => {
+    const roadmap = makeConversation({ sessionId: 's-roadmap', title: 'Q3 Roadmap', active: false });
+    const untitled = makeConversation({ sessionId: 's-bugfix', title: 'Untitled thread', active: false });
+    (api.conversationHistory.messages as ReturnType<typeof vi.fn>).mockImplementation(
+      (_mindId: string, sessionId: string) => Promise.resolve(
+        sessionId === 's-bugfix'
+          ? [{ id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'SAML SSO login fails' }], timestamp: 1 }]
+          : [],
+      ),
+    );
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [roadmap, untitled] },
+    });
+
+    fireEvent.change(screen.getByLabelText('Search conversations'), { target: { value: 'saml' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Q3 Roadmap')).toBeNull();
+      expect(screen.getByText('Untitled thread')).toBeTruthy();
+    });
+    expect(api.conversationHistory.messages).toHaveBeenCalledWith(mind.mindId, 's-bugfix');
+  });
+
+  it('exports the selected conversation as Markdown through the save-dialog IPC', async () => {
+    const conversation = makeConversation({ title: 'Planning thread' });
+    (api.conversationHistory.export as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: 'saved',
+      path: 'C:/tmp/planning.md',
+      format: 'markdown',
+    });
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [conversation] },
+      activeConversationByMind: { [mind.mindId]: conversation.sessionId },
+      conversationViewByMind: { [mind.mindId]: { status: 'ready', sessionId: conversation.sessionId, streaming: false, modelSwitching: false } },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export Planning thread' }));
+    fireEvent.click(await screen.findByText('Export as Markdown'));
+
+    await waitFor(() => {
+      expect(api.conversationHistory.export).toHaveBeenCalledWith(mind.mindId, conversation.sessionId, 'markdown');
+    });
+  });
+
+  it('exports the selected conversation as JSON through the save-dialog IPC', async () => {
+    const conversation = makeConversation({ title: 'Planning thread' });
+    (api.conversationHistory.export as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: 'saved',
+      path: 'C:/tmp/planning.json',
+      format: 'json',
+    });
+    renderHistoryPanel({
+      activeMindId: mind.mindId,
+      minds: [mind],
+      conversationHistoryByMind: { [mind.mindId]: [conversation] },
+      activeConversationByMind: { [mind.mindId]: conversation.sessionId },
+      conversationViewByMind: { [mind.mindId]: { status: 'ready', sessionId: conversation.sessionId, streaming: false, modelSwitching: false } },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export Planning thread' }));
+    fireEvent.click(await screen.findByText('Export as JSON'));
+
+    await waitFor(() => {
+      expect(api.conversationHistory.export).toHaveBeenCalledWith(mind.mindId, conversation.sessionId, 'json');
+    });
+  });
 });
 
 function renderHistoryPanel(testInitialState?: Partial<AppState>) {

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -20,6 +20,12 @@ const log = Logger.create('ConversationHistoryPanel');
 const HISTORY_COLLAPSED_STORAGE_KEY = 'chamber:conversation-history-collapsed';
 const SEARCH_DEBOUNCE_MS = 180;
 const CONTENT_SEARCH_MIN_QUERY_LENGTH = 2;
+const MAX_CONTENT_LOADS_PER_PASS = 8;
+
+interface CachedTranscriptText {
+  updatedAt: string;
+  text: string;
+}
 
 export function ConversationHistoryPanel() {
   const { activeMindId, conversationHistoryByMind, activeConversationByMind, conversationViewByMind, streamingByMind } = useAppState();
@@ -38,7 +44,7 @@ export function ConversationHistoryPanel() {
   const [contentIndexVersion, setContentIndexVersion] = useState(0);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const creatingConversationRef = useRef(false);
-  const contentIndexByMind = useRef<Map<string, Map<string, string>>>(new Map());
+  const contentIndexByMind = useRef<Map<string, Map<string, CachedTranscriptText>>>(new Map());
   const contentLoadsInFlight = useRef<Set<string>>(new Set());
 
   const conversations = useMemo<ConversationSummary[] | undefined>(() => {
@@ -47,10 +53,17 @@ export function ConversationHistoryPanel() {
   }, [activeMindId, conversationHistoryByMind]);
   const visibleConversations = conversations ?? [];
   const filteredConversations = useMemo(() => {
-    const contentIndex = activeMindId ? contentIndexByMind.current.get(activeMindId) : undefined;
     // contentIndexVersion forces recompute when best-effort content loads resolve.
     void contentIndexVersion;
-    return filterConversations(visibleConversations, debouncedQuery, contentIndex);
+    const mindIndex = activeMindId ? contentIndexByMind.current.get(activeMindId) : undefined;
+    const freshIndex = mindIndex
+      ? new Map(
+          visibleConversations
+            .filter((conversation) => mindIndex.get(conversation.sessionId)?.updatedAt === conversation.updatedAt)
+            .map((conversation) => [conversation.sessionId, mindIndex.get(conversation.sessionId)!.text] as const),
+        )
+      : undefined;
+    return filterConversations(visibleConversations, debouncedQuery, freshIndex);
   }, [visibleConversations, debouncedQuery, activeMindId, contentIndexVersion]);
   const selectedConversationId = activeMindId ? activeConversationByMind[activeMindId] : undefined;
   const activeConversationView = activeMindId ? conversationViewByMind[activeMindId] : undefined;
@@ -122,9 +135,10 @@ export function ConversationHistoryPanel() {
   }, [activeMindId]);
 
   // Best-effort content index for search: lazily load each conversation's
-  // transcript once (read-only, cached) while a query is active, so search can
-  // match message bodies without disturbing the active chat. Title matching
-  // still works if a transcript fails to load.
+  // transcript (read-only, cached by sessionId + updatedAt) while a query is
+  // active, so search can match message bodies without disturbing the active
+  // chat. Loads are bounded per pass and re-run until every conversation is
+  // cached. Title matching still works if a transcript fails to load.
   useEffect(() => {
     if (!activeMindId) return;
     const normalized = normalizeSearchQuery(debouncedQuery);
@@ -133,16 +147,17 @@ export function ConversationHistoryPanel() {
     const mindId = activeMindId;
     let mindIndex = contentIndexByMind.current.get(mindId);
     if (!mindIndex) {
-      mindIndex = new Map<string, string>();
+      mindIndex = new Map<string, CachedTranscriptText>();
       contentIndexByMind.current.set(mindId, mindIndex);
     }
     const index = mindIndex;
 
     const pending = visibleConversations.filter((conversation) => {
       if (conversation.hasMessages === false) return false;
-      if (index.has(conversation.sessionId)) return false;
+      const cached = index.get(conversation.sessionId);
+      if (cached && cached.updatedAt === conversation.updatedAt) return false;
       return !contentLoadsInFlight.current.has(`${mindId}:${conversation.sessionId}`);
-    });
+    }).slice(0, MAX_CONTENT_LOADS_PER_PASS);
     if (pending.length === 0) return;
 
     let cancelled = false;
@@ -151,9 +166,9 @@ export function ConversationHistoryPanel() {
       contentLoadsInFlight.current.add(key);
       try {
         const messages = await window.electronAPI.conversationHistory.messages(mindId, conversation.sessionId);
-        index.set(conversation.sessionId, conversationSearchText(messages));
+        index.set(conversation.sessionId, { updatedAt: conversation.updatedAt, text: conversationSearchText(messages) });
       } catch (error) {
-        index.set(conversation.sessionId, '');
+        index.set(conversation.sessionId, { updatedAt: conversation.updatedAt, text: '' });
         log.warn('Failed to load conversation content for search:', error);
       } finally {
         contentLoadsInFlight.current.delete(key);
@@ -165,7 +180,7 @@ export function ConversationHistoryPanel() {
     return () => {
       cancelled = true;
     };
-  }, [activeMindId, debouncedQuery, visibleConversations]);
+  }, [activeMindId, debouncedQuery, visibleConversations, contentIndexVersion]);
 
   useEffect(() => {
     if (!activeMindId || !selectedConversationId || isActiveMindBusy || creatingConversationRef.current) return;

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -46,6 +46,8 @@ export function ConversationHistoryPanel() {
   const creatingConversationRef = useRef(false);
   const contentIndexByMind = useRef<Map<string, Map<string, CachedTranscriptText>>>(new Map());
   const contentLoadsInFlight = useRef<Set<string>>(new Set());
+  const isMountedRef = useRef(true);
+  useEffect(() => () => { isMountedRef.current = false; }, []);
 
   const conversations = useMemo<ConversationSummary[] | undefined>(() => {
     if (!activeMindId) return undefined;
@@ -160,7 +162,6 @@ export function ConversationHistoryPanel() {
     }).slice(0, MAX_CONTENT_LOADS_PER_PASS);
     if (pending.length === 0) return;
 
-    let cancelled = false;
     void Promise.all(pending.map(async (conversation) => {
       const key = `${mindId}:${conversation.sessionId}`;
       contentLoadsInFlight.current.add(key);
@@ -174,12 +175,11 @@ export function ConversationHistoryPanel() {
         contentLoadsInFlight.current.delete(key);
       }
     })).then(() => {
-      if (!cancelled) setContentIndexVersion((version) => version + 1);
+      // Gate on mounted, not a per-run cleanup flag: a dep change (e.g. the next
+      // keystroke) re-runs this effect, but the batch still finished and
+      // populated the cache, so it must still trigger a recompute.
+      if (isMountedRef.current) setContentIndexVersion((version) => version + 1);
     });
-
-    return () => {
-      cancelled = true;
-    };
   }, [activeMindId, debouncedQuery, visibleConversations, contentIndexVersion]);
 
   useEffect(() => {

--- a/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
+++ b/apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx
@@ -1,10 +1,11 @@
-import { ChevronLeft, ChevronRight, Pencil, Plus, Trash2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, Pencil, Plus, Search, Trash2, X } from 'lucide-react';
 import { getErrorMessage } from '@chamber/shared/getErrorMessage';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ConversationSummary } from '@chamber/shared/types';
+import type { ConversationExportFormat, ConversationSummary } from '@chamber/shared/types';
 import { useAppDispatch, useAppState } from '../../lib/store';
 import { Logger } from '../../lib/logger';
 import { cn } from '../../lib/utils';
+import { conversationSearchText, filterConversations, normalizeSearchQuery } from './conversationSearch';
 import {
   Dialog,
   DialogContent,
@@ -13,9 +14,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 
 const log = Logger.create('ConversationHistoryPanel');
 const HISTORY_COLLAPSED_STORAGE_KEY = 'chamber:conversation-history-collapsed';
+const SEARCH_DEBOUNCE_MS = 180;
+const CONTENT_SEARCH_MIN_QUERY_LENGTH = 2;
 
 export function ConversationHistoryPanel() {
   const { activeMindId, conversationHistoryByMind, activeConversationByMind, conversationViewByMind, streamingByMind } = useAppState();
@@ -27,14 +31,27 @@ export function ConversationHistoryPanel() {
   const [pendingDeleteConversation, setPendingDeleteConversation] = useState<ConversationSummary | null>(null);
   const [loadingMindId, setLoadingMindId] = useState<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(() => localStorage.getItem(HISTORY_COLLAPSED_STORAGE_KEY) === 'true');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [exportingId, setExportingId] = useState<string | null>(null);
+  const [exportMenuId, setExportMenuId] = useState<string | null>(null);
+  const [contentIndexVersion, setContentIndexVersion] = useState(0);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const creatingConversationRef = useRef(false);
+  const contentIndexByMind = useRef<Map<string, Map<string, string>>>(new Map());
+  const contentLoadsInFlight = useRef<Set<string>>(new Set());
 
   const conversations = useMemo<ConversationSummary[] | undefined>(() => {
     if (!activeMindId) return undefined;
     return conversationHistoryByMind[activeMindId];
   }, [activeMindId, conversationHistoryByMind]);
   const visibleConversations = conversations ?? [];
+  const filteredConversations = useMemo(() => {
+    const contentIndex = activeMindId ? contentIndexByMind.current.get(activeMindId) : undefined;
+    // contentIndexVersion forces recompute when best-effort content loads resolve.
+    void contentIndexVersion;
+    return filterConversations(visibleConversations, debouncedQuery, contentIndex);
+  }, [visibleConversations, debouncedQuery, activeMindId, contentIndexVersion]);
   const selectedConversationId = activeMindId ? activeConversationByMind[activeMindId] : undefined;
   const activeConversationView = activeMindId ? conversationViewByMind[activeMindId] : undefined;
   const isActiveMindStreaming = activeMindId
@@ -92,6 +109,63 @@ export function ConversationHistoryPanel() {
       cancelled = true;
     };
   }, [activeMindId, dispatch]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedQuery(searchQuery), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    setSearchQuery('');
+    setDebouncedQuery('');
+    setExportMenuId(null);
+  }, [activeMindId]);
+
+  // Best-effort content index for search: lazily load each conversation's
+  // transcript once (read-only, cached) while a query is active, so search can
+  // match message bodies without disturbing the active chat. Title matching
+  // still works if a transcript fails to load.
+  useEffect(() => {
+    if (!activeMindId) return;
+    const normalized = normalizeSearchQuery(debouncedQuery);
+    if (normalized.length < CONTENT_SEARCH_MIN_QUERY_LENGTH) return;
+
+    const mindId = activeMindId;
+    let mindIndex = contentIndexByMind.current.get(mindId);
+    if (!mindIndex) {
+      mindIndex = new Map<string, string>();
+      contentIndexByMind.current.set(mindId, mindIndex);
+    }
+    const index = mindIndex;
+
+    const pending = visibleConversations.filter((conversation) => {
+      if (conversation.hasMessages === false) return false;
+      if (index.has(conversation.sessionId)) return false;
+      return !contentLoadsInFlight.current.has(`${mindId}:${conversation.sessionId}`);
+    });
+    if (pending.length === 0) return;
+
+    let cancelled = false;
+    void Promise.all(pending.map(async (conversation) => {
+      const key = `${mindId}:${conversation.sessionId}`;
+      contentLoadsInFlight.current.add(key);
+      try {
+        const messages = await window.electronAPI.conversationHistory.messages(mindId, conversation.sessionId);
+        index.set(conversation.sessionId, conversationSearchText(messages));
+      } catch (error) {
+        index.set(conversation.sessionId, '');
+        log.warn('Failed to load conversation content for search:', error);
+      } finally {
+        contentLoadsInFlight.current.delete(key);
+      }
+    })).then(() => {
+      if (!cancelled) setContentIndexVersion((version) => version + 1);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeMindId, debouncedQuery, visibleConversations]);
 
   useEffect(() => {
     if (!activeMindId || !selectedConversationId || isActiveMindBusy || creatingConversationRef.current) return;
@@ -224,6 +298,19 @@ export function ConversationHistoryPanel() {
     void performDeleteConversation(conversation);
   };
 
+  const exportConversation = async (conversation: ConversationSummary, format: ConversationExportFormat) => {
+    if (!activeMindId || exportingId) return;
+    setExportMenuId(null);
+    setExportingId(conversation.sessionId);
+    try {
+      await window.electronAPI.conversationHistory.export(activeMindId, conversation.sessionId, format);
+    } catch (error) {
+      log.error('Failed to export conversation:', error);
+    } finally {
+      setExportingId(null);
+    }
+  };
+
   return (
     <aside
       aria-label="Conversation history"
@@ -268,6 +355,32 @@ export function ConversationHistoryPanel() {
             </button>
           </div>
 
+          {activeMindId ? (
+            <div className="border-b border-border px-2 py-2">
+              <div className="relative">
+                <Search size={13} className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="Search conversations"
+                  aria-label="Search conversations"
+                  className="w-full rounded-md border border-border bg-background py-1.5 pl-7 pr-7 text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
+                />
+                {searchQuery ? (
+                  <button
+                    type="button"
+                    onClick={() => setSearchQuery('')}
+                    aria-label="Clear search"
+                    className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+                  >
+                    <X size={13} />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+
           <div className="flex-1 overflow-y-auto p-2">
             {!activeMindId ? (
               <p className="px-2 py-3 text-xs text-muted-foreground">Select an agent to see history</p>
@@ -275,13 +388,15 @@ export function ConversationHistoryPanel() {
               <p className="px-2 py-3 text-xs text-muted-foreground">Loading history...</p>
             ) : visibleConversations.length === 0 ? (
               <p className="px-2 py-3 text-xs text-muted-foreground">No conversations yet</p>
+            ) : filteredConversations.length === 0 ? (
+              <p className="px-2 py-3 text-xs text-muted-foreground">No conversations match your search</p>
             ) : null}
             {selectedConversationError ? (
               <p role="alert" className="mb-2 rounded-md border border-destructive/30 bg-destructive/10 px-2 py-2 text-xs text-destructive">
                 {selectedConversationError}
               </p>
             ) : null}
-            {visibleConversations.map((conversation) => {
+            {filteredConversations.map((conversation) => {
               const isSelected = conversation.sessionId === selectedConversationId || conversation.active;
 
               return (
@@ -322,6 +437,37 @@ export function ConversationHistoryPanel() {
                   </button>
 
                   <div className="flex items-center">
+                    <Popover
+                      open={exportMenuId === conversation.sessionId}
+                      onOpenChange={(open) => setExportMenuId(open ? conversation.sessionId : null)}
+                    >
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          disabled={exportingId !== null}
+                          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 data-[state=open]:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+                          aria-label={`Export ${conversation.title}`}
+                        >
+                          <Download size={13} />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-44 p-1">
+                        <button
+                          type="button"
+                          onClick={() => { void exportConversation(conversation, 'markdown'); }}
+                          className="w-full rounded-md px-2 py-1.5 text-left text-sm text-foreground hover:bg-accent"
+                        >
+                          Export as Markdown
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { void exportConversation(conversation, 'json'); }}
+                          className="w-full rounded-md px-2 py-1.5 text-left text-sm text-foreground hover:bg-accent"
+                        >
+                          Export as JSON
+                        </button>
+                      </PopoverContent>
+                    </Popover>
                     <button
                       type="button"
                       onClick={() => startRename(conversation)}

--- a/apps/web/src/renderer/components/history/conversationSearch.test.ts
+++ b/apps/web/src/renderer/components/history/conversationSearch.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import type { ChatMessage, ConversationSummary } from '@chamber/shared/types';
+import { conversationSearchText, filterConversations, normalizeSearchQuery } from './conversationSearch';
+
+function makeConversation(overrides: Partial<ConversationSummary>): ConversationSummary {
+  return {
+    sessionId: 'session',
+    title: 'Untitled',
+    createdAt: '2026-05-05T22:00:00.000Z',
+    updatedAt: '2026-05-05T22:00:00.000Z',
+    kind: 'chat',
+    active: false,
+    hasMessages: true,
+    ...overrides,
+  };
+}
+
+const roadmap = makeConversation({ sessionId: 's-roadmap', title: 'Q3 Roadmap planning' });
+const standup = makeConversation({ sessionId: 's-standup', title: 'Daily standup notes' });
+const bugfix = makeConversation({ sessionId: 's-bugfix', title: 'Login bug triage' });
+const conversations = [roadmap, standup, bugfix];
+
+describe('normalizeSearchQuery', () => {
+  it('trims and lowercases the query', () => {
+    expect(normalizeSearchQuery('  RoadMap  ')).toBe('roadmap');
+  });
+});
+
+describe('filterConversations', () => {
+  it('returns a copy of the full list for an empty or whitespace query', () => {
+    expect(filterConversations(conversations, '')).toEqual(conversations);
+    expect(filterConversations(conversations, '   ')).toEqual(conversations);
+    expect(filterConversations(conversations, '')).not.toBe(conversations);
+  });
+
+  it('matches by title case-insensitively', () => {
+    expect(filterConversations(conversations, 'roadmap')).toEqual([roadmap]);
+    expect(filterConversations(conversations, 'STANDUP')).toEqual([standup]);
+  });
+
+  it('returns an empty list when nothing matches and no content is indexed', () => {
+    expect(filterConversations(conversations, 'nonexistent')).toEqual([]);
+  });
+
+  it('matches by indexed message content when the title does not match', () => {
+    const contentIndex = new Map<string, string>([
+      ['s-bugfix', 'the user cannot authenticate with saml sso'],
+    ]);
+
+    expect(filterConversations(conversations, 'saml', contentIndex)).toEqual([bugfix]);
+  });
+
+  it('prefers a title match even when content is not indexed', () => {
+    const contentIndex = new Map<string, string>();
+    expect(filterConversations(conversations, 'triage', contentIndex)).toEqual([bugfix]);
+  });
+});
+
+describe('conversationSearchText', () => {
+  it('flattens text and reasoning blocks into a lowercase string and ignores non-text blocks', () => {
+    const messages: ChatMessage[] = [
+      { id: 'u1', role: 'user', timestamp: 1, blocks: [{ type: 'text', content: 'Deploy the API' }] },
+      {
+        id: 'a1',
+        role: 'assistant',
+        timestamp: 2,
+        blocks: [
+          { type: 'reasoning', reasoningId: 'r1', content: 'Check CANARY first' },
+          { type: 'text', content: 'Rolling out now' },
+          { type: 'image', name: 'chart.png', mimeType: 'image/png', dataUrl: 'data:image/png;base64,AAAA' },
+        ],
+      },
+    ];
+
+    const text = conversationSearchText(messages);
+
+    expect(text).toContain('deploy the api');
+    expect(text).toContain('check canary first');
+    expect(text).toContain('rolling out now');
+    expect(text).not.toContain('chart.png');
+  });
+
+  it('returns an empty string for a conversation with no text blocks', () => {
+    expect(conversationSearchText([])).toBe('');
+  });
+});

--- a/apps/web/src/renderer/components/history/conversationSearch.ts
+++ b/apps/web/src/renderer/components/history/conversationSearch.ts
@@ -1,0 +1,42 @@
+import type { ChatMessage, ConversationSummary } from '@chamber/shared/types';
+
+export type ConversationContentIndex = ReadonlyMap<string, string>;
+
+/** Trim and lowercase a raw search box value for case-insensitive matching. */
+export function normalizeSearchQuery(query: string): string {
+  return query.trim().toLowerCase();
+}
+
+/**
+ * Filter a mind's conversations by a search query. A conversation matches when
+ * its title contains the query, or when the optional content index holds a
+ * cached transcript for that conversation that contains the query. An empty
+ * query returns the list unchanged; per-mind scoping is the caller's concern.
+ */
+export function filterConversations(
+  conversations: readonly ConversationSummary[],
+  query: string,
+  contentIndex?: ConversationContentIndex,
+): ConversationSummary[] {
+  const normalized = normalizeSearchQuery(query);
+  if (!normalized) return [...conversations];
+
+  return conversations.filter((conversation) => {
+    if (conversation.title.toLowerCase().includes(normalized)) return true;
+    const content = contentIndex?.get(conversation.sessionId);
+    return content ? content.includes(normalized) : false;
+  });
+}
+
+/** Flatten a conversation's text-bearing blocks into a lowercase search string. */
+export function conversationSearchText(messages: readonly ChatMessage[]): string {
+  const parts: string[] = [];
+  for (const message of messages) {
+    for (const block of message.blocks) {
+      if (block.type === 'text' || block.type === 'reasoning') {
+        parts.push(block.content);
+      }
+    }
+  }
+  return parts.join('\n').toLowerCase();
+}

--- a/apps/web/src/renderer/lib/store/reducers/helpers.ts
+++ b/apps/web/src/renderer/lib/store/reducers/helpers.ts
@@ -1,16 +1,10 @@
 import { modelSelectionEqualsModel, modelSelectionKey, modelSelectionKeyFromModel } from '@chamber/shared/model-selection';
 import type { ChatEvent, ChatMessage, ContentBlock, ConversationSummary } from '@chamber/shared/types';
+import { applyChatEventToMessage } from '@chamber/shared';
 import type { AppState, ConversationViewState } from '../state';
 
 export function nonEmptyString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
-}
-
-export function updateChatMessage<T extends ChatMessage>(
-  message: T,
-  updates: Partial<Pick<ChatMessage, 'blocks' | 'isStreaming'>>,
-): T {
-  return { ...message, ...updates };
 }
 
 export function selectedModelForActiveMind(
@@ -95,130 +89,5 @@ export function getPlainContent(message: ChatMessage): string {
 }
 
 export function handleChatEvent<T extends ChatMessage>(messages: T[], messageId: string, event: ChatEvent): T[] {
-  return messages.map((m) => {
-    if (m.id !== messageId) return m;
-
-    const blocks = [...m.blocks];
-
-    switch (event.type) {
-      case 'chunk': {
-        const last = blocks[blocks.length - 1];
-        if (last && last.type === 'text') {
-          blocks[blocks.length - 1] = { ...last, content: last.content + event.content, sdkMessageId: event.sdkMessageId };
-        } else {
-          blocks.push({ type: 'text', sdkMessageId: event.sdkMessageId, content: event.content });
-        }
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'tool_start': {
-        blocks.push({
-          type: 'tool_call',
-          toolCallId: event.toolCallId,
-          toolName: event.toolName,
-          status: 'running',
-          arguments: event.args,
-          parentToolCallId: event.parentToolCallId,
-        });
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'tool_progress': {
-        const idx = blocks.findIndex(b => b.type === 'tool_call' && b.toolCallId === event.toolCallId);
-        if (idx >= 0) {
-          const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
-          blocks[idx] = { ...block, output: (block.output || '') + event.message + '\n' };
-        }
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'tool_output': {
-        const idx = blocks.findIndex(b => b.type === 'tool_call' && b.toolCallId === event.toolCallId);
-        if (idx >= 0) {
-          const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
-          blocks[idx] = { ...block, output: (block.output || '') + event.output };
-        }
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'tool_done': {
-        const idx = blocks.findIndex(b => b.type === 'tool_call' && b.toolCallId === event.toolCallId);
-        if (idx >= 0) {
-          const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
-          blocks[idx] = {
-            ...block,
-            status: event.success ? 'done' : 'error',
-            ...(event.result && { output: (block.output || '') + event.result }),
-            ...(event.error && { error: event.error }),
-          };
-        }
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'permission_request': {
-        if (blocks.some(b => b.type === 'permission' && b.requestId === event.requestId)) {
-          return m;
-        }
-        blocks.push({
-          type: 'permission',
-          requestId: event.requestId,
-          kind: event.kind,
-          summary: event.summary,
-          outcome: 'pending',
-          ...(event.toolCallId ? { toolCallId: event.toolCallId } : {}),
-        });
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'permission_outcome': {
-        const idx = blocks.findIndex(b => b.type === 'permission' && b.requestId === event.requestId);
-        if (idx >= 0) {
-          const block = blocks[idx] as Extract<ContentBlock, { type: 'permission' }>;
-          blocks[idx] = { ...block, outcome: event.outcome };
-        }
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'reasoning': {
-        const last = blocks[blocks.length - 1];
-        if (last && last.type === 'reasoning' && last.reasoningId === event.reasoningId) {
-          blocks[blocks.length - 1] = { ...last, content: last.content + event.content };
-        } else {
-          blocks.push({ type: 'reasoning', reasoningId: event.reasoningId, content: event.content });
-        }
-        return updateChatMessage(m, { blocks });
-      }
-
-      case 'message_final': {
-        // Reconciliation: add text only if this sdkMessageId was never streamed via chunks.
-        const hasThisMessage = blocks.some(b => b.type === 'text' && b.sdkMessageId === event.sdkMessageId);
-        if (!hasThisMessage && event.content) {
-          blocks.push({ type: 'text', sdkMessageId: event.sdkMessageId, content: event.content });
-          return updateChatMessage(m, { blocks });
-        }
-        return m;
-      }
-
-      case 'reconnecting':
-        return m;
-
-      case 'done':
-        return updateChatMessage(m, { isStreaming: false });
-
-      case 'error':
-        return updateChatMessage(m, {
-          isStreaming: false,
-          blocks: [...blocks, { type: 'text' as const, content: `Error: ${event.message}` }],
-        });
-
-      case 'timeout':
-        return updateChatMessage(m, {
-          isStreaming: false,
-          blocks: [...blocks, { type: 'text' as const, content: `Agent timed out after ${Math.round(event.timeoutMs / 1000)}s` }],
-        });
-
-      default:
-        return m;
-    }
-  });
+  return messages.map((m) => (m.id === messageId ? (applyChatEventToMessage(m, event) as T) : m));
 }

--- a/apps/web/src/test/helpers.ts
+++ b/apps/web/src/test/helpers.ts
@@ -120,6 +120,8 @@ export function mockElectronAPI(): ElectronAPI {
       resume: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
       rename: vi.fn().mockResolvedValue([]),
       delete: vi.fn().mockResolvedValue({ sessionId: '', messages: [], conversations: [] }),
+      messages: vi.fn().mockResolvedValue([]),
+      export: vi.fn().mockResolvedValue({ status: 'canceled' }),
     },
     mind: {
       add: vi.fn().mockResolvedValue({ mindId: 'test-1234', mindPath: 'C:\\test', identity: { name: 'Test', systemMessage: '' }, status: 'ready' }),

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -422,6 +422,35 @@ describe('ChatService', () => {
     });
   });
 
+  describe('getConversationExportFilename', () => {
+    it('resolves the filename from the summary without reading the transcript', () => {
+      mockMindManager.listConversationHistory.mockReturnValueOnce([
+        {
+          sessionId: 'session-1',
+          title: 'Design review',
+          createdAt: '2026-05-05T22:00:00.000Z',
+          updatedAt: '2026-05-05T22:30:00.000Z',
+          kind: 'chat',
+          active: true,
+          hasMessages: true,
+        },
+      ]);
+
+      const markdownName = svc.getConversationExportFilename('valid-mind', 'session-1', 'markdown');
+
+      expect(markdownName).toBe('design-review.md');
+      expect(mockMindManager.getConversationMessages).not.toHaveBeenCalled();
+    });
+
+    it('throws when the conversation is unknown', () => {
+      mockMindManager.listConversationHistory.mockReturnValueOnce([]);
+
+      expect(() => svc.getConversationExportFilename('valid-mind', 'missing', 'json')).toThrow(
+        'Conversation missing not found',
+      );
+    });
+  });
+
   describe('listModels', () => {
     it('returns models from the minds client', async () => {
       const models = await svc.listModels('valid-mind');

--- a/packages/services/src/chat/ChatService.test.ts
+++ b/packages/services/src/chat/ChatService.test.ts
@@ -3,6 +3,7 @@ import { ChatService } from './ChatService';
 import { TurnQueue } from './TurnQueue';
 import { Logger } from '../logger';
 import type { MindManager } from '../mind';
+import type { ChatMessage, ConversationSummary } from '@chamber/shared/types';
 
 type AllEventsHandler = (event: unknown) => void;
 type TypedHandler = (event: unknown) => void;
@@ -91,10 +92,11 @@ const mockMindManager = {
   recoverActiveConversationSession: vi.fn(),
   startNewConversation: vi.fn(),
   markActiveConversationHasMessages: vi.fn(),
-  listConversationHistory: vi.fn(() => []),
+  listConversationHistory: vi.fn<() => ConversationSummary[]>(() => []),
   resumeConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
   deleteConversation: vi.fn(async () => ({ sessionId: 'session-1', messages: [], conversations: [] })),
   renameConversation: vi.fn(() => []),
+  getConversationMessages: vi.fn<(mindId: string, sessionId: string) => Promise<ChatMessage[]>>(async () => []),
   setMindModel: vi.fn(async () => null),
 };
 
@@ -349,6 +351,74 @@ describe('ChatService', () => {
 
       await svc.cancelMessage('valid-mind', 'msg-1');
       await send;
+    });
+  });
+
+  describe('getConversationMessages', () => {
+    it('delegates to mindManager.getConversationMessages', async () => {
+      const messages = [{ id: 'u1', role: 'user' as const, blocks: [{ type: 'text' as const, content: 'hi' }], timestamp: 1 }];
+      mockMindManager.getConversationMessages.mockResolvedValueOnce(messages);
+
+      const result = await svc.getConversationMessages('valid-mind', 'session-1');
+
+      expect(mockMindManager.getConversationMessages).toHaveBeenCalledWith('valid-mind', 'session-1');
+      expect(result).toBe(messages);
+    });
+  });
+
+  describe('exportConversation', () => {
+    it('serializes a known conversation to markdown using its summary and messages', async () => {
+      mockMindManager.listConversationHistory.mockReturnValueOnce([
+        {
+          sessionId: 'session-1',
+          title: 'Design review',
+          createdAt: '2026-05-05T22:00:00.000Z',
+          updatedAt: '2026-05-05T22:30:00.000Z',
+          kind: 'chat',
+          active: true,
+          hasMessages: true,
+        },
+      ]);
+      mockMindManager.getConversationMessages.mockResolvedValueOnce([
+        { id: 'u1', role: 'user', blocks: [{ type: 'text', content: 'Ship it?' }], timestamp: 1 },
+      ]);
+
+      const result = await svc.exportConversation('valid-mind', 'session-1', 'markdown');
+
+      expect(result.format).toBe('markdown');
+      expect(result.filename).toBe('design-review.md');
+      expect(result.content).toContain('# Design review');
+      expect(result.content).toContain('Ship it?');
+    });
+
+    it('serializes a known conversation to json', async () => {
+      mockMindManager.listConversationHistory.mockReturnValueOnce([
+        {
+          sessionId: 'session-1',
+          title: 'Design review',
+          createdAt: '2026-05-05T22:00:00.000Z',
+          updatedAt: '2026-05-05T22:30:00.000Z',
+          kind: 'chat',
+          active: true,
+          hasMessages: true,
+        },
+      ]);
+      mockMindManager.getConversationMessages.mockResolvedValueOnce([]);
+
+      const result = await svc.exportConversation('valid-mind', 'session-1', 'json');
+
+      expect(result.format).toBe('json');
+      expect(result.filename).toBe('design-review.json');
+      expect(JSON.parse(result.content).sessionId).toBe('session-1');
+    });
+
+    it('throws when the conversation is not in the mind history', async () => {
+      mockMindManager.listConversationHistory.mockReturnValueOnce([]);
+
+      await expect(svc.exportConversation('valid-mind', 'missing', 'markdown')).rejects.toThrow(
+        'Conversation missing not found',
+      );
+      expect(mockMindManager.getConversationMessages).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -25,7 +25,7 @@ import { clearCopilotModelsCache } from '../sdk/modelCacheCompat';
 import { mapSdkModelList } from '../sdk/sdkModelMapper';
 import { TurnQueue } from './TurnQueue';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext, type DateTimeContextProvider } from './currentDateTimeContext';
-import { buildConversationExport } from './conversationExport';
+import { buildConversationExport, conversationExportFilename } from './conversationExport';
 import { TurnLifecycleTrace } from './turnLifecycleTrace';
 
 const log = Logger.create('ChatService');
@@ -423,19 +423,32 @@ export class ChatService {
     return this.mindManager.getConversationMessages(mindId, sessionId);
   }
 
+  /**
+   * Resolve the suggested export file name without reading the transcript, so
+   * the save dialog can be shown before any expensive read/serialize work.
+   */
+  getConversationExportFilename(mindId: string, sessionId: string, format: ConversationExportFormat): string {
+    return conversationExportFilename(this.requireConversationSummary(mindId, sessionId), format);
+  }
+
   async exportConversation(
     mindId: string,
     sessionId: string,
     format: ConversationExportFormat,
   ): Promise<ConversationExport> {
+    const conversation = this.requireConversationSummary(mindId, sessionId);
+    const messages = await this.mindManager.getConversationMessages(mindId, sessionId);
+    return buildConversationExport(conversation, messages, format);
+  }
+
+  private requireConversationSummary(mindId: string, sessionId: string): ConversationSummary {
     const conversation = this.mindManager
       .listConversationHistory(mindId)
       .find((candidate) => candidate.sessionId === sessionId);
     if (!conversation) {
       throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
     }
-    const messages = await this.mindManager.getConversationMessages(mindId, sessionId);
-    return buildConversationExport(conversation, messages, format);
+    return conversation;
   }
 
   async listModels(mindId: string): Promise<ModelInfo[]> {

--- a/packages/services/src/chat/ChatService.ts
+++ b/packages/services/src/chat/ChatService.ts
@@ -3,7 +3,7 @@
 
 import type { MindManager } from '../mind';
 import { getErrorMessage } from '@chamber/shared/getErrorMessage';
-import type { ChatEvent, ChatImageAttachment, ConversationResumeResult, ConversationSummary, ModelInfo } from '@chamber/shared/types';
+import type { ChatEvent, ChatImageAttachment, ChatMessage, ConversationExport, ConversationExportFormat, ConversationResumeResult, ConversationSummary, ModelInfo } from '@chamber/shared/types';
 import { modelSelectionKeyFromModel } from '@chamber/shared/model-selection';
 import type { CopilotSession } from '../mind/types';
 import { isStaleSessionError, SEND_TIMEOUT_MS, sendTimeoutError } from '@chamber/shared/sessionErrors';
@@ -25,6 +25,7 @@ import { clearCopilotModelsCache } from '../sdk/modelCacheCompat';
 import { mapSdkModelList } from '../sdk/sdkModelMapper';
 import { TurnQueue } from './TurnQueue';
 import { getCurrentDateTimeContext, injectCurrentDateTimeContext, type DateTimeContextProvider } from './currentDateTimeContext';
+import { buildConversationExport } from './conversationExport';
 import { TurnLifecycleTrace } from './turnLifecycleTrace';
 
 const log = Logger.create('ChatService');
@@ -416,6 +417,25 @@ export class ChatService {
 
   renameConversation(mindId: string, sessionId: string, title: string): ConversationSummary[] {
     return this.mindManager.renameConversation(mindId, sessionId, title);
+  }
+
+  getConversationMessages(mindId: string, sessionId: string): Promise<ChatMessage[]> {
+    return this.mindManager.getConversationMessages(mindId, sessionId);
+  }
+
+  async exportConversation(
+    mindId: string,
+    sessionId: string,
+    format: ConversationExportFormat,
+  ): Promise<ConversationExport> {
+    const conversation = this.mindManager
+      .listConversationHistory(mindId)
+      .find((candidate) => candidate.sessionId === sessionId);
+    if (!conversation) {
+      throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
+    }
+    const messages = await this.mindManager.getConversationMessages(mindId, sessionId);
+    return buildConversationExport(conversation, messages, format);
   }
 
   async listModels(mindId: string): Promise<ModelInfo[]> {

--- a/packages/services/src/chat/conversationExport.test.ts
+++ b/packages/services/src/chat/conversationExport.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import type { ChatMessage, ConversationSummary } from '@chamber/shared/types';
+import {
+  buildConversationExport,
+  conversationExportFilename,
+  serializeConversationToJson,
+  serializeConversationToMarkdown,
+  slugifyConversationTitle,
+} from './conversationExport';
+
+const conversation: ConversationSummary = {
+  sessionId: 'session-42',
+  title: 'Planning: the Q3 roadmap!',
+  createdAt: '2026-05-05T22:00:00.000Z',
+  updatedAt: '2026-05-05T22:30:00.000Z',
+  kind: 'chat',
+  active: true,
+  hasMessages: true,
+};
+
+const messages: ChatMessage[] = [
+  {
+    id: 'u1',
+    role: 'user',
+    timestamp: Date.parse('2026-05-05T22:00:00.000Z'),
+    blocks: [{ type: 'text', content: 'How should we plan Q3?' }],
+  },
+  {
+    id: 'a1',
+    role: 'assistant',
+    timestamp: Date.parse('2026-05-05T22:00:05.000Z'),
+    blocks: [
+      { type: 'reasoning', reasoningId: 'r1', content: 'Consider capacity first.' },
+      { type: 'text', content: 'Start by ranking initiatives.' },
+      {
+        type: 'tool_call',
+        toolCallId: 't1',
+        toolName: 'list_issues',
+        status: 'done',
+        arguments: { label: 'roadmap' },
+        output: 'Found 3 issues',
+      },
+    ],
+  },
+];
+
+const options = { exportedAt: '2026-06-01T00:00:00.000Z' };
+
+describe('slugifyConversationTitle', () => {
+  it('lowercases, strips punctuation, and collapses separators', () => {
+    expect(slugifyConversationTitle('Planning: the Q3 roadmap!')).toBe('planning-the-q3-roadmap');
+  });
+
+  it('returns an empty string when nothing survives normalization', () => {
+    expect(slugifyConversationTitle('!!!')).toBe('');
+  });
+});
+
+describe('conversationExportFilename', () => {
+  it('uses the slugified title with a format extension', () => {
+    expect(conversationExportFilename(conversation, 'markdown')).toBe('planning-the-q3-roadmap.md');
+    expect(conversationExportFilename(conversation, 'json')).toBe('planning-the-q3-roadmap.json');
+  });
+
+  it('falls back to the session id when the title has no usable slug', () => {
+    const untitled: ConversationSummary = { ...conversation, title: '   ' };
+    expect(conversationExportFilename(untitled, 'markdown')).toBe('session-42.md');
+  });
+});
+
+describe('serializeConversationToMarkdown', () => {
+  it('renders a readable header and one section per turn', () => {
+    const md = serializeConversationToMarkdown(conversation, messages, options);
+
+    expect(md).toContain('# Planning: the Q3 roadmap!');
+    expect(md).toContain('- Session: session-42');
+    expect(md).toContain('- Exported: 2026-06-01T00:00:00.000Z');
+    expect(md).toContain('- Messages: 2');
+    expect(md).toContain('## User');
+    expect(md).toContain('How should we plan Q3?');
+    expect(md).toContain('## Assistant');
+    expect(md).toContain('Start by ranking initiatives.');
+  });
+
+  it('renders reasoning as a blockquote and tool calls with fenced arguments and output', () => {
+    const md = serializeConversationToMarkdown(conversation, messages, options);
+
+    expect(md).toContain('> Reasoning');
+    expect(md).toContain('> Consider capacity first.');
+    expect(md).toContain('**Tool call:** `list_issues` (done)');
+    expect(md).toContain('```json');
+    expect(md).toContain('"label": "roadmap"');
+    expect(md).toContain('Found 3 issues');
+  });
+
+  it('renders image and permission blocks as compact placeholders without em dashes', () => {
+    const withMedia: ChatMessage[] = [
+      {
+        id: 'a2',
+        role: 'assistant',
+        timestamp: 0,
+        blocks: [
+          { type: 'image', name: 'chart.png', mimeType: 'image/png', dataUrl: 'data:image/png;base64,AAAA' },
+          { type: 'permission', requestId: 'p1', kind: 'shell', summary: 'run ls', outcome: 'approved' },
+        ],
+      },
+    ];
+
+    const md = serializeConversationToMarkdown(conversation, withMedia, options);
+
+    expect(md).toContain('_[image: chart.png (image/png)]_');
+    expect(md).toContain('_[permission: shell - run ls (approved)]_');
+    expect(md).not.toContain('base64,AAAA');
+    expect(md).not.toContain('\u2014');
+  });
+
+  it('notes when a conversation has no messages', () => {
+    const md = serializeConversationToMarkdown(conversation, [], options);
+    expect(md).toContain('_No messages in this conversation._');
+  });
+});
+
+describe('serializeConversationToJson', () => {
+  it('produces valid JSON that preserves metadata and full message blocks', () => {
+    const json = serializeConversationToJson(conversation, messages, options);
+    expect(json.endsWith('\n')).toBe(true);
+
+    const parsed = JSON.parse(json);
+    expect(parsed.sessionId).toBe('session-42');
+    expect(parsed.title).toBe('Planning: the Q3 roadmap!');
+    expect(parsed.exportedAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(parsed.messages).toHaveLength(2);
+    expect(parsed.messages[1].blocks[2].toolName).toBe('list_issues');
+  });
+});
+
+describe('buildConversationExport', () => {
+  it('selects the markdown serializer and filename', () => {
+    const result = buildConversationExport(conversation, messages, 'markdown', options);
+    expect(result.format).toBe('markdown');
+    expect(result.filename).toBe('planning-the-q3-roadmap.md');
+    expect(result.content).toContain('# Planning: the Q3 roadmap!');
+  });
+
+  it('selects the json serializer and filename', () => {
+    const result = buildConversationExport(conversation, messages, 'json', options);
+    expect(result.format).toBe('json');
+    expect(result.filename).toBe('planning-the-q3-roadmap.json');
+    expect(() => JSON.parse(result.content)).not.toThrow();
+  });
+});

--- a/packages/services/src/chat/conversationExport.test.ts
+++ b/packages/services/src/chat/conversationExport.test.ts
@@ -114,6 +114,32 @@ describe('serializeConversationToMarkdown', () => {
     expect(md).not.toContain('\u2014');
   });
 
+  it('escapes tool output that itself contains a code fence so the block cannot close early', () => {
+    const withFence: ChatMessage[] = [
+      {
+        id: 'a3',
+        role: 'assistant',
+        timestamp: 0,
+        blocks: [
+          {
+            type: 'tool_call',
+            toolCallId: 't9',
+            toolName: 'cat',
+            status: 'done',
+            output: 'here is code:\n```js\nconst x = 1;\n```\ndone',
+          },
+        ],
+      },
+    ];
+
+    const md = serializeConversationToMarkdown(conversation, withFence, options);
+
+    // The outer fence must be longer than the inner ``` so it does not close early.
+    expect(md).toContain('````');
+    expect(md).toContain('```js');
+    expect(md).toContain('const x = 1;');
+  });
+
   it('notes when a conversation has no messages', () => {
     const md = serializeConversationToMarkdown(conversation, [], options);
     expect(md).toContain('_No messages in this conversation._');

--- a/packages/services/src/chat/conversationExport.ts
+++ b/packages/services/src/chat/conversationExport.ts
@@ -1,0 +1,147 @@
+// Pure serialization of a conversation into shareable Markdown or JSON.
+// No Electron or filesystem access — the desktop IPC layer owns the save dialog
+// and file write; this module only turns a conversation + its messages into text.
+
+import type {
+  ChatMessage,
+  ContentBlock,
+  ConversationExport,
+  ConversationExportFormat,
+  ConversationSummary,
+} from '@chamber/shared/types';
+
+export interface ConversationExportOptions {
+  /** ISO timestamp recorded in the export. Injectable for deterministic tests. */
+  exportedAt?: string;
+}
+
+/** Build the serialized payload plus a suggested file name for a save dialog. */
+export function buildConversationExport(
+  conversation: ConversationSummary,
+  messages: ChatMessage[],
+  format: ConversationExportFormat,
+  options: ConversationExportOptions = {},
+): ConversationExport {
+  const exportedAt = options.exportedAt ?? new Date().toISOString();
+  const content = format === 'json'
+    ? serializeConversationToJson(conversation, messages, { exportedAt })
+    : serializeConversationToMarkdown(conversation, messages, { exportedAt });
+  return {
+    format,
+    filename: conversationExportFilename(conversation, format),
+    content,
+  };
+}
+
+/** `Planning thread` + `markdown` -> `planning-thread.md`. */
+export function conversationExportFilename(
+  conversation: ConversationSummary,
+  format: ConversationExportFormat,
+): string {
+  const extension = format === 'json' ? 'json' : 'md';
+  const slug = slugifyConversationTitle(conversation.title) || conversation.sessionId || 'conversation';
+  return `${slug}.${extension}`;
+}
+
+export function slugifyConversationTitle(title: string): string {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+export function serializeConversationToJson(
+  conversation: ConversationSummary,
+  messages: ChatMessage[],
+  options: ConversationExportOptions = {},
+): string {
+  const payload = {
+    sessionId: conversation.sessionId,
+    title: conversation.title,
+    kind: conversation.kind,
+    createdAt: conversation.createdAt,
+    updatedAt: conversation.updatedAt,
+    exportedAt: options.exportedAt ?? new Date().toISOString(),
+    messages,
+  };
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+export function serializeConversationToMarkdown(
+  conversation: ConversationSummary,
+  messages: ChatMessage[],
+  options: ConversationExportOptions = {},
+): string {
+  const exportedAt = options.exportedAt ?? new Date().toISOString();
+  const lines: string[] = [
+    `# ${conversation.title || 'Conversation'}`,
+    '',
+    `- Session: ${conversation.sessionId}`,
+    `- Created: ${conversation.createdAt}`,
+    `- Updated: ${conversation.updatedAt}`,
+    `- Exported: ${exportedAt}`,
+    `- Messages: ${messages.length}`,
+    '',
+  ];
+
+  if (messages.length === 0) {
+    lines.push('_No messages in this conversation._', '');
+    return `${lines.join('\n')}`;
+  }
+
+  for (const message of messages) {
+    lines.push(`## ${roleHeading(message.role)}`, '');
+    const rendered = message.blocks.map(renderBlockToMarkdown).filter((block) => block.length > 0);
+    lines.push(rendered.length > 0 ? rendered.join('\n\n') : '_(empty message)_', '');
+  }
+
+  return `${lines.join('\n')}`;
+}
+
+function roleHeading(role: ChatMessage['role']): string {
+  return role === 'assistant' ? 'Assistant' : 'User';
+}
+
+function renderBlockToMarkdown(block: ContentBlock): string {
+  switch (block.type) {
+    case 'text':
+      return block.content.trim();
+    case 'reasoning':
+      return blockquote(`Reasoning\n\n${block.content.trim()}`);
+    case 'tool_call':
+      return renderToolCall(block);
+    case 'image':
+      return `_[image: ${block.name} (${block.mimeType})]_`;
+    case 'permission':
+      return `_[permission: ${block.kind} - ${block.summary} (${block.outcome})]_`;
+    default:
+      return '';
+  }
+}
+
+function renderToolCall(block: Extract<ContentBlock, { type: 'tool_call' }>): string {
+  const parts: string[] = [`**Tool call:** \`${block.toolName}\` (${block.status})`];
+  if (block.arguments && Object.keys(block.arguments).length > 0) {
+    parts.push(fencedCode(JSON.stringify(block.arguments, null, 2), 'json'));
+  }
+  if (block.output) {
+    parts.push(fencedCode(block.output));
+  }
+  if (block.error) {
+    parts.push(`Error: ${block.error}`);
+  }
+  return parts.join('\n\n');
+}
+
+function blockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => (line.length > 0 ? `> ${line}` : '>'))
+    .join('\n');
+}
+
+function fencedCode(text: string, language = ''): string {
+  return `\`\`\`${language}\n${text}\n\`\`\``;
+}

--- a/packages/services/src/chat/conversationExport.ts
+++ b/packages/services/src/chat/conversationExport.ts
@@ -143,5 +143,9 @@ function blockquote(text: string): string {
 }
 
 function fencedCode(text: string, language = ''): string {
-  return `\`\`\`${language}\n${text}\n\`\`\``;
+  // Use a fence longer than any backtick run in the content so tool output that
+  // itself contains code fences cannot prematurely close the block.
+  const longestBacktickRun = (text.match(/`+/g) ?? []).reduce((max, run) => Math.max(max, run.length), 0);
+  const fence = '`'.repeat(Math.max(3, longestBacktickRun + 1));
+  return `${fence}${language}\n${text}\n${fence}`;
 }

--- a/packages/services/src/chat/sessionTranscript.test.ts
+++ b/packages/services/src/chat/sessionTranscript.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mapSessionEventsToChatMessages } from './sessionTranscript';
+
+describe('mapSessionEventsToChatMessages', () => {
+  it('folds a rich assistant turn into ordered reasoning, tool, permission, and text blocks', () => {
+    const events = [
+      { type: 'user.message', timestamp: '2026-05-05T22:00:00.000Z', data: { messageId: 'u1', content: 'Deploy the API' } },
+      { type: 'assistant.reasoning', timestamp: '2026-05-05T22:00:01.000Z', data: { reasoningId: 'r1', content: 'Check the pipeline first.' } },
+      { type: 'tool.execution_start', timestamp: '2026-05-05T22:00:02.000Z', data: { toolCallId: 't1', toolName: 'run_shell', arguments: { command: 'ls -la' } } },
+      { type: 'permission.requested', timestamp: '2026-05-05T22:00:03.000Z', data: { requestId: 'p1', permissionRequest: { kind: 'shell', fullCommandText: 'ls -la', toolCallId: 't1' } } },
+      { type: 'permission.completed', timestamp: '2026-05-05T22:00:04.000Z', data: { requestId: 'p1', result: { kind: 'approved' } } },
+      { type: 'tool.execution_complete', timestamp: '2026-05-05T22:00:05.000Z', data: { toolCallId: 't1', success: true, result: { content: 'file1\nfile2' } } },
+      { type: 'assistant.message', timestamp: '2026-05-05T22:00:06.000Z', data: { messageId: 'a1', content: 'Done deploying.' } },
+    ];
+
+    const messages = mapSessionEventsToChatMessages(events);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      id: 'u1',
+      role: 'user',
+      blocks: [{ type: 'text', content: 'Deploy the API' }],
+    });
+
+    const assistant = messages[1];
+    expect(assistant.role).toBe('assistant');
+    expect(assistant.id).toBe('a1');
+    expect(assistant.blocks).toEqual([
+      { type: 'reasoning', reasoningId: 'r1', content: 'Check the pipeline first.' },
+      { type: 'tool_call', toolCallId: 't1', toolName: 'run_shell', status: 'done', arguments: { command: 'ls -la' }, output: 'file1\nfile2' },
+      { type: 'permission', requestId: 'p1', kind: 'shell', summary: 'ls -la', outcome: 'approved', toolCallId: 't1' },
+      { type: 'text', sdkMessageId: 'a1', content: 'Done deploying.' },
+    ]);
+  });
+
+  it('splits separate user turns into separate assistant messages', () => {
+    const events = [
+      { type: 'user.message', timestamp: '2026-05-05T22:00:00.000Z', data: { messageId: 'u1', content: 'First question' } },
+      { type: 'assistant.message', timestamp: '2026-05-05T22:00:01.000Z', data: { messageId: 'a1', content: 'First answer' } },
+      { type: 'user.message', timestamp: '2026-05-05T22:00:02.000Z', data: { messageId: 'u2', content: 'Second question' } },
+      { type: 'assistant.message', timestamp: '2026-05-05T22:00:03.000Z', data: { messageId: 'a2', content: 'Second answer' } },
+    ];
+
+    const messages = mapSessionEventsToChatMessages(events);
+
+    expect(messages.map((m) => ({ id: m.id, role: m.role }))).toEqual([
+      { id: 'u1', role: 'user' },
+      { id: 'a1', role: 'assistant' },
+      { id: 'u2', role: 'user' },
+      { id: 'a2', role: 'assistant' },
+    ]);
+  });
+
+  it('strips Chamber-injected datetime context from user messages', () => {
+    const events = [
+      {
+        type: 'user.message',
+        timestamp: '2026-05-05T22:00:00.000Z',
+        data: {
+          messageId: 'u1',
+          content: '<current_datetime>\n2026-05-07T03:19:51.220Z\n</current_datetime>\n<timezone>\nAmerica/New_York\n</timezone>\n\nreal question',
+        },
+      },
+    ];
+
+    const messages = mapSessionEventsToChatMessages(events);
+
+    expect(messages[0].blocks).toEqual([{ type: 'text', content: 'real question' }]);
+  });
+
+  it('skips malformed tool and permission events without throwing and keeps the rest of the turn', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const events = [
+      { type: 'user.message', timestamp: '2026-05-05T22:00:00.000Z', data: { messageId: 'u1', content: 'go' } },
+      { type: 'tool.execution_start', timestamp: '2026-05-05T22:00:01.000Z', data: { toolName: 'missing_id' } },
+      { type: 'assistant.message', timestamp: '2026-05-05T22:00:02.000Z', data: { messageId: 'a1', content: 'still here' } },
+    ];
+
+    const messages = mapSessionEventsToChatMessages(events);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[1].blocks).toEqual([{ type: 'text', sdkMessageId: 'a1', content: 'still here' }]);
+    warn.mockRestore();
+  });
+
+  it('marks a failed tool call as error with its message', () => {
+    const events = [
+      { type: 'tool.execution_start', timestamp: '2026-05-05T22:00:00.000Z', data: { toolCallId: 't1', toolName: 'grep', arguments: {} } },
+      { type: 'tool.execution_complete', timestamp: '2026-05-05T22:00:01.000Z', data: { toolCallId: 't1', success: false, error: { message: 'no matches' } } },
+    ];
+
+    const messages = mapSessionEventsToChatMessages(events);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].blocks[0]).toMatchObject({ type: 'tool_call', status: 'error', error: 'no matches' });
+  });
+
+  it('returns an empty array for an empty or non-object event log', () => {
+    expect(mapSessionEventsToChatMessages([])).toEqual([]);
+    expect(mapSessionEventsToChatMessages([null, 42, 'nope'])).toEqual([]);
+  });
+});

--- a/packages/services/src/chat/sessionTranscript.ts
+++ b/packages/services/src/chat/sessionTranscript.ts
@@ -1,0 +1,177 @@
+// Maps a persisted SDK session transcript (session.getEvents()) into the
+// ChatMessage[] shape the renderer uses for live chat. Reusing the same
+// ChatEvent fold (applyChatEventToMessage) and the same SDK event parsers as
+// live streaming keeps a resumed, exported, or searched conversation visually
+// identical to the live timeline, including tool calls, reasoning, and
+// permission prompts rather than plain text only.
+
+import type { ChatEvent, ChatMessage } from '@chamber/shared/types';
+import { applyChatEventToMessage } from '@chamber/shared';
+import { Logger } from '../logger';
+import { stripInjectedCurrentDateTimeContext } from './currentDateTimeContext';
+import {
+  mapSdkPermissionCompleted,
+  mapSdkPermissionRequested,
+  mapSdkToolExecutionComplete,
+  mapSdkToolExecutionStart,
+} from '../sdk/sdkChatEventMapper';
+
+const log = Logger.create('sessionTranscript');
+
+interface RawSessionEvent {
+  type?: string;
+  timestamp?: unknown;
+  id?: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Fold a persisted session event log into ordered ChatMessages. User messages
+ * start a new turn; every assistant-side event (text, reasoning, tool call,
+ * permission) until the next user message accumulates into a single assistant
+ * message, mirroring how live chat renders one assistant bubble per turn.
+ *
+ * Malformed events are skipped rather than thrown: history assembly must stay
+ * resilient so resume/export/search never fail on a single unexpected event,
+ * unlike the live stream path which surfaces contract drift loudly.
+ */
+export function mapSessionEventsToChatMessages(events: readonly unknown[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  let assistant: ChatMessage | null = null;
+  let assistantIdOverride: string | null = null;
+
+  const flushAssistant = (): void => {
+    if (assistant && assistant.blocks.length > 0) {
+      messages.push(assistantIdOverride ? { ...assistant, id: assistantIdOverride } : assistant);
+    }
+    assistant = null;
+    assistantIdOverride = null;
+  };
+
+  const foldIntoAssistant = (event: RawSessionEvent, index: number, chatEvent: ChatEvent | null): void => {
+    if (!chatEvent) return;
+    if (!assistant) {
+      assistant = {
+        id: assistantMessageId(event, index),
+        role: 'assistant',
+        blocks: [],
+        timestamp: toTimestamp(event.timestamp),
+      };
+    }
+    assistant = applyChatEventToMessage(assistant, chatEvent);
+  };
+
+  events.forEach((raw, index) => {
+    if (typeof raw !== 'object' || raw === null) return;
+    const event = raw as RawSessionEvent;
+    const data = typeof event.data === 'object' && event.data !== null ? event.data : {};
+
+    switch (event.type) {
+      case 'user.message': {
+        flushAssistant();
+        const content = extractTextContent(data);
+        if (!content) return;
+        messages.push({
+          id: messageId(data, event, index, 'user'),
+          role: 'user',
+          blocks: [{ type: 'text', content: stripInjectedCurrentDateTimeContext(content) }],
+          timestamp: toTimestamp(event.timestamp),
+        });
+        return;
+      }
+
+      case 'assistant.reasoning': {
+        const content = typeof data.content === 'string' ? data.content : '';
+        if (!content) return;
+        const reasoningId = typeof data.reasoningId === 'string' ? data.reasoningId : `reasoning-${index}`;
+        foldIntoAssistant(event, index, { type: 'reasoning', reasoningId, content });
+        return;
+      }
+
+      case 'assistant.message': {
+        const content = extractTextContent(data);
+        if (!content) return;
+        const sdkMessageId = typeof data.messageId === 'string' ? data.messageId : `assistant-${index}`;
+        // The assistant message id is the most meaningful identifier for the
+        // whole turn; adopt the first one seen even if reasoning/tool events
+        // opened the accumulator earlier with a synthesized id.
+        if (assistantIdOverride === null && typeof data.messageId === 'string') {
+          assistantIdOverride = data.messageId;
+        }
+        foldIntoAssistant(event, index, { type: 'message_final', sdkMessageId, content });
+        return;
+      }
+
+      case 'tool.execution_start':
+        foldIntoAssistant(event, index, safeMap('tool.execution_start', () => mapSdkToolExecutionStart(raw)));
+        return;
+
+      case 'tool.execution_complete':
+        foldIntoAssistant(event, index, safeMap('tool.execution_complete', () => mapSdkToolExecutionComplete(raw)));
+        return;
+
+      case 'permission.requested':
+        foldIntoAssistant(event, index, safeMap('permission.requested', () => mapSdkPermissionRequested(raw)));
+        return;
+
+      case 'permission.completed':
+        foldIntoAssistant(event, index, safeMap('permission.completed', () => mapSdkPermissionCompleted(raw)));
+        return;
+
+      default:
+        return;
+    }
+  });
+
+  flushAssistant();
+  return messages;
+}
+
+function safeMap<T extends ChatEvent>(eventName: string, map: () => T): T | null {
+  try {
+    return map();
+  } catch (error) {
+    log.warn(`Skipping malformed ${eventName} event while mapping session history:`, error);
+    return null;
+  }
+}
+
+function extractTextContent(data: Record<string, unknown>): string | null {
+  const value = data.content ?? data.message ?? data.text ?? data.prompt;
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const content = value
+      .map((item) => {
+        if (typeof item === 'string') return item;
+        if (typeof item !== 'object' || item === null) return '';
+        const block = item as Record<string, unknown>;
+        return typeof block.text === 'string' ? block.text : '';
+      })
+      .filter(Boolean)
+      .join('\n');
+    return content || null;
+  }
+  return null;
+}
+
+function messageId(
+  data: Record<string, unknown>,
+  event: RawSessionEvent,
+  index: number,
+  role: 'user' | 'assistant',
+): string {
+  if (typeof data.messageId === 'string') return data.messageId;
+  if (typeof event.id === 'string') return event.id;
+  return `${role}-${index}`;
+}
+
+function assistantMessageId(event: RawSessionEvent, index: number): string {
+  const data = typeof event.data === 'object' && event.data !== null ? event.data : {};
+  return messageId(data, event, index, 'assistant');
+}
+
+function toTimestamp(value: unknown): number {
+  if (typeof value === 'number') return value;
+  const parsed = Date.parse(String(value ?? ''));
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -995,7 +995,7 @@ describe('MindManager', () => {
         {
           id: 'a1',
           role: 'assistant',
-          blocks: [{ type: 'text', content: 'hello human' }],
+          blocks: [{ type: 'text', sdkMessageId: 'a1', content: 'hello human' }],
           timestamp: Date.parse('2026-05-05T22:00:01.000Z'),
         },
       ]);
@@ -1262,7 +1262,7 @@ describe('MindManager', () => {
         {
           id: 'a1',
           role: 'assistant',
-          blocks: [{ type: 'text', content: 'archived answer' }],
+          blocks: [{ type: 'text', sdkMessageId: 'a1', content: 'archived answer' }],
           timestamp: Date.parse('2026-05-05T22:00:01.000Z'),
         },
       ]);
@@ -1273,6 +1273,69 @@ describe('MindManager', () => {
       await expect(manager.getConversationMessages(mind.mindId, 'missing-session')).rejects.toThrow(
         'Conversation missing-session not found',
       );
+    });
+
+    it('does not disconnect a throwaway read session that a concurrent resume promoted to active', async () => {
+      const readOnlySession = createSessionStub();
+      let releaseGetEvents: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => { releaseGetEvents = resolve; });
+      readOnlySession.getEvents.mockImplementation(async () => {
+        await gate;
+        return [
+          { type: 'assistant.message', timestamp: '2026-05-05T22:00:01.000Z', data: { messageId: 'a1', content: 'archived answer' } },
+        ];
+      });
+      const activeSession = createSessionStub();
+      activeSession.getEvents.mockResolvedValue([]);
+
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+      await manager.startNewConversation(mind.mindId);
+      const inactive = manager.listConversationHistory(mind.mindId).find((conversation) => !conversation.active);
+      expect(inactive).toBeDefined();
+
+      mockResumeSession.mockClear();
+      mockResumeSession
+        .mockResolvedValueOnce(readOnlySession)  // background read-only load
+        .mockResolvedValueOnce(activeSession);   // concurrent resume promotes to active
+
+      const readPromise = manager.getConversationMessages(mind.mindId, inactive!.sessionId);
+      await vi.waitFor(() => { expect(mockResumeSession).toHaveBeenCalledTimes(1); });
+
+      await manager.resumeConversation(mind.mindId, inactive!.sessionId);
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(inactive!.sessionId);
+      expect(manager.getMind(mind.mindId)?.session).toBe(activeSession);
+
+      releaseGetEvents?.();
+      await readPromise;
+
+      // The background read must not tear down the SDK session that the resume
+      // just promoted to active, nor the live session the user now sees.
+      expect(readOnlySession.disconnect).not.toHaveBeenCalled();
+      expect(activeSession.disconnect).not.toHaveBeenCalled();
+      expect(manager.getMind(mind.mindId)?.session).toBe(activeSession);
+    });
+
+    it('deduplicates concurrent read-only transcript loads for the same conversation', async () => {
+      const readOnlySession = createSessionStub();
+      readOnlySession.getEvents.mockResolvedValue([
+        { type: 'assistant.message', timestamp: '2026-05-05T22:00:01.000Z', data: { messageId: 'a1', content: 'archived' } },
+      ]);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+      await manager.startNewConversation(mind.mindId);
+      const inactive = manager.listConversationHistory(mind.mindId).find((conversation) => !conversation.active);
+      mockResumeSession.mockClear();
+      mockResumeSession.mockResolvedValue(readOnlySession);
+
+      const [first, second] = await Promise.all([
+        manager.getConversationMessages(mind.mindId, inactive!.sessionId),
+        manager.getConversationMessages(mind.mindId, inactive!.sessionId),
+      ]);
+
+      expect(mockResumeSession).toHaveBeenCalledTimes(1);
+      expect(readOnlySession.disconnect).toHaveBeenCalledTimes(1);
+      expect(first).toEqual(second);
     });
 
     it('renames only Chamber-owned conversation metadata', async () => {

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -1201,6 +1201,80 @@ describe('MindManager', () => {
       });
     });
 
+    it('getConversationMessages reads the active conversation from its live session without resuming', async () => {
+      const activeSession = createSessionStub();
+      activeSession.getEvents.mockResolvedValue([
+        {
+          type: 'user.message',
+          timestamp: '2026-05-05T22:00:00.000Z',
+          data: { messageId: 'u1', content: 'active content' },
+        },
+      ]);
+      mockCreateSession.mockResolvedValueOnce(activeSession);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      const activeSessionId = mind.activeSessionId!;
+      manager.markActiveConversationHasMessages(mind.mindId, 'Active chat');
+      mockResumeSession.mockClear();
+
+      const messages = await manager.getConversationMessages(mind.mindId, activeSessionId);
+
+      expect(mockResumeSession).not.toHaveBeenCalled();
+      expect(activeSession.disconnect).not.toHaveBeenCalled();
+      expect(messages).toEqual([
+        {
+          id: 'u1',
+          role: 'user',
+          blocks: [{ type: 'text', content: 'active content' }],
+          timestamp: Date.parse('2026-05-05T22:00:00.000Z'),
+        },
+      ]);
+    });
+
+    it('getConversationMessages resumes an inactive conversation read-only and leaves the active session untouched', async () => {
+      const readOnlySession = createSessionStub();
+      readOnlySession.getEvents.mockResolvedValue([
+        {
+          type: 'assistant.message',
+          timestamp: '2026-05-05T22:00:01.000Z',
+          data: { messageId: 'a1', content: 'archived answer' },
+        },
+      ]);
+      const mind = await manager.loadMind('/tmp/agents/q');
+      manager.markActiveConversationHasMessages(mind.mindId, 'Existing chat');
+      await manager.startNewConversation(mind.mindId);
+      const activeSessionBefore = manager.getMind(mind.mindId)?.session;
+      const activeSessionIdBefore = manager.getMind(mind.mindId)?.activeSessionId;
+      const inactive = manager.listConversationHistory(mind.mindId).find((conversation) => !conversation.active);
+      expect(inactive).toBeDefined();
+      mockResumeSession.mockClear();
+      mockResumeSession.mockResolvedValueOnce(readOnlySession);
+
+      const messages = await manager.getConversationMessages(mind.mindId, inactive!.sessionId);
+
+      expect(mockResumeSession).toHaveBeenCalledWith(
+        inactive!.sessionId,
+        expect.objectContaining({ workingDirectory: '/tmp/agents/q' }),
+      );
+      expect(readOnlySession.disconnect).toHaveBeenCalled();
+      expect(manager.getMind(mind.mindId)?.session).toBe(activeSessionBefore);
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(activeSessionIdBefore);
+      expect(messages).toEqual([
+        {
+          id: 'a1',
+          role: 'assistant',
+          blocks: [{ type: 'text', content: 'archived answer' }],
+          timestamp: Date.parse('2026-05-05T22:00:01.000Z'),
+        },
+      ]);
+    });
+
+    it('getConversationMessages throws for an unknown conversation', async () => {
+      const mind = await manager.loadMind('/tmp/agents/q');
+      await expect(manager.getConversationMessages(mind.mindId, 'missing-session')).rejects.toThrow(
+        'Conversation missing-session not found',
+      );
+    });
+
     it('renames only Chamber-owned conversation metadata', async () => {
       const mind = await manager.loadMind('/tmp/agents/q');
       const sessionId = manager.listConversationHistory(mind.mindId)[0].sessionId;

--- a/packages/services/src/mind/MindManager.test.ts
+++ b/packages/services/src/mind/MindManager.test.ts
@@ -1275,7 +1275,7 @@ describe('MindManager', () => {
       );
     });
 
-    it('does not disconnect a throwaway read session that a concurrent resume promoted to active', async () => {
+    it('serializes a background read against a concurrent resume so the opened conversation is never torn down', async () => {
       const readOnlySession = createSessionStub();
       let releaseGetEvents: (() => void) | undefined;
       const gate = new Promise<void>((resolve) => { releaseGetEvents = resolve; });
@@ -1296,24 +1296,32 @@ describe('MindManager', () => {
 
       mockResumeSession.mockClear();
       mockResumeSession
-        .mockResolvedValueOnce(readOnlySession)  // background read-only load
-        .mockResolvedValueOnce(activeSession);   // concurrent resume promotes to active
+        .mockResolvedValueOnce(readOnlySession)  // background read-only load (holds the lock)
+        .mockResolvedValueOnce(activeSession);   // resume, once the read releases the lock
 
+      // The read acquires the per-mind lock and parks on getEvents.
       const readPromise = manager.getConversationMessages(mind.mindId, inactive!.sessionId);
       await vi.waitFor(() => { expect(mockResumeSession).toHaveBeenCalledTimes(1); });
 
-      await manager.resumeConversation(mind.mindId, inactive!.sessionId);
-      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(inactive!.sessionId);
-      expect(manager.getMind(mind.mindId)?.session).toBe(activeSession);
+      // The resume must queue behind the read rather than promote mid-read.
+      const resumePromise = manager.resumeConversation(mind.mindId, inactive!.sessionId);
+      await Promise.resolve();
+      expect(mockResumeSession).toHaveBeenCalledTimes(1);
+      expect(manager.getMind(mind.mindId)?.activeSessionId).not.toBe(inactive!.sessionId);
 
       releaseGetEvents?.();
-      await readPromise;
+      const messages = await readPromise;
+      await resumePromise;
 
-      // The background read must not tear down the SDK session that the resume
-      // just promoted to active, nor the live session the user now sees.
-      expect(readOnlySession.disconnect).not.toHaveBeenCalled();
+      // The read read its transcript and disconnected only its own throwaway,
+      // which happened before the resume created the live session.
+      expect(messages).toEqual([
+        { id: 'a1', role: 'assistant', blocks: [{ type: 'text', sdkMessageId: 'a1', content: 'archived answer' }], timestamp: Date.parse('2026-05-05T22:00:01.000Z') },
+      ]);
+      // The live session the user opened is intact and active.
       expect(activeSession.disconnect).not.toHaveBeenCalled();
       expect(manager.getMind(mind.mindId)?.session).toBe(activeSession);
+      expect(manager.getMind(mind.mindId)?.activeSessionId).toBe(inactive!.sessionId);
     });
 
     it('deduplicates concurrent read-only transcript loads for the same conversation', async () => {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -17,7 +17,8 @@ import { loadChamberMindConfig } from './chamberMindConfig';
 import type { CopilotClientFactory } from '../sdk/CopilotClientFactory';
 import { approveForSessionCompat } from '../sdk/approveForSessionCompat';
 import type { IdentityLoader } from '../chat/IdentityLoader';
-import { getCurrentDateTimeContext, injectCurrentDateTimeContext, stripInjectedCurrentDateTimeContext } from '../chat/currentDateTimeContext';
+import { getCurrentDateTimeContext, injectCurrentDateTimeContext } from '../chat/currentDateTimeContext';
+import { mapSessionEventsToChatMessages } from '../chat/sessionTranscript';
 import type { ChamberToolProvider } from '../chamberTools';
 import type { ConfigService } from '../config/ConfigService';
 import type { ViewDiscovery } from '../lens/ViewDiscovery';
@@ -84,6 +85,10 @@ export class MindManager extends EventEmitter {
   private minds = new Map<string, InternalMindContext>();
   private pathToId = new Map<string, string>();
   private loading = new Map<string, Promise<MindContext>>();
+  // Deduplicates concurrent read-only transcript loads for the same
+  // `mindId:sessionId`, so history search fan-out and an export cannot resume
+  // the same SDK session twice and race each other's teardown.
+  private readonly inFlightConversationReads = new Map<string, Promise<ChatMessage[]>>();
   // Lowercased+NFC display names held by in-flight `loadMind({enforceUnique:true})`
   // calls. Two concurrent uniqueness-enforcing loads with colliding identity
   // names would otherwise both pass the `this.minds`-only check because neither
@@ -606,9 +611,18 @@ export class MindManager extends EventEmitter {
   /**
    * Read a conversation's messages without changing the mind's active session.
    * The active conversation is read from its live session; any other
-   * conversation is resumed into a throwaway session that is disconnected
-   * immediately after its transcript is read, so the user's current chat is
-   * never disturbed. Used by history search (content lookup) and export.
+   * conversation is resumed into a throwaway session that is disconnected once
+   * its transcript is read, so the user's current chat is never disturbed.
+   * Used by history search (content lookup) and export.
+   *
+   * Two safety properties guard against a background read tearing down a
+   * conversation the user just opened:
+   *   1. Concurrent reads of the same session are deduplicated via
+   *      `inFlightConversationReads`, so only one throwaway session exists.
+   *   2. Before disconnecting the throwaway session, we re-check whether a
+   *      concurrent resume promoted this session to the mind's active session.
+   *      If so, the live session now owns that SDK session id and we must not
+   *      disconnect it.
    */
   async getConversationMessages(mindId: string, sessionId: string): Promise<ChatMessage[]> {
     const context = this.minds.get(mindId);
@@ -620,6 +634,28 @@ export class MindManager extends EventEmitter {
 
     if (context.activeSessionId === sessionId && context.session) {
       return this.getMessagesForSession(context.session);
+    }
+
+    const key = `${mindId}:${sessionId}`;
+    const existing = this.inFlightConversationReads.get(key);
+    if (existing) return existing;
+
+    const load = this.readConversationMessagesReadOnly(mindId, sessionId, context)
+      .finally(() => this.inFlightConversationReads.delete(key));
+    this.inFlightConversationReads.set(key, load);
+    return load;
+  }
+
+  private async readConversationMessagesReadOnly(
+    mindId: string,
+    sessionId: string,
+    context: InternalMindContext,
+  ): Promise<ChatMessage[]> {
+    // A resume may have promoted this session to active between the caller's
+    // guard and here; read from the live session instead of resuming a rival.
+    const beforeLoad = this.minds.get(mindId);
+    if (beforeLoad?.activeSessionId === sessionId && beforeLoad.session) {
+      return this.getMessagesForSession(beforeLoad.session);
     }
 
     const sessionTools = this.getSessionTools(mindId, context.mindPath);
@@ -636,7 +672,11 @@ export class MindManager extends EventEmitter {
     try {
       return await this.getMessagesForSession(readOnlySession);
     } finally {
-      await readOnlySession.disconnect().catch(() => { /* session already disconnected */ });
+      const current = this.minds.get(mindId);
+      const promotedToActive = current?.activeSessionId === sessionId && Boolean(current.session);
+      if (!promotedToActive) {
+        await readOnlySession.disconnect().catch(() => { /* session already disconnected */ });
+      }
     }
   }
 
@@ -1359,51 +1399,7 @@ export class MindManager extends EventEmitter {
 
   private async getMessagesForSession(session: CopilotSession): Promise<ChatMessage[]> {
     const events = await session.getEvents();
-    return events.flatMap((event, index) => this.mapSessionEventToChatMessage(event, index));
-  }
-
-  private mapSessionEventToChatMessage(event: unknown, index: number): ChatMessage[] {
-    if (typeof event !== 'object' || event === null) return [];
-    const record = event as Record<string, unknown>;
-    const data = typeof record.data === 'object' && record.data !== null
-      ? record.data as Record<string, unknown>
-      : {};
-    const rawContent = this.extractMessageContent(data);
-    const content = record.type === 'user.message' && rawContent
-      ? stripInjectedCurrentDateTimeContext(rawContent)
-      : rawContent;
-    if (!content) return [];
-    const timestamp = typeof record.timestamp === 'number'
-      ? record.timestamp
-      : Date.parse(String(record.timestamp ?? '')) || Date.now();
-    const id = typeof data.messageId === 'string'
-      ? data.messageId
-      : `${String(record.type ?? 'session-event')}-${index}`;
-    if (record.type === 'user.message') {
-      return [{ id, role: 'user', blocks: [{ type: 'text', content }], timestamp }];
-    }
-    if (record.type === 'assistant.message') {
-      return [{ id, role: 'assistant', blocks: [{ type: 'text', content }], timestamp }];
-    }
-    return [];
-  }
-
-  private extractMessageContent(data: Record<string, unknown>): string | null {
-    const value = data.content ?? data.message ?? data.text ?? data.prompt;
-    if (typeof value === 'string') return value;
-    if (Array.isArray(value)) {
-      const content = value
-        .map((item) => {
-          if (typeof item === 'string') return item;
-          if (typeof item !== 'object' || item === null) return '';
-          const block = item as Record<string, unknown>;
-          return typeof block.text === 'string' ? block.text : '';
-        })
-        .filter(Boolean)
-        .join('\n');
-      return content || null;
-    }
-    return null;
+    return mapSessionEventsToChatMessages(events);
   }
 
   async sendBackgroundPrompt(mindPath: string, prompt: string): Promise<void> {

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -603,6 +603,43 @@ export class MindManager extends EventEmitter {
     };
   }
 
+  /**
+   * Read a conversation's messages without changing the mind's active session.
+   * The active conversation is read from its live session; any other
+   * conversation is resumed into a throwaway session that is disconnected
+   * immediately after its transcript is read, so the user's current chat is
+   * never disturbed. Used by history search (content lookup) and export.
+   */
+  async getConversationMessages(mindId: string, sessionId: string): Promise<ChatMessage[]> {
+    const context = this.minds.get(mindId);
+    if (!context) throw new Error(`Mind ${mindId} not found`);
+    const record = this.knownMindRecords.get(mindId);
+    if (!record?.conversations?.some((conversation) => conversation.sessionId === sessionId)) {
+      throw new Error(`Conversation ${sessionId} not found for mind ${mindId}`);
+    }
+
+    if (context.activeSessionId === sessionId && context.session) {
+      return this.getMessagesForSession(context.session);
+    }
+
+    const sessionTools = this.getSessionTools(mindId, context.mindPath);
+    const readOnlySession = await this.loadConversationSession(
+      context.client,
+      'conversation',
+      context.mindPath,
+      context.identity.systemMessage,
+      sessionTools,
+      sessionId,
+      context.selectedModel,
+      context.selectedModelProvider,
+    );
+    try {
+      return await this.getMessagesForSession(readOnlySession);
+    } finally {
+      await readOnlySession.disconnect().catch(() => { /* session already disconnected */ });
+    }
+  }
+
   listConversationHistory(mindId: string): ConversationSummary[] {
     const context = this.minds.get(mindId);
     const record = this.knownMindRecords.get(mindId);

--- a/packages/services/src/mind/MindManager.ts
+++ b/packages/services/src/mind/MindManager.ts
@@ -89,6 +89,13 @@ export class MindManager extends EventEmitter {
   // `mindId:sessionId`, so history search fan-out and an export cannot resume
   // the same SDK session twice and race each other's teardown.
   private readonly inFlightConversationReads = new Map<string, Promise<ChatMessage[]>>();
+  // Serializes per-mind session-lifecycle mutations (resume, delete, and
+  // read-only transcript loads) so a background read can never resume or
+  // disconnect an SDK session id while a resume/delete is concurrently
+  // promoting that same id to the mind's active session. The SDK keys live
+  // sessions by id and `disconnect()` destroys the shared runtime session, so
+  // these operations must not interleave for a given mind.
+  private readonly sessionLifecycleLocks = new Map<string, Promise<unknown>>();
   // Lowercased+NFC display names held by in-flight `loadMind({enforceUnique:true})`
   // calls. Two concurrent uniqueness-enforcing loads with colliding identity
   // names would otherwise both pass the `this.minds`-only check because neither
@@ -564,6 +571,10 @@ export class MindManager extends EventEmitter {
   }
 
   async resumeConversation(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
+    return this.withMindSessionLock(mindId, () => this.resumeConversationUnlocked(mindId, sessionId));
+  }
+
+  private async resumeConversationUnlocked(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
     const record = this.knownMindRecords.get(mindId);
@@ -615,14 +626,18 @@ export class MindManager extends EventEmitter {
    * its transcript is read, so the user's current chat is never disturbed.
    * Used by history search (content lookup) and export.
    *
-   * Two safety properties guard against a background read tearing down a
-   * conversation the user just opened:
+   * Safety against a background read tearing down a conversation the user just
+   * opened rests on three properties:
    *   1. Concurrent reads of the same session are deduplicated via
    *      `inFlightConversationReads`, so only one throwaway session exists.
-   *   2. Before disconnecting the throwaway session, we re-check whether a
-   *      concurrent resume promoted this session to the mind's active session.
-   *      If so, the live session now owns that SDK session id and we must not
-   *      disconnect it.
+   *   2. The throwaway resume/read/disconnect runs under the per-mind
+   *      `sessionLifecycleLocks`, so it cannot interleave with a `resume`/
+   *      `delete` that promotes the same id to active. The read either runs
+   *      fully before the promotion (and safely disconnects its own throwaway)
+   *      or fully after it (and observes the id as active, reading the live
+   *      session instead of resuming a rival).
+   *   3. Inside the lock we re-check the active session before touching it, so
+   *      a promotion that landed first is honored.
    */
   async getConversationMessages(mindId: string, sessionId: string): Promise<ChatMessage[]> {
     const context = this.minds.get(mindId);
@@ -640,10 +655,33 @@ export class MindManager extends EventEmitter {
     const existing = this.inFlightConversationReads.get(key);
     if (existing) return existing;
 
-    const load = this.readConversationMessagesReadOnly(mindId, sessionId, context)
+    const load = this.withMindSessionLock(mindId, () => this.readConversationMessagesReadOnly(mindId, sessionId, context))
       .finally(() => this.inFlightConversationReads.delete(key));
     this.inFlightConversationReads.set(key, load);
     return load;
+  }
+
+  /**
+   * Serialize a session-lifecycle operation for a single mind, mirroring the
+   * per-mind queue used by `setMindModel`. Operations for different minds run
+   * concurrently; operations for the same mind run one at a time in call order.
+   */
+  private async withMindSessionLock<T>(mindId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.sessionLifecycleLocks.get(mindId) ?? Promise.resolve();
+    let release: () => void;
+    const current = new Promise<void>((resolve) => { release = resolve; });
+    const queued = previous.then(() => current, () => current);
+    this.sessionLifecycleLocks.set(mindId, queued);
+    await previous.catch(() => { /* previous caller observes its own failure */ });
+
+    try {
+      return await operation();
+    } finally {
+      release!();
+      if (this.sessionLifecycleLocks.get(mindId) === queued) {
+        this.sessionLifecycleLocks.delete(mindId);
+      }
+    }
   }
 
   private async readConversationMessagesReadOnly(
@@ -651,8 +689,10 @@ export class MindManager extends EventEmitter {
     sessionId: string,
     context: InternalMindContext,
   ): Promise<ChatMessage[]> {
-    // A resume may have promoted this session to active between the caller's
-    // guard and here; read from the live session instead of resuming a rival.
+    // Under the per-mind lock, no resume/delete can run concurrently. Still
+    // re-check: a resume/delete that ran just before us may have already
+    // promoted this session to active, in which case read the live session
+    // rather than resuming a rival throwaway for the same id.
     const beforeLoad = this.minds.get(mindId);
     if (beforeLoad?.activeSessionId === sessionId && beforeLoad.session) {
       return this.getMessagesForSession(beforeLoad.session);
@@ -672,6 +712,10 @@ export class MindManager extends EventEmitter {
     try {
       return await this.getMessagesForSession(readOnlySession);
     } finally {
+      // The lock guarantees no live session adopted this id while we read, so
+      // disconnecting our throwaway cannot tear down an active conversation.
+      // The active-session guard is defense in depth for the read-after-promote
+      // ordering handled above.
       const current = this.minds.get(mindId);
       const promotedToActive = current?.activeSessionId === sessionId && Boolean(current.session);
       if (!promotedToActive) {
@@ -716,6 +760,10 @@ export class MindManager extends EventEmitter {
   }
 
   async deleteConversation(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
+    return this.withMindSessionLock(mindId, () => this.deleteConversationUnlocked(mindId, sessionId));
+  }
+
+  private async deleteConversationUnlocked(mindId: string, sessionId: string): Promise<ConversationResumeResult> {
     const context = this.minds.get(mindId);
     if (!context) throw new Error(`Mind ${mindId} not found`);
     const record = this.knownMindRecords.get(mindId);

--- a/packages/shared/src/chat-transcript.test.ts
+++ b/packages/shared/src/chat-transcript.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import type { ChatMessage } from './types';
+import { applyChatEventToMessage } from './chat-transcript';
+
+function assistant(): ChatMessage {
+  return { id: 'm1', role: 'assistant', blocks: [], timestamp: 0 };
+}
+
+describe('applyChatEventToMessage', () => {
+  it('appends and extends text blocks from chunks', () => {
+    let message = applyChatEventToMessage(assistant(), { type: 'chunk', content: 'Hel', sdkMessageId: 's1' });
+    message = applyChatEventToMessage(message, { type: 'chunk', content: 'lo', sdkMessageId: 's1' });
+    expect(message.blocks).toEqual([{ type: 'text', sdkMessageId: 's1', content: 'Hello' }]);
+  });
+
+  it('creates a running tool block and resolves it on tool_done', () => {
+    let message = applyChatEventToMessage(assistant(), { type: 'tool_start', toolCallId: 't1', toolName: 'grep', args: { q: 'x' } });
+    expect(message.blocks[0]).toMatchObject({ type: 'tool_call', status: 'running' });
+    message = applyChatEventToMessage(message, { type: 'tool_done', toolCallId: 't1', success: true, result: 'match' });
+    expect(message.blocks[0]).toMatchObject({ type: 'tool_call', status: 'done', output: 'match' });
+  });
+
+  it('records reasoning and coalesces same-id reasoning deltas', () => {
+    let message = applyChatEventToMessage(assistant(), { type: 'reasoning', reasoningId: 'r1', content: 'think ' });
+    message = applyChatEventToMessage(message, { type: 'reasoning', reasoningId: 'r1', content: 'more' });
+    expect(message.blocks).toEqual([{ type: 'reasoning', reasoningId: 'r1', content: 'think more' }]);
+  });
+
+  it('adds a permission block and updates its outcome, ignoring duplicate requests', () => {
+    let message = applyChatEventToMessage(assistant(), { type: 'permission_request', requestId: 'p1', kind: 'shell', summary: 'ls', toolCallId: 't1' });
+    const afterDuplicate = applyChatEventToMessage(message, { type: 'permission_request', requestId: 'p1', kind: 'shell', summary: 'ls' });
+    expect(afterDuplicate).toBe(message);
+    message = applyChatEventToMessage(message, { type: 'permission_outcome', requestId: 'p1', outcome: 'approved' });
+    expect(message.blocks[0]).toMatchObject({ type: 'permission', requestId: 'p1', outcome: 'approved' });
+  });
+
+  it('does not mutate the input message', () => {
+    const original = assistant();
+    const next = applyChatEventToMessage(original, { type: 'chunk', content: 'x' });
+    expect(original.blocks).toEqual([]);
+    expect(next).not.toBe(original);
+  });
+});

--- a/packages/shared/src/chat-transcript.ts
+++ b/packages/shared/src/chat-transcript.ts
@@ -1,0 +1,140 @@
+import type { ChatEvent, ChatMessage, ContentBlock } from './types';
+
+/**
+ * Fold a single {@link ChatEvent} into a {@link ChatMessage}, returning the
+ * updated message. This is the one source of truth for how streaming chat
+ * events accumulate into ordered content blocks, shared by the renderer's live
+ * chat reducer and the main-process session-history transcript mapper so that a
+ * resumed, exported, or searched conversation renders exactly like live chat.
+ *
+ * The function is pure: it never mutates `message`. When an event does not
+ * change anything (unknown tool/permission id, duplicate permission request,
+ * already-reconciled final message), the original `message` reference is
+ * returned so callers can rely on referential equality to skip re-renders.
+ */
+export function applyChatEventToMessage(message: ChatMessage, event: ChatEvent): ChatMessage {
+  const blocks = [...message.blocks];
+
+  switch (event.type) {
+    case 'chunk': {
+      const last = blocks[blocks.length - 1];
+      if (last && last.type === 'text') {
+        blocks[blocks.length - 1] = { ...last, content: last.content + event.content, sdkMessageId: event.sdkMessageId };
+      } else {
+        blocks.push({ type: 'text', sdkMessageId: event.sdkMessageId, content: event.content });
+      }
+      return { ...message, blocks };
+    }
+
+    case 'tool_start': {
+      blocks.push({
+        type: 'tool_call',
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        status: 'running',
+        arguments: event.args,
+        parentToolCallId: event.parentToolCallId,
+      });
+      return { ...message, blocks };
+    }
+
+    case 'tool_progress': {
+      const idx = blocks.findIndex((b) => b.type === 'tool_call' && b.toolCallId === event.toolCallId);
+      if (idx >= 0) {
+        const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
+        blocks[idx] = { ...block, output: (block.output || '') + event.message + '\n' };
+      }
+      return { ...message, blocks };
+    }
+
+    case 'tool_output': {
+      const idx = blocks.findIndex((b) => b.type === 'tool_call' && b.toolCallId === event.toolCallId);
+      if (idx >= 0) {
+        const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
+        blocks[idx] = { ...block, output: (block.output || '') + event.output };
+      }
+      return { ...message, blocks };
+    }
+
+    case 'tool_done': {
+      const idx = blocks.findIndex((b) => b.type === 'tool_call' && b.toolCallId === event.toolCallId);
+      if (idx >= 0) {
+        const block = blocks[idx] as Extract<ContentBlock, { type: 'tool_call' }>;
+        blocks[idx] = {
+          ...block,
+          status: event.success ? 'done' : 'error',
+          ...(event.result && { output: (block.output || '') + event.result }),
+          ...(event.error && { error: event.error }),
+        };
+      }
+      return { ...message, blocks };
+    }
+
+    case 'permission_request': {
+      if (blocks.some((b) => b.type === 'permission' && b.requestId === event.requestId)) {
+        return message;
+      }
+      blocks.push({
+        type: 'permission',
+        requestId: event.requestId,
+        kind: event.kind,
+        summary: event.summary,
+        outcome: 'pending',
+        ...(event.toolCallId ? { toolCallId: event.toolCallId } : {}),
+      });
+      return { ...message, blocks };
+    }
+
+    case 'permission_outcome': {
+      const idx = blocks.findIndex((b) => b.type === 'permission' && b.requestId === event.requestId);
+      if (idx >= 0) {
+        const block = blocks[idx] as Extract<ContentBlock, { type: 'permission' }>;
+        blocks[idx] = { ...block, outcome: event.outcome };
+      }
+      return { ...message, blocks };
+    }
+
+    case 'reasoning': {
+      const last = blocks[blocks.length - 1];
+      if (last && last.type === 'reasoning' && last.reasoningId === event.reasoningId) {
+        blocks[blocks.length - 1] = { ...last, content: last.content + event.content };
+      } else {
+        blocks.push({ type: 'reasoning', reasoningId: event.reasoningId, content: event.content });
+      }
+      return { ...message, blocks };
+    }
+
+    case 'message_final': {
+      // Reconciliation: add text only if this sdkMessageId was never streamed via chunks.
+      const hasThisMessage = blocks.some((b) => b.type === 'text' && b.sdkMessageId === event.sdkMessageId);
+      if (!hasThisMessage && event.content) {
+        blocks.push({ type: 'text', sdkMessageId: event.sdkMessageId, content: event.content });
+        return { ...message, blocks };
+      }
+      return message;
+    }
+
+    case 'done':
+      return { ...message, isStreaming: false };
+
+    case 'error':
+      return {
+        ...message,
+        isStreaming: false,
+        blocks: [...blocks, { type: 'text', content: `Error: ${event.message}` }],
+      };
+
+    case 'timeout':
+      return {
+        ...message,
+        isStreaming: false,
+        blocks: [...blocks, { type: 'text', content: `Agent timed out after ${Math.round(event.timeoutMs / 1000)}s` }],
+      };
+
+    case 'reconnecting':
+      return message;
+
+    default:
+      return message;
+  }
+}

--- a/packages/shared/src/electron-types.ts
+++ b/packages/shared/src/electron-types.ts
@@ -41,7 +41,10 @@ import type {
   ByoLlmSaveResult,
   ChatEvent,
   ChatImageAttachment,
+  ChatMessage,
   ChatReplayEvent,
+  ConversationExportFormat,
+  ConversationExportResult,
   ConversationResumeResult,
   ConversationSummary,
   DesktopUpdateActionResult,
@@ -76,6 +79,8 @@ export interface ElectronAPI {
     resume: (mindId: string, sessionId: string) => Promise<ConversationResumeResult>;
     rename: (mindId: string, sessionId: string, title: string) => Promise<ConversationSummary[]>;
     delete: (mindId: string, sessionId: string) => Promise<ConversationResumeResult>;
+    messages: (mindId: string, sessionId: string) => Promise<ChatMessage[]>;
+    export: (mindId: string, sessionId: string, format: ConversationExportFormat) => Promise<ConversationExportResult>;
   };
   mind: {
     add: (mindPath: string) => Promise<MindContext>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export { parseIpcArgs } from './ipc-validation';
 export { Logger, type LogLevel } from './logger';
 export { escapeXml } from './escapeXml';
 export { getErrorMessage } from './getErrorMessage';
+export { applyChatEventToMessage } from './chat-transcript';

--- a/packages/shared/src/ipc-channels.test.ts
+++ b/packages/shared/src/ipc-channels.test.ts
@@ -15,6 +15,8 @@ describe('IPC channel constants', () => {
     expect(IPC.CONVERSATION_HISTORY.RESUME).toBe('conversationHistory:resume');
     expect(IPC.CONVERSATION_HISTORY.RENAME).toBe('conversationHistory:rename');
     expect(IPC.CONVERSATION_HISTORY.DELETE).toBe('conversationHistory:delete');
+    expect(IPC.CONVERSATION_HISTORY.MESSAGES).toBe('conversationHistory:messages');
+    expect(IPC.CONVERSATION_HISTORY.EXPORT).toBe('conversationHistory:export');
 
     expect(IPC.MIND.ADD).toBe('mind:add');
     expect(IPC.MIND.REMOVE).toBe('mind:remove');

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -26,6 +26,8 @@ export const IPC = {
     RESUME: 'conversationHistory:resume',
     RENAME: 'conversationHistory:rename',
     DELETE: 'conversationHistory:delete',
+    MESSAGES: 'conversationHistory:messages',
+    EXPORT: 'conversationHistory:export',
   },
   MIND: {
     ADD: 'mind:add',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -280,6 +280,21 @@ export interface ConversationResumeResult {
   conversations: ConversationSummary[];
 }
 
+export type ConversationExportFormat = 'markdown' | 'json';
+
+/** Serialized conversation payload produced by the chat/history service. */
+export interface ConversationExport {
+  format: ConversationExportFormat;
+  /** Suggested file name including extension (e.g. `planning-thread.md`). */
+  filename: string;
+  content: string;
+}
+
+/** Outcome of a main-process save-dialog export. */
+export type ConversationExportResult =
+  | { status: 'saved'; path: string; format: ConversationExportFormat }
+  | { status: 'canceled' };
+
 export interface MarketplaceRegistry {
   id: string;
   label: string;


### PR DESCRIPTION
﻿## Summary

Adds search and export to the conversation history panel, and hardens the read-only transcript path they depend on.

- **Search**: a debounced search box filters the active mind's conversations by title and by message content. Content is looked up read-only via a new IPC, cached per `sessionId + updatedAt`, loaded in bounded batches, and never disturbs the active chat. Per-mind scoping resets on mind switch; a clear button empties the query.
- **Export**: a per-conversation action exports Markdown or JSON via an Electron save dialog. The dialog is shown before any transcript read/serialize, so a cancel does no expensive work.
- **Rich transcripts**: a shared session-history mapper folds the persisted SDK event log into `ChatMessage[]` preserving text, tool, reasoning, and permission blocks, reusing the exact live-chat block fold (`applyChatEventToMessage`). Resume, delete, export, and search now render transcripts consistent with live chat instead of text only.

## Notable changes

- `packages/shared/src/chat-transcript.ts` - extracts the renderer's `handleChatEvent` block fold into `applyChatEventToMessage`, now the single source of truth shared by the renderer reducer and the history mapper.
- `packages/services/src/chat/sessionTranscript.ts` - `mapSessionEventsToChatMessages`, grouping one assistant message per user turn; malformed events are skipped (history stays resilient) rather than thrown like the live path.
- `packages/services/src/chat/conversationExport.ts` - Markdown/JSON serializers; code fences are sized longer than any backtick run in tool output so they cannot close early.
- `packages/services/src/mind/MindManager.ts` - `getConversationMessages` reads a non-active conversation via a throwaway resumed session. Reads are deduplicated per session and routed through a per-mind session-lifecycle lock (shared with `resumeConversation`/`deleteConversation`) so a background read can never resume or disconnect an SDK session id while a concurrent resume/delete promotes that same id to active. This closes the teardown and event-routing race an active-session recheck alone only narrowed.
- `apps/desktop/src/main/ipc/conversationHistory.ts` + `preload.ts` - new `conversationHistory:messages` and `conversationHistory:export` IPC.
- `apps/web/src/renderer/components/history/ConversationHistoryPanel.tsx` - search box, export popover, and the bounded content-index effect (recompute gated on mounted, not the per-run cleanup flag).

## Tests

- Colocated Vitest for the filter logic, the serializer (including fence escaping), the shared fold, the session-history mapper (tool/reasoning/permission events), the export IPC (dialog-before-work ordering), and the panel (live filter + export).
- Two `MindManager` regression tests: a delayed-`getEvents` read serialized against a concurrent resume proving the opened conversation is never torn down, and read-load deduplication.
- `npm run lint` clean. `npm test`: 2260 passed, 2 skipped, 1 failed. The single failure is a pre-existing, environment-only Windows issue: `MindProfileService` "rejects symlinked profile files" calls `fs.symlinkSync`, which needs elevated privileges on Windows (EPERM); it fails identically on a clean `master` checkout and is unrelated to this change.
- `npm run smoke:sdk` passed, validating the transcript mapper's SDK event-shape assumptions and the session-resume path against the live runtime.

## Reviewed

Uncle Bob reviewed the branch; his High finding (residual teardown/routing race) and Medium/Low findings (suppressed search recompute, unescaped export fences) are all fixed in this PR.

No closing issue reference: this is a self-contained UX slice with no tracked issue.

---

## Upstream issue linkage

Fixes #364. The shared rich transcript mapper preserves tool/reasoning/permission blocks when conversations are resumed, searched, and exported.

## Source branch

Fork PR: https://github.com/patschmittdev/chamber/pull/7
Head: `patschmittdev:patschmittdev-feat-history-search-export`
