### PR TITLE
Add Linux authentication and distribution support

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -31,7 +31,7 @@ ask once. If the channel is ambiguous, ask once.
 
 | Channel  | Audience    | Workflow                                  | Distribution                     | Platforms                           |
 | -------- | ----------- | ----------------------------------------- | -------------------------------- | ----------------------------------- |
-| Insiders | Invite-only | `.github/workflows/release-insiders.yml`  | Azure Blob `chamberinsiders`     | Windows + macOS arm64 (signed + notarized) |
+| Insiders | Invite-only | `.github/workflows/release-insiders.yml`  | Azure Blob `chamberinsiders`     | Windows + macOS arm64; Linux x64 preview |
 | Stable   | Public      | `.github/workflows/release.yml`           | GitHub Releases                  | Windows + macOS arm64 (+x64 opt-in; macOS can be disabled by repo variable) |
 
 Both are `workflow_dispatch` only — neither fires on push.
@@ -157,7 +157,7 @@ Required state:
 
 ```
 Which channel?
-  insiders  – Windows + macOS arm64 (signed + notarized), invite-only, fast cadence
+  insiders  – Windows + macOS arm64, plus Linux x64 preview; invite-only
   stable    – public, full platforms, requires macOS notary warmup
 ```
 
@@ -229,11 +229,12 @@ Surface the new tag, the Windows install URL
 (`https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe`),
 the macOS DMG
 (`https://chamberinsiders.blob.core.windows.net/releases/Chamber-<version>-arm64.dmg`),
+the versioned Linux ZIP and DEB under the same blob root,
 and the auto-update feeds
 (`https://chamberinsiders.blob.core.windows.net/releases/insiders.yml` for Windows;
 `https://chamberinsiders.blob.core.windows.net/releases/latest-mac.yml` for macOS).
-Existing testers auto-update on both platforms; new testers need the install URL
-out-of-band.
+Windows and macOS testers auto-update. Linux preview testers must download each
+version manually.
 
 ### 3b. Stable dispatch
 
@@ -581,12 +582,13 @@ see exactly what happened. Example:
 
 ```
 ✅ Dispatched insiders release
-   - Channel:      insiders (Windows + macOS arm64)
+   - Channel:      insiders (Windows + macOS arm64; Linux x64 preview)
    - Next tag:     v0.62.4-insiders.4
    - Audience:     invited testers only
    - Install URL:  https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe
    - macOS DMG:    https://chamberinsiders.blob.core.windows.net/releases/Chamber-<version>-arm64.dmg
-   - Auto-update:  existing testers receive it automatically (both platforms)
+   - Linux:        versioned ZIP + DEB under the same blob root (manual updates)
+   - Auto-update:  existing Windows and macOS testers receive it automatically
    - Run:          <gh URL>
    - Checklist:    ~/.copilot/session-state/<id>/files/release-vX.Y.Z-<channel>-checklist.md
 ```

--- a/.github/skills/release/assets/insiders-checklist.md
+++ b/.github/skills/release/assets/insiders-checklist.md
@@ -29,7 +29,7 @@ placeholders haven't been substituted yet.
 
 ## Phase 2 — Channel chosen: insiders
 
-- [ ] `[channel-confirmed]` User confirmed `insiders` (Windows + macOS arm64, invite-only).
+- [ ] `[channel-confirmed]` User confirmed `insiders` (Windows + macOS arm64; Linux x64 preview; invite-only).
 
 ## Phase 3a — Compute & dispatch
 
@@ -42,9 +42,9 @@ placeholders haven't been substituted yet.
 ## Phase 3a.4 — After success
 
 - [ ] `[tag-pushed]` New tag `v{{VERSION}}` appears in `git tag -l 'v*-insiders.*' --sort=-v:refname | head -3`.
-- [ ] `[install-url-surfaced]` Install URLs surfaced to user: Windows <https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe> and macOS arm64 DMG at `Chamber-{{VERSION}}-arm64.dmg` under the same blob root.
+- [ ] `[install-url-surfaced]` Install URLs surfaced to user: Windows <https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe>, macOS arm64 DMG at `Chamber-{{VERSION}}-arm64.dmg`, and versioned Linux x64 ZIP + DEB under the same blob root.
 - [ ] `[update-feed-surfaced]` Auto-update feeds surfaced: <https://chamberinsiders.blob.core.windows.net/releases/insiders.yml> (Windows) and <https://chamberinsiders.blob.core.windows.net/releases/latest-mac.yml> (macOS).
-- [ ] `[tester-note]` Reminded user that existing testers auto-update; new testers need the install URL out-of-band.
+- [ ] `[tester-note]` Reminded user that Windows and macOS auto-update, while Linux preview builds require manual downloads.
 
 ## Phase 4 — Summary
 

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -229,10 +229,13 @@ jobs:
           npm install
 
       - name: Install Linux packaging tools
-        run: sudo apt-get update && sudo apt-get install --yes fakeroot
+        run: sudo apt-get update && sudo apt-get install --yes fakeroot xvfb
 
       - name: Build Linux ZIP and DEB packages
         run: npm run make:forge
+
+      - name: Smoke packaged Linux app
+        run: xvfb-run --auto-servernum npm run smoke:linux-package
 
       - name: Stage artifacts
         run: |

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -207,8 +207,49 @@ jobs:
           path: staged/*
           if-no-files-found: error
 
+  build-linux:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Apply insiders version
+        run: |
+          npm version "${{ needs.prepare.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm install
+
+      - name: Install Linux packaging tools
+        run: sudo apt-get update && sudo apt-get install --yes fakeroot
+
+      - name: Build Linux ZIP and DEB packages
+        run: npm run make:forge
+
+      - name: Stage artifacts
+        run: |
+          mkdir -p staged
+          find out/make/zip/linux/x64 -maxdepth 1 -type f -name '*.zip' -exec cp {} staged/ \;
+          find out/make/deb/x64 -maxdepth 1 -type f -name '*.deb' -exec cp {} staged/ \;
+          test "$(find staged -maxdepth 1 -type f | wc -l)" -eq 2
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: insiders-linux
+          path: staged/*
+          if-no-files-found: error
+
   publish:
-    needs: [prepare, build-windows, build-macos]
+    needs: [prepare, build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Expose bounded per-mind skill discovery** — Adds renderer-safe on-disk skill metadata IPC with asynchronous bounded reads, deterministic limits, and path/link safeguards without conflating managed provenance or integrity.
 - **Add insiders-gated local voice dictation** — Adds local Foundry/Nemotron dictation with a dedicated Settings page, chat mic and push-to-talk controls, explicit runtime capability gating, and insiders-only prepared runtime packaging. (#385) (#385)
 - **Add local WTD topology advice for automation authors** — Give Insiders minds a verified local workflow-shape advisor before they author ttasks DAGs, while keeping execution in ttasks-ts (#400)
+- **Distribute Chamber for Linux** — Insiders releases now publish Linux x64 ZIP and DEB previews, while Arch users can build a native Pacman package locally with `npm run make:arch`.
 
 ### Refactor
 

--- a/INSIDERS.md
+++ b/INSIDERS.md
@@ -2,7 +2,8 @@
 
 Chamber Insiders is the fast-cadence prerelease channel. Builds ship sooner than the public stable releases on GitHub Releases. **This page is invitation-only**: it is not linked from the README or product website. If someone forwarded you the link, that's the invitation.
 
-Insiders ships **Windows only**. macOS Insiders is intentionally not built; the public stable release on GitHub Releases is the macOS channel.
+Insiders ships signed Windows and notarized macOS arm64 builds. Linux x64
+ZIP and DEB packages are available as an early preview with manual updates.
 
 ## What you're trusting
 
@@ -21,21 +22,30 @@ If you would like to be removed from the invite list, tell whoever invited you. 
 
 ## Install
 
-1. Download the latest Windows installer:
+1. Download the artifact for your platform:
 
    ```
    https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe
    ```
 
-   (Or the exact tagged file shared with you.)
+   Linux artifacts use the versioned names
+   `Chamber-linux-x64-<version>.zip` and
+   `chamber_<version>_amd64.deb` under the same blob root. Use the ZIP
+   on Arch and other non-Debian distributions.
 
-2. Run the installer. SmartScreen should accept it because the file is signed with Chamber's Trusted Signing certificate.
+2. Run the installer, or extract the Linux ZIP and launch `chamber`.
+   SmartScreen should accept the Windows installer because it is signed
+   with Chamber's Trusted Signing certificate.
 
-3. Done. Future updates are automatic.
+3. Windows and macOS update automatically. Linux preview updates are
+   downloaded manually.
 
 ## Updates
 
-Once installed, Chamber Insiders checks the same Azure Blob URL on a regular cadence. When a newer `vX.Y.Z-insiders.N` is published you'll get an in-app prompt to restart and update. There is no separate action required.
+On Windows and macOS, Chamber Insiders checks the Azure Blob on a
+regular cadence. When a newer `vX.Y.Z-insiders.N` is published, you
+will get an in-app prompt to restart and update. Linux preview users
+must download each new ZIP or DEB.
 
 You will never see public stable releases on this channel. You also will never accidentally roll back from Insiders to stable: electron-updater refuses to downgrade.
 
@@ -52,7 +62,8 @@ You will remain on the version you have installed until the public stable channe
 ## Caveats
 
 - The download URL is unlisted, not access-controlled. Anyone with the URL can fetch.
-- Builds are signed but **not notarized for macOS** (because macOS isn't built for this channel at all).
+- Linux preview artifacts are unsigned, omit the unsupported voice and
+  WTD runtimes, and do not auto-update.
 - There is no SLA. Insiders builds may regress, break auto-update, or be pulled without notice.
 
 ## Reporting issues

--- a/INSIDERS.md
+++ b/INSIDERS.md
@@ -64,6 +64,9 @@ You will remain on the version you have installed until the public stable channe
 - The download URL is unlisted, not access-controlled. Anyone with the URL can fetch.
 - Linux preview artifacts are unsigned, omit the unsupported voice and
   WTD runtimes, and do not auto-update.
+- The portable Linux ZIP requires unprivileged user namespaces. Hardened
+  systems that disable them should use a native package with a root-owned
+  setuid Chromium sandbox helper instead.
 - There is no SLA. Insiders builds may regress, break auto-update, or be pulled without notice.
 
 ## Reporting issues

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ A2A complements tools. MCP-style tools and marketplace CLIs give a mind access t
 - **Canvas** — Render sandboxed HTML dashboards and reports in the browser with live reload and an action back-channel.
 - **Cron** — Schedule TypeScript automation scripts authored by minds under `.chamber/automation/*.ts` and executed via the bundled ttasks runtime.
 - **Marketplace links** — Enroll Genesis mind registries from `chamber://install?registry=...` links.
-- **Desktop updates** — Windows installer and update metadata are produced by the release pipeline.
+- **Desktop updates** — Windows and macOS update metadata plus Linux preview artifacts are produced by the release pipeline.
 
 ## Install
 
 Download the latest Windows build from [chmbr.dev](https://chmbr.dev) or from the [latest GitHub release](https://github.com/ianphil/chamber/releases/latest).
 
-Windows x64 is the primary packaged target today. macOS and Linux support are planned through the same workspace architecture.
+Windows x64 is the primary packaged target today. macOS is available through the release pipeline, and Linux x64 ZIP/DEB builds are available as manual-update Insiders previews.
 
 ## Quick Start
 

--- a/ai-docs/release-channels.md
+++ b/ai-docs/release-channels.md
@@ -130,6 +130,9 @@ insider, then promote.
 - Linux x64 ZIP and DEB preview artifacts, built on Ubuntu and updated
   manually. Voice and WTD runtimes are omitted because their native
   dependencies do not support Linux yet.
+- The portable ZIP relies on unprivileged user namespaces for Chromium's
+  sandbox. Hardened systems that disable them need a native package with
+  a root-owned setuid sandbox helper; the sandbox must never be disabled.
 - Windows auto-update reads `insiders.yml`; macOS reads
   `latest-mac.yml`. Linux preview builds do not auto-update.
 

--- a/ai-docs/release-channels.md
+++ b/ai-docs/release-channels.md
@@ -6,7 +6,7 @@ nothing is published on push to `master`.
 | Channel  | Audience               | Workflow                                | Distribution                                       | Platforms                |
 | -------- | ---------------------- | --------------------------------------- | -------------------------------------------------- | ------------------------ |
 | Stable   | Public                 | `.github/workflows/release.yml`         | GitHub Releases                                    | Windows + macOS arm64 (+ optional Intel) |
-| Insiders | Invite-only            | `.github/workflows/release-insiders.yml`| Azure Blob `chamberinsiders/releases` (unlisted)   | Windows only             |
+| Insiders | Invite-only            | `.github/workflows/release-insiders.yml`| Azure Blob `chamberinsiders/releases` (unlisted)   | Windows + macOS arm64; Linux x64 preview |
 
 ## Mental model
 
@@ -125,10 +125,13 @@ insider, then promote.
 
 ### What it is
 
-- Windows-only signed NSIS installer, published to a private Azure Blob.
-- Auto-update reads `insiders.yml` from the same blob.
-- macOS is intentionally excluded until the Apple Developer ID
-  notarization warmup completes. Insider testers run Windows only.
+- Signed Windows NSIS and notarized macOS arm64 packages, published to
+  an unlisted Azure Blob.
+- Linux x64 ZIP and DEB preview artifacts, built on Ubuntu and updated
+  manually. Voice and WTD runtimes are omitted because their native
+  dependencies do not support Linux yet.
+- Windows auto-update reads `insiders.yml`; macOS reads
+  `latest-mac.yml`. Linux preview builds do not auto-update.
 
 ### Where artifacts live
 
@@ -139,6 +142,8 @@ insider, then promote.
 - Stable install URL (overwritten on each cut):
   `https://chamberinsiders.blob.core.windows.net/releases/Chamber-Setup-latest-insiders.exe`
 - Auto-update feed: `https://chamberinsiders.blob.core.windows.net/releases/insiders.yml`
+- Linux artifacts are versioned Forge outputs under the same blob root:
+  `Chamber-linux-x64-<version>.zip` and `chamber_<version>_amd64.deb`.
 
 ### Authentication
 
@@ -172,10 +177,12 @@ insider, then promote.
      advances/resets the `-insiders.N` counter against existing tags.
    - Run `npm install` to refresh the lockfile in the runner workspace.
    - Sign via the existing Trusted Signing identity.
-   - Build with `CHAMBER_RELEASE_CHANNEL=insiders` and
+   - Build Windows and macOS with `CHAMBER_RELEASE_CHANNEL=insiders` and
      `CHAMBER_BUILDER_UPDATE_URL` pointing at the blob. The embedded
      `app-update.yml` ships `channel: insiders` so the installed app
      reads `insiders.yml` on update checks.
+   - Build the Linux x64 ZIP and DEB with Electron Forge. These preview
+     artifacts omit unsupported voice/WTD runtimes and updater metadata.
    - Validate the manifest with
      `node scripts/validate-builder-release.js --channel=insiders`.
    - Upload artifacts to the blob via `az storage blob upload-batch
@@ -190,8 +197,10 @@ insider, then promote.
   `Chamber-Setup-latest-insiders.exe` from the URL above and run it.
   Share this URL out-of-band — it is not linked from the website or
   README.
-- Subsequent updates: nothing. The installed app polls `insiders.yml`
-  and self-updates.
+- Linux: download the versioned ZIP or DEB from the same blob. ZIP is
+  the portable option, including for Arch; DEB targets Debian/Ubuntu.
+- Subsequent Windows and macOS updates are automatic. Linux preview
+  updates require downloading the next version manually.
 - Revert to stable: uninstall, then install the latest GitHub Release.
   Mind data lives in the user profile and is preserved across reinstall.
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -589,6 +589,7 @@ async function initializeRuntime(voiceRuntimeAvailable: boolean): Promise<void> 
   updaterService = new UpdaterService({
     currentVersion: app.getVersion(),
     isPackaged: app.isPackaged,
+    isSupportedPlatform: process.platform !== 'linux',
     allowDevUpdates: process.env.CHAMBER_UPDATER_ALLOW_DEV === '1',
     setQuitting: () => {
       isQuitting = true;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -38,6 +38,7 @@ import {
   CanvasService,
   ChamberCopilotService,
   listStoredGitHubCredentials,
+  LinuxKeyringCredentialStore,
   ChatroomService,
   ChatService,
   ConfigService,
@@ -96,6 +97,7 @@ import {
   type AppPaths,
   type ChamberToolProvider,
   type CredentialStore,
+  type KeyringModule,
   type GenesisMindTemplateMarketplaceSource,
   type Notifier,
   type WtdRuntimeResolution,
@@ -189,6 +191,15 @@ function loadKeytar(): CredentialStore {
   }
 
   return runtimeRequire(path.join(process.resourcesPath, 'keytar', 'lib', 'keytar.js')) as CredentialStore;
+}
+
+function loadCredentialStore(): CredentialStore {
+  if (process.platform !== 'linux') return loadKeytar();
+
+  const modulePath = app.isPackaged
+    ? path.join(process.resourcesPath, '@napi-rs', `keyring-linux-${process.arch}-gnu`)
+    : '@napi-rs/keyring';
+  return new LinuxKeyringCredentialStore(runtimeRequire(modulePath) as KeyringModule);
 }
 
 function loadSharp(): typeof sharpModule {
@@ -378,7 +389,7 @@ async function initializeRuntime(voiceRuntimeAvailable: boolean): Promise<void> 
     const config = configService.load();
     configService.save({ ...config, activeLogin: login });
   };
-  credentialStore = loadKeytar();
+  credentialStore = loadCredentialStore();
   sharp = loadSharp();
   const githubRegistryClient = GitHubRegistryClient.withCredentialStore(credentialStore, userAgent);
   authService = new AuthService(

--- a/apps/desktop/src/main/updater/UpdaterService.test.ts
+++ b/apps/desktop/src/main/updater/UpdaterService.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import type { AppUpdater } from 'electron-updater';
+
+import { UpdaterService } from './UpdaterService';
+
+describe('UpdaterService', () => {
+  it('disables automatic updates on unsupported packaged platforms', () => {
+    const service = new UpdaterService({
+      currentVersion: '1.2.3',
+      isPackaged: true,
+      isSupportedPlatform: false,
+      updater: {} as AppUpdater,
+    });
+
+    expect(service.getState()).toMatchObject({
+      enabled: false,
+      status: 'disabled',
+      message: 'Automatic updates are not available on this platform.',
+    });
+  });
+});

--- a/apps/desktop/src/main/updater/UpdaterService.ts
+++ b/apps/desktop/src/main/updater/UpdaterService.ts
@@ -28,6 +28,7 @@ interface UpdaterLogger {
 export interface UpdaterServiceOptions {
   readonly currentVersion: string;
   readonly isPackaged: boolean;
+  readonly isSupportedPlatform?: boolean;
   readonly updater?: AppUpdater;
   readonly logger?: UpdaterLogger;
   readonly allowDevUpdates?: boolean;
@@ -50,11 +51,16 @@ export class UpdaterService {
     this.updater = options.updater ?? autoUpdater;
     this.logger = options.logger ?? console;
     this.setQuitting = options.setQuitting;
-    const enabled = options.isPackaged || options.allowDevUpdates === true;
+    const supported = options.isSupportedPlatform !== false;
+    const enabled = supported && (options.isPackaged || options.allowDevUpdates === true);
     this.state = createUpdateState(
       options.currentVersion,
       enabled,
-      enabled ? undefined : 'Updates are available only in packaged builds.',
+      enabled
+        ? undefined
+        : supported
+          ? 'Updates are available only in packaged builds.'
+          : 'Automatic updates are not available on this platform.',
     );
     this.configureUpdater();
   }

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
         'sharp',
         '@azure/msal-node-extensions',
         '@azure/msal-node-runtime',
+        '@napi-rs/keyring',
         'chamber-copilot',
         'vscode-jsonrpc',
         /^vscode-jsonrpc\//,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,6 +14,7 @@
     "@chamber/services": "file:../../packages/services",
     "@chamber/wire-contracts": "file:../../packages/wire-contracts",
     "@hono/node-server": "^2.0.0",
+    "@napi-rs/keyring": "^1.3.0",
     "hono": "^4.12.27",
     "keytar": "^7.9.0",
     "ws": "^8.21.0"

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -14,6 +14,7 @@ import {
   CopilotClientFactory,
   getChamberToolsBinDir,
   IdentityLoader,
+  LinuxKeyringCredentialStore,
   listStoredGitHubCredentials,
   MessageRouter,
   MindManager,
@@ -21,6 +22,7 @@ import {
   TurnQueue,
   ViewDiscovery,
   type CredentialStore,
+  type KeyringModule,
 } from '@chamber/services';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -30,21 +32,35 @@ import type { ChamberCtx } from './types';
 const port = Number(process.env.CHAMBER_SERVER_PORT ?? 0);
 const allowedOrigin = process.env.CHAMBER_ALLOWED_ORIGIN ?? 'http://127.0.0.1';
 
-// Defer loading the keytar native addon until an auth method is actually
+// Defer loading the native credential addon until an auth method is actually
 // invoked. On Windows, keytar.node is locked the moment Node loads it, which
 // breaks `electron-forge start`'s rebuild step (it can't unlink keytar.node
 // to swap it for Electron's ABI). The loopback server runs as part of
 // Playwright's webServer during desktop smoke runs and never exercises auth
 // in CHAMBER_E2E mode, so deferring the load keeps Forge's rebuild unblocked.
-async function loadKeytar(): Promise<CredentialStore> {
+let platformCredentialStore: Promise<CredentialStore> | undefined;
+
+async function loadPlatformCredentialStore(): Promise<CredentialStore> {
+  if (process.platform === 'linux') {
+    const mod = await import('@napi-rs/keyring');
+    return new LinuxKeyringCredentialStore(mod as KeyringModule);
+  }
+
   const mod = await import('keytar');
   return ((mod as { default?: CredentialStore }).default ?? (mod as unknown as CredentialStore));
 }
+
+function getPlatformCredentialStore(): Promise<CredentialStore> {
+  platformCredentialStore ??= loadPlatformCredentialStore();
+  return platformCredentialStore;
+}
+
 const credentialStore: CredentialStore = {
-  findCredentials: async (service) => (await loadKeytar()).findCredentials(service),
+  findCredentials: async (service) => (await getPlatformCredentialStore()).findCredentials(service),
   setPassword: async (service, account, password) =>
-    (await loadKeytar()).setPassword(service, account, password),
-  deletePassword: async (service, account) => (await loadKeytar()).deletePassword(service, account),
+    (await getPlatformCredentialStore()).setPassword(service, account, password),
+  deletePassword: async (service, account) =>
+    (await getPlatformCredentialStore()).deletePassword(service, account),
 };
 
 const configService = new ConfigService();

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -124,6 +124,7 @@ const baseExtraResource = [
   './resources/sqlite-runtime',
   './resources/automation-runtime',
   './node_modules/keytar',
+  ...(process.platform === 'linux' ? ['./node_modules/@napi-rs'] : []),
 ];
 
 const config: ForgeConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@azure/msal-node": "^5.2.0",
         "@azure/msal-node-extensions": "^5.2.0",
         "@fontsource-variable/inter": "^5.2.8",
+        "@napi-rs/keyring": "^1.3.0",
         "better-sqlite3": "12.10.0",
         "chamber-copilot": "0.5.11",
         "class-variance-authority": "^0.7.1",
@@ -2677,6 +2678,240 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "@chamber/services": "file:../../packages/services",
         "@chamber/wire-contracts": "file:../../packages/wire-contracts",
         "@hono/node-server": "^2.0.0",
+        "@napi-rs/keyring": "^1.3.0",
         "hono": "^4.12.27",
         "keytar": "^7.9.0",
         "ws": "^8.21.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "smoke:a2a-relay": "npm run playwright:install && playwright test --config config/playwright.config.ts --project=electron --workers=1 --headed tests/e2e/electron/a2a-relay-roundtrip.spec.ts",
     "smoke:byo-llm": "npm run playwright:install && playwright test --config config/playwright.config.ts --project=electron --workers=1 tests/e2e/electron/byo-llm-settings.spec.ts",
     "smoke:packaged-runtime": "npm --workspace @chamber/server run build && node scripts/packaged-smoke.js",
+    "smoke:linux-package": "node scripts/smoke-linux-package.js",
     "smoke:voice-runtime": "node scripts/voice-runtime-smoke.js",
     "smoke:automation": "node scripts/prepare-automation-runtime.js && node scripts/run-automation-smoke.js",
     "smoke:wtd-runtime": "node scripts/wtd-runtime-smoke.js"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "node scripts/check-sdk-versions.js && node scripts/check-voice-sdk-version.js && node scripts/prepare-wtd-runtime.js --dev && electron-forge start",
     "package": "npm --workspace @chamber/server run build && node scripts/prepare-node-runtime.js && node scripts/prepare-voice-runtime.js && electron-forge package",
     "make": "npm run make:builder",
+    "make:arch": "npm run package && node scripts/make-arch.js",
     "make:forge": "npm --workspace @chamber/server run build && node scripts/prepare-node-runtime.js && node scripts/prepare-voice-runtime.js && electron-forge make",
     "make:builder": "npm run package && node scripts/prepare-builder-prepackaged.js && electron-builder --win nsis --x64 --prepackaged out/Chamber-win32-x64 --config config/electron-builder.config.cjs --publish never",
     "make:builder:mac": "npm run package && node scripts/prepare-builder-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && node scripts/sign-macos-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && node scripts/notarize-macos-prepackaged.js --platform=darwin --arch=$(node -p \"process.arch\") && electron-builder --mac --$(node -p \"process.arch\") --prepackaged out/Chamber-darwin-$(node -p \"process.arch\")/Chamber.app --config config/electron-builder.config.cjs --publish never",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@azure/msal-node": "^5.2.0",
     "@azure/msal-node-extensions": "^5.2.0",
     "@fontsource-variable/inter": "^5.2.8",
+    "@napi-rs/keyring": "^1.3.0",
     "better-sqlite3": "12.10.0",
     "chamber-copilot": "0.5.11",
     "class-variance-authority": "^0.7.1",

--- a/packages/services/src/auth/LinuxKeyringCredentialStore.test.ts
+++ b/packages/services/src/auth/LinuxKeyringCredentialStore.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LinuxKeyringCredentialStore, type KeyringModule } from './LinuxKeyringCredentialStore';
+
+function createKeyring() {
+  const entries = new Map<string, string>();
+  const key = (service: string, username: string) => `${service}\0${username}`;
+
+  class FakeAsyncEntry {
+    constructor(
+      private readonly service: string,
+      private readonly username: string,
+    ) {}
+
+    async setPassword(password: string): Promise<void> {
+      entries.set(key(this.service, this.username), password);
+    }
+
+    async deleteCredential(): Promise<boolean> {
+      return entries.delete(key(this.service, this.username));
+    }
+  }
+
+  const findCredentialsAsync = vi.fn(async (service: string) =>
+    [...entries.entries()]
+      .filter(([entryKey]) => entryKey.startsWith(`${service}\0`))
+      .map(([entryKey, password]) => ({
+        account: entryKey.slice(service.length + 1),
+        password,
+      })));
+
+  return {
+    entries,
+    keyring: {
+      AsyncEntry: FakeAsyncEntry,
+      findCredentialsAsync,
+    } satisfies KeyringModule,
+    findCredentialsAsync,
+  };
+}
+
+describe('LinuxKeyringCredentialStore', () => {
+  it('lists credentials written with Copilot keyring usernames', async () => {
+    const { entries, keyring, findCredentialsAsync } = createKeyring();
+    entries.set('copilot-cli\0https://github.com:alice', 'token');
+    const store = new LinuxKeyringCredentialStore(keyring);
+
+    await expect(store.findCredentials('copilot-cli')).resolves.toEqual([
+      { account: 'https://github.com:alice', password: 'token' },
+    ]);
+    expect(findCredentialsAsync).toHaveBeenCalledWith('copilot-cli');
+  });
+
+  it('sets and deletes credentials through keyed entries', async () => {
+    const { entries, keyring } = createKeyring();
+    const store = new LinuxKeyringCredentialStore(keyring);
+    const account = 'https://github.com:alice';
+
+    await store.setPassword('copilot-cli', account, 'token');
+    expect(entries.get(`copilot-cli\0${account}`)).toBe('token');
+
+    await expect(store.deletePassword('copilot-cli', account)).resolves.toBe(true);
+    await expect(store.deletePassword('copilot-cli', account)).resolves.toBe(false);
+  });
+});

--- a/packages/services/src/auth/LinuxKeyringCredentialStore.ts
+++ b/packages/services/src/auth/LinuxKeyringCredentialStore.ts
@@ -1,0 +1,30 @@
+import type { CredentialStore } from '../ports';
+
+interface KeyringEntry {
+  setPassword(password: string): Promise<void>;
+  deleteCredential(): Promise<boolean>;
+}
+
+export interface KeyringModule {
+  AsyncEntry: new (service: string, username: string) => KeyringEntry;
+  findCredentialsAsync(service: string): Promise<Array<{ account: string; password: string }>>;
+}
+
+export class LinuxKeyringCredentialStore implements CredentialStore {
+  constructor(private readonly keyring: KeyringModule) {}
+
+  findCredentials(service: string): Promise<Array<{ account: string; password: string }>> {
+    return this.keyring.findCredentialsAsync(service);
+  }
+
+  async setPassword(service: string, account: string, password: string): Promise<void> {
+    await new this.keyring.AsyncEntry(service, account).setPassword(password);
+  }
+
+  async deletePassword(service: string, account: string): Promise<boolean> {
+    const credentials = await this.findCredentials(service);
+    if (!credentials.some((credential) => credential.account === account)) return false;
+    await new this.keyring.AsyncEntry(service, account).deleteCredential();
+    return true;
+  }
+}

--- a/packages/services/src/auth/index.ts
+++ b/packages/services/src/auth/index.ts
@@ -8,3 +8,5 @@ export {
   listStoredGitHubCredentials,
 } from './AuthService';
 export type { AuthProgress, StartLoginOptions, StoredGitHubCredential } from './AuthService';
+export { LinuxKeyringCredentialStore } from './LinuxKeyringCredentialStore';
+export type { KeyringModule } from './LinuxKeyringCredentialStore';

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -15,6 +15,7 @@ package() {
   install -d "$pkgdir/opt/chamber"
   cp -a "$package_dir/." "$pkgdir/opt/chamber/"
   chmod 755 "$pkgdir/opt/chamber"
+  chmod 4755 "$pkgdir/opt/chamber/chrome-sandbox"
 
   install -d "$pkgdir/usr/bin"
   ln -s /opt/chamber/chamber "$pkgdir/usr/bin/chamber"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,26 @@
+pkgname=chamber
+pkgver="${CHAMBER_VERSION:?CHAMBER_VERSION is required}"
+pkgrel=1
+pkgdesc='Desktop workspace for AI agents'
+arch=('x86_64')
+url='https://github.com/ianphil/chamber'
+license=('MIT')
+depends=('alsa-lib' 'gtk3' 'libsecret' 'libxss' 'nss')
+options=('!strip')
+
+package() {
+  local package_dir="${CHAMBER_PACKAGE_DIR:?CHAMBER_PACKAGE_DIR is required}"
+  local repo_root="${CHAMBER_REPO_ROOT:?CHAMBER_REPO_ROOT is required}"
+
+  install -d "$pkgdir/opt/chamber"
+  cp -a "$package_dir/." "$pkgdir/opt/chamber/"
+  chmod 755 "$pkgdir/opt/chamber"
+
+  install -d "$pkgdir/usr/bin"
+  ln -s /opt/chamber/chamber "$pkgdir/usr/bin/chamber"
+
+  install -Dm644 "$repo_root/packaging/arch/chamber.desktop" \
+    "$pkgdir/usr/share/applications/chamber.desktop"
+  install -Dm644 "$repo_root/assets/app.svg" \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/chamber.svg"
+}

--- a/packaging/arch/chamber.desktop
+++ b/packaging/arch/chamber.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Chamber
+Comment=Desktop workspace for AI agents
+Exec=chamber %U
+Icon=chamber
+Terminal=false
+Type=Application
+Categories=Utility;
+MimeType=x-scheme-handler/chamber;

--- a/scripts/make-arch.js
+++ b/scripts/make-arch.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const packageDir = path.join(repoRoot, 'out', 'Chamber-linux-x64');
+const outputDir = path.join(repoRoot, 'out', 'make', 'arch', 'x64');
+const pkgbuildDir = path.join(repoRoot, 'packaging', 'arch');
+const version = require('../package.json').version.replaceAll('-', '_');
+
+if (process.platform !== 'linux' || process.arch !== 'x64') {
+  throw new Error(`Arch packages must be built on linux-x64, found ${process.platform}-${process.arch}.`);
+}
+if (!fs.existsSync(path.join(packageDir, 'chamber'))) {
+  throw new Error(`Packaged Chamber executable not found at ${packageDir}.`);
+}
+
+fs.mkdirSync(outputDir, { recursive: true });
+const result = spawnSync('makepkg', ['--clean', '--cleanbuild', '--force'], {
+  cwd: pkgbuildDir,
+  env: {
+    ...process.env,
+    CHAMBER_PACKAGE_DIR: packageDir,
+    CHAMBER_REPO_ROOT: repoRoot,
+    CHAMBER_VERSION: version,
+    PKGDEST: outputDir,
+  },
+  stdio: 'inherit',
+});
+
+if (result.error || result.status !== 0) {
+  throw new Error(`makepkg failed${result.error ? `: ${result.error.message}` : '.'}`);
+}
+
+const artifact = path.join(outputDir, `chamber-${version}-1-x86_64.pkg.tar.zst`);
+if (!fs.existsSync(artifact)) {
+  throw new Error(`Arch package was not created at ${artifact}.`);
+}
+
+console.log(`Arch package ready at ${artifact}`);

--- a/scripts/prepare-copilot-runtime.js
+++ b/scripts/prepare-copilot-runtime.js
@@ -308,6 +308,10 @@ function createIsolatedCopilotEnvironment(homeDir, baseEnv = process.env) {
     ...baseEnv,
     HOME: homeDir,
     USERPROFILE: homeDir,
+    XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+    XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+    XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+    XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
   };
 }
 

--- a/scripts/prepare-sharp-runtime.js
+++ b/scripts/prepare-sharp-runtime.js
@@ -148,7 +148,10 @@ function main() {
 
   fs.rmSync(stagingDir, { recursive: true, force: true });
   copyRuntimeManifest(stagingDir);
-  runCommand(getNpmCommand(), ['ci', '--omit=dev'], { cwd: stagingDir, env: process.env });
+  runCommand(getNpmCommand(), ['ci', '--omit=dev'], {
+    cwd: stagingDir,
+    env: { ...process.env, SHARP_IGNORE_GLOBAL_LIBVIPS: '1' },
+  });
   validateRuntimeDir(stagingDir, targetPlatform, targetArch);
   promoteRuntime(targetPlatform, targetArch);
 

--- a/scripts/smoke-linux-package.js
+++ b/scripts/smoke-linux-package.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const packageRoot = path.join(repoRoot, 'out', 'Chamber-linux-x64');
+const executable = path.join(packageRoot, 'chamber');
+const keyringBinding = path.join(
+  packageRoot,
+  'resources',
+  '@napi-rs',
+  'keyring-linux-x64-gnu',
+  'keyring.linux-x64-gnu.node',
+);
+const readyMarker = '[SdkLoader] Copilot runtime ready mode=packaged';
+const timeoutMs = 30_000;
+
+async function main() {
+  if (process.platform !== 'linux' || process.arch !== 'x64') {
+    throw new Error(`Linux package smoke requires linux-x64, found ${process.platform}-${process.arch}.`);
+  }
+  for (const requiredPath of [executable, keyringBinding]) {
+    if (!fs.existsSync(requiredPath)) {
+      throw new Error(`Linux package smoke is missing ${requiredPath}.`);
+    }
+  }
+
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chamber-linux-smoke-'));
+  const child = spawn(executable, [`--user-data-dir=${userDataDir}`], {
+    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+
+  const capture = (chunk) => {
+    output += chunk.toString();
+  };
+  child.stdout.on('data', capture);
+  child.stderr.on('data', capture);
+
+  try {
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Timed out waiting for packaged Linux startup.\n${output}`));
+      }, timeoutMs);
+
+      const inspect = () => {
+        if (!output.includes(readyMarker)) return;
+        clearTimeout(timeout);
+        resolve();
+      };
+      child.stdout.on('data', inspect);
+      child.stderr.on('data', inspect);
+      child.once('exit', (code, signal) => {
+        clearTimeout(timeout);
+        reject(new Error(`Packaged Linux app exited before startup (code=${code}, signal=${signal}).\n${output}`));
+      });
+      child.once('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    if (child.exitCode !== null) {
+      throw new Error(`Packaged Linux app exited immediately after startup.\n${output}`);
+    }
+    console.log('[smoke:linux-package] OK');
+  } finally {
+    child.kill('SIGTERM');
+    await new Promise((resolve) => {
+      if (child.exitCode !== null) {
+        resolve();
+        return;
+      }
+      child.once('exit', resolve);
+      setTimeout(() => {
+        child.kill('SIGKILL');
+      }, 5_000).unref();
+    });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/e2e/electron/electronApp.ts
+++ b/tests/e2e/electron/electronApp.ts
@@ -4,6 +4,10 @@ import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
 import { canAccessRepoWithChamberCredentials } from './chamberRepoAccess';
+import {
+  LinuxKeyringCredentialStore,
+  type KeyringModule,
+} from '../../../packages/services/src/auth/LinuxKeyringCredentialStore';
 
 export const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
@@ -159,8 +163,8 @@ function logsPreview(logs: string[]): string {
  * guard return true on entries the runtime never tries — causing specs to
  * run when the runtime can't actually fetch the repo.
  *
- * Loads keytar lazily so the Playwright runner process doesn't hold the
- * keytar.node native addon open. On Windows, an open keytar.node prevents
+ * Loads the platform credential module lazily so the Playwright runner does
+ * not hold keytar.node open. On Windows, an open keytar.node prevents
  * `electron-forge start` from rebuilding it for Electron's ABI (EPERM on
  * unlink), which breaks every Electron spec. See CHANGELOG #250 for the
  * original incident. The keytar dynamic import here is the only deferral
@@ -176,6 +180,14 @@ function logsPreview(logs: string[]): string {
  * into Playwright's runner process.
  */
 export async function canAccessRepo(nwo: string): Promise<boolean> {
+  if (process.platform === 'linux') {
+    const keyringModule = await import('@napi-rs/keyring');
+    return canAccessRepoWithChamberCredentials(
+      nwo,
+      new LinuxKeyringCredentialStore(keyringModule as KeyringModule),
+    );
+  }
+
   const keytarModule = await import('keytar');
   const keytar = ((keytarModule as { default?: typeof import('keytar') }).default
     ?? (keytarModule as unknown as typeof import('keytar')));

--- a/tests/invariants/security-boundaries.invariant.test.ts
+++ b/tests/invariants/security-boundaries.invariant.test.ts
@@ -72,6 +72,7 @@ describe('security boundary invariants', () => {
       path.join(repoRoot, 'apps', 'server', 'src', 'bin.ts'),
       path.join(repoRoot, 'apps', 'server', 'src', 'privileged-protocol.ts'),
       path.join(repoRoot, 'packages', 'services', 'src', 'auth', 'AuthService.ts'),
+      path.join(repoRoot, 'packages', 'services', 'src', 'auth', 'LinuxKeyringCredentialStore.ts'),
       path.join(repoRoot, 'packages', 'services', 'src', 'byo-llm', 'ByoLlmStore.ts'),
       path.join(repoRoot, 'packages', 'services', 'src', 'ports.ts'),
     ]);

--- a/tests/regression/forge-config.test.ts
+++ b/tests/regression/forge-config.test.ts
@@ -99,6 +99,9 @@ describe('forge config', () => {
       expect(extraResource).toContain('./resources/copilot-runtime');
       expect(extraResource).toContain('./resources/sqlite-runtime');
       expect(extraResource).toContain('./node_modules/keytar');
+      if (process.platform === 'linux') {
+        expect(extraResource).toContain('./node_modules/@napi-rs');
+      }
       expect(extraResource).not.toContain('./apps/desktop/src/main/assets/managed-skills');
       expect(extraResource).not.toContain('./apps/desktop/src/main/assets/lens-skill');
       expect(extraResource).not.toContain('./apps/desktop/src/main/assets/ttasks-skill');

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -35,6 +35,7 @@ describe('packaging scripts', () => {
     }
 
     expect(packageJson.scripts.make).toBe('npm run make:builder');
+    expect(packageJson.scripts['make:arch']).toBe('npm run package && node scripts/make-arch.js');
     expect(packageJson.scripts['make:builder']).toContain('npm run package');
     expect(packageJson.scripts['make:builder'].indexOf('npm run package')).toBeLessThan(
       packageJson.scripts['make:builder'].indexOf('electron-builder')
@@ -111,6 +112,12 @@ describe('packaging scripts', () => {
     expect(insidersWorkflow).toContain('insiders.yml');
     expect(insidersWorkflow).toContain('build-macos:');
     expect(insidersWorkflow).toContain('runs-on: macos-latest');
+    expect(insidersWorkflow).toContain('build-linux:');
+    expect(insidersWorkflow).toContain('npm run make:forge');
+    expect(insidersWorkflow).toContain('name: insiders-linux');
+    expect(insidersWorkflow).toContain('out/make/zip/linux/x64');
+    expect(insidersWorkflow).toContain('out/make/deb/x64');
+    expect(insidersWorkflow).toContain('needs: [prepare, build-windows, build-macos, build-linux]');
     expect(insidersWorkflow).toContain('tag: ${{ steps.bump.outputs.tag }}');
     expect(insidersWorkflow).toContain('git push origin "${{ needs.prepare.outputs.tag }}"');
     expect(insidersWorkflow).not.toContain('git push origin HEAD');

--- a/tests/regression/packaging-scripts.test.ts
+++ b/tests/regression/packaging-scripts.test.ts
@@ -117,6 +117,7 @@ describe('packaging scripts', () => {
     expect(insidersWorkflow).toContain('name: insiders-linux');
     expect(insidersWorkflow).toContain('out/make/zip/linux/x64');
     expect(insidersWorkflow).toContain('out/make/deb/x64');
+    expect(insidersWorkflow).toContain('xvfb-run --auto-servernum npm run smoke:linux-package');
     expect(insidersWorkflow).toContain('needs: [prepare, build-windows, build-macos, build-linux]');
     expect(insidersWorkflow).toContain('tag: ${{ steps.bump.outputs.tag }}');
     expect(insidersWorkflow).toContain('git push origin "${{ needs.prepare.outputs.tag }}"');

--- a/tests/regression/prepare-copilot-runtime.test.ts
+++ b/tests/regression/prepare-copilot-runtime.test.ts
@@ -56,15 +56,24 @@ describe('prepare-copilot-runtime', () => {
 
   it('isolates runtime validation from the developer Copilot cache', async () => {
     const { createIsolatedCopilotEnvironment } = await loadPrepareRuntime();
+    const homeDir = path.join(os.tmpdir(), 'copilot-home');
 
-    expect(createIsolatedCopilotEnvironment('C:\\temp\\copilot-home', {
-      PATH: 'C:\\tools',
-      HOME: 'C:\\Users\\developer',
-      USERPROFILE: 'C:\\Users\\developer',
+    expect(createIsolatedCopilotEnvironment(homeDir, {
+      PATH: '/tools',
+      HOME: '/home/developer',
+      USERPROFILE: '/home/developer',
+      XDG_CACHE_HOME: '/home/developer/.cache',
+      XDG_CONFIG_HOME: '/home/developer/.config',
+      XDG_DATA_HOME: '/home/developer/.local/share',
+      XDG_STATE_HOME: '/home/developer/.local/state',
     })).toMatchObject({
-      PATH: 'C:\\tools',
-      HOME: 'C:\\temp\\copilot-home',
-      USERPROFILE: 'C:\\temp\\copilot-home',
+      PATH: '/tools',
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+      XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+      XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+      XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
     });
   });
 


### PR DESCRIPTION
## Summary

- use the Copilot-compatible Secret Service schema on Linux while retaining Keytar on Windows and macOS
- package and smoke Linux x64 ZIP/DEB artifacts in the Insiders release workflow
- add a local `npm run make:arch` Pacman package with a hardened Chromium sandbox
- disable unsupported Linux auto-updates and document manual preview updates

## Notable changes

- isolates packaged Copilot validation from XDG user caches
- prevents Sharp from selecting a host-global libvips during packaging
- routes desktop, server, and Electron test credentials through the Linux keyring adapter
- launches the packaged Linux app under Xvfb before release upload

## Validation

- `npm run lint`
- `npm test`
- `npm run smoke:sdk`
- `npm run smoke:server-sdk`
- `npm run smoke:web`
- `npm run smoke:desktop` (35 passed; opt-in/repository-gated specs skipped)
- `npm run smoke:linux-package`
- `npm run package`
- `npm run make:arch`
- Pacman-installed build launched successfully from `/opt/chamber`

No issue is linked; this work originated from direct Linux bring-up and packaging validation.