### PR TITLE
fix: resolve renderer Vite config path to absolute in forge.config.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stop Copilot CLI auth popups after sign-in** — Pass Chamber's stored GitHub OAuth token into SDK-created CLI clients and disable CLI auto-login so device-flow browser prompts only occur from Chamber's explicit sign-in flow.
 - **Isolate packaged Copilot runtime validation** — Runs the bundled CLI smoke check with a temporary home so self-updated developer cache builds cannot cause false package-version mismatches.
 - **Promote WTD runtimes across Windows volumes** — Falls back to copy-and-remove when temporary staging and the Actions workspace are on different drives, so Insiders packaging can complete (#400)
+- **Resolve renderer Vite config path to absolute in forge.config.ts** — electron-forge start failed with UNRESOLVED_ENTRY because the renderer config was a relative string; changed to path.resolve(__dirname, ...) so Electron Forge resolves it correctly regardless of cwd
 
 ### Tests
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -206,7 +206,7 @@ const config: ForgeConfig = {
       renderer: [
         {
           name: PACKAGED_RENDERER_NAME,
-          config: 'apps/web/vite.electron.config.ts',
+          config: path.resolve(__dirname, 'apps/web/vite.electron.config.ts'),
         },
       ],
     }),


### PR DESCRIPTION
## Problem

`electron-forge start` fails immediately with:

```text
[UNRESOLVED_ENTRY] Cannot resolve entry module apps/web/vite.electron.config.ts
```

The renderer entry in `forge.config.ts` uses a bare relative string for the Vite config path. Electron Forge resolves this relative to the process working directory, which can differ from the project root when launched by Forge internals.

## Fix

Switch to an absolute path with `path.resolve(__dirname, ...)`, consistent with the path handling already used in this file:

```diff
-          config: 'apps/web/vite.electron.config.ts',
+          config: path.resolve(__dirname, 'apps/web/vite.electron.config.ts'),
```

`path` is already imported. No new dependencies.

## Validation

- The change is scoped to a single renderer config path.
- Using `path.resolve(__dirname, ...)` removes working directory sensitivity.
- The `build` entries remain relative and are not affected by this renderer resolution path.